### PR TITLE
Accept and return profiles on users API

### DIFF
--- a/src/api/v1/users.ts
+++ b/src/api/v1/users.ts
@@ -5,18 +5,53 @@ import { z } from "zod";
 const usersRouter = Router();
 const prisma = new PrismaClient();
 
-type GetUserRequestParams = {
+export type ReturnedUser = {
   id: string;
+  privyUserId: string;
+  device: {
+    id: string;
+    os: DeviceOS;
+    name: string | null;
+  };
+  identity: {
+    id: string;
+    privyAddress: string;
+    xmtpId: string | null;
+  };
+  profile: {
+    id: string;
+    name: string;
+    description: string | null;
+  } | null;
 };
 
-// GET /users/:id - Get a single user by ID
+type GetUserRequestParams = {
+  privyUserId: string;
+};
+
+// GET /users/:privyUserId - Get a single user by Privy user ID
 usersRouter.get(
-  "/:id",
+  "/:privyUserId",
   async (req: Request<GetUserRequestParams>, res: Response) => {
     try {
-      const { id } = req.params;
+      const { privyUserId } = req.params;
       const user = await prisma.user.findUnique({
-        where: { id },
+        where: { privyUserId },
+        include: {
+          devices: {
+            include: {
+              identities: {
+                include: {
+                  identity: {
+                    include: {
+                      profile: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       });
 
       if (!user) {
@@ -24,7 +59,41 @@ usersRouter.get(
         return;
       }
 
-      res.json(user);
+      // format user data for response
+      const {
+        id,
+        devices: [
+          {
+            id: deviceId,
+            os: deviceOs,
+            name: deviceName,
+            identities: [{ identity }],
+          },
+        ],
+      } = user;
+      const returnedUser = {
+        id,
+        privyUserId,
+        device: {
+          id: deviceId,
+          os: deviceOs,
+          name: deviceName,
+        },
+        identity: {
+          id: identity.id,
+          privyAddress: identity.privyAddress,
+          xmtpId: identity.xmtpId,
+        },
+        profile: identity.profile
+          ? {
+              id: identity.profile.id,
+              name: identity.profile.name,
+              description: identity.profile.description,
+            }
+          : null,
+      } satisfies ReturnedUser;
+
+      res.json(returnedUser);
     } catch {
       res.status(500).json({ error: "Failed to fetch user" });
     }
@@ -42,24 +111,15 @@ const userCreateSchema = z.object({
     privyAddress: z.string(),
     xmtpId: z.string(),
   }),
+  profile: z
+    .object({
+      name: z.string(),
+      description: z.string().optional(),
+    })
+    .optional(),
 });
 
 export type CreateUserRequestBody = z.infer<typeof userCreateSchema>;
-
-export type CreatedUser = {
-  id: string;
-  privyUserId: string;
-  device: {
-    id: string;
-    os: DeviceOS;
-    name: string | null;
-  };
-  identity: {
-    id: string;
-    privyAddress: string;
-    xmtpId: string;
-  };
-};
 
 // POST /users - Create a new user
 usersRouter.post(
@@ -73,7 +133,9 @@ usersRouter.post(
         privyUserId,
         device,
         identity: { privyAddress, xmtpId },
+        profile,
       } = userCreateSchema.parse(req.body);
+
       // create new user
       const createdUser = await prisma.user.create({
         data: {
@@ -93,6 +155,14 @@ usersRouter.post(
                           privyUserId,
                         },
                       },
+                      profile: profile
+                        ? {
+                            create: {
+                              name: profile.name,
+                              description: profile.description,
+                            },
+                          }
+                        : undefined,
                     },
                   },
                 },
@@ -105,45 +175,53 @@ usersRouter.post(
             include: {
               identities: {
                 include: {
-                  identity: true,
+                  identity: {
+                    include: {
+                      profile: true,
+                    },
+                  },
                 },
               },
             },
           },
         },
       });
+
+      // format user data for response
       const {
         id,
         devices: [
           {
             id: deviceId,
-            os,
-            name,
-            identities: [
-              {
-                identity: { id: identityId },
-              },
-            ],
+            os: deviceOs,
+            name: deviceName,
+            identities: [{ identity }],
           },
         ],
       } = createdUser;
-      // format user data for response
-      const user = {
+      const returnedUser = {
         id,
         privyUserId,
         device: {
           id: deviceId,
-          os,
-          name,
+          os: deviceOs,
+          name: deviceName,
         },
         identity: {
-          id: identityId,
-          privyAddress,
-          xmtpId,
+          id: identity.id,
+          privyAddress: identity.privyAddress,
+          xmtpId: identity.xmtpId,
         },
-      } satisfies CreatedUser;
+        profile: identity.profile
+          ? {
+              id: identity.profile.id,
+              name: identity.profile.name,
+              description: identity.profile.description,
+            }
+          : null,
+      } satisfies ReturnedUser;
 
-      res.status(201).json(user);
+      res.status(201).json(returnedUser);
     } catch (error) {
       if (error instanceof z.ZodError) {
         res.status(400).json({ error: "Invalid request body" });
@@ -161,19 +239,19 @@ const userUpdateSchema = z.object({
 
 type UpdateUserRequestBody = z.infer<typeof userUpdateSchema>;
 
-// PUT /users/:id - Update a user
+// PUT /users/:privyUserId - Update a user by Privy user ID
 usersRouter.put(
-  "/:id",
+  "/:privyUserId",
   async (
     req: Request<GetUserRequestParams, unknown, UpdateUserRequestBody>,
     res: Response,
   ) => {
     try {
-      const { id } = req.params;
+      const { privyUserId } = req.params;
       const validatedData = userUpdateSchema.partial().parse(req.body);
 
       const user = await prisma.user.update({
-        where: { id },
+        where: { privyUserId },
         data: validatedData,
       });
 

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -33,6 +33,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   // clean up the database before each test
+  await prisma.profile.deleteMany();
   await prisma.device.deleteMany();
   await prisma.user.deleteMany();
 });

--- a/tests/identities.test.ts
+++ b/tests/identities.test.ts
@@ -33,6 +33,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  await prisma.profile.deleteMany();
   await prisma.identitiesOnDevice.deleteMany();
   await prisma.deviceIdentity.deleteMany();
   await prisma.device.deleteMany();

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -14,7 +14,7 @@ import {
 } from "bun:test";
 import express from "express";
 import metadataRouter from "@/api/v1/metadata";
-import usersRouter, { type CreatedUser } from "@/api/v1/users";
+import usersRouter, { type ReturnedUser } from "@/api/v1/users";
 import { jsonMiddleware } from "@/middleware/json";
 
 const app = express();
@@ -36,6 +36,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   // clean up the database before each test
+  await prisma.profile.deleteMany();
   await prisma.identitiesOnDevice.deleteMany();
   await prisma.conversationMetadata.deleteMany();
   await prisma.deviceIdentity.deleteMany();
@@ -73,7 +74,7 @@ describe("/metadata API", () => {
         },
       }),
     });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     const response = await fetch(
       `http://localhost:3005/metadata/conversation/${createdUser.identity.id}`,
@@ -140,7 +141,7 @@ describe("/metadata API", () => {
         },
       }),
     });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     // Create metadata
     const createMetadataResponse = await fetch(
@@ -196,7 +197,7 @@ describe("/metadata API", () => {
         },
       }),
     });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     // Create metadata
     const createMetadataResponse = await fetch(

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -10,7 +10,7 @@ import {
 } from "bun:test";
 import express from "express";
 import profilesRouter, { type SearchProfilesResult } from "@/api/v1/profiles";
-import usersRouter, { type CreatedUser } from "@/api/v1/users";
+import usersRouter, { type ReturnedUser } from "@/api/v1/users";
 import { jsonMiddleware } from "@/middleware/json";
 
 const app = express();
@@ -65,34 +65,21 @@ describe("/profiles API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
-      }),
-    });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
-
-    // Create a profile
-    const createProfileResponse = await fetch(
-      `http://localhost:3004/profiles/${createdUser.identity.id}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+        profile: {
           name: "Test Profile",
           description: "Test Description",
-        }),
-      },
-    );
-
-    const createdProfile = (await createProfileResponse.json()) as Profile;
+        },
+      }),
+    });
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     const response = await fetch(
-      `http://localhost:3004/profiles/${createdProfile.id}`,
+      `http://localhost:3004/profiles/${createdUser.profile?.id}`,
     );
     const profile = (await response.json()) as Profile;
 
     expect(response.status).toBe(200);
-    expect(profile.id).toBe(createdProfile.id);
+    expect(profile.id).toBe(createdUser.profile!.id);
     expect(profile.name).toBe("Test Profile");
     expect(profile.description).toBe("Test Description");
   });
@@ -116,7 +103,7 @@ describe("/profiles API", () => {
         },
       }),
     });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     // Create a profile
     const createProfileResponse = await fetch(
@@ -179,21 +166,13 @@ describe("/profiles API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
+        profile: {
+          name: "Test Profile",
+          description: "Test Description",
+        },
       }),
     });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
-
-    // Create a profile
-    await fetch(`http://localhost:3004/profiles/${createdUser.identity.id}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "Test Profile",
-        description: "Test Description",
-      }),
-    });
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     // Try to create another profile for the same device identity
     const createProfileResponse = await fetch(
@@ -235,7 +214,7 @@ describe("/profiles API", () => {
         },
       }),
     });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     const response = await fetch(
       `http://localhost:3004/profiles/${createdUser.identity.id}`,
@@ -272,30 +251,17 @@ describe("/profiles API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
-      }),
-    });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
-
-    // Create a profile
-    const createProfileResponse = await fetch(
-      `http://localhost:3004/profiles/${createdUser.identity.id}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+        profile: {
           name: "Test Profile",
           description: "Test Description",
-        }),
-      },
-    );
-
-    const createdProfile = (await createProfileResponse.json()) as Profile;
+        },
+      }),
+    });
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     // Update the profile
     const response = await fetch(
-      `http://localhost:3004/profiles/${createdProfile.id}`,
+      `http://localhost:3004/profiles/${createdUser.profile?.id}`,
       {
         method: "PUT",
         headers: {
@@ -311,7 +277,7 @@ describe("/profiles API", () => {
     const updatedProfile = (await response.json()) as Profile;
 
     expect(response.status).toBe(200);
-    expect(updatedProfile.id).toBe(createdProfile.id);
+    expect(updatedProfile.id).toBe(createdUser.profile!.id);
     expect(updatedProfile.name).toBe("Updated Name");
     expect(updatedProfile.description).toBe("Updated Description");
   });
@@ -333,29 +299,16 @@ describe("/profiles API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
-      }),
-    });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
-
-    // Create a profile
-    const createProfileResponse = await fetch(
-      `http://localhost:3004/profiles/${createdUser.identity.id}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+        profile: {
           name: "Test Profile",
           description: "Test Description",
-        }),
-      },
-    );
-
-    const createdProfile = (await createProfileResponse.json()) as Profile;
+        },
+      }),
+    });
+    const createdUser = (await createUserResponse.json()) as ReturnedUser;
 
     const response = await fetch(
-      `http://localhost:3004/profiles/${createdProfile.id}`,
+      `http://localhost:3004/profiles/${createdUser.profile?.id}`,
       {
         method: "PUT",
         headers: {
@@ -392,7 +345,7 @@ describe("/profiles API", () => {
 
   test("GET /profiles/search returns matching profiles", async () => {
     // Create a user with a profile
-    const createUserResponse = await fetch("http://localhost:3004/users", {
+    await fetch("http://localhost:3004/users", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -407,19 +360,10 @@ describe("/profiles API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
-      }),
-    });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
-
-    // Create a profile
-    await fetch(`http://localhost:3004/profiles/${createdUser.identity.id}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "Alice Wonder",
-        description: "Test Description",
+        profile: {
+          name: "Alice Wonder",
+          description: "Test Description",
+        },
       }),
     });
 
@@ -438,7 +382,7 @@ describe("/profiles API", () => {
 
   test("GET /profiles/search is case insensitive", async () => {
     // Create a user with a profile
-    const createUserResponse = await fetch("http://localhost:3004/users", {
+    await fetch("http://localhost:3004/users", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -453,19 +397,10 @@ describe("/profiles API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
-      }),
-    });
-    const createdUser = (await createUserResponse.json()) as CreatedUser;
-
-    // Create a profile
-    await fetch(`http://localhost:3004/profiles/${createdUser.identity.id}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "Alice Wonder",
-        description: "Test Description",
+        profile: {
+          name: "Alice Wonder",
+          description: "Test Description",
+        },
       }),
     });
 
@@ -519,7 +454,7 @@ describe("/profiles API", () => {
 
     test("returns success false when username is taken", async () => {
       // Create a user first
-      const createUserResponse = await fetch("http://localhost:3004/users", {
+      await fetch("http://localhost:3004/users", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -534,19 +469,10 @@ describe("/profiles API", () => {
             privyAddress: "test-privy-address",
             xmtpId: "test-xmtp-id",
           },
-        }),
-      });
-      const createdUser = (await createUserResponse.json()) as CreatedUser;
-
-      // Create a profile with the username we want to check
-      await fetch(`http://localhost:3004/profiles/${createdUser.identity.id}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: "takenusername",
-          description: "Test Description",
+          profile: {
+            name: "takenusername",
+            description: "Test Description",
+          },
         }),
       });
 

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "http";
-import { DeviceOS, PrismaClient, type User } from "@prisma/client";
+import { DeviceOS, PrismaClient } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -9,7 +9,7 @@ import {
   test,
 } from "bun:test";
 import express from "express";
-import usersRouter, { type CreatedUser } from "@/api/v1/users";
+import usersRouter, { type ReturnedUser } from "@/api/v1/users";
 import { jsonMiddleware } from "@/middleware/json";
 
 const app = express();
@@ -33,6 +33,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   // clean up the database before each test
+  await prisma.profile.deleteMany();
   await prisma.identitiesOnDevice.deleteMany();
   await prisma.deviceIdentity.deleteMany();
   await prisma.device.deleteMany();
@@ -56,9 +57,12 @@ describe("/users API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
+        profile: {
+          name: "Test User",
+        },
       }),
     });
-    const user = (await response.json()) as CreatedUser;
+    const user = (await response.json()) as ReturnedUser;
 
     expect(response.status).toBe(201);
     expect(user.privyUserId).toBe("test-privy-user-id");
@@ -69,10 +73,45 @@ describe("/users API", () => {
     expect(user.identity.id).toBeDefined();
     expect(user.identity.privyAddress).toBe("test-privy-address");
     expect(user.identity.xmtpId).toBe("test-xmtp-id");
+    expect(user.profile?.name).toBe("Test User");
+  });
+
+  test("POST /users creates a new user without a profile", async () => {
+    const response = await fetch("http://localhost:3001/users", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        privyUserId: "test-privy-user-id",
+        device: {
+          os: DeviceOS.ios,
+          name: "iPhone 14",
+        },
+        identity: {
+          privyAddress: "test-privy-address",
+          xmtpId: "test-xmtp-id",
+        },
+      }),
+    });
+    const user = (await response.json()) as ReturnedUser;
+
+    expect(response.status).toBe(201);
+    expect(user.privyUserId).toBe("test-privy-user-id");
+    expect(user.id).toBeDefined();
+    expect(user.device.id).toBeDefined();
+    expect(user.device.os).toBe(DeviceOS.ios);
+    expect(user.device.name).toBe("iPhone 14");
+    expect(user.identity.id).toBeDefined();
+    expect(user.identity.privyAddress).toBe("test-privy-address");
+    expect(user.identity.xmtpId).toBe("test-xmtp-id");
+    expect(user.profile).toBeNull();
   });
 
   test("GET /users/:id returns 404 for non-existent user", async () => {
-    const response = await fetch("http://localhost:3001/users/nonexistent-id");
+    const response = await fetch(
+      "http://localhost:3001/users/nonexistent-privy-id",
+    );
     const data = (await response.json()) as { error: string };
 
     expect(response.status).toBe(404);
@@ -96,15 +135,18 @@ describe("/users API", () => {
           privyAddress: "test-privy-address",
           xmtpId: "test-xmtp-id",
         },
+        profile: {
+          name: "Test User",
+        },
       }),
     });
-    const createdUser = (await createResponse.json()) as CreatedUser;
+    const createdUser = (await createResponse.json()) as ReturnedUser;
 
     // fetch the user
     const response = await fetch(
-      `http://localhost:3001/users/${createdUser.id}`,
+      `http://localhost:3001/users/${createdUser.privyUserId}`,
     );
-    const user = (await response.json()) as User;
+    const user = (await response.json()) as ReturnedUser;
 
     expect(response.status).toBe(200);
     expect(user.id).toBe(createdUser.id);
@@ -128,13 +170,16 @@ describe("/users API", () => {
           privyAddress: "old-privy-address",
           xmtpId: "old-xmtp-id",
         },
+        profile: {
+          name: "Test User",
+        },
       }),
     });
-    const createdUser = (await createResponse.json()) as CreatedUser;
+    const createdUser = (await createResponse.json()) as ReturnedUser;
 
     // update the user
     const updateResponse = await fetch(
-      `http://localhost:3001/users/${createdUser.id}`,
+      `http://localhost:3001/users/${createdUser.privyUserId}`,
       {
         method: "PUT",
         headers: {
@@ -145,7 +190,7 @@ describe("/users API", () => {
         }),
       },
     );
-    const updatedUser = (await updateResponse.json()) as User;
+    const updatedUser = (await updateResponse.json()) as ReturnedUser;
 
     expect(updateResponse.status).toBe(200);
     expect(updatedUser.id).toBe(createdUser.id);


### PR DESCRIPTION
# Summary

- Added optional `profile` argument when creating a new user
- Added profile to returned user when creating or fetching users
- Added all user data to returned value when fetching a user
- Refactored user create and fetch to accept a Privy user ID