### PR TITLE
feat: Restart min app version

### DIFF
--- a/src/api/v1/appConfig.ts
+++ b/src/api/v1/appConfig.ts
@@ -3,7 +3,7 @@ import { Router } from "express";
 const appConfigRouter = Router();
 
 appConfigRouter.get("/", (req, res) => {
-  res.json({ minimumAppVersion: { ios: "2.2.34", android: "2.2.34" } });
+  res.json({ minimumAppVersion: { ios: "1.0.0", android: "1.0.0" } });
 });
 
 export default appConfigRouter;


### PR DESCRIPTION
### Lower minimum app version requirements from 2.2.34 to 1.0.0 for iOS and Android platforms in `appConfig` API endpoint
Updates the minimum version requirements in [appConfig.ts](https://github.com/ephemeraHQ/convos-backend/pull/46/files#diff-e3cf032df9103347fa4f21ecbfadc7dcac52f8425b45a269e457d560a3688d70) by modifying the API response to specify version `1.0.0` as the minimum supported version for both iOS and Android platforms, down from the previous requirement of `2.2.34`.

#### 📍Where to Start
Begin reviewing the version configuration changes in [appConfig.ts](https://github.com/ephemeraHQ/convos-backend/pull/46/files#diff-e3cf032df9103347fa4f21ecbfadc7dcac52f8425b45a269e457d560a3688d70), which contains the modified minimum version requirements for the API response.

----

_[Macroscope](https://app.macroscope.com) summarized 5de8247._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the minimum supported version for both iOS and Android devices to 1.0.0, ensuring that users now have a lower version threshold to meet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->