### PR TITLE
Add temporary API key

### DIFF
--- a/src/api/v1/wallets/constants.ts
+++ b/src/api/v1/wallets/constants.ts
@@ -7,3 +7,5 @@
 export const ETHEREUM_WALLET_DEFAULT_PATH = "m/44'/60'/0'/0/0";
 export const DEFAULT_SUB_ORG_NAME = "Default SubOrg";
 export const DEFAULT_USER_NAME = "Default User";
+export const DEFAULT_API_KEY_NAME = "Default key";
+export const API_KEY_EXPIRATION_TIME = 60 * 60; // 1 hour

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -10,7 +10,10 @@ import {
   test,
 } from "bun:test";
 import express from "express";
-import { DEFAULT_USER_NAME } from "@/api/v1/wallets/constants";
+import {
+  DEFAULT_API_KEY_NAME,
+  DEFAULT_USER_NAME,
+} from "@/api/v1/wallets/constants";
 import type {
   CreateSubOrgRequestBody,
   CreateSubOrgReturned,
@@ -74,6 +77,7 @@ describe("/wallets API", () => {
         attestationObject: "test-attestation-object",
         transports: [],
       },
+      ephemeralPublicKey: "test-api-key",
     };
 
     const response = await fetch(`http://localhost:${port}/wallets`, {
@@ -97,7 +101,13 @@ describe("/wallets API", () => {
         rootUsers: [
           expect.objectContaining({
             userName: DEFAULT_USER_NAME,
-            apiKeys: [],
+            apiKeys: [
+              expect.objectContaining({
+                apiKeyName: DEFAULT_API_KEY_NAME,
+                publicKey: createSubOrgBody.ephemeralPublicKey,
+                curveType: "API_KEY_CURVE_P256",
+              }),
+            ],
             authenticators: [
               {
                 authenticatorName: "Passkey",


### PR DESCRIPTION
### TL;DR

Added support for temporary API keys during SubOrg creation.

## How to use

- When registering the new wallet, create an ephemeral p256 key and include the public key in the `temporaryApiPublicKey` field.
- Use that key to create the first session. The key will expire in 60 minutes. Any sessions created after that time should use the passkey and not the ephemeral key. 

### What changed?

- Added two new constants: `DEFAULT_API_KEY_NAME` and `API_KEY_EXPIRATION_TIME` (set to 1 hour)
- Updated the `createSubOrgRequestBodySchema` to accept an optional `temporaryApiPublicKey` parameter
- Modified the `createSubOrg` handler to create an API key with the provided public key when available
- Updated tests to verify API key creation functionality

### How to test?

1. Make a request to create a SubOrg with a `temporaryApiPublicKey` parameter
2. Verify that the response includes an API key with the provided public key
3. Confirm the API key has the correct name and curve type

### Why make this change?

This change enables clients to create a temporary API key during SubOrg creation, which can be used for immediate authentication without requiring additional setup steps. The temporary key expires after one hour, providing a secure way to bootstrap initial access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for including an optional temporary API key with expiration when creating a sub-organization.
- **Tests**
	- Updated tests to verify the new temporary API key feature during sub-organization creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->