### PR TITLE
Use a single client instance of prisma

### DIFF
--- a/src/api/v1/devices.ts
+++ b/src/api/v1/devices.ts
@@ -1,10 +1,9 @@
-import { PrismaClient } from "@prisma/client";
 import { Router, type Request, type Response } from "express";
 import { z } from "zod";
+import { prisma } from "@/utils/prisma";
 import { DeviceSchema } from "../../../prisma/generated/zod";
 
 const devicesRouter = Router();
-const prisma = new PrismaClient();
 
 export type GetDeviceRequestParams = {
   userId: string;

--- a/src/api/v1/identities.ts
+++ b/src/api/v1/identities.ts
@@ -1,9 +1,8 @@
-import { PrismaClient } from "@prisma/client";
 import { Router, type Request, type Response } from "express";
 import { z } from "zod";
+import { prisma } from "@/utils/prisma";
 
 const identitiesRouter = Router();
-const prisma = new PrismaClient();
 
 // Schema for creating and updating a device identity
 const deviceIdentitySchema = z.object({

--- a/src/api/v1/metadata.ts
+++ b/src/api/v1/metadata.ts
@@ -1,9 +1,8 @@
-import { PrismaClient } from "@prisma/client";
 import { Router, type Request, type Response } from "express";
 import { z } from "zod";
+import { prisma } from "@/utils/prisma";
 
 const metadataRouter = Router();
-const prisma = new PrismaClient();
 
 type GetMetadataRequestParams = {
   conversationId: string;

--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -1,10 +1,9 @@
-import { PrismaClient } from "@prisma/client";
 import { Expo, type ExpoPushMessage } from "expo-server-sdk";
 import type { Request, Response } from "express";
 import type { NotificationResponse } from "@/notifications/client";
 import { getHttpDeliveryNotificationAuthHeader } from "@/notifications/utils";
+import { prisma } from "@/utils/prisma";
 
-const prisma = new PrismaClient();
 const expo = new Expo();
 
 if (!process.env.XMTP_NOTIFICATION_SECRET) {

--- a/src/api/v1/profiles/handlers/check-username.ts
+++ b/src/api/v1/profiles/handlers/check-username.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from "@prisma/client";
 import type { Request, Response } from "express";
-
-const prisma = new PrismaClient();
+import { prisma } from "@/utils/prisma";
 
 type CheckUsernameParams = {
   username: string;

--- a/src/api/v1/profiles/handlers/get-profile.ts
+++ b/src/api/v1/profiles/handlers/get-profile.ts
@@ -1,11 +1,9 @@
-import { PrismaClient } from "@prisma/client";
 import type { Request, Response } from "express";
+import { prisma } from "@/utils/prisma";
 import type {
   GetProfileRequestParams,
   ProfileRequestResult,
 } from "../profiles.types";
-
-const prisma = new PrismaClient();
 
 export async function getProfile(
   req: Request<GetProfileRequestParams>,

--- a/src/api/v1/profiles/handlers/get-public-profile.ts
+++ b/src/api/v1/profiles/handlers/get-public-profile.ts
@@ -1,8 +1,6 @@
-import { PrismaClient } from "@prisma/client";
 import type { Request, Response } from "express";
+import { prisma } from "@/utils/prisma";
 import type { PublicProfileResult } from "../profiles.types";
-
-const prisma = new PrismaClient();
 
 type GetPublicProfileParams = {
   username: string;

--- a/src/api/v1/profiles/handlers/search-profiles.ts
+++ b/src/api/v1/profiles/handlers/search-profiles.ts
@@ -1,9 +1,7 @@
-import { PrismaClient } from "@prisma/client";
 import type { Request, Response } from "express";
 import { isAddress } from "viem";
+import { prisma } from "@/utils/prisma";
 import type { ProfileRequestResult } from "../profiles.types";
-
-const prisma = new PrismaClient();
 
 type SearchProfilesQuery = {
   query: string;

--- a/src/api/v1/profiles/handlers/update-profile.ts
+++ b/src/api/v1/profiles/handlers/update-profile.ts
@@ -1,6 +1,6 @@
-import { PrismaClient } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { prisma } from "@/utils/prisma";
 import type { profileBaseSchema } from "../profile.schema";
 import type { ProfileValidationResponse } from "../profile.types";
 import type { GetProfileRequestParams } from "../profiles.types";
@@ -9,8 +9,6 @@ import {
   validateOnChainName,
   validateProfileUpdate,
 } from "./validate-profile";
-
-const prisma = new PrismaClient();
 
 // Use Zod schema for type definition
 export type UpdateProfileRequestBody = Partial<

--- a/src/api/v1/profiles/handlers/validate-profile.ts
+++ b/src/api/v1/profiles/handlers/validate-profile.ts
@@ -1,5 +1,5 @@
-import { PrismaClient } from "@prisma/client";
 import { z } from "zod";
+import { prisma } from "@/utils/prisma";
 import { checkNameOwnership } from "../../../../utils/thirdweb";
 import { getAddressesForInboxId } from "../../../../utils/xmtp";
 import { profileCreationSchema, profileUpdateSchema } from "../profile.schema";
@@ -7,8 +7,6 @@ import type {
   ProfileValidationRequest,
   ProfileValidationResponse,
 } from "../profile.types";
-
-const prisma = new PrismaClient();
 
 export enum ProfileValidationErrorType {
   USERNAME_TAKEN = "USERNAME_TAKEN",

--- a/src/api/v1/users/handlers/create-user.ts
+++ b/src/api/v1/users/handlers/create-user.ts
@@ -1,14 +1,13 @@
-import { DeviceOS, PrismaClient } from "@prisma/client";
+import { DeviceOS } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { prisma } from "@/utils/prisma";
 import {
   validateOnChainName,
   validateProfileRequiredFields,
   validateProfileSchema,
   validateUsernameUniqueness,
 } from "../../profiles/handlers/validate-profile";
-
-const prisma = new PrismaClient();
 
 export const createUserRequestBodySchema = z.object({
   privyUserId: z.string(),

--- a/src/api/v1/users/handlers/get-current-user.ts
+++ b/src/api/v1/users/handlers/get-current-user.ts
@@ -1,8 +1,7 @@
-import { PrismaClient, type DeviceIdentity } from "@prisma/client";
+import { type DeviceIdentity } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
-
-const prisma = new PrismaClient();
+import { prisma } from "@/utils/prisma";
 
 const querySchema = z.object({
   device_id: z.string().optional(),

--- a/src/api/v1/wallets/handlers/create-suborg.ts
+++ b/src/api/v1/wallets/handlers/create-suborg.ts
@@ -1,7 +1,7 @@
-import { PrismaClient } from "@prisma/client";
 import { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { prisma } from "@/utils/prisma";
 import {
   API_KEY_EXPIRATION_TIME,
   DEFAULT_API_KEY_NAME,
@@ -10,8 +10,6 @@ import {
   ETHEREUM_WALLET_DEFAULT_PATH,
 } from "../constants";
 import { getTurnkeyConfig } from "../utils";
-
-const prisma = new PrismaClient();
 
 const turnkeyConfig = getTurnkeyConfig();
 

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();

--- a/tests/authenticate.test.ts
+++ b/tests/authenticate.test.ts
@@ -1,5 +1,4 @@
 import type { Server } from "http";
-import { PrismaClient } from "@prisma/client";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import express from "express";
 import * as jose from "jose";
@@ -9,6 +8,7 @@ import authenticateRouter, {
   type AuthenticateResponse,
 } from "@/api/v1/authenticate";
 import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
 import { createClient, createHeaders } from "./helpers";
 
 // mock environment variable
@@ -19,7 +19,6 @@ const app = express();
 app.use(jsonMiddleware);
 app.use("/authenticate", authenticateRouter);
 
-const prisma = new PrismaClient();
 let server: Server;
 
 beforeAll(() => {

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "http";
-import { DeviceOS, PrismaClient, type Device } from "@prisma/client";
+import { DeviceOS, type Device } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -16,6 +16,7 @@ import type {
 } from "@/api/v1/users/handlers/create-user";
 import usersRouter from "@/api/v1/users/users.router";
 import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
 
 // Constants used throughout tests
 const AUTH_XMTP_ID = "test-xmtp-id";
@@ -33,7 +34,6 @@ app.use((req, res, next) => {
 app.use("/users", usersRouter);
 app.use("/devices", devicesRouter);
 
-const prisma = new PrismaClient();
 let server: Server;
 
 beforeAll(() => {

--- a/tests/identities.test.ts
+++ b/tests/identities.test.ts
@@ -1,9 +1,5 @@
 import type { Server } from "http";
-import {
-  PrismaClient,
-  type DeviceIdentity,
-  type IdentitiesOnDevice,
-} from "@prisma/client";
+import { type DeviceIdentity, type IdentitiesOnDevice } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -15,6 +11,7 @@ import {
 import express from "express";
 import identitiesRouter from "@/api/v1/identities";
 import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
 
 const app = express();
 app.use(jsonMiddleware);
@@ -28,7 +25,6 @@ app.use((req, res, next) => {
 
 app.use("/identities", identitiesRouter);
 
-const prisma = new PrismaClient();
 let server: Server;
 
 beforeAll(() => {

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -1,9 +1,5 @@
 import type { Server } from "http";
-import {
-  DeviceOS,
-  PrismaClient,
-  type ConversationMetadata,
-} from "@prisma/client";
+import { DeviceOS, type ConversationMetadata } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -20,6 +16,7 @@ import type {
 } from "@/api/v1/users/handlers/create-user";
 import usersRouter from "@/api/v1/users/users.router";
 import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
 
 const app = express();
 app.use(jsonMiddleware);
@@ -36,7 +33,6 @@ app.use((req, res, next) => {
 app.use("/users", usersRouter);
 app.use("/metadata", metadataRouter);
 
-const prisma = new PrismaClient();
 let server: Server;
 
 beforeAll(() => {

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "http";
-import { DeviceOS, PrismaClient, type Profile } from "@prisma/client";
+import { DeviceOS, type Profile } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -19,13 +19,13 @@ import type {
 } from "@/api/v1/users/handlers/create-user";
 import usersRouter from "@/api/v1/users/users.router";
 import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
 
 const app = express();
 app.use(jsonMiddleware);
 app.use("/users", usersRouter);
 app.use("/profiles", profilesRouter);
 
-const prisma = new PrismaClient();
 let server: Server;
 
 beforeAll(() => {

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "http";
-import { DeviceOS, PrismaClient } from "@prisma/client";
+import { DeviceOS } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -16,12 +16,12 @@ import type {
 import type { ReturnedCurrentUser } from "@/api/v1/users/handlers/get-current-user";
 import usersRouter from "@/api/v1/users/users.router";
 import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
 
 const app = express();
 app.use(jsonMiddleware);
 app.use("/users", usersRouter);
 
-const prisma = new PrismaClient();
 let server: Server;
 
 beforeAll(() => {

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,5 +1,4 @@
 import type { Server } from "http";
-import { PrismaClient } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -20,13 +19,13 @@ import type {
 } from "@/api/v1/wallets/handlers/create-suborg";
 import walletsRouter from "@/api/v1/wallets/wallets.router";
 import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
 import { getServerPort } from "./helpers";
 
 const app = express();
 app.use(jsonMiddleware);
 app.use("/wallets", walletsRouter);
 
-const prisma = new PrismaClient();
 let server: Server;
 let port: number;
 


### PR DESCRIPTION
# Summary

- Removed multiple instances of Prisma client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Centralized database client usage by switching to a shared instance across all application and test modules. This improves resource management and consistency in database operations.
- **Tests**
	- Updated all test files to use the shared database client instance, ensuring consistent test setup and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->