### PR TITLE
feat: Switch Privy to Turnkey

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,6 @@
     "rimraf": "^6.0.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
-  }
+  },
+  "packageManager": "yarn@4.6.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728"
 }

--- a/prisma/migrations/20250429165702_change_privy_fields_to_turnkey/migration.sql
+++ b/prisma/migrations/20250429165702_change_privy_fields_to_turnkey/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `privyAddress` on the `DeviceIdentity` table. All the data in the column will be lost.
+  - You are about to drop the column `privyUserId` on the `User` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[turnkeyUserId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `turnkeyAddress` to the `DeviceIdentity` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `turnkeyUserId` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "User_privyUserId_key";
+
+-- AlterTable
+ALTER TABLE "DeviceIdentity" DROP COLUMN "privyAddress",
+ADD COLUMN     "turnkeyAddress" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "privyUserId",
+ADD COLUMN     "turnkeyUserId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_turnkeyUserId_key" ON "User"("turnkeyUserId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ datasource db {
 
 model User {
   id             String           @id @default(uuid())
-  privyUserId    String           @unique
+  turnkeyUserId    String           @unique
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
   devices        Device[]
@@ -50,7 +50,7 @@ model DeviceIdentity {
   id                   String                 @id @default(uuid())
   userId               String
   xmtpId               String?
-  privyAddress         String
+  turnkeyAddress         String
   createdAt            DateTime               @default(now())
   updatedAt            DateTime               @updatedAt
   profile              Profile?

--- a/src/api/v1/identities.ts
+++ b/src/api/v1/identities.ts
@@ -7,7 +7,7 @@ const identitiesRouter = Router();
 // Schema for creating and updating a device identity
 const deviceIdentitySchema = z.object({
   xmtpId: z.string().optional(),
-  privyAddress: z.string(),
+  turnkeyAddress: z.string(),
 });
 
 export type GetDeviceIdentitiesRequestParams = {

--- a/src/api/v1/profiles/handlers/get-profile.ts
+++ b/src/api/v1/profiles/handlers/get-profile.ts
@@ -27,7 +27,7 @@ export async function getProfile(
         deviceIdentity: {
           select: {
             xmtpId: true,
-            privyAddress: true,
+            turnkeyAddress: true,
           },
         },
       },
@@ -45,7 +45,7 @@ export async function getProfile(
       description: profile.description,
       avatar: profile.avatar,
       xmtpId: profile.deviceIdentity.xmtpId,
-      privyAddress: profile.deviceIdentity.privyAddress,
+      turnkeyAddress: profile.deviceIdentity.turnkeyAddress,
     };
 
     res.json(profileResult);

--- a/src/api/v1/profiles/handlers/get-public-profile.ts
+++ b/src/api/v1/profiles/handlers/get-public-profile.ts
@@ -29,7 +29,7 @@ export async function getPublicProfile(
         deviceIdentity: {
           select: {
             xmtpId: true,
-            privyAddress: true,
+            turnkeyAddress: true,
           },
         },
       },
@@ -47,7 +47,7 @@ export async function getPublicProfile(
       description: profile.description,
       avatar: profile.avatar,
       xmtpId: profile.deviceIdentity.xmtpId,
-      privyAddress: profile.deviceIdentity.privyAddress,
+      turnkeyAddress: profile.deviceIdentity.turnkeyAddress,
     };
 
     res.json(publicProfile);

--- a/src/api/v1/profiles/handlers/search-profiles.ts
+++ b/src/api/v1/profiles/handlers/search-profiles.ts
@@ -27,7 +27,7 @@ export async function searchProfiles(
             ? [
                 {
                   deviceIdentity: {
-                    privyAddress: trimmedQuery,
+                    turnkeyAddress: trimmedQuery,
                   },
                 },
               ]
@@ -55,7 +55,7 @@ export async function searchProfiles(
         deviceIdentity: {
           select: {
             xmtpId: true,
-            privyAddress: true,
+            turnkeyAddress: true,
           },
         },
       },
@@ -72,7 +72,7 @@ export async function searchProfiles(
             avatar: profile.avatar,
             description: profile.description,
             xmtpId: profile.deviceIdentity.xmtpId,
-            privyAddress: profile.deviceIdentity.privyAddress,
+            turnkeyAddress: profile.deviceIdentity.turnkeyAddress,
           }) satisfies ProfileRequestResult,
       ),
     );

--- a/src/api/v1/profiles/profiles.types.ts
+++ b/src/api/v1/profiles/profiles.types.ts
@@ -8,11 +8,11 @@ export type ProfileRequestResult = Pick<
   Profile,
   "id" | "name" | "username" | "description" | "avatar"
 > &
-  Pick<DeviceIdentity, "xmtpId" | "privyAddress">;
+  Pick<DeviceIdentity, "xmtpId" | "turnkeyAddress">;
 
 // Public profile data exposed via API
 export type PublicProfileResult = Pick<
   Profile,
   "name" | "username" | "description" | "avatar"
 > &
-  Pick<DeviceIdentity, "xmtpId" | "privyAddress">;
+  Pick<DeviceIdentity, "xmtpId" | "turnkeyAddress">;

--- a/src/api/v1/users/handlers/create-user.ts
+++ b/src/api/v1/users/handlers/create-user.ts
@@ -10,13 +10,13 @@ import {
 } from "../../profiles/handlers/validate-profile";
 
 export const createUserRequestBodySchema = z.object({
-  privyUserId: z.string(),
+  turnkeyUserId: z.string(),
   device: z.object({
     os: z.enum(Object.keys(DeviceOS) as [DeviceOS, ...DeviceOS[]]),
     name: z.string().nullable().optional(),
   }),
   identity: z.object({
-    privyAddress: z.string(),
+    turnkeyAddress: z.string(),
     xmtpId: z.string(),
   }),
   profile: z.object({
@@ -31,7 +31,7 @@ export type CreateUserRequestBody = z.infer<typeof createUserRequestBodySchema>;
 
 export type CreatedReturnedUser = {
   id: string;
-  privyUserId: string;
+  turnkeyUserId: string;
   device: {
     id: string;
     os: DeviceOS;
@@ -39,7 +39,7 @@ export type CreatedReturnedUser = {
   };
   identity: {
     id: string;
-    privyAddress: string;
+    turnkeyAddress: string;
     xmtpId: string | null;
   };
   profile: {
@@ -115,7 +115,7 @@ export async function createUser(
     // Create user
     const createdUser = await prisma.user.create({
       data: {
-        privyUserId: body.privyUserId,
+        turnkeyUserId: body.turnkeyUserId,
         devices: {
           create: {
             os: body.device.os,
@@ -124,11 +124,11 @@ export async function createUser(
               create: {
                 identity: {
                   create: {
-                    privyAddress: body.identity.privyAddress,
+                    turnkeyAddress: body.identity.turnkeyAddress,
                     xmtpId: body.identity.xmtpId,
                     user: {
                       connect: {
-                        privyUserId: body.privyUserId,
+                        turnkeyUserId: body.turnkeyUserId,
                       },
                     },
                     profile: {
@@ -148,7 +148,7 @@ export async function createUser(
       },
       select: {
         id: true,
-        privyUserId: true,
+        turnkeyUserId: true,
         devices: {
           select: {
             id: true,
@@ -159,7 +159,7 @@ export async function createUser(
                 identity: {
                   select: {
                     id: true,
-                    privyAddress: true,
+                    turnkeyAddress: true,
                     xmtpId: true,
                     profile: {
                       select: {
@@ -198,7 +198,7 @@ export async function createUser(
 
     const returnedUser: CreatedReturnedUser = {
       id: createdUser.id,
-      privyUserId: createdUser.privyUserId,
+      turnkeyUserId: createdUser.turnkeyUserId,
       device: {
         id: createdDevice.id,
         os: createdDevice.os,
@@ -206,7 +206,7 @@ export async function createUser(
       },
       identity: {
         id: createdIdentity.id,
-        privyAddress: createdIdentity.privyAddress,
+        turnkeyAddress: createdIdentity.turnkeyAddress,
         xmtpId: createdIdentity.xmtpId,
       },
       profile: {

--- a/src/api/v1/users/handlers/get-current-user.ts
+++ b/src/api/v1/users/handlers/get-current-user.ts
@@ -11,7 +11,7 @@ type QueryParams = z.infer<typeof querySchema>;
 
 export type ReturnedCurrentUser = {
   id: string;
-  identities: Array<Pick<DeviceIdentity, "id" | "privyAddress" | "xmtpId">>;
+  identities: Array<Pick<DeviceIdentity, "id" | "turnkeyAddress" | "xmtpId">>;
 };
 
 export async function getCurrentUser(
@@ -39,7 +39,7 @@ export async function getCurrentUser(
                 identity: {
                   select: {
                     id: true,
-                    privyAddress: true,
+                    turnkeyAddress: true,
                     xmtpId: true,
                   },
                 },
@@ -57,14 +57,14 @@ export async function getCurrentUser(
 
     const uniqueIdentities = new Map<
       string,
-      Pick<DeviceIdentity, "id" | "privyAddress" | "xmtpId">
+      Pick<DeviceIdentity, "id" | "turnkeyAddress" | "xmtpId">
     >();
 
     user.devices.forEach((device) => {
       device.identities.forEach(({ identity }) => {
         uniqueIdentities.set(identity.id, {
           id: identity.id,
-          privyAddress: identity.privyAddress,
+          turnkeyAddress: identity.turnkeyAddress,
           xmtpId: identity.xmtpId,
         });
       });

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -62,13 +62,13 @@ describe("/devices API", () => {
   test("POST /devices/:userId creates a new device", async () => {
     // Create test user first via API
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-devices-privy-user-id",
+      turnkeyUserId: "test-devices-turnkey-user-id",
       device: {
         os: DeviceOS.ios,
         name: "Test Initial Device",
       },
       identity: {
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {
@@ -114,13 +114,13 @@ describe("/devices API", () => {
   test("GET /devices/:userId/:deviceId returns 404 for non-existent device", async () => {
     // Create test user first via API
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-devices-privy-user-id-2",
+      turnkeyUserId: "test-devices-turnkey-user-id-2",
       device: {
         os: DeviceOS.ios,
         name: "Test Initial Device",
       },
       identity: {
-        privyAddress: "test-privy-address-2",
+        turnkeyAddress: "test-turnkey-address-2",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {
@@ -153,13 +153,13 @@ describe("/devices API", () => {
   test("GET /devices/:userId/:deviceId returns device when exists", async () => {
     // Create test user first via API
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-devices-privy-user-id-3",
+      turnkeyUserId: "test-devices-turnkey-user-id-3",
       device: {
         os: DeviceOS.ios,
         name: "Test Initial Device",
       },
       identity: {
-        privyAddress: "test-privy-address-3",
+        turnkeyAddress: "test-turnkey-address-3",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {
@@ -213,13 +213,13 @@ describe("/devices API", () => {
   test("GET /devices/:userId returns all devices for a user", async () => {
     // Create test user first via API
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-devices-privy-user-id-4",
+      turnkeyUserId: "test-devices-turnkey-user-id-4",
       device: {
         os: DeviceOS.ios,
         name: "Test Initial Device",
       },
       identity: {
-        privyAddress: "test-privy-address-4",
+        turnkeyAddress: "test-turnkey-address-4",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {
@@ -276,13 +276,13 @@ describe("/devices API", () => {
   test("PUT /devices/:userId/:deviceId updates device", async () => {
     // Create test user first via API
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-devices-privy-user-id-5",
+      turnkeyUserId: "test-devices-turnkey-user-id-5",
       device: {
         os: DeviceOS.ios,
         name: "Test Initial Device",
       },
       identity: {
-        privyAddress: "test-privy-address-5",
+        turnkeyAddress: "test-turnkey-address-5",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {
@@ -347,13 +347,13 @@ describe("/devices API", () => {
   test("POST /devices/:userId validates request body", async () => {
     // Create test user first via API
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-devices-privy-user-id-6",
+      turnkeyUserId: "test-devices-turnkey-user-id-6",
       device: {
         os: DeviceOS.ios,
         name: "Test Initial Device",
       },
       identity: {
-        privyAddress: "test-privy-address-6",
+        turnkeyAddress: "test-turnkey-address-6",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {

--- a/tests/identities.test.ts
+++ b/tests/identities.test.ts
@@ -59,7 +59,7 @@ describe("/identities API", () => {
         user: {
           create: {
             id: "test-user-id",
-            privyUserId: "test-identities-privy-user-id",
+            turnkeyUserId: "test-identities-turnkey-user-id",
           },
         },
       },
@@ -69,7 +69,7 @@ describe("/identities API", () => {
     await prisma.deviceIdentity.create({
       data: {
         userId: testUserId,
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: "test-xmtp-id",
       },
     });
@@ -84,7 +84,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -92,7 +92,7 @@ describe("/identities API", () => {
     const identity = (await response.json()) as DeviceIdentity;
 
     expect(response.status).toBe(201);
-    expect(identity.privyAddress).toBe("0x123");
+    expect(identity.turnkeyAddress).toBe("0x123");
     expect(identity.xmtpId).toBe("test-xmtp-id");
 
     const response2 = await fetch(
@@ -103,7 +103,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -124,7 +124,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -139,7 +139,7 @@ describe("/identities API", () => {
     expect(response.status).toBe(200);
     expect(identities).toHaveLength(1);
     expect(identities[0].id).toBe(createdIdentity.id);
-    expect(identities[0].privyAddress).toBe("0x123");
+    expect(identities[0].turnkeyAddress).toBe("0x123");
   });
 
   test("GET /identities/:identityId returns single identity", async () => {
@@ -152,7 +152,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -166,7 +166,7 @@ describe("/identities API", () => {
 
     expect(response.status).toBe(200);
     expect(identity.id).toBe(createdIdentity.id);
-    expect(identity.privyAddress).toBe("0x123");
+    expect(identity.turnkeyAddress).toBe("0x123");
     expect(identity.xmtpId).toBe("test-xmtp-id");
   });
 
@@ -180,7 +180,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -195,7 +195,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x456",
+          turnkeyAddress: "0x456",
           xmtpId: "new-xmtp-id",
         }),
       },
@@ -204,7 +204,7 @@ describe("/identities API", () => {
 
     expect(response.status).toBe(200);
     expect(updatedIdentity.id).toBe(createdIdentity.id);
-    expect(updatedIdentity.privyAddress).toBe("0x456");
+    expect(updatedIdentity.turnkeyAddress).toBe("0x456");
     expect(updatedIdentity.xmtpId).toBe("new-xmtp-id");
   });
 
@@ -218,7 +218,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -269,7 +269,7 @@ describe("/identities API", () => {
     expect(getResponse.status).toBe(200);
     expect(deviceIdentities).toHaveLength(1);
     expect(deviceIdentities[0].id).toBe(createdIdentity.id);
-    expect(deviceIdentities[0].privyAddress).toBe("0x123");
+    expect(deviceIdentities[0].turnkeyAddress).toBe("0x123");
   });
 
   test("DELETE /identities/:identityId/link unlinks identity from device", async () => {
@@ -282,7 +282,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -324,7 +324,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          // missing required privyAddress
+          // missing required turnkeyAddress
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -345,7 +345,7 @@ describe("/identities API", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          privyAddress: "0x123",
+          turnkeyAddress: "0x123",
           xmtpId: "test-xmtp-id",
         }),
       },
@@ -366,7 +366,7 @@ describe("/identities API", () => {
       (identity) => identity.id === createdIdentity.id,
     );
     expect(foundIdentity).toBeDefined();
-    expect(foundIdentity?.privyAddress).toBe("0x123");
+    expect(foundIdentity?.turnkeyAddress).toBe("0x123");
     expect(foundIdentity?.userId).toBe(testUserId);
 
     // unlink the identity
@@ -399,7 +399,7 @@ describe("/identities API", () => {
       (identity) => identity.id === createdIdentity.id,
     );
     expect(foundIdentityAfterUnlink).toBeDefined();
-    expect(foundIdentityAfterUnlink?.privyAddress).toBe("0x123");
+    expect(foundIdentityAfterUnlink?.turnkeyAddress).toBe("0x123");
     expect(foundIdentityAfterUnlink?.userId).toBe(testUserId);
   });
 

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -69,13 +69,13 @@ describe("/metadata API", () => {
   test("POST /metadata/conversation creates new metadata", async () => {
     // Create a user first with profile
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-metadata-privy-user-id",
+      turnkeyUserId: "test-metadata-turnkey-user-id",
       device: {
         os: DeviceOS.ios,
         name: "iPhone 14",
       },
       identity: {
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {
@@ -150,13 +150,13 @@ describe("/metadata API", () => {
   test("GET /metadata/conversation/:deviceIdentityId/:conversationId returns metadata when exists", async () => {
     // Create a user first
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-metadata-privy-user-id",
+      turnkeyUserId: "test-metadata-turnkey-user-id",
       device: {
         os: DeviceOS.ios,
         name: "iPhone 14",
       },
       identity: {
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {
@@ -218,13 +218,13 @@ describe("/metadata API", () => {
   test("POST /metadata/conversation updates existing metadata", async () => {
     // Create a user first
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-metadata-privy-user-id",
+      turnkeyUserId: "test-metadata-turnkey-user-id",
       device: {
         os: DeviceOS.ios,
         name: "iPhone 14",
       },
       identity: {
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: AUTH_XMTP_ID,
       },
       profile: {

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -48,13 +48,13 @@ beforeEach(async () => {
 });
 
 const createUserBody: CreateUserRequestBody = {
-  privyUserId: "test-profiles-privy-user-id",
+  turnkeyUserId: "test-profiles-turnkey-user-id",
   device: {
     os: DeviceOS.ios,
     name: "iPhone 14",
   },
   identity: {
-    privyAddress: "test-privy-address",
+    turnkeyAddress: "test-turnkey-address",
     xmtpId: "test-xmtp-id",
   },
   profile: {
@@ -65,13 +65,13 @@ const createUserBody: CreateUserRequestBody = {
 };
 
 const firstUserBody: CreateUserRequestBody = {
-  privyUserId: "test-profiles-privy-user-id-6",
+  turnkeyUserId: "test-profiles-turnkey-user-id-6",
   device: {
     os: DeviceOS.ios,
     name: "iPhone 14 Pro",
   },
   identity: {
-    privyAddress: "test-privy-address-6",
+    turnkeyAddress: "test-turnkey-address-6",
     xmtpId: "test-xmtp-id-6",
   },
   profile: {
@@ -82,13 +82,13 @@ const firstUserBody: CreateUserRequestBody = {
 };
 
 const secondUserBody: CreateUserRequestBody = {
-  privyUserId: "test-profiles-privy-user-id-7",
+  turnkeyUserId: "test-profiles-turnkey-user-id-7",
   device: {
     os: DeviceOS.ios,
     name: "iPhone 14",
   },
   identity: {
-    privyAddress: "test-privy-address-7",
+    turnkeyAddress: "test-turnkey-address-7",
     xmtpId: "test-xmtp-id-7",
   },
   profile: {
@@ -800,7 +800,7 @@ describe("/profiles API", () => {
     const vitalikUserBody = {
       ...createUserBody,
       identity: {
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: "vitalik-xmtp-id", // This will return vitalik's address in the mock
       },
     };

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -49,13 +49,13 @@ beforeEach(async () => {
 describe("/users API", () => {
   test("POST /users creates a new user", async () => {
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-users-privy-user-id",
+      turnkeyUserId: "test-users-turnkey-user-id",
       device: {
         os: DeviceOS.ios,
         name: "iPhone 14",
       },
       identity: {
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: "test-xmtp-id",
       },
       profile: {
@@ -75,14 +75,14 @@ describe("/users API", () => {
     expect(response.status).toBe(201);
 
     const user = (await response.json()) as CreatedReturnedUser;
-    expect(user.privyUserId).toBe(createUserBody.privyUserId);
+    expect(user.turnkeyUserId).toBe(createUserBody.turnkeyUserId);
     expect(user.id).toBeDefined();
     expect(user.device.id).toBeDefined();
     expect(user.device.os).toBe(createUserBody.device.os);
     expect(user.device.name!).toBe(createUserBody.device.name!);
     expect(user.identity.id).toBeDefined();
-    expect(user.identity.privyAddress).toBe(
-      createUserBody.identity.privyAddress,
+    expect(user.identity.turnkeyAddress).toBe(
+      createUserBody.identity.turnkeyAddress,
     );
     expect(user.identity.xmtpId).toBe(createUserBody.identity.xmtpId);
     expect(user.profile.name).toBe(createUserBody.profile.name);
@@ -98,13 +98,13 @@ describe("/users API", () => {
   test("GET /users/me returns current user", async () => {
     // First create a user
     const createUserBody: CreateUserRequestBody = {
-      privyUserId: "test-privy-user-id",
+      turnkeyUserId: "test-turnkey-user-id",
       device: {
         os: DeviceOS.ios,
         name: "iPhone 14",
       },
       identity: {
-        privyAddress: "test-privy-address",
+        turnkeyAddress: "test-turnkey-address",
         xmtpId: "test-xmtp-id",
       },
       profile: {
@@ -117,7 +117,7 @@ describe("/users API", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer test-privy-user-id",
+        Authorization: "Bearer test-turnkey-user-id",
       },
       body: JSON.stringify(createUserBody),
     });
@@ -126,7 +126,7 @@ describe("/users API", () => {
     // Then try to get /me with auth header
     const response = await fetch("http://localhost:3001/users/me", {
       headers: {
-        Authorization: "Bearer test-privy-user-id",
+        Authorization: "Bearer test-turnkey-user-id",
       },
     });
 
@@ -135,7 +135,7 @@ describe("/users API", () => {
     const user = (await response.json()) as ReturnedCurrentUser;
     expect(user.id).toBeDefined();
     expect(user.identities).toHaveLength(1);
-    expect(user.identities[0].privyAddress).toBe("test-privy-address");
+    expect(user.identities[0].turnkeyAddress).toBe("test-turnkey-address");
     expect(user.identities[0].xmtpId).toBe("test-xmtp-id");
   });
 });


### PR DESCRIPTION
_Macroscope is automatically generating a summary of this pull request..._

<picture>
<source media="(prefers-color-scheme: dark)" srcset="https://prasso.ai/static/prassoai-pr-loader-small-dark-no-text.gif">
<img src="https://prasso.ai/static/prassoai-pr-loader-small-light-no-text.gif" alt="_Macroscope is automatically generating a summary of this pull request..._">
</picture>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the package configuration to specify the use of Yarn 4.6.0 as the package manager.

- **Refactor**
  - Renamed all user and device identity fields from "privy" to "turnkey" across the application, including APIs, database schema, and response structures.

- **Tests**
  - Updated all test cases to use the new "turnkey" field names for user IDs and addresses, ensuring consistency with the refactored API and database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->