### PR TITLE
feat: Add mutable content for non silent notifications

### DIFF
--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -86,7 +86,6 @@ export async function handleXmtpNotification(req: Request, res: Response) {
           data: baseMessageData,
           // Required for iOS silent notifications
           _contentAvailable: true,
-          mutableContent: true,
           // Required for Android silent notifications
           priority: "normal",
           // Ensure no visible alerts
@@ -99,6 +98,7 @@ export async function handleXmtpNotification(req: Request, res: Response) {
           body: "New message",
           data: baseMessageData,
           priority: "high",
+          mutableContent: true,
         };
 
     // Send the notification


### PR DESCRIPTION
### Move mutable content flag from silent to regular notifications in `handleXmtpNotification` function
The notification configuration in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/54/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e) has been updated to modify where the `mutableContent` flag is set:

* Removed `mutableContent: true` from silent notification configuration
* Added `mutableContent: true` to regular notification configuration

#### 📍Where to Start
Begin reviewing the `handleXmtpNotification` function in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/54/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e) where the notification configuration changes have been made.

----

_[Macroscope](https://app.macroscope.com) summarized 49d1079._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification handling to ensure that regular notifications now include mutable content, while silent notifications no longer do. This may enhance notification display and behavior for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->