### PR TITLE
Upgrade xmtp SDK

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@prisma/client": "^6.3.1",
         "@prisma/instrumentation": "^6.7.0",
         "@turnkey/sdk-server": "^3.0.1",
-        "@xmtp/node-sdk": "^0.0.47",
+        "@xmtp/node-sdk": "^2.0.8",
         "cors": "^2.8.5",
         "expo-server-sdk": "^3.14.0",
         "express": "^5.0.1",
@@ -922,15 +922,15 @@
 
     "@walletconnect/window-metadata": ["@walletconnect/window-metadata@1.0.1", "", { "dependencies": { "@walletconnect/window-getters": "^1.0.1", "tslib": "1.14.1" } }, "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA=="],
 
-    "@xmtp/content-type-group-updated": ["@xmtp/content-type-group-updated@2.0.0", "", { "dependencies": { "@xmtp/content-type-primitives": "^2.0.0", "@xmtp/proto": "^3.72.0" } }, "sha512-gxYM4gM2IuKXpOwDcu6+RS7tkUMX6VStgdzFq8ruo3GVLZ03mwb9zjMNVhFwyRcdx6mNSDOTV01y+5P8aslkRg=="],
+    "@xmtp/content-type-group-updated": ["@xmtp/content-type-group-updated@2.0.2", "", { "dependencies": { "@xmtp/content-type-primitives": "^2.0.2", "@xmtp/proto": "^3.78.0" } }, "sha512-ZUGLtzWALo5jimk5hYBVXjbdaKT6zP6a9wK0Urzl9H+Xv2w+H3fYDhwAidU0PXTcLL81qlUM6joxKVlsF5udvA=="],
 
-    "@xmtp/content-type-primitives": ["@xmtp/content-type-primitives@2.0.0", "", { "dependencies": { "@xmtp/proto": "^3.72.0" } }, "sha512-ZutFl+dv9jZgGdRDuZZuJj9XNhq1RfSiCryX25HGs/3rVS3FYfVc3y26iV4jdSN2UALCkznXFuD/GXv5eZSN/w=="],
+    "@xmtp/content-type-primitives": ["@xmtp/content-type-primitives@2.0.2", "", { "dependencies": { "@xmtp/proto": "^3.78.0" } }, "sha512-OTUsCD48sO2Eg69dfre32OSnXSkmefbSZA4L0S58LqYK6+hMymFRRjEH4fvPzXc9WCw5FmCYEG7DFAaB680HiQ=="],
 
-    "@xmtp/content-type-text": ["@xmtp/content-type-text@2.0.0", "", { "dependencies": { "@xmtp/content-type-primitives": "^2.0.0" } }, "sha512-WcFMhjubA6E8j42L6XIsLipDo5AP70TdS2taEH2Ry6V1NeZf8+cjHVrwh60fZeGnrcLWy/tDV4QyXUsD3j045w=="],
+    "@xmtp/content-type-text": ["@xmtp/content-type-text@2.0.2", "", { "dependencies": { "@xmtp/content-type-primitives": "^2.0.2" } }, "sha512-nlRufOYPrG5sNbruNPCsb6Qk9/jmJ5lMooPsZEo4Dbwda/2S4bSvrrIncT6if7M2SCha3hxtlgJlFGeTtHy4gQ=="],
 
-    "@xmtp/node-bindings": ["@xmtp/node-bindings@0.0.41", "", {}, "sha512-gb2LHuFOlbGUb873OnXvcpFgPqbwjaTny/4S7sVu5+OePhrHnz7tJCGl34ysGWDnRLxo4rQH2uLiUuEUBoWK0Q=="],
+    "@xmtp/node-bindings": ["@xmtp/node-bindings@1.1.8", "", {}, "sha512-TU96Rh6SD69SJWe7RBKcg6ZtUKHtiOlLL9OSFry2EhMWqXcEMVZc+nnbHNwdaujLBERSjLi3Hk/sSdJhJ2RvVw=="],
 
-    "@xmtp/node-sdk": ["@xmtp/node-sdk@0.0.47", "", { "dependencies": { "@xmtp/content-type-group-updated": "^2.0.0", "@xmtp/content-type-primitives": "^2.0.0", "@xmtp/content-type-text": "^2.0.0", "@xmtp/node-bindings": "^0.0.41", "@xmtp/proto": "^3.72.3" } }, "sha512-SM7NaSJ6Lt5ilMNr26mAkaZ8XvCLVxbQM+oSszs6nnUUizZKnPdYs5SotQZRRrxB7ce+zHv+xw82By/cltv12w=="],
+    "@xmtp/node-sdk": ["@xmtp/node-sdk@2.0.8", "", { "dependencies": { "@xmtp/content-type-group-updated": "^2.0.2", "@xmtp/content-type-primitives": "^2.0.2", "@xmtp/content-type-text": "^2.0.2", "@xmtp/node-bindings": "1.1.8", "@xmtp/proto": "^3.78.0" } }, "sha512-UwI8fTNyKtPAt3iLNr908/vPMbxFx6LVPHJ2DjcIgL5cLPDW+y0NkM9yts88EQSccR1EzOpy52IKjkRHXMVdPQ=="],
 
     "@xmtp/proto": ["@xmtp/proto@3.78.0", "", { "dependencies": { "long": "^5.2.0", "protobufjs": "^7.0.0", "rxjs": "^7.8.0", "undici": "^5.8.1" } }, "sha512-JHkkvbdyqpWo1YOg88uOrc2GAsPnfXhIWaUKyIjXQdt4LltR4iAMgXcr1CFN+xjUmOBkAwwJ2JywUYv/uA4yZA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@prisma/client": "^6.3.1",
     "@prisma/instrumentation": "^6.7.0",
     "@turnkey/sdk-server": "^3.0.1",
-    "@xmtp/node-sdk": "^0.0.47",
+    "@xmtp/node-sdk": "^2.0.8",
     "cors": "^2.8.5",
     "expo-server-sdk": "^3.14.0",
     "express": "^5.0.1",

--- a/src/utils/identifier.ts
+++ b/src/utils/identifier.ts
@@ -1,0 +1,8 @@
+import { IdentifierKind, type Identifier } from "@xmtp/node-sdk";
+
+export function addressToIdentifier(address: string): Identifier {
+  return {
+    identifier: address,
+    identifierKind: IdentifierKind.Ethereum,
+  };
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -7,6 +7,7 @@ import * as jose from "jose";
 import { createWalletClient, http, toBytes, toHex } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
+import { addressToIdentifier } from "@/utils/identifier";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const testEncryptionKey = getRandomValues(new Uint8Array(32));
@@ -27,8 +28,8 @@ export const createUser = () => {
 
 export const createSigner = (user: User): Signer => {
   return {
-    walletType: "EOA",
-    getAddress: () => user.account.address,
+    type: "EOA",
+    getIdentifier: () => addressToIdentifier(user.account.address),
     signMessage: async (message: string) => {
       const signature = await user.wallet.signMessage({
         message,
@@ -42,7 +43,8 @@ export type User = ReturnType<typeof createUser>;
 
 export const createClient = async () => {
   const user = createUser();
-  return Client.create(createSigner(user), testEncryptionKey, {
+  return Client.create(createSigner(user), {
+    dbEncryptionKey: testEncryptionKey,
     env: process.env.XMTP_ENV as "local" | "dev" | "production",
     dbPath: join(__dirname, `./test-${user.account.address}.db3`),
   });

--- a/tests/notifications.client.test.ts
+++ b/tests/notifications.client.test.ts
@@ -139,8 +139,8 @@ describe("Notifications", () => {
         installationId: "invite-subscribe-test",
         topics: [inviteTopic],
       });
-      await client.conversations.newDm(client2.accountAddress);
-      await client.conversations.newGroup([client2.accountAddress]);
+      await client.conversations.newDm(client2.inboxId);
+      await client.conversations.newGroup([client2.inboxId]);
 
       // end stream after 5 seconds (increased from 2 seconds to prevent timeout)
       setTimeout(() => {
@@ -191,7 +191,7 @@ describe("Notifications", () => {
         },
       });
 
-      const dm = await client.conversations.newDm(client2.accountAddress);
+      const dm = await client.conversations.newDm(client2.inboxId);
 
       await client2.conversations.sync();
       const dm2 = await client2.conversations.getConversationById(dm.id);
@@ -264,9 +264,9 @@ describe("Notifications", () => {
       });
 
       const group = await client.conversations.newGroup([
-        client2.accountAddress,
-        client3.accountAddress,
-        client4.accountAddress,
+        client2.inboxId,
+        client3.inboxId,
+        client4.inboxId,
       ]);
       await client2.conversations.sync();
       await client3.conversations.sync();
@@ -346,7 +346,7 @@ describe("Notifications", () => {
         },
       });
 
-      const dm = await client.conversations.newDm(client2.accountAddress);
+      const dm = await client.conversations.newDm(client2.inboxId);
 
       await client2.conversations.sync();
       const dm2 = await client2.conversations.getConversationById(dm.id);
@@ -430,9 +430,9 @@ describe("Notifications", () => {
       });
 
       const group = await client.conversations.newGroup([
-        client2.accountAddress,
-        client3.accountAddress,
-        client4.accountAddress,
+        client2.inboxId,
+        client3.inboxId,
+        client4.inboxId,
       ]);
 
       await client2.conversations.sync();


### PR DESCRIPTION
### TL;DR

Upgraded XMTP Node SDK from version 0.0.47 to 2.0.8.

### What changed?

- Updated `@xmtp/node-sdk` from version `^0.0.47` to `^2.0.8` in both `package.json` and `bun.lock`
- Updated related XMTP dependencies in `bun.lock`:
  - `@xmtp/content-type-group-updated` from 2.0.0 to 2.0.2
  - `@xmtp/content-type-primitives` from 2.0.0 to 2.0.2
  - `@xmtp/content-type-text` from 2.0.0 to 2.0.2
  - `@xmtp/node-bindings` from 0.0.41 to 1.1.8

### How to test?

1. Run `bun install` to update dependencies
2. Verify that all XMTP-related functionality continues to work as expected
3. Test any messaging features that rely on the XMTP SDK

### Why make this change?

The XMTP Node SDK has undergone a major version upgrade from version 0.0.47 to 2.0.8, which likely includes significant improvements, bug fixes, and potentially new features. This update ensures we're using the latest stable version of the SDK for messaging functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved support for Ethereum-based identifiers in messaging features.
	- Added structured identifier format for Ethereum addresses.
- **Bug Fixes**
	- Enhanced compatibility with the latest version of the XMTP SDK.
- **Tests**
	- Updated tests to use new identifier formats and adapt to SDK changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->