### PR TITLE
Fix pino-http logging

### DIFF
--- a/src/middleware/pino.ts
+++ b/src/middleware/pino.ts
@@ -1,3 +1,4 @@
+import { context as otelContext, trace } from "@opentelemetry/api";
 import pinoHttp from "pino-http";
 import logger from "@/utils/logger";
 
@@ -8,8 +9,14 @@ export const pinoMiddleware = pinoHttp({
     remove: true,
   },
   customProps: function (req) {
-    return {
-      pathname: req.url?.split("?")[0] || "",
-    };
+    const pathname = req.url?.split("?")[0] || "";
+
+    const span = trace.getSpan(otelContext.active());
+    if (!span) {
+      return { pathname };
+    }
+
+    const { traceId, spanId } = span.spanContext();
+    return { pathname, trace_id: traceId, span_id: spanId }; // adds to every log
   },
 });


### PR DESCRIPTION
### TL;DR

- Add OpenTelemetry trace and span IDs to logs for better observability.
- Fixes an issue where logs were not attached to traces in DataDog


### What changed?

- Imported OpenTelemetry context and trace modules
- Enhanced the Pino middleware's `customProps` function to:
  - Extract the current active span from OpenTelemetry context
  - Add `trace_id` and `span_id` to log entries when a span is available
  - Maintain backward compatibility when no span is present

### How to test?

1. Run the application with OpenTelemetry tracing enabled
2. Make a request to any endpoint
3. Check the logs to verify they include `trace_id` and `span_id` fields
4. Confirm these IDs match the trace and span IDs in your tracing system

### Why make this change?

This change improves observability by correlating logs with traces. When investigating issues, engineers can now easily connect log entries to their corresponding traces in the OpenTelemetry system, enabling faster debugging and better understanding of request flows through the system.