### PR TITLE
Fix terraform values

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -59,8 +59,8 @@ jobs:
           terraform-org: xmtp
           terraform-workspace: convos_dev
           variable-name: api_image
-          variable-value: "ghcr.io/${{ github.repository_owner }}/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
-          variable-value-required-prefix: "ghcr.io/${{ github.repository_owner }}/convos-backend@sha256:"
+          variable-value: "ghcr.io/ephemerahq/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
+          variable-value-required-prefix: "ghcr.io/ephemerahq/convos-backend@sha256:"
 
   deploy_prod:
     name: Deploy new images to infra
@@ -79,5 +79,5 @@ jobs:
           terraform-org: xmtp
           terraform-workspace: convos_prod
           variable-name: api_image
-          variable-value: "ghcr.io/${{ github.repository_owner }}/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
-          variable-value-required-prefix: "ghcr.io/${{ github.repository_owner }}/convos-backend@sha256:"
+          variable-value: "ghcr.io/ephemerahq/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
+          variable-value-required-prefix: "ghcr.io/ephemerahq/convos-backend@sha256:"


### PR DESCRIPTION
## tl;dr

- Docker doesn't allow uppercase characters in image names. We are pushing to `ephemerahq` but specifying the image as `ephemeraHQ` based on `{{github.repository_owner}}` which is breaking automated deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment configuration to use a fixed image namespace for AWS deployments, ensuring consistent Docker image references for both development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->