### PR TITLE
Fix log leveling to work with DataDog

### DIFF
--- a/src/middleware/pino.ts
+++ b/src/middleware/pino.ts
@@ -17,6 +17,8 @@ export const pinoMiddleware = pinoHttp({
     }
 
     const { traceId, spanId } = span.spanContext();
-    return { pathname, trace_id: traceId, span_id: spanId }; // adds to every log
+    // https://docs.datadoghq.com/opentelemetry/correlate/logs_and_traces/?tab=nodejs
+    const ddSpanId = BigInt(`0x${spanId}`).toString();
+    return { pathname, "dd.trace_id": traceId, "dd.span_id": ddSpanId }; // adds to every log
   },
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,12 @@ import pino, { type LoggerOptions } from "pino";
 
 export const pinoConfig: LoggerOptions = {
   level: process.env.LOG_LEVEL || "info",
+  formatters: {
+    level(label, _number) {
+      // Use the label for the level instead of the default, which is to use a number
+      return { level: label };
+    },
+  },
   transport:
     process.env.LOG_FORMAT === "json"
       ? undefined


### PR DESCRIPTION
### TL;DR

Updated the Pino logger configuration to use text labels for log levels instead of numbers.

### What changed?

Added a `formatters` configuration to the Pino logger that modifies how log levels are displayed. The new formatter ensures that the human-readable label (like "info", "error", etc.) is used in logs instead of the default numeric representation.

### How to test?

1. Generate logs at different levels in your application
2. Verify that logs show text labels (e.g., "level": "info") instead of numbers
3. Check that this works in both development and production environments

### Why make this change?

This change improves log readability by using descriptive text labels instead of numeric values for log levels. This makes logs more human-friendly and easier to parse visually when debugging issues, especially for developers who may not be familiar with Pino's numeric level mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated logging output to display log level labels as strings instead of numbers for improved readability.
  - Enhanced log correlation with Datadog by adjusting trace and span ID formats for better integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->