### PR TITLE
feat: Add eth address in the notification data

### DIFF
--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -52,6 +52,13 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       where: {
         pushToken: notification.installation.delivery_mechanism.token,
       },
+      include: {
+        identities: {
+          include: {
+            identity: true,
+          },
+        },
+      },
     });
 
     if (!device) {
@@ -61,6 +68,10 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       res.status(404).end();
       return;
     }
+
+    const primaryIdentity = device.identities[0].identity;
+
+    const turnkeyAddress = primaryIdentity.turnkeyAddress;
 
     const expoPushToken = device.expoToken;
 
@@ -79,6 +90,7 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       messageType: notification.message_context.message_type,
       encryptedMessage: notification.message.message,
       timestamp: notification.message.timestamp_ns,
+      ethAddress: turnkeyAddress,
     };
 
     // Create the message based on whether it's silent or regular

--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -69,11 +69,19 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       return;
     }
 
-    const primaryIdentity = device.identities[0].identity;
-
-    const turnkeyAddress = primaryIdentity.turnkeyAddress;
-
     const expoPushToken = device.expoToken;
+    const turnkeyAddress =
+      device.identities.length > 0
+        ? device.identities[0].identity.turnkeyAddress
+        : undefined;
+
+    if (!turnkeyAddress) {
+      req.log.error(
+        `Device with push token ${notification.installation.delivery_mechanism.token} has no identity`,
+      );
+      res.status(200).end();
+      return;
+    }
 
     // Validate the Expo push token
     if (!Expo.isExpoPushToken(expoPushToken)) {


### PR DESCRIPTION
### Add Ethereum address from Turnkey to XMTP notification payload in notification handler
The XMTP notification handler now includes identity-related data in the device query and adds the Turnkey Ethereum address to the notification payload. Changes in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/63/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e) include:

* Add `include` clause to Prisma query to fetch identity information with device data
* Extract primary identity and Turnkey address from device data
* Include Turnkey Ethereum address in `baseMessageData` notification payload

#### 📍Where to Start
Begin reviewing the XMTP notification handler in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/63/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e), focusing on the device query and notification payload construction.

----

_[Macroscope](https://app.macroscope.com) summarized 70fef92._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Push notifications now include an additional field displaying the associated Ethereum address.

- **Bug Fixes**
  - Improved retrieval of identity information for devices receiving notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->