### PR TITLE
Idempotent suborg creation

### DIFF
--- a/prisma/migrations/20250505190441_idempotent_suborg_creates/migration.sql
+++ b/prisma/migrations/20250505190441_idempotent_suborg_creates/migration.sql
@@ -1,0 +1,14 @@
+/*
+ Warnings:
+ 
+ - A unique constraint covering the columns `[credentialId]` on the table `SubOrg` will be added. If there are existing duplicate values, this will fail.
+ - Added the required column `credentialId` to the `SubOrg` table without a default value. This is not possible if the table is not empty.
+ 
+ */
+--TruncateTable
+TRUNCATE TABLE "SubOrg";
+-- AlterTable
+ALTER TABLE "SubOrg"
+ADD COLUMN "credentialId" TEXT NOT NULL;
+-- CreateIndex
+CREATE UNIQUE INDEX "SubOrg_credentialId_key" ON "SubOrg"("credentialId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ datasource db {
 
 model User {
   id             String           @id @default(uuid())
-  turnkeyUserId    String           @unique
+  turnkeyUserId  String           @unique
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
   devices        Device[]
@@ -50,7 +50,7 @@ model DeviceIdentity {
   id                   String                 @id @default(uuid())
   userId               String
   xmtpId               String?
-  turnkeyAddress         String
+  turnkeyAddress       String
   createdAt            DateTime               @default(now())
   updatedAt            DateTime               @updatedAt
   profile              Profile?
@@ -100,6 +100,7 @@ model ConversationMetadata {
 model SubOrg {
   id                   String   @id
   defaultWalletAddress String
+  credentialId         String   @unique
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
 }

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -46,6 +46,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await prisma.subOrg.deleteMany();
+  mock.restore();
 });
 
 describe("/wallets API", () => {
@@ -120,5 +121,19 @@ describe("/wallets API", () => {
         ],
       }),
     );
+
+    // Try again with the same credentialId
+    const response2 = await fetch(`http://localhost:${port}/wallets`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(createSubOrgBody),
+    });
+    expect(response2.status).toBe(200);
+
+    const data2 = (await response2.json()) as CreateSubOrgReturned;
+    expect(data2).toEqual(data);
+    expect(mockCreateSubOrg).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### TL;DR

Make SubOrg creation idempotent by adding a unique credentialId field and checking for existing SubOrgs before creating new ones.

Turnkey recommends this approach since multiple suborgs can be created for a single credential with their APIs.

### Possible Improvements
- Would be nicer if this all happened inside a transaction, so we could protect against multiple concurrent requests. But that feels higher risk, so taking a safer approach for now.

### What changed?

- Added a `credentialId` column to the `SubOrg` table with a unique constraint
- Created a migration script to add the new column and unique index
- Modified the `createSubOrg` handler to check if a SubOrg with the given credentialId already exists
- If a SubOrg already exists with the provided credentialId, return it instead of creating a new one
- Added a helper function `findExistingSuborg` to look up SubOrgs by credentialId
- Enhanced error logging for request body validation
- Updated tests to verify idempotent behavior

### How to test?

1. Run the migration to update the database schema
2. Make a POST request to `/wallets` with a valid SubOrg creation payload
3. Make the same request again with the same credentialId
4. Verify that the second request returns the same SubOrg without creating a new one
5. Run the updated tests to confirm the idempotent behavior

### Why make this change?

This change prevents duplicate SubOrg creation when the same credentials are used multiple times. By making the operation idempotent, we improve reliability and prevent potential data inconsistencies when clients retry operations. This is particularly important for handling network issues or retries during the SubOrg creation process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for idempotent creation of sub-organizations using a unique credential ID. Repeated requests with the same credential ID will return the existing sub-organization instead of creating duplicates.

- **Bug Fixes**
  - Improved error logging for request validation failures.

- **Tests**
  - Enhanced tests to verify idempotent behavior when creating sub-organizations with the same credential ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->