### PR TITLE
feat: Get profile by `xmtpId` or `username`

### DIFF
--- a/src/api/v1/profiles/handlers/get-public-profile.ts
+++ b/src/api/v1/profiles/handlers/get-public-profile.ts
@@ -3,7 +3,8 @@ import { prisma } from "@/utils/prisma";
 import type { PublicProfileResult } from "../profiles.types";
 
 type GetPublicProfileParams = {
-  username: string;
+  username?: string;
+  xmtpId?: string;
 };
 
 export async function getPublicProfile(
@@ -11,20 +12,26 @@ export async function getPublicProfile(
   res: Response,
 ) {
   try {
-    const { username } = req.params;
+    const { username, xmtpId } = req.params;
 
-    if (!username) {
-      res.status(400).json({ error: "Username is required" });
+    if (!username && !xmtpId) {
+      res.status(400).json({ error: "Either username or xmtpId is required" });
       return;
     }
 
     const profile = await prisma.profile.findFirst({
-      where: {
-        username: {
-          equals: username,
-          mode: "insensitive",
-        },
-      },
+      where: username
+        ? {
+            username: {
+              equals: username,
+              mode: "insensitive",
+            },
+          }
+        : {
+            deviceIdentity: {
+              xmtpId,
+            },
+          },
       include: {
         deviceIdentity: {
           select: {

--- a/src/api/v1/profiles/profiles-public.router.ts
+++ b/src/api/v1/profiles/profiles-public.router.ts
@@ -4,8 +4,8 @@ import { getPublicProfile } from "./handlers/get-public-profile";
 const publicProfilesRouter = Router();
 
 // Define public routes
-publicProfilesRouter.get("/:username", getPublicProfile);
 publicProfilesRouter.get("/username/:username", getPublicProfile);
 publicProfilesRouter.get("/xmtpId/:xmtpId", getPublicProfile);
+publicProfilesRouter.get("/:username", getPublicProfile);
 
 export default publicProfilesRouter;

--- a/src/api/v1/profiles/profiles-public.router.ts
+++ b/src/api/v1/profiles/profiles-public.router.ts
@@ -5,5 +5,7 @@ const publicProfilesRouter = Router();
 
 // Define public routes
 publicProfilesRouter.get("/:username", getPublicProfile);
+publicProfilesRouter.get("/username/:username", getPublicProfile);
+publicProfilesRouter.get("/xmtpId/:xmtpId", getPublicProfile);
 
 export default publicProfilesRouter;


### PR DESCRIPTION
Public endpoints:

```
/api/v1/profiles/public/:username # for backward compatibility
/api/v1/profiles/public/username/:username
/api/v1/profiles/public/xmtpId/:xmtpId
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to look up public profiles using either a username or an xmtpId.
  - Introduced new routes for fetching public profiles by username or xmtpId, providing more flexible search options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->