### PR TITLE
feat: add a get batch profiles endpoint

### DIFF
--- a/src/api/v1/profiles/handlers/get-batch-profiles.ts
+++ b/src/api/v1/profiles/handlers/get-batch-profiles.ts
@@ -1,0 +1,79 @@
+import type { RequestHandler } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+import { batchGetProfilesSchema } from "../profile.schema";
+import type {
+  BatchGetProfilesRequestBody,
+  BatchProfilesResponse,
+  ProfileRequestResult,
+} from "../profiles.types";
+
+// Use a RequestHandler type with generic parameters
+export const getBatchProfiles: RequestHandler<
+  unknown,
+  BatchProfilesResponse | { error: string; details?: z.ZodIssue[] },
+  BatchGetProfilesRequestBody
+> = async (req, res) => {
+  try {
+    // Validate request body
+    let validatedData;
+    try {
+      validatedData = batchGetProfilesSchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({
+          error: "Invalid request body",
+          details: error.errors,
+        });
+        return;
+      }
+      throw error;
+    }
+
+    const { xmtpIds } = validatedData;
+
+    // Get profiles with matching xmtpIds
+    const profiles = await prisma.profile.findMany({
+      where: {
+        deviceIdentity: {
+          xmtpId: {
+            in: xmtpIds,
+          },
+        },
+      },
+      include: {
+        deviceIdentity: {
+          select: {
+            xmtpId: true,
+            turnkeyAddress: true,
+          },
+        },
+      },
+    });
+
+    // Convert array to map keyed by xmtpId
+    const profilesMap: Record<string, ProfileRequestResult> = {};
+
+    profiles.forEach((profile) => {
+      if (profile.deviceIdentity.xmtpId) {
+        profilesMap[profile.deviceIdentity.xmtpId] = {
+          id: profile.id,
+          name: profile.name,
+          username: profile.username,
+          description: profile.description,
+          avatar: profile.avatar,
+          xmtpId: profile.deviceIdentity.xmtpId,
+          turnkeyAddress: profile.deviceIdentity.turnkeyAddress,
+        };
+      }
+    });
+
+    const response: BatchProfilesResponse = {
+      profiles: profilesMap,
+    };
+
+    res.json(response);
+  } catch {
+    res.status(500).json({ error: "Failed to fetch profiles" });
+  }
+};

--- a/src/api/v1/profiles/profile.schema.ts
+++ b/src/api/v1/profiles/profile.schema.ts
@@ -53,3 +53,13 @@ export const profileUpdateSchema = profileBaseSchema.partial();
 export type ProfileSchemaType = z.infer<typeof profileBaseSchema>;
 export type ProfileCreationType = z.infer<typeof profileCreationSchema>;
 export type ProfileUpdateType = z.infer<typeof profileUpdateSchema>;
+
+// Batch profiles schemas
+export const batchGetProfilesSchema = z.object({
+  xmtpIds: z
+    .array(z.string())
+    .min(1, "At least one xmtpId is required")
+    .max(1000, "Maximum of 1000 xmtpIds allowed"),
+});
+
+export type BatchGetProfilesSchemaType = z.infer<typeof batchGetProfilesSchema>;

--- a/src/api/v1/profiles/profiles.router.ts
+++ b/src/api/v1/profiles/profiles.router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { checkUsername } from "./handlers/check-username";
+import { getBatchProfiles } from "./handlers/get-batch-profiles";
 import { getProfile } from "./handlers/get-profile";
 import { searchProfiles } from "./handlers/search-profiles";
 import { updateProfile } from "./handlers/update-profile";
@@ -9,6 +10,7 @@ const profilesRouter = Router();
 // Define all routes
 profilesRouter.get("/search", searchProfiles);
 profilesRouter.get("/check/:username", checkUsername);
+profilesRouter.post("/batch", getBatchProfiles);
 profilesRouter.get("/:xmtpId", getProfile);
 profilesRouter.put("/:xmtpId", updateProfile);
 

--- a/src/api/v1/profiles/profiles.types.ts
+++ b/src/api/v1/profiles/profiles.types.ts
@@ -16,3 +16,13 @@ export type PublicProfileResult = Pick<
   "name" | "username" | "description" | "avatar"
 > &
   Pick<DeviceIdentity, "xmtpId" | "turnkeyAddress">;
+
+// Batch profile request body
+export type BatchGetProfilesRequestBody = {
+  xmtpIds: string[];
+};
+
+// Batch profiles response format
+export type BatchProfilesResponse = {
+  profiles: Record<string, ProfileRequestResult>;
+};

--- a/tests/profiles-batch.test.ts
+++ b/tests/profiles-batch.test.ts
@@ -1,0 +1,170 @@
+import type { Server } from "http";
+import type { DeviceIdentity, Profile } from "@prisma/client";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import express from "express";
+import profilesRouter from "@/api/v1/profiles/profiles.router";
+import type { BatchProfilesResponse } from "@/api/v1/profiles/profiles.types";
+import { jsonMiddleware } from "@/middleware/json";
+import { prisma } from "@/utils/prisma";
+
+const app = express();
+app.use(jsonMiddleware);
+
+// Add type declaration to augment Request type
+declare module "express-serve-static-core" {
+  interface Request {
+    auth?: {
+      userId: string;
+    };
+  }
+}
+
+// Mock auth middleware for tests
+app.use((req, res, next) => {
+  req.auth = {
+    userId: "test-user-id",
+  };
+  next();
+});
+
+// Register routes
+app.use("/profiles", profilesRouter);
+
+let server: Server;
+let baseUrl: string;
+
+describe("Batch Profile endpoints", () => {
+  const testProfiles: (Profile & { deviceIdentity: DeviceIdentity })[] = [];
+  const xmtpIds = ["test-xmtp-id-1", "test-xmtp-id-2", "test-xmtp-id-3"];
+  const testUserId = "test-user-id";
+
+  beforeAll(async () => {
+    // Create test user
+    const testUser = await prisma.user.create({
+      data: {
+        id: testUserId,
+        turnkeyUserId: "test-turnkey-user-id",
+      },
+    });
+
+    // Start server on random port
+    server = app.listen(0);
+    const address = server.address();
+    const port = typeof address === "object" ? address?.port : 0;
+    baseUrl = `http://localhost:${port}`;
+
+    // Create test device identities and profiles
+    for (let i = 0; i < xmtpIds.length; i++) {
+      const deviceIdentity = await prisma.deviceIdentity.create({
+        data: {
+          xmtpId: xmtpIds[i],
+          turnkeyAddress: `0x${i}123456789`,
+          userId: testUser.id,
+        },
+      });
+
+      const profile = await prisma.profile.create({
+        data: {
+          name: `Test User ${i}`,
+          username: `testuser${i}`,
+          description: `Test description ${i}`,
+          avatar: `https://example.com/avatar${i}.png`,
+          deviceIdentityId: deviceIdentity.id,
+        },
+        include: {
+          deviceIdentity: true,
+        },
+      });
+
+      testProfiles.push(profile);
+    }
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    for (const profile of testProfiles) {
+      await prisma.profile.delete({
+        where: { id: profile.id },
+      });
+
+      await prisma.deviceIdentity.delete({
+        where: { id: profile.deviceIdentityId },
+      });
+    }
+
+    // Delete test user
+    await prisma.user.delete({
+      where: { id: testUserId },
+    });
+
+    server.close();
+  });
+
+  test("POST /profiles/batch should return profiles for valid xmtpIds", async () => {
+    const response = await fetch(`${baseUrl}/profiles/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        xmtpIds: [xmtpIds[0], xmtpIds[1], "non-existent-id"],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as BatchProfilesResponse;
+    expect(body.profiles).toBeDefined();
+
+    // Should only return profiles for existing IDs
+    expect(Object.keys(body.profiles).length).toBe(2);
+
+    // Verify profile data
+    expect(body.profiles[xmtpIds[0]]).toBeDefined();
+    expect(body.profiles[xmtpIds[0]].name).toBe("Test User 0");
+    expect(body.profiles[xmtpIds[0]].username).toBe("testuser0");
+
+    expect(body.profiles[xmtpIds[1]]).toBeDefined();
+    expect(body.profiles[xmtpIds[1]].name).toBe("Test User 1");
+    expect(body.profiles[xmtpIds[1]].username).toBe("testuser1");
+
+    // Non-existent ID should not be in the response
+    expect(body.profiles["non-existent-id"]).toBeUndefined();
+  });
+
+  test("POST /profiles/batch should return 400 for invalid requests", async () => {
+    // Empty array
+    const emptyResponse = await fetch(`${baseUrl}/profiles/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ xmtpIds: [] }),
+    });
+
+    expect(emptyResponse.status).toBe(400);
+
+    // Missing xmtpIds
+    const missingResponse = await fetch(`${baseUrl}/profiles/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(missingResponse.status).toBe(400);
+
+    // Too many IDs (mocking the validation)
+    const tooManyIdsArray = Array(1001).fill("id");
+    const tooManyResponse = await fetch(`${baseUrl}/profiles/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ xmtpIds: tooManyIdsArray }),
+    });
+
+    expect(tooManyResponse.status).toBe(400);
+  });
+});


### PR DESCRIPTION
This will enable us to load a set of profiles simultaneously in the group details view, eliminating the need to send an individual API call for each profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a batch profile retrieval endpoint, allowing users to fetch multiple profiles at once using a list of IDs.

- **Bug Fixes**
  - Improved input validation and error handling for batch profile requests.

- **Tests**
  - Added comprehensive tests to ensure correct behavior and error handling for the new batch profile retrieval endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->