### PR TITLE
fix: Remove console logs

### DIFF
--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -43,13 +43,6 @@ export async function registerInstallation(
       }),
     ]);
 
-    console.log(
-      "deviceIdentityForAuthenticatedUser:",
-      deviceIdentityForAuthenticatedUser,
-    );
-    console.log("deviceOwnerCheck:", deviceOwnerCheck);
-    console.log("identityOwnerCheck:", identityOwnerCheck);
-
     if (!deviceIdentityForAuthenticatedUser) {
       res.status(403).json({ error: "Forbidden: Device access denied" });
       return;


### PR DESCRIPTION
### Remove debugging console logs from `registerInstallation` handler in notifications API
Removes three `console.log` statements from [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/68/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) that were logging authentication and device ownership check information.

#### 📍Where to Start
Start with the `registerInstallation` handler in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/68/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd)

----

_[Macroscope](https://app.macroscope.com) summarized c3c3779._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed unnecessary console log statements from the notifications system to improve clarity and reduce noise in application logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->