### PR TITLE
Only deploy to prod from main

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -66,7 +66,7 @@ jobs:
     name: Deploy new images to infra
     runs-on: ubuntu-latest
     needs: push_to_registry
-    if: github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### TL;DR

Updated GitHub workflow to deploy from main branch instead of dev branch.

## WARNING

`main` is very out of date. We will need to merge `dev` into main before anything else goes in there or we are going to be deploying very old code to prod.

### What changed?

Modified the `.github/workflows/deploy-aws.yml` file to change the branch condition for deployment from `refs/heads/dev` to `refs/heads/main`. This means the deployment job will now only run when changes are pushed to the main branch instead of the dev branch.

### How to test?

1. Push a change to the main branch and verify that the deployment workflow runs
2. Push a change to the dev branch and verify that the deployment workflow does not run

### Why make this change?

This change aligns our deployment process with our updated branching strategy, where production deployments should be triggered from the main branch rather than the dev branch. This ensures a more standard GitFlow workflow where main represents the production-ready code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment workflow so that production deployments now occur only when changes are pushed to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->