### PR TITLE
fix: Put back new push notification registering system

### DIFF
--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -1,10 +1,14 @@
 import { Expo, type ExpoPushMessage } from "expo-server-sdk";
 import type { Request, Response } from "express";
-import type { NotificationResponse } from "@/notifications/client";
+import {
+  createNotificationClient,
+  type NotificationResponse,
+} from "@/notifications/client";
 import { getHttpDeliveryNotificationAuthHeader } from "@/notifications/utils";
 import { prisma } from "@/utils/prisma";
 
 const expo = new Expo();
+const notificationClient = createNotificationClient();
 
 if (!process.env.XMTP_NOTIFICATION_SECRET) {
   throw new Error("XMTP_NOTIFICATION_SECRET is not set");
@@ -18,6 +22,11 @@ if (!process.env.XMTP_NOTIFICATION_SECRET) {
  * from the authorized XMTP server.
  */
 export async function handleXmtpNotification(req: Request, res: Response) {
+  let identityOnDeviceToCleanup: {
+    xmtpInstallationId: string | null;
+    deviceId: string;
+  } | null = null;
+
   try {
     const notification = req.body as NotificationResponse;
 
@@ -48,51 +57,69 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       return;
     }
 
-    const device = await prisma.device.findFirst({
+    const identityOnDevice = await prisma.identitiesOnDevice.findUnique({
       where: {
-        pushToken: notification.installation.delivery_mechanism.token,
+        xmtpInstallationId: notification.installation.id,
       },
       include: {
-        identities: {
-          include: {
-            identity: true,
-          },
-        },
+        device: true,
+        identity: true,
       },
     });
 
-    if (!device) {
-      req.log.error(
-        `Device with push token ${notification.installation.delivery_mechanism.token} not found`,
+    if (!identityOnDevice || !identityOnDevice.xmtpInstallationId) {
+      req.log.warn(
+        `No active device/identity found for xmtpInstallationId ${notification.installation.id}. This installation might have been cleaned up already.`,
       );
-      res.status(404).end();
+      try {
+        await notificationClient.deleteInstallation({
+          installationId: notification.installation.id,
+        });
+        req.log.info(
+          `Requested deletion of orphaned xmtpInstallationId ${notification.installation.id} from XMTP server.`,
+        );
+      } catch (deleteError) {
+        req.log.error(
+          { error: deleteError },
+          `Failed to request deletion of orphaned xmtpInstallationId ${notification.installation.id}`,
+        );
+      }
+      res.status(200).end();
       return;
     }
 
+    identityOnDeviceToCleanup = {
+      xmtpInstallationId: identityOnDevice.xmtpInstallationId,
+      deviceId: identityOnDevice.deviceId,
+    };
+
+    const { device, identity } = identityOnDevice;
     const expoPushToken = device.expoToken;
-    const turnkeyAddress =
-      device.identities.length > 0
-        ? device.identities[0].identity.turnkeyAddress
-        : undefined;
+    const turnkeyAddress = identity.turnkeyAddress;
 
     if (!turnkeyAddress) {
       req.log.error(
-        `Device with push token ${notification.installation.delivery_mechanism.token} has no identity`,
+        `DeviceIdentity ${identity.id} for xmtpInstallationId ${notification.installation.id} has no turnkeyAddress`,
       );
       res.status(200).end();
       return;
     }
 
-    // Validate the Expo push token
-    if (!Expo.isExpoPushToken(expoPushToken)) {
-      req.log.error(
-        `Push token ${expoPushToken} is not a valid Expo push token`,
+    if (!expoPushToken || !Expo.isExpoPushToken(expoPushToken)) {
+      req.log.warn(
+        `Expo push token for Device ${device.id} (xmtpInstallationId ${notification.installation.id}) is invalid or missing: ${expoPushToken}. Cleaning up.`,
       );
+      if (identityOnDeviceToCleanup.xmtpInstallationId) {
+        await cleanupFailedInstallation({
+          xmtpInstallationId: identityOnDeviceToCleanup.xmtpInstallationId,
+          deviceId: identityOnDeviceToCleanup.deviceId,
+          req,
+        });
+      }
       res.status(200).end();
       return;
     }
 
-    // Prepare the base message data that's common for both silent and regular notifications
     const baseMessageData = {
       contentTopic: notification.message.content_topic,
       messageType: notification.message_context.message_type,
@@ -101,21 +128,15 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       ethAddress: turnkeyAddress,
     };
 
-    // Create the message based on whether it's silent or regular
     const message: ExpoPushMessage = notification.subscription.is_silent
       ? {
-          // Silent notification configuration
           to: expoPushToken,
           data: baseMessageData,
-          // Required for iOS silent notifications
           _contentAvailable: true,
-          // Required for Android silent notifications
           priority: "normal",
-          // Ensure no visible alerts
           sound: undefined,
         }
       : {
-          // Regular notification configuration
           to: expoPushToken,
           sound: "default",
           body: "New message",
@@ -124,25 +145,93 @@ export async function handleXmtpNotification(req: Request, res: Response) {
           mutableContent: true,
         };
 
-    // Send the notification
     const chunks = expo.chunkPushNotifications([message]);
-    const sendPromises = chunks.map(async (chunk) => {
+
+    for (const chunk of chunks) {
       try {
-        const ticketChunk = await expo.sendPushNotificationsAsync(chunk);
-        req.log.info({ ticketChunk }, "push notification sent");
-        return ticketChunk;
+        const tickets = await expo.sendPushNotificationsAsync(chunk);
+
+        for (const ticket of tickets) {
+          const expoPushReceipt = ticket;
+
+          if (expoPushReceipt.status === "error") {
+            req.log.error(
+              {
+                details: expoPushReceipt.details,
+                xmtpInstallationId: notification.installation.id,
+              },
+              `Error sending push notification: ${expoPushReceipt.message}`,
+            );
+
+            if (
+              expoPushReceipt.details &&
+              expoPushReceipt.details.error === "DeviceNotRegistered"
+            ) {
+              req.log.info(
+                `DeviceNotRegistered error for token ${expoPushToken} (xmtpInstallationId ${notification.installation.id}). Initiating cleanup.`,
+              );
+
+              if (identityOnDeviceToCleanup.xmtpInstallationId) {
+                await cleanupFailedInstallation({
+                  xmtpInstallationId:
+                    identityOnDeviceToCleanup.xmtpInstallationId,
+                  deviceId: identityOnDeviceToCleanup.deviceId,
+                  req,
+                });
+              }
+            }
+          }
+        }
       } catch (error) {
-        req.log.error({ error }, "Error sending push notification:");
-        throw error;
+        req.log.error(
+          { error, xmtpInstallationId: notification.installation.id },
+          "Critical error sending push notifications chunk",
+        );
       }
-    });
+    }
 
-    await Promise.all(sendPromises);
-
-    // Respond with success
     res.status(200).end();
   } catch (error) {
-    console.error("Error processing notification:", error);
+    req.log.error({ error }, "Outer error processing notification");
     res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+async function cleanupFailedInstallation(args: {
+  xmtpInstallationId: string;
+  deviceId: string;
+  req: Request;
+}) {
+  const { xmtpInstallationId, deviceId, req } = args;
+
+  try {
+    req.log.info(
+      `Cleaning up installation: ${xmtpInstallationId} for device: ${deviceId}`,
+    );
+    await prisma.$transaction([
+      prisma.identitiesOnDevice.updateMany({
+        where: { xmtpInstallationId: xmtpInstallationId },
+        data: { xmtpInstallationId: null },
+      }),
+      prisma.device.update({
+        where: { id: deviceId },
+        data: { expoToken: null },
+      }),
+    ]);
+    req.log.info(
+      `Successfully cleaned xmtpInstallationId ${xmtpInstallationId} and expoToken for device ${deviceId} from local DB.`,
+    );
+
+    await notificationClient.deleteInstallation({
+      installationId: xmtpInstallationId,
+    });
+    req.log.info(
+      `Successfully requested deletion of xmtpInstallationId ${xmtpInstallationId} from XMTP server.`,
+    );
+  } catch (cleanupError) {
+    req.log.error(
+      { error: cleanupError, xmtpInstallationId, deviceId },
+      "Failed during cleanup of installation",
+    );
   }
 }

--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -1,16 +1,14 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { createNotificationClient } from "@/notifications/client";
+import { prisma } from "@/utils/prisma";
 
-// Schema for registration
 const registrationSchema = z.object({
-  installationId: z.string(),
-  deliveryMechanism: z.object({
-    deliveryMechanismType: z.object({
-      case: z.enum(["apnsDeviceToken", "firebaseDeviceToken", "customToken"]),
-      value: z.string(),
-    }),
-  }),
+  deviceId: z.string(),
+  identityId: z.string(),
+  xmtpInstallationId: z.string(),
+  expoToken: z.string(),
+  pushToken: z.string(),
 });
 
 type RegisterInstallationRequestBody = z.infer<typeof registrationSchema>;
@@ -22,11 +20,97 @@ export async function registerInstallation(
   res: Response,
 ) {
   try {
+    const authenticatedXmtpId = req.app.locals.xmtpId;
+
     const validatedData = registrationSchema.parse(req.body);
 
+    const [
+      deviceIdentityForAuthenticatedUser,
+      deviceOwnerCheck,
+      identityOwnerCheck,
+    ] = await Promise.all([
+      prisma.deviceIdentity.findFirst({
+        where: { xmtpId: authenticatedXmtpId },
+        select: { userId: true },
+      }),
+      prisma.device.findUnique({
+        where: { id: validatedData.deviceId },
+        select: { userId: true },
+      }),
+      prisma.deviceIdentity.findUnique({
+        where: { id: validatedData.identityId },
+        select: { userId: true },
+      }),
+    ]);
+
+    if (!deviceIdentityForAuthenticatedUser) {
+      res.status(403).json({ error: "Forbidden: Device access denied" });
+      return;
+    }
+
+    // Check device ownership
+    if (
+      !deviceOwnerCheck ||
+      deviceOwnerCheck.userId !== deviceIdentityForAuthenticatedUser.userId
+    ) {
+      req.log.warn(
+        `User ${deviceIdentityForAuthenticatedUser.userId} attempt to register for unowned/unknown device ${validatedData.deviceId}`,
+      );
+      res.status(403).json({ error: "Forbidden: Device access denied" });
+      return;
+    }
+
+    // Check identity ownership
+    if (
+      !identityOwnerCheck ||
+      identityOwnerCheck.userId !== deviceIdentityForAuthenticatedUser.userId
+    ) {
+      req.log.warn(
+        `User ${deviceIdentityForAuthenticatedUser.userId} attempt to register for unowned/unknown identity ${validatedData.identityId}`,
+      );
+      res.status(403).json({ error: "Forbidden: Identity access denied" });
+      return;
+    }
+
+    await prisma.$transaction([
+      // 1. Update Device the device push tokens
+      prisma.device.update({
+        where: {
+          id: validatedData.deviceId,
+        },
+        data: {
+          expoToken: validatedData.expoToken,
+          pushToken: validatedData.pushToken,
+        },
+      }),
+      // 2. Update IdentitiesOnDevice with the xmtpInstallationId
+      prisma.identitiesOnDevice.upsert({
+        where: {
+          deviceId_identityId: {
+            deviceId: validatedData.deviceId,
+            identityId: validatedData.identityId,
+          },
+        },
+        create: {
+          deviceId: validatedData.deviceId,
+          identityId: validatedData.identityId,
+          xmtpInstallationId: validatedData.xmtpInstallationId,
+        },
+        update: {
+          xmtpInstallationId: validatedData.xmtpInstallationId,
+        },
+      }),
+    ]);
+
+    // 3. Register with the XMTP notification server
     const response = await notificationClient.registerInstallation({
-      installationId: validatedData.installationId,
-      deliveryMechanism: validatedData.deliveryMechanism,
+      installationId: validatedData.xmtpInstallationId,
+      deliveryMechanism: {
+        deliveryMechanismType: {
+          case: "customToken",
+          value: validatedData.expoToken,
+        },
+      },
     });
 
     res.status(201).json({
@@ -35,9 +119,10 @@ export async function registerInstallation(
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Invalid request body" });
+      res.status(400).json({ errors: error.errors });
       return;
     }
+    req.log.error({ error }, "Failed to register installation");
     res.status(500).json({ error: "Failed to register installation" });
   }
 }

--- a/src/api/v1/notifications/handlers/unregister-installation.ts
+++ b/src/api/v1/notifications/handlers/unregister-installation.ts
@@ -1,10 +1,11 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { createNotificationClient } from "@/notifications/client";
+import { prisma } from "@/utils/prisma";
 
 // Schema for unregistration
 const unregisterRequestParamsSchema = z.object({
-  installationId: z.string(),
+  xmtpInstallationId: z.string(),
 });
 
 type UnregisterRequestParams = z.infer<typeof unregisterRequestParamsSchema>;
@@ -16,14 +17,69 @@ export async function unregisterInstallation(
   res: Response,
 ) {
   try {
-    const validatedData = unregisterRequestParamsSchema.parse(req.params);
+    const authenticatedXmtpId = req.app.locals.xmtpId;
 
+    const { xmtpInstallationId } = unregisterRequestParamsSchema.parse(
+      req.params,
+    );
+
+    const [deviceIdentityForUser, identityOnDeviceForInstallation] =
+      await Promise.all([
+        prisma.deviceIdentity.findFirstOrThrow({
+          where: { xmtpId: authenticatedXmtpId },
+          select: { userId: true },
+        }),
+        prisma.identitiesOnDevice.findUnique({
+          where: {
+            xmtpInstallationId: xmtpInstallationId,
+          },
+          include: {
+            device: { select: { userId: true } },
+          },
+        }),
+      ]);
+
+    if (!identityOnDeviceForInstallation) {
+      res.status(404).json({ error: "Installation not found" });
+      return;
+    }
+
+    // Verify that the installation belongs to the authenticated user
+    if (
+      identityOnDeviceForInstallation.device.userId !==
+      deviceIdentityForUser.userId
+    ) {
+      req.log.warn(
+        `User ${deviceIdentityForUser.userId} attempt to unregister unowned installation ${xmtpInstallationId}`,
+      );
+      res.status(403).json({ error: "Forbidden: Installation access denied" });
+      return;
+    }
+
+    // 1. Nullify xmtpInstallationId in our DB
+    await prisma.$transaction([
+      prisma.identitiesOnDevice.update({
+        where: {
+          xmtpInstallationId: xmtpInstallationId,
+        },
+        data: {
+          xmtpInstallationId: null,
+        },
+      }),
+    ]);
+
+    // 2. Delete from XMTP notification server
     await notificationClient.deleteInstallation({
-      installationId: validatedData.installationId,
+      installationId: xmtpInstallationId,
     });
 
-    res.status(200).send();
-  } catch {
+    res.status(200).send("Installation unregistered successfully");
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ errors: error.errors });
+      return;
+    }
+    req.log.error({ error }, "Failed to unregister installation");
     res.status(500).json({ error: "Failed to delete installation" });
   }
 }

--- a/src/api/v1/notifications/notifications.router.ts
+++ b/src/api/v1/notifications/notifications.router.ts
@@ -11,7 +11,7 @@ notificationsRouter.post("/register", registerInstallation);
 notificationsRouter.post("/subscribe", subscribeToTopics);
 notificationsRouter.post("/unsubscribe", unsubscribeFromTopics);
 notificationsRouter.delete(
-  "/unregister/:installationId",
+  "/unregister/:xmtpInstallationId",
   unregisterInstallation,
 );
 


### PR DESCRIPTION
### Restore XMTP push notification registration system with improved authentication and error handling in notification handlers
* Refactors XMTP notification handling in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/72/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e) to use installation ID-based lookups and implement comprehensive error handling
* Rewrites [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/72/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) with new authentication checks and transaction-based database updates
* Updates [unregister-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/72/files#diff-a17b268f05d5b036f7fe7086d3910b0ecca003982a5b2c8ed2dbe6e016a18c5f) to include authentication and proper database cleanup
* Renames route parameter in [notifications.router.ts](https://github.com/ephemeraHQ/convos-backend/pull/72/files#diff-ef5122f02fceb0f8912d17a0ebad9f481b2b10ebb1c9b7973df65eff15cd8d65) for consistency
* Adds comprehensive test coverage in [notifications.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/72/files#diff-d2f84d516070b396c376019371e3945fa101f01a38e0a7cb8d668e6ee5558e76) for authentication and database operations

#### 📍Where to Start
Start with the registration flow in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/72/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) which contains the core authentication and database transaction logic for the notification system.

----

_[Macroscope](https://app.macroscope.com) summarized 68caa67._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved push notification reliability with enhanced handling of invalid or orphaned device installations.
  - Authorization checks added to ensure only device and identity owners can register or unregister installations.

- **Bug Fixes**
  - More robust error handling and validation for push token and installation registration flows.
  - Consistent cleanup of unregistered or invalid installations.

- **Tests**
  - Expanded and restructured test coverage for notification registration, unregistration, and subscription endpoints, including authorization and validation scenarios.

- **Chores**
  - Updated API parameter names for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->