### PR TITLE
fix: Delete duplicates SQL in migration file

### DIFF
--- a/prisma/migrations/20250514145741_unique_device_identity_on_user_id_and_xmtp_id/migration.sql
+++ b/prisma/migrations/20250514145741_unique_device_identity_on_user_id_and_xmtp_id/migration.sql
@@ -1,18 +1,41 @@
--- Delete duplicate DeviceIdentity records that lack a profile,
--- keeping the one that has a profile for the same userId and xmtpId.
-DELETE FROM "DeviceIdentity"
-WHERE id IN (
+-- Step 1: Delete referencing rows from IdentitiesOnDevice
+-- that link to the DeviceIdentity records we are about to delete.
+DELETE FROM "IdentitiesOnDevice"
+WHERE "identityId" IN (
+    -- This is the same subquery used to identify the DeviceIdentity records for deletion
     SELECT di.id
     FROM "DeviceIdentity" di
     WHERE
-        -- Condition A: This DeviceIdentity has no associated profile
         NOT EXISTS (
             SELECT 1
             FROM "Profile" p
             WHERE p."deviceIdentityId" = di.id
         )
-        -- Condition B: There EXISTS another DeviceIdentity for the same userId and xmtpId
-        -- that DOES have an associated profile.
+        AND EXISTS (
+            SELECT 1
+            FROM "DeviceIdentity" di_valid
+            JOIN "Profile" p_valid ON di_valid.id = p_valid."deviceIdentityId"
+            WHERE
+                di_valid."userId" = di."userId"
+                AND (
+                    (di_valid."xmtpId" IS NULL AND di."xmtpId" IS NULL) OR
+                    (di_valid."xmtpId" = di."xmtpId")
+                )
+        )
+);
+
+-- Step 2: Now delete the DeviceIdentity records
+-- (Your existing DELETE statement)
+DELETE FROM "DeviceIdentity"
+WHERE id IN (
+    SELECT di.id
+    FROM "DeviceIdentity" di
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM "Profile" p
+            WHERE p."deviceIdentityId" = di.id
+        )
         AND EXISTS (
             SELECT 1
             FROM "DeviceIdentity" di_valid


### PR DESCRIPTION
### Add two-step deletion process in migration to prevent foreign key violations when removing duplicate `DeviceIdentity` records
The migration file [20250514145741_unique_device_identity_on_user_id_and_xmtp_id/migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/73/files#diff-835ae815156a2205146baa2b0df0a766e2ecff911d650ab34e5258736d47ad14) now implements a two-step deletion process:

* Delete referencing rows from `IdentitiesOnDevice` table that link to target `DeviceIdentity` records
* Remove duplicate `DeviceIdentity` records where no associated `Profile` exists and another `DeviceIdentity` record exists with the same `userId` and `xmtpId` that has an associated `Profile`

#### 📍Where to Start
Begin reviewing the migration file at [20250514145741_unique_device_identity_on_user_id_and_xmtp_id/migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/73/files#diff-835ae815156a2205146baa2b0df0a766e2ecff911d650ab34e5258736d47ad14) which contains the modified SQL deletion steps.

----

_[Macroscope](https://app.macroscope.com) summarized 461e821._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data integrity during device identity cleanup by ensuring related records are properly removed before deleting duplicate device identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->