### PR TITLE
Simplify migration

### DIFF
--- a/prisma/migrations/20250514145741_unique_device_identity_on_user_id_and_xmtp_id/migration.sql
+++ b/prisma/migrations/20250514145741_unique_device_identity_on_user_id_and_xmtp_id/migration.sql
@@ -1,59 +1,57 @@
--- Step 1: Delete referencing rows from IdentitiesOnDevice
--- that link to the DeviceIdentity records we are about to delete.
-DELETE FROM "IdentitiesOnDevice"
-WHERE "identityId" IN (
-    -- This is the same subquery used to identify the DeviceIdentity records for deletion
-    SELECT di.id
-    FROM "DeviceIdentity" di
-    WHERE
-        NOT EXISTS (
-            SELECT 1
-            FROM "Profile" p
-            WHERE p."deviceIdentityId" = di.id
+-- Step 1: Delete referencing rows from DeviceIdentities
+WITH device_identities_to_delete AS (
+  SELECT id
+  from "DeviceIdentity" di
+  WHERE NOT EXISTS (
+      SELECT 1
+      FROM "Profile" p
+      WHERE p."deviceIdentityId" = di.id
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM "DeviceIdentity" di_valid
+        JOIN "Profile" p_valid ON di_valid.id = p_valid."deviceIdentityId"
+      WHERE di_valid."userId" = di."userId"
+        AND (
+          (
+            di_valid."xmtpId" IS NULL
+            AND di."xmtpId" IS NULL
+          )
+          OR (di_valid."xmtpId" = di."xmtpId")
         )
-        AND EXISTS (
-            SELECT 1
-            FROM "DeviceIdentity" di_valid
-            JOIN "Profile" p_valid ON di_valid.id = p_valid."deviceIdentityId"
-            WHERE
-                di_valid."userId" = di."userId"
-                AND (
-                    (di_valid."xmtpId" IS NULL AND di."xmtpId" IS NULL) OR
-                    (di_valid."xmtpId" = di."xmtpId")
-                )
-        )
-);
-
--- Step 2: Now delete the DeviceIdentity records
--- (Your existing DELETE statement)
+    )
+),
+identities_on_device_deleted AS (
+  DELETE FROM "IdentitiesOnDevice"
+  WHERE "identityId" IN (
+      SELECT id
+      FROM device_identities_to_delete
+    )
+),
+profiles_deleted AS (
+  DELETE FROM "Profile"
+  WHERE "deviceIdentityId" IN (
+      SELECT id
+      FROM device_identities_to_delete
+    )
+),
+conversation_metadata_deleted AS (
+  DELETE FROM "ConversationMetadata"
+  WHERE "deviceIdentityId" IN (
+      SELECT id
+      FROM device_identities_to_delete
+    )
+)
 DELETE FROM "DeviceIdentity"
 WHERE id IN (
-    SELECT di.id
-    FROM "DeviceIdentity" di
-    WHERE
-        NOT EXISTS (
-            SELECT 1
-            FROM "Profile" p
-            WHERE p."deviceIdentityId" = di.id
-        )
-        AND EXISTS (
-            SELECT 1
-            FROM "DeviceIdentity" di_valid
-            JOIN "Profile" p_valid ON di_valid.id = p_valid."deviceIdentityId"
-            WHERE
-                di_valid."userId" = di."userId"
-                AND (
-                    (di_valid."xmtpId" IS NULL AND di."xmtpId" IS NULL) OR
-                    (di_valid."xmtpId" = di."xmtpId")
-                )
-        )
-);
-
+    SELECT id
+    FROM device_identities_to_delete
+  );
 /*
-  Warnings:
-
-  - A unique constraint covering the columns `[userId,xmtpId]` on the table `DeviceIdentity` will be added. If there are existing duplicate values, this will fail.
-
-*/
+ Warnings:
+ 
+ - A unique constraint covering the columns `[userId,xmtpId]` on the table `DeviceIdentity` will be added. If there are existing duplicate values, this will fail.
+ 
+ */
 -- CreateIndex
 CREATE UNIQUE INDEX "DeviceIdentity_userId_xmtpId_key" ON "DeviceIdentity"("userId", "xmtpId");


### PR DESCRIPTION
### Restructure SQL migration to handle dependent table deletions when enforcing unique DeviceIdentity constraints
The migration uses Common Table Expressions (CTEs) to organize the deletion of records from multiple dependent tables (`Profile`, `ConversationMetadata`, `IdentitiesOnDevice`, and `DeviceIdentity`) before creating a unique index on `DeviceIdentity(userId, xmtpId)`. The SQL in [migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/75/files#diff-835ae815156a2205146baa2b0df0a766e2ecff911d650ab34e5258736d47ad14) maintains the core logic for identifying records while improving the deletion process through sequential operations.

#### 📍Where to Start
Begin reviewing the CTE definitions in [migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/75/files#diff-835ae815156a2205146baa2b0df0a766e2ecff911d650ab34e5258736d47ad14) which identify the `DeviceIdentity` records to be deleted.

----

_[Macroscope](https://app.macroscope.com) summarized f270a67._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the process for deleting device identities that are no longer associated with any profiles, ensuring related data is properly cleaned up across multiple areas of the app. This enhances data integrity and prevents potential issues with orphaned records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->