### PR TITLE
fix: Register notification validate body

### DIFF
--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -12,7 +12,7 @@ const registrationSchema = z.object({
   deviceId: z.string(),
   pushToken: z.string(),
   expoToken: z.string(),
-  installations: z.array(installationItemSchema).default([]),
+  installations: z.array(installationItemSchema),
 });
 
 const registerInstallationResponseSchema = z.array(

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -153,7 +153,11 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ deviceId: testDeviceId }),
+        body: JSON.stringify({
+          deviceId: testDeviceId,
+          expoToken: "test-expo-token-register",
+          pushToken: "test-push-token-register",
+        }),
       },
     );
     expect(response.status).toBe(400);


### PR DESCRIPTION
### Make installations field required in notifications registration API validation schema to fix body validation
The validation schema in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/78/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) has been modified by removing the default empty array value for the `installations` field in `registrationSchema`. The corresponding test in [notifications.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/78/files#diff-d2f84d516070b396c376019371e3945fa101f01a38e0a7cb8d668e6ee5558e76) has been updated to include `expoToken` and `pushToken` fields while omitting the now-required `installations` field to validate the schema changes.

#### 📍Where to Start
Start with the `registrationSchema` definition in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/78/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) to understand the validation schema changes.

----

_[Macroscope](https://app.macroscope.com) summarized 77c7563._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for notification registration by requiring the `installations` field to be explicitly provided in requests.
- **Tests**
  - Updated tests to ensure requests missing the `installations` field are correctly rejected with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->