### PR TITLE
fix: Only delete specified device invalid installations

### DIFF
--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -12,6 +12,8 @@ const registrationSchema = z.object({
   deviceId: z.string(),
   pushToken: z.string(),
   expoToken: z.string(),
+  // List of installations to register
+  // We will also check for any other identities on device that don't have any of those installations and delete them
   installations: z.array(installationItemSchema),
 });
 
@@ -118,6 +120,7 @@ export async function registerInstallation(
         // Find all the identities on the device that are not in the new installations
         const staleIdentitiesOnDevice = await tx.identitiesOnDevice.findMany({
           where: {
+            deviceId: validatedData.deviceId,
             AND: [
               {
                 xmtpInstallationId: {


### PR DESCRIPTION
### Restrict device installation deletion to only remove invalid installations from the specified device in the `register-installation` handler
* Adds device ID filtering to the `staleIdentitiesOnDevice` query in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/79/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) to prevent deletion of installations from unrelated devices
* Adds documentation for the `installations` field in the `registrationSchema` object explaining the registration and deletion behavior

#### 📍Where to Start
Begin reviewing the changes in the `staleIdentitiesOnDevice` query within [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/79/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) where the `deviceId` field was added to the `where` clause.

----

_[Macroscope](https://app.macroscope.com) summarized a0e957b._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when removing stale identities on a device by ensuring only identities associated with the specified device are considered for removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->