### PR TITLE
fix: Add onCascade migration

### DIFF
--- a/prisma/migrations/20250520142935_add_on_cascade/migration.sql
+++ b/prisma/migrations/20250520142935_add_on_cascade/migration.sql
@@ -1,0 +1,35 @@
+-- DropForeignKey
+ALTER TABLE "ConversationMetadata" DROP CONSTRAINT "ConversationMetadata_deviceIdentityId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Device" DROP CONSTRAINT "Device_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DeviceIdentity" DROP CONSTRAINT "DeviceIdentity_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "IdentitiesOnDevice" DROP CONSTRAINT "IdentitiesOnDevice_deviceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "IdentitiesOnDevice" DROP CONSTRAINT "IdentitiesOnDevice_identityId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Profile" DROP CONSTRAINT "Profile_deviceIdentityId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Device" ADD CONSTRAINT "Device_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DeviceIdentity" ADD CONSTRAINT "DeviceIdentity_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IdentitiesOnDevice" ADD CONSTRAINT "IdentitiesOnDevice_deviceId_fkey" FOREIGN KEY ("deviceId") REFERENCES "Device"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IdentitiesOnDevice" ADD CONSTRAINT "IdentitiesOnDevice_identityId_fkey" FOREIGN KEY ("identityId") REFERENCES "DeviceIdentity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_deviceIdentityId_fkey" FOREIGN KEY ("deviceIdentityId") REFERENCES "DeviceIdentity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ConversationMetadata" ADD CONSTRAINT "ConversationMetadata_deviceIdentityId_fkey" FOREIGN KEY ("deviceIdentityId") REFERENCES "DeviceIdentity"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
### Add ON CASCADE behavior to foreign key constraints in database schema for automatic record management
Modifies existing foreign key constraints in the database schema by adding `ON DELETE CASCADE` and `ON UPDATE CASCADE` clauses in [20250520142935_add_on_cascade/migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/81/files#diff-b37119a32f27d10ac722f4ff97e20d5571f22d9909d5e792adccb8e9c191b657). The changes affect relationships between:

* `User` table relationships with `Device` and `DeviceIdentity` tables
* `Device` table relationships with `IdentitiesOnDevice` table
* `DeviceIdentity` table relationships with `IdentitiesOnDevice`, `Profile`, and `ConversationMetadata` tables

#### 📍Where to Start
Begin by reviewing the migration file [20250520142935_add_on_cascade/migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/81/files#diff-b37119a32f27d10ac722f4ff97e20d5571f22d9909d5e792adccb8e9c191b657) which contains the foreign key constraint modifications.

----

_[Macroscope](https://app.macroscope.com) summarized 2ad5898._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated database relationships to automatically remove or update related records when referenced entries are deleted or changed, improving data consistency and reducing manual cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->