### PR TITLE
fix: Remove not necessary deviceId on legacy notification registration

### DIFF
--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -18,7 +18,6 @@ const currentRegistrationSchema = z.object({
 });
 
 const legacyRegistrationSchema = z.object({
-  deviceId: z.string(),
   installationId: z.string(),
   deliveryMechanism: z.object({
     deliveryMechanismType: z.object({


### PR DESCRIPTION
### Remove `deviceId` field requirement from legacy notification registration schema to simplify installation registration
The `legacyRegistrationSchema` validation in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/82/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd) now only requires the `installationId` field, removing the previously mandatory `deviceId` field from the schema definition.

#### 📍Where to Start
Start with the schema changes in the `legacyRegistrationSchema` within [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/82/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd).

----

_[Macroscope](https://app.macroscope.com) summarized c902240._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the requirement for the `deviceId` field during legacy notification registration. Users registering legacy installations are no longer asked to provide a device ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->