### PR TITLE
feat: Add installationId to notification

### DIFF
--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -150,6 +150,7 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       encryptedMessage: notification.message.message,
       timestamp: notification.message.timestamp_ns,
       ethAddress: turnkeyAddress,
+      installationId: notification.installation.id,
     };
 
     const message: ExpoPushMessage = notification.subscription.is_silent

--- a/src/notifications/client.ts
+++ b/src/notifications/client.ts
@@ -1,13 +1,7 @@
-import { create } from "@bufbuild/protobuf";
 import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-node";
 import { type HmacKey } from "@xmtp/node-sdk";
-import {
-  Notifications,
-  Subscription_HmacKeySchema,
-  SubscriptionSchema,
-  type Subscription,
-} from "@/notifications/gen/notifications/v1/service_pb";
+import { Notifications } from "@/notifications/gen/notifications/v1/service_pb";
 
 export function createNotificationClient() {
   if (!process.env.NOTIFICATION_SERVER_URL) {
@@ -49,31 +43,3 @@ export type NotificationResponse = {
     is_silent: boolean;
   };
 };
-
-export async function subscribeToTopics(
-  // The installationId we want to apply the subscription to
-  installationId: string,
-  // A notifications server client, like the one generated above.
-  notificationClient: ReturnType<typeof createNotificationClient>,
-  topics: Topic[],
-) {
-  // convert topics to subscriptions
-  const subscriptions = topics.map(
-    (topic): Subscription =>
-      create(SubscriptionSchema, {
-        topic: topic.topic,
-        isSilent: false,
-        hmacKeys: topic.hmacKeys.map((v) =>
-          create(Subscription_HmacKeySchema, {
-            thirtyDayPeriodsSinceEpoch: Number(v.epoch),
-            key: Uint8Array.from(v.key),
-          }),
-        ),
-      }),
-  );
-
-  await notificationClient.subscribeWithMetadata({
-    installationId,
-    subscriptions,
-  });
-}


### PR DESCRIPTION
### Add installationId to notification data payload in XMTP notification handler and remove subscribeToTopics function from notification client
- Adds `installationId` field to `baseMessageData` object in XMTP notification handler, populated from `notification.installation.id` and included in push notifications sent to clients in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/83/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e)
- Removes `subscribeToTopics` function and related imports from notification client module in [client.ts](https://github.com/ephemeraHQ/convos-backend/pull/83/files#diff-5e63127ae8931e94ca574770a10a816072cfbd2e59a476e247d870161400f59c)

#### 📍Where to Start
Start with the XMTP notification handler in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/83/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e) where the `installationId` field is added to the notification payload.

----

_[Macroscope](https://app.macroscope.com) summarized be289ca._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an installation ID property to push notification messages for improved notification context.

- **Refactor**
  - Simplified notification client by removing the topic subscription helper and related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->