### PR TITLE
fix: Conflicts

### DIFF
--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -50,8 +50,6 @@ services:
     image: postgres:16
     environment:
       POSTGRES_PASSWORD: notifications
-    ports:
-      - 5433:5432
 
   notification_server:
     image: xmtp/notifications-server:latest


### PR DESCRIPTION
### Remove PostgreSQL port mapping from Docker Compose configuration to merge main to dev
Removes the port mapping configuration (5433:5432) for the PostgreSQL service in [dev/compose.yml](https://github.com/ephemeraHQ/convos-backend/pull/87/files#diff-179aaaa54e90c327e1f24333cdd54163b98fd92fdcdf94a383ae7a2e709748a9), eliminating direct host machine access to the PostgreSQL database on port 5433.

#### 📍Where to Start
Start with the PostgreSQL service configuration in [dev/compose.yml](https://github.com/ephemeraHQ/convos-backend/pull/87/files#diff-179aaaa54e90c327e1f24333cdd54163b98fd92fdcdf94a383ae7a2e709748a9).

----

_[Macroscope](https://app.macroscope.com) summarized 40e93f3._