### PR TITLE
feat: add Namestone Integration for Profile Management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,6 @@ TURNKEY_API_PRIVATE_KEY=
 TURNKEY_ORGANIZATION_ID=
 
 # Namestone
-NAMESTONE_API_BASE_URL="https://namestone.com/api/public_v1"
+NAMESTONE_BASE_URL="https://namestone.com/api/public_v1"
 NAMESTONE_API_KEY=
 NAMESTONE_DOMAIN=convosapp.eth|convos.org

--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,8 @@ TURNKEY_API_PRIVATE_KEY=
 
 # Turnkey Organization ID
 TURNKEY_ORGANIZATION_ID=
+
+# Namestone
+NAMESTONE_API_BASE_URL="https://namestone.com/api/public_v1"
+NAMESTONE_API_KEY=
+NAMESTONE_DOMAIN=convosapp.eth|convos.org

--- a/src/utils/namestone.ts
+++ b/src/utils/namestone.ts
@@ -28,13 +28,18 @@ class NamestoneService {
   constructor() {
     this.apiKey = process.env.NAMESTONE_API_KEY || "";
     this.domain = process.env.NAMESTONE_DOMAIN || "";
-    this.baseUrl = process.env.NAMESTONE_BASE_URL || "https://namestone.com/api/public_v1";
+    this.baseUrl =
+      process.env.NAMESTONE_BASE_URL || "https://namestone.com/api/public_v1";
 
     if (!this.apiKey) {
-      console.warn("NAMESTONE_API_KEY not configured - Namestone integration disabled");
+      console.warn(
+        "NAMESTONE_API_KEY not configured - Namestone integration disabled",
+      );
     }
     if (!this.domain) {
-      console.warn("NAMESTONE_DOMAIN not configured - Namestone integration disabled");
+      console.warn(
+        "NAMESTONE_DOMAIN not configured - Namestone integration disabled",
+      );
     }
   }
 
@@ -69,7 +74,7 @@ class NamestoneService {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": this.apiKey,
+          Authorization: this.apiKey,
         },
         body: JSON.stringify(requestBody),
       });
@@ -79,14 +84,15 @@ class NamestoneService {
         throw new Error(`HTTP ${response.status}: ${errorText}`);
       }
 
-      const result = await response.json();
+      const result = (await response.json()) as NamestoneResponse;
       return {
+        ...result,
         success: true,
         message: `Successfully set name ${args.username}.${this.domain}`,
-        ...result,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
       logError("Failed to set Namestone name", {
         username: args.username,
         domain: this.domain,
@@ -122,7 +128,7 @@ class NamestoneService {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": this.apiKey,
+          Authorization: this.apiKey,
         },
         body: JSON.stringify(requestBody),
       });
@@ -132,14 +138,15 @@ class NamestoneService {
         throw new Error(`HTTP ${response.status}: ${errorText}`);
       }
 
-      const result = await response.json();
+      const result = (await response.json()) as NamestoneResponse;
       return {
+        ...result,
         success: true,
         message: `Successfully deleted name ${args.username}.${this.domain}`,
-        ...result,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
       logError("Failed to delete Namestone name", {
         username: args.username,
         domain: this.domain,

--- a/src/utils/namestone.ts
+++ b/src/utils/namestone.ts
@@ -1,0 +1,158 @@
+import { logError } from "./errors";
+
+// Namestone API types
+export type NamestoneSetNameRequest = {
+  name: string;
+  domain: string;
+  address: string;
+  text_records?: Record<string, string>;
+  coin_types?: Record<string, string>;
+};
+
+export type NamestoneDeleteNameRequest = {
+  name: string;
+  domain: string;
+};
+
+export type NamestoneResponse = {
+  success: boolean;
+  message?: string;
+  error?: string;
+};
+
+class NamestoneService {
+  private readonly apiKey: string;
+  private readonly domain: string;
+  private readonly baseUrl: string;
+
+  constructor() {
+    this.apiKey = process.env.NAMESTONE_API_KEY || "";
+    this.domain = process.env.NAMESTONE_DOMAIN || "";
+    this.baseUrl = process.env.NAMESTONE_BASE_URL || "https://namestone.com/api/public_v1";
+
+    if (!this.apiKey) {
+      console.warn("NAMESTONE_API_KEY not configured - Namestone integration disabled");
+    }
+    if (!this.domain) {
+      console.warn("NAMESTONE_DOMAIN not configured - Namestone integration disabled");
+    }
+  }
+
+  private isEnabled(): boolean {
+    return !!(this.apiKey && this.domain);
+  }
+
+  /**
+   * Sets a name (subdomain) for a given address and domain
+   */
+  async setName(args: {
+    username: string;
+    address: string;
+    textRecords?: Record<string, string>;
+  }): Promise<NamestoneResponse> {
+    if (!this.isEnabled()) {
+      return {
+        success: false,
+        error: "Namestone service not configured",
+      };
+    }
+
+    try {
+      const requestBody: NamestoneSetNameRequest = {
+        name: args.username,
+        domain: this.domain,
+        address: args.address,
+        text_records: args.textRecords,
+      };
+
+      const response = await fetch(`${this.baseUrl}/set-name`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": this.apiKey,
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP ${response.status}: ${errorText}`);
+      }
+
+      const result = await response.json();
+      return {
+        success: true,
+        message: `Successfully set name ${args.username}.${this.domain}`,
+        ...result,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      logError("Failed to set Namestone name", {
+        username: args.username,
+        domain: this.domain,
+        address: args.address,
+        error: errorMessage,
+      });
+
+      return {
+        success: false,
+        error: `Failed to set name: ${errorMessage}`,
+      };
+    }
+  }
+
+  /**
+   * Deletes a name (subdomain) for a given domain
+   */
+  async deleteName(args: { username: string }): Promise<NamestoneResponse> {
+    if (!this.isEnabled()) {
+      return {
+        success: false,
+        error: "Namestone service not configured",
+      };
+    }
+
+    try {
+      const requestBody: NamestoneDeleteNameRequest = {
+        name: args.username,
+        domain: this.domain,
+      };
+
+      const response = await fetch(`${this.baseUrl}/delete-name`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": this.apiKey,
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP ${response.status}: ${errorText}`);
+      }
+
+      const result = await response.json();
+      return {
+        success: true,
+        message: `Successfully deleted name ${args.username}.${this.domain}`,
+        ...result,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      logError("Failed to delete Namestone name", {
+        username: args.username,
+        domain: this.domain,
+        error: errorMessage,
+      });
+
+      return {
+        success: false,
+        error: `Failed to delete name: ${errorMessage}`,
+      };
+    }
+  }
+}
+
+// Export singleton instance
+export const namestoneService = new NamestoneService();


### PR DESCRIPTION
Automatically registers and manages usernames with Namestone when users create or update their profiles.

## Changes
- **New**: `src/utils/namestone.ts` - Namestone service with `setName()` and `deleteName()` methods
- **Modified**: `src/api/v1/users/handlers/create-user.ts` - Auto-register username on profile creation
- **Modified**: `src/api/v1/profiles/handlers/update-profile.ts` - Handle username changes and metadata updates
- **Updated**: `.env.example` - Added Namestone config variables

## Configuration
```env
NAMESTONE_BASE_URL=
NAMESTONE_API_KEY=
NAMESTONE_DOMAIN=convosapp.eth | convos.org
```

## Behavior
- **Profile creation**: Registers username with Namestone (async, non-blocking)
- **Profile updates**: 
  - Username change → delete old name, set new name
  - Metadata change → update text records
- **Error handling**: Namestone failures are logged but don't block operations
- **Graceful degradation**: Works without Namestone configuration

All Namestone operations are asynchronous and won't affect user experience if they fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated Namestone service to automatically register and update usernames and related profile information with the Namestone API when users are created or profiles are updated.
- **Chores**
  - Updated environment variable examples to include new Namestone configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->