### PR TITLE
feat: auto-trigger prod deployment after dev-to-main sync

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -6,6 +6,9 @@ on:
       - main
       - dev
   pull_request:
+  repository_dispatch:
+    types: [deploy-main]
+
 permissions:
   contents: read
   packages: write
@@ -17,6 +20,8 @@ jobs:
       digest: ${{ steps.digest.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'repository_dispatch' && 'main' || github.ref }}
       - name: Log in to the container registry
         uses: docker/login-action@v3
         with:
@@ -66,7 +71,7 @@ jobs:
     name: Deploy new images to infra
     runs-on: ubuntu-latest
     needs: push_to_registry
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'repository_dispatch' && github.event.client_payload.ref == 'main')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -75,6 +75,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'repository_dispatch' && 'main' || github.ref }}
       - name: Deploy Testnet
         uses: xmtp-labs/terraform-deployer@v1
         timeout-minutes: 20

--- a/.github/workflows/sync-dev-to-main.yml
+++ b/.github/workflows/sync-dev-to-main.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write # Need write access to push to main
+  actions: write # Need to trigger repository dispatch events
 
 jobs:
   sync-branches:
@@ -66,6 +67,24 @@ jobs:
           echo "**Merge Details:**" >> $GITHUB_STEP_SUMMARY
           echo "- Merge commit: \`$(git log -1 --oneline)\`" >> $GITHUB_STEP_SUMMARY
           echo "- Triggered by: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger deployment workflow
+        if: steps.merge.outputs.success == 'true'
+        run: |
+          response=$(curl -s -w "%{http_code}" -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d '{"event_type":"deploy-main","client_payload":{"ref":"main","triggered_by":"sync-workflow"}}')
+
+          http_code=$(echo "$response" | tail -c 4)
+          if [ "$http_code" = "204" ]; then
+            echo "✅ Successfully triggered deployment workflow"
+          else
+            echo "❌ Failed to trigger deployment workflow (HTTP $http_code)"
+            echo "Response: $response"
+            exit 1
+          fi
 
       - name: Report merge failure
         if: steps.merge.outputs.success == 'false'

--- a/.github/workflows/sync-dev-to-main.yml
+++ b/.github/workflows/sync-dev-to-main.yml
@@ -71,18 +71,38 @@ jobs:
       - name: Trigger deployment workflow
         if: steps.merge.outputs.success == 'true'
         run: |
-          response=$(curl -s -w "%{http_code}" -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/dispatches \
-            -d '{"event_type":"deploy-main","client_payload":{"ref":"main","triggered_by":"sync-workflow"}}')
+          # Create temp files for response and status code
+          response_file=$(mktemp)
+          http_code_file=$(mktemp)
 
-          http_code=$(echo "$response" | tail -c 4)
-          if [ "$http_code" = "204" ]; then
-            echo "✅ Successfully triggered deployment workflow"
+          # Make API call with proper separation of response body and status code
+          if curl -sf -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -o "$response_file" \
+            -w "%{http_code}" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d '{"event_type":"deploy-main","client_payload":{"ref":"main","triggered_by":"sync-workflow"}}' \
+            > "$http_code_file" 2>/dev/null; then
+
+            http_code=$(cat "$http_code_file")
+            response=$(cat "$response_file")
+
+            # Clean up temp files
+            rm -f "$response_file" "$http_code_file"
+
+            if [ "$http_code" = "204" ]; then
+              echo "✅ Successfully triggered deployment workflow"
+            else
+              echo "❌ Unexpected HTTP status code: $http_code"
+              [ -n "$response" ] && echo "Response: $response"
+              exit 1
+            fi
           else
-            echo "❌ Failed to trigger deployment workflow (HTTP $http_code)"
-            echo "Response: $response"
+            # Clean up temp files on failure
+            rm -f "$response_file" "$http_code_file"
+            echo "❌ Failed to trigger deployment workflow - curl command failed"
+            echo "This could be due to network issues, authentication problems, or API errors"
             exit 1
           fi
 

--- a/.github/workflows/sync-dev-to-main.yml
+++ b/.github/workflows/sync-dev-to-main.yml
@@ -17,6 +17,16 @@ jobs:
           fetch-depth: 0 # Need full history for merge
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Validate branch
+        run: |
+          if [ "${{ github.ref_name }}" != "dev" ]; then
+            echo "❌ This workflow must be run from the 'dev' branch only"
+            echo "Current branch: ${{ github.ref_name }}"
+            echo "Expected branch: dev"
+            exit 1
+          fi
+          echo "✅ Running from correct branch: dev"
+
       - name: Configure Git
         run: |
           git config user.name "${{ github.actor }}"


### PR DESCRIPTION
This PR features:
- Only allow the `dev-to-main` workflow to run from `dev` branch
- Auto-trigger prod deployment after `dev-to-main` sync
  - Add repository dispatch to sync workflow
  - Handle dispatch events in deploy workflow
  - Add error handling and proper permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for triggering production deployments manually or externally via repository dispatch events.
  * Enhanced the workflow to automatically trigger a production deployment after merging changes from the development branch to the main branch.

* **Chores**
  * Improved workflow validation to ensure actions only run on the appropriate branches.
  * Expanded workflow permissions to support new deployment triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->