### PR TITLE
feat: add invite request system for join requests

### DIFF
--- a/src/api/v1/invites/handlers/get-invite-requests.ts
+++ b/src/api/v1/invites/handlers/get-invite-requests.ts
@@ -18,8 +18,8 @@ export interface InviteRequestItem {
     id: string;
     xmtpId: string;
     profile: {
-      name: string;
-      username: string;
+      name: string | null;
+      username: string | null;
       description: string | null;
       avatar: string | null;
     } | null;

--- a/src/api/v1/invites/handlers/get-invite-requests.ts
+++ b/src/api/v1/invites/handlers/get-invite-requests.ts
@@ -1,0 +1,138 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const querySchema = z.object({
+  status: z.enum(["PENDING", "ACCEPTED", "REJECTED"]).optional(),
+  groupId: z.string().optional(),
+});
+
+export type GetInviteRequestsQuery = z.infer<typeof querySchema>;
+
+export interface InviteRequestItem {
+  id: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  requester: {
+    id: string;
+    xmtpId: string;
+    profile: {
+      name: string;
+      username: string;
+      description: string | null;
+      avatar: string | null;
+    } | null;
+  };
+  inviteCode: {
+    id: string;
+    name: string | null;
+    description: string | null;
+    groupId: string;
+  };
+}
+
+export interface GetInviteRequestsResponse {
+  requests: InviteRequestItem[];
+  total: number;
+}
+
+export async function getInviteRequests(
+  req: Request<unknown, unknown, unknown, GetInviteRequestsQuery>,
+  res: Response,
+) {
+  try {
+    const query = await querySchema.parseAsync(req.query);
+    const { xmtpId } = req.app.locals;
+
+    // Find the authenticated user's identity
+    const identity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId },
+    });
+
+    if (!identity) {
+      res.status(404).json({
+        success: false,
+        message: "Identity not found",
+      });
+      return;
+    }
+
+    // Build the where clause for filtering
+    const whereClause = {
+      inviteCode: {
+        createdById: identity.id,
+        ...(query.groupId && { groupId: query.groupId }),
+      },
+      ...(query.status && { status: query.status }),
+    };
+
+    // Get the requests for invite codes created by this user
+    const requests = await prisma.inviteCodeRequest.findMany({
+      where: whereClause,
+      include: {
+        requester: {
+          include: {
+            profile: true,
+          },
+        },
+        inviteCode: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            groupId: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    const response: GetInviteRequestsResponse = {
+      requests: requests.map((request) => ({
+        id: request.id,
+        status: request.status,
+        createdAt: request.createdAt.toISOString(),
+        updatedAt: request.updatedAt.toISOString(),
+        requester: {
+          id: request.requester.id,
+          xmtpId: request.requester.xmtpId,
+          profile: request.requester.profile
+            ? {
+                name: request.requester.profile.name,
+                username: request.requester.profile.username,
+                description: request.requester.profile.description,
+                avatar: request.requester.profile.avatar,
+              }
+            : null,
+        },
+        inviteCode: {
+          id: request.inviteCode.id,
+          name: request.inviteCode.name,
+          description: request.inviteCode.description,
+          groupId: request.inviteCode.groupId,
+        },
+      })),
+      total: requests.length,
+    };
+
+    res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({
+        success: false,
+        message: "Invalid query parameters",
+        errors: error.errors,
+      });
+      return;
+    }
+
+    req.log.error({ error }, "Error fetching invite requests");
+    res.status(500).json({
+      success: false,
+      message: "Failed to fetch invite requests",
+    });
+  }
+}

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -114,9 +114,9 @@ export async function requestToJoin(
 
     // Log notification info (no actual notifications sent)
     logRequestNotification({
-      requesterName: requesterIdentity.profile?.name,
+      requesterName: requesterIdentity.profile?.name ?? undefined,
       requesterXmtpId: requesterIdentity.xmtpId,
-      inviteCreatorName: inviteCode.createdBy.profile?.name,
+      inviteCreatorName: inviteCode.createdBy.profile?.name ?? undefined,
       groupId: inviteCode.groupId,
     });
 

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -1,0 +1,165 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const requestToJoinSchema = z.object({
+  inviteId: z.string().min(1, "Invite ID is required"),
+});
+
+export type RequestToJoinRequestBody = z.infer<typeof requestToJoinSchema>;
+
+export type RequestToJoinResponse = {
+  id: string;
+  status: string;
+  inviteId: string;
+  createdAt: string;
+};
+
+export async function requestToJoin(
+  req: Request<unknown, unknown, RequestToJoinRequestBody>,
+  res: Response,
+) {
+  try {
+    const body = await requestToJoinSchema.parseAsync(req.body);
+    const { xmtpId } = req.app.locals;
+
+    // Find the requester's identity
+    const requesterIdentity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId },
+      include: { profile: true },
+    });
+
+    if (!requesterIdentity) {
+      res.status(404).json({
+        success: false,
+        message: "Identity not found",
+      });
+      return;
+    }
+
+    // Find the invite code
+    const inviteCode = await prisma.inviteCode.findUnique({
+      where: { id: body.inviteId },
+      include: {
+        createdBy: {
+          include: {
+            profile: true,
+          },
+        },
+      },
+    });
+
+    if (!inviteCode) {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
+      });
+      return;
+    }
+
+    // Check if invite is active
+    if (inviteCode.status !== "ACTIVE") {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
+      });
+      return;
+    }
+
+    // Check if invite is expired
+    if (inviteCode.expiresAt && inviteCode.expiresAt < new Date()) {
+      res.status(400).json({
+        success: false,
+        message: "Invite has expired",
+      });
+      return;
+    }
+
+    // Check if invite requires approval (if autoApprove is true, they should use a different endpoint)
+    if (inviteCode.autoApprove) {
+      res.status(400).json({
+        success: false,
+        message:
+          "This invite does not require approval. You can join directly.",
+      });
+      return;
+    }
+
+    // Check if user already has a pending/accepted request
+    const existingRequest = await prisma.inviteCodeRequest.findUnique({
+      where: {
+        inviteCodeId_requesterId: {
+          inviteCodeId: body.inviteId,
+          requesterId: requesterIdentity.id,
+        },
+      },
+    });
+
+    if (existingRequest) {
+      res.status(409).json({
+        success: false,
+        message: `You already have a ${existingRequest.status.toLowerCase()} request for this group`,
+      });
+      return;
+    }
+
+    // Create the request
+    const request = await prisma.inviteCodeRequest.create({
+      data: {
+        inviteCodeId: body.inviteId,
+        requesterId: requesterIdentity.id,
+        status: "PENDING",
+      },
+    });
+
+    // Log notification info (no actual notifications sent)
+    logRequestNotification({
+      requesterName: requesterIdentity.profile?.name,
+      requesterXmtpId: requesterIdentity.xmtpId,
+      inviteCreatorName: inviteCode.createdBy.profile?.name,
+      groupId: inviteCode.groupId,
+    });
+
+    const response: RequestToJoinResponse = {
+      id: request.id,
+      status: request.status,
+      inviteId: request.inviteCodeId,
+      createdAt: request.createdAt.toISOString(),
+    };
+
+    res.status(201).json(response);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({
+        success: false,
+        message: "Invalid request body",
+        errors: error.errors,
+      });
+      return;
+    }
+
+    req.log.error({ error }, "Error creating join request");
+    res.status(500).json({
+      success: false,
+      message: "Failed to create join request",
+    });
+  }
+}
+
+function logRequestNotification(args: {
+  requesterName?: string;
+  requesterXmtpId: string;
+  inviteCreatorName?: string;
+  groupId: string;
+}) {
+  const { requesterName, requesterXmtpId, inviteCreatorName, groupId } = args;
+
+  console.log("🔔 Join Request Created:");
+  console.log(
+    `   📧 Would notify invite creator (${inviteCreatorName || "Unknown"})`,
+  );
+  console.log(
+    `   👤 Request from: ${requesterName || "Unknown"} (${requesterXmtpId})`,
+  );
+  console.log(`   🎫 For group: ${groupId}`);
+}

--- a/src/api/v1/invites/invites.router.ts
+++ b/src/api/v1/invites/invites.router.ts
@@ -1,8 +1,12 @@
 import { Router } from "express";
 import { createInviteCode } from "./handlers/create-invite-code";
+import { getInviteRequests } from "./handlers/get-invite-requests";
+import { requestToJoin } from "./handlers/request-to-join";
 
 const invitesRouter = Router();
 
 invitesRouter.post("/", createInviteCode);
+invitesRouter.post("/request", requestToJoin);
+invitesRouter.get("/requests", getInviteRequests);
 
 export default invitesRouter;

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -1,0 +1,291 @@
+import type { Server } from "http";
+import { DeviceOS, InviteCodeRequestStatus } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import type {
+  RequestToJoinRequestBody,
+  RequestToJoinResponse,
+} from "@/api/v1/invites/handlers/request-to-join";
+import invitesRouter from "@/api/v1/invites/invites.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+
+// Mock authentication by setting the request locals
+app.use((req, _res, next) => {
+  req.app.locals.xmtpId = "test-xmtp-id-requester";
+  req.app.locals.xmtpInstallationId = "test-installation-id";
+  next();
+});
+
+app.use("/invites", invitesRouter);
+
+let server: Server;
+
+beforeAll(() => {
+  server = app.listen(3011);
+});
+
+afterAll(() => {
+  server.close();
+});
+
+beforeEach(async () => {
+  // Clean up the database before each test
+  await prisma.inviteCodeNotificationTarget.deleteMany();
+  await prisma.inviteCodeRequest.deleteMany();
+  await prisma.inviteCodeUse.deleteMany();
+  await prisma.inviteCode.deleteMany();
+  await prisma.profile.deleteMany();
+  await prisma.identitiesOnDevice.deleteMany();
+  await prisma.conversationMetadata.deleteMany();
+  await prisma.deviceIdentity.deleteMany();
+  await prisma.device.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+async function createTestUsers() {
+  // Create invite creator user
+  const creatorUser = await prisma.user.create({
+    data: {
+      turnkeyUserId: "test-creator-user",
+      devices: {
+        create: {
+          os: DeviceOS.ios,
+          name: "Test Creator Device",
+          expoToken: "ExponentPushToken[test-creator-token]",
+        },
+      },
+      DeviceIdentity: {
+        create: {
+          xmtpId: "test-creator-xmtp-id",
+          turnkeyAddress: "0x1234creator",
+          profile: {
+            create: {
+              name: "Test Creator",
+              username: "testcreator",
+              description: "Test creator user",
+            },
+          },
+        },
+      },
+    },
+  });
+
+  // Create requester user
+  const requesterUser = await prisma.user.create({
+    data: {
+      turnkeyUserId: "test-requester-user",
+      devices: {
+        create: {
+          os: DeviceOS.android,
+          name: "Test Requester Device",
+          expoToken: "ExponentPushToken[test-requester-token]",
+        },
+      },
+      DeviceIdentity: {
+        create: {
+          xmtpId: "test-xmtp-id-requester",
+          turnkeyAddress: "0x1234requester",
+          profile: {
+            create: {
+              name: "Test Requester",
+              username: "testrequester",
+              description: "Test requester user",
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return { creatorUser, requesterUser };
+}
+
+async function createTestInviteCode(args: { autoApprove?: boolean } = {}) {
+  await createTestUsers();
+
+  const creatorIdentity = await prisma.deviceIdentity.findFirst({
+    where: { xmtpId: "test-creator-xmtp-id" },
+  });
+
+  return await prisma.inviteCode.create({
+    data: {
+      groupId: "test-group-123",
+      name: "Test Group Invite",
+      autoApprove: args.autoApprove ?? false, // Default to requiring approval
+      createdById: creatorIdentity!.id,
+    },
+  });
+}
+
+interface ErrorResponse {
+  success: boolean;
+  message: string;
+}
+
+describe("/invites/request API", () => {
+  test("server is running", async () => {
+    const response = await fetch("http://localhost:3011/invites");
+    expect(response.status).toBeDefined();
+  });
+
+  test("POST /invites/request creates a new join request", async () => {
+    const inviteCode = await createTestInviteCode();
+
+    const requestBody: RequestToJoinRequestBody = {
+      inviteId: inviteCode.id,
+    };
+
+    const response = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(201);
+
+    const joinRequest = (await response.json()) as RequestToJoinResponse;
+    expect(joinRequest.id).toBeDefined();
+    expect(joinRequest.status).toBe("PENDING");
+    expect(joinRequest.inviteId).toBe(inviteCode.id);
+    expect(joinRequest.createdAt).toBeDefined();
+
+    // Verify the request was created in the database
+    const dbRequest = await prisma.inviteCodeRequest.findUnique({
+      where: { id: joinRequest.id },
+    });
+    expect(dbRequest).toBeTruthy();
+    expect(dbRequest?.status).toBe(InviteCodeRequestStatus.PENDING);
+  });
+
+  test("POST /invites/request rejects request for auto-approve invite", async () => {
+    const inviteCode = await createTestInviteCode({ autoApprove: true });
+
+    const requestBody: RequestToJoinRequestBody = {
+      inviteId: inviteCode.id,
+    };
+
+    const response = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(400);
+
+    const error = (await response.json()) as ErrorResponse;
+    expect(error.success).toBe(false);
+    expect(error.message).toContain("does not require approval");
+  });
+
+  test("POST /invites/request rejects duplicate request", async () => {
+    const inviteCode = await createTestInviteCode();
+    const requesterIdentity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId: "test-xmtp-id-requester" },
+    });
+
+    // Create an existing request
+    await prisma.inviteCodeRequest.create({
+      data: {
+        inviteCodeId: inviteCode.id,
+        requesterId: requesterIdentity!.id,
+        status: "PENDING",
+      },
+    });
+
+    const requestBody: RequestToJoinRequestBody = {
+      inviteId: inviteCode.id,
+    };
+
+    const response = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(409);
+
+    const error = (await response.json()) as ErrorResponse;
+    expect(error.success).toBe(false);
+    expect(error.message).toContain("already have a pending request");
+  });
+
+  test("POST /invites/request returns 404 for non-existent invite", async () => {
+    await createTestUsers();
+
+    const requestBody: RequestToJoinRequestBody = {
+      inviteId: "non-existent-invite-id",
+    };
+
+    const response = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(404);
+
+    const error = (await response.json()) as ErrorResponse;
+    expect(error.success).toBe(false);
+    expect(error.message).toBe("Invite not found");
+  });
+
+  test("POST /invites/request returns 404 for identity not found", async () => {
+    // Don't create the requester, so identity won't be found
+    const inviteCode = await createTestInviteCode();
+
+    // Override the mock authentication to use a non-existent xmtpId
+    const testApp = express();
+    testApp.use(pinoMiddleware);
+    testApp.use(jsonMiddleware);
+    testApp.use((req, _res, next) => {
+      req.app.locals.xmtpId = "non-existent-xmtp-id";
+      next();
+    });
+    testApp.use("/invites", invitesRouter);
+
+    const testServer = testApp.listen(3012);
+
+    try {
+      const requestBody: RequestToJoinRequestBody = {
+        inviteId: inviteCode.id,
+      };
+
+      const response = await fetch("http://localhost:3012/invites/request", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      expect(response.status).toBe(404);
+
+      const error = (await response.json()) as ErrorResponse;
+      expect(error.success).toBe(false);
+      expect(error.message).toBe("Identity not found");
+    } finally {
+      testServer.close();
+    }
+  });
+});


### PR DESCRIPTION
- Add POST /invites/request endpoint for requesting to join groups
- Add GET /invites/requests endpoint for inviters to view pending requests
- Remove Expo notification dependencies as requested
- Add comprehensive test coverage for request functionality
- Fix all linter issues and type safety warnings
- Support filtering requests by status and groupId
- Prevent duplicate requests and handle edge cases (expired, auto-approve, etc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to request to join a group via an invite code that requires approval.
  * Users can now view a list of their invite code requests, including detailed status and related information.
* **Bug Fixes**
  * Prevented duplicate join requests for the same invite and user.
  * Proper error messages are now shown for invalid, non-existent, or auto-approval invite codes.
* **Tests**
  * Introduced comprehensive tests covering join request creation, error handling, and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->