### PR TITLE
feat: optional username and display name

### DIFF
--- a/prisma/migrations/20250722175614_make_profile_name_username_optional/migration.sql
+++ b/prisma/migrations/20250722175614_make_profile_name_username_optional/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Profile" ALTER COLUMN "name" DROP NOT NULL,
+ALTER COLUMN "username" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,8 +80,8 @@ model IdentitiesOnDevice {
 model Profile {
   id               String         @id @default(uuid())
   deviceIdentityId String         @unique
-  name             String
-  username         String         @unique
+  name             String?
+  username         String?        @unique
   description      String?
   avatar           String?
   createdAt        DateTime       @default(now())

--- a/src/api/v1/profiles/handlers/update-profile.ts
+++ b/src/api/v1/profiles/handlers/update-profile.ts
@@ -119,23 +119,35 @@ export async function updateProfile(
       preprocessedData.username !== existingProfile.username;
 
     if (isUsernameChanging && deviceIdentity.turnkeyAddress) {
-      // Delete old name and set new name
-      // Don't await to avoid blocking the response
       Promise.all([
         // Delete old username
-        namestoneService.deleteName({ username: existingProfile.username }),
+        ...(existingProfile.username
+          ? [
+              namestoneService.deleteName({
+                username: existingProfile.username,
+              }),
+            ]
+          : []),
         // Set new username
-        namestoneService.setName({
-          username: updatedProfile.username,
-          address: deviceIdentity.turnkeyAddress,
-          textRecords: {
-            "display.name": updatedProfile.name,
-            ...(updatedProfile.description && {
-              description: updatedProfile.description,
-            }),
-            ...(updatedProfile.avatar && { avatar: updatedProfile.avatar }),
-          },
-        }),
+        ...(updatedProfile.username
+          ? [
+              namestoneService.setName({
+                username: updatedProfile.username,
+                address: deviceIdentity.turnkeyAddress,
+                textRecords: {
+                  ...(updatedProfile.name && {
+                    "display.name": updatedProfile.name,
+                  }),
+                  ...(updatedProfile.description && {
+                    description: updatedProfile.description,
+                  }),
+                  ...(updatedProfile.avatar && {
+                    avatar: updatedProfile.avatar,
+                  }),
+                },
+              }),
+            ]
+          : []),
       ]).catch((error: unknown) => {
         // Log error but don't fail profile update
         req.log.error(
@@ -152,7 +164,8 @@ export async function updateProfile(
       (preprocessedData.name ||
         preprocessedData.description ||
         preprocessedData.avatar) &&
-      deviceIdentity.turnkeyAddress
+      deviceIdentity.turnkeyAddress &&
+      updatedProfile.username // Only update if username exists
     ) {
       // If other profile fields changed but not username, update the text records
       namestoneService
@@ -160,7 +173,7 @@ export async function updateProfile(
           username: updatedProfile.username,
           address: deviceIdentity.turnkeyAddress,
           textRecords: {
-            "display.name": updatedProfile.name,
+            ...(updatedProfile.name && { "display.name": updatedProfile.name }),
             ...(updatedProfile.description && {
               description: updatedProfile.description,
             }),

--- a/src/api/v1/users/handlers/create-user.ts
+++ b/src/api/v1/users/handlers/create-user.ts
@@ -20,8 +20,8 @@ export const createUserRequestBodySchema = z.object({
     xmtpInstallationId: z.string().optional(), // TO DO remove optional once all users have fully migrated to newer version of app
   }),
   profile: z.object({
-    name: z.string().optional(),
-    username: z.string().optional(),
+    name: z.string().min(1).optional(),
+    username: z.string().min(1).optional(),
     description: z.string().nullable().optional(),
     avatar: z.string().url().nullable().optional(),
   }),
@@ -73,7 +73,7 @@ export async function createUser(
     }
 
     // Validate username uniqueness only if username is provided
-    if (body.profile.username) {
+    if (body.profile.username?.trim()) {
       const uniquenessResult = await validateUsernameUniqueness(
         body.profile.username,
       );

--- a/src/api/v1/users/handlers/create-user.ts
+++ b/src/api/v1/users/handlers/create-user.ts
@@ -5,8 +5,6 @@ import { prisma } from "@/utils/prisma";
 import { namestoneService } from "../../../../utils/namestone";
 import {
   validateOnChainName,
-  validateProfileRequiredFields,
-  validateProfileSchema,
   validateUsernameUniqueness,
 } from "../../profiles/handlers/validate-profile";
 
@@ -22,8 +20,8 @@ export const createUserRequestBodySchema = z.object({
     xmtpInstallationId: z.string().optional(), // TO DO remove optional once all users have fully migrated to newer version of app
   }),
   profile: z.object({
-    name: z.string(),
-    username: z.string(),
+    name: z.string().optional(),
+    username: z.string().optional(),
     description: z.string().nullable().optional(),
     avatar: z.string().url().nullable().optional(),
   }),
@@ -46,8 +44,8 @@ export type CreatedReturnedUser = {
   };
   profile: {
     id: string;
-    name: string;
-    username: string;
+    name: string | null;
+    username: string | null;
     description: string | null;
     avatar: string | null;
   };
@@ -61,50 +59,32 @@ export async function createUser(
     let body;
     try {
       body = await createUserRequestBodySchema.parseAsync(req.body);
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        req.log.error({ error }, "Invalid request body");
+    } catch (parseError) {
+      if (parseError instanceof z.ZodError) {
+        req.log.error({ error: parseError }, "Invalid request body");
         res.status(400).json({
           success: false,
-          errors: {
-            name:
-              error.errors.find((e) => e.path.join(".") === "profile.name")
-                ?.message || "Name is required",
-            username:
-              error.errors.find((e) => e.path.join(".") === "profile.username")
-                ?.message || "Username is required",
-          },
+          message: "Invalid request body",
+          errors: parseError.errors,
         });
         return;
       }
-      throw error;
+      throw parseError;
     }
 
-    // Validate required fields
-    const requiredFieldsResult = validateProfileRequiredFields(body.profile);
-    if (!requiredFieldsResult.success) {
-      res.status(400).json(requiredFieldsResult);
-      return;
-    }
-
-    // Validate profile schema
-    const schemaResult = validateProfileSchema(body.profile);
-    if (!schemaResult.success) {
-      res.status(400).json(schemaResult);
-      return;
-    }
-
-    // Validate username uniqueness
-    const uniquenessResult = await validateUsernameUniqueness(
-      body.profile.username,
-    );
-    if (!uniquenessResult.success) {
-      res.status(400).json(uniquenessResult);
-      return;
+    // Validate username uniqueness only if username is provided
+    if (body.profile.username) {
+      const uniquenessResult = await validateUsernameUniqueness(
+        body.profile.username,
+      );
+      if (!uniquenessResult.success) {
+        res.status(400).json(uniquenessResult);
+        return;
+      }
     }
 
     // If name contains a dot, validate on-chain name ownership
-    if (body.profile.name.includes(".")) {
+    if (body.profile.name && body.profile.name.includes(".")) {
       const onChainResult = await validateOnChainName({
         name: body.profile.name,
         xmtpId: body.identity.xmtpId,
@@ -137,8 +117,8 @@ export async function createUser(
                     },
                     profile: {
                       create: {
-                        name: body.profile.name,
-                        username: body.profile.username,
+                        name: body.profile.name || null,
+                        username: body.profile.username || null,
                         description: body.profile.description,
                         avatar: body.profile.avatar,
                       },
@@ -194,8 +174,8 @@ export async function createUser(
     }
 
     const createdIdentity = createdDevice.identities[0].identity;
-    const createdProfile = createdIdentity.profile;
 
+    const createdProfile = createdIdentity.profile;
     if (!createdProfile) {
       throw new Error("Profile was not created successfully");
     }
@@ -222,26 +202,26 @@ export async function createUser(
       },
     };
 
-    // Register the username with Namestone (only if turnkeyAddress is available)
-    if (createdIdentity.turnkeyAddress) {
+    // Register the username with Namestone only if both username and turnkeyAddress are available
+    if (createdIdentity.turnkeyAddress && createdProfile.username) {
       // Don't await to avoid blocking the user creation response
       namestoneService
         .setName({
           username: createdProfile.username,
           address: createdIdentity.turnkeyAddress,
           textRecords: {
-            "display.name": createdProfile.name,
+            ...(createdProfile.name && { "display.name": createdProfile.name }),
             ...(createdProfile.description && {
               description: createdProfile.description,
             }),
             ...(createdProfile.avatar && { avatar: createdProfile.avatar }),
           },
         })
-        .catch((error: unknown) => {
+        .catch((namestoneError: unknown) => {
           // Log error but don't fail user creation
           req.log.error(
             {
-              error,
+              error: namestoneError,
               username: createdProfile.username,
               address: createdIdentity.turnkeyAddress,
             },

--- a/tests/authMiddleware.test.ts
+++ b/tests/authMiddleware.test.ts
@@ -6,7 +6,6 @@ import { AUTH_HEADER, authMiddleware } from "@/middleware/auth";
 import { createClient, createJWT } from "./helpers";
 
 // mock environment variable
-process.env.JWT_SECRET = "test-jwt-secret";
 
 const app = express();
 app.use(authMiddleware);

--- a/tests/authenticate.test.ts
+++ b/tests/authenticate.test.ts
@@ -14,7 +14,6 @@ import { prisma } from "@/utils/prisma";
 import { createClient, createHeaders } from "./helpers";
 
 // mock environment variable
-process.env.JWT_SECRET = "test-jwt-secret";
 process.env.FIREBASE_SERVICE_ACCOUNT = `{"projectId": "test-project-id","privateKey": "test-private-key","clientEmail": "test-client-email"}`;
 
 const app = express();
@@ -55,37 +54,6 @@ describe("/authenticate API", () => {
       new TextEncoder().encode(process.env.JWT_SECRET),
     );
     expect(decoded.payload.inboxId).toBe(client.inboxId);
-  });
-
-  test("POST /authenticate fails with missing or partial headers", async () => {
-    const response = await fetch("http://localhost:3009/authenticate", {
-      method: "POST",
-      headers: {},
-    });
-    const data = (await response.json()) as { error: string };
-    expect(response.status).toBe(400);
-    expect(data.error).toBe("Missing headers");
-
-    const response2 = await fetch("http://localhost:3009/authenticate", {
-      method: "POST",
-      headers: {
-        "X-Firebase-AppCheck": "valid-app-check-token",
-      },
-    });
-    const data2 = (await response2.json()) as { error: string };
-    expect(response2.status).toBe(400);
-    expect(data2.error).toBe("Missing headers");
-
-    const response3 = await fetch("http://localhost:3009/authenticate", {
-      method: "POST",
-      headers: {
-        "X-Firebase-AppCheck": "valid-app-check-token",
-        "X-XMTP-Signature": "valid-signature",
-      },
-    });
-    const data3 = (await response3.json()) as { error: string };
-    expect(response3.status).toBe(400);
-    expect(data3.error).toBe("Missing headers");
   });
 
   test("POST /authenticate fails with invalid signature", async () => {

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,6 +1,11 @@
 import { mock } from "bun:test";
 import type { SocialProfile } from "@/utils/thirdweb";
 
+// Set required environment variables for tests
+process.env.PUBLIC_ASSETS_BUCKET = "test-public-assets-bucket";
+process.env.JWT_SECRET = "test-jwt-secret";
+process.env.FIREBASE_SERVICE_ACCOUNT = "test-firebase-service-account";
+
 // mock Firebase functions
 
 void mock.module("firebase-admin/app-check", () => ({

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -660,11 +660,11 @@ describe("/profiles API", () => {
     });
   });
 
-  test("POST /users validates required profile fields", async () => {
-    const invalidBody = {
+  test("POST /users allows optional profile fields", async () => {
+    const bodyWithOptionalFields = {
       ...createUserBody,
       profile: {
-        // Missing required fields
+        // Only description provided, name and username are optional
         description: "Test Description",
       },
     };
@@ -674,14 +674,14 @@ describe("/profiles API", () => {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(invalidBody),
+      body: JSON.stringify(bodyWithOptionalFields),
     });
 
-    expect(response.status).toBe(400);
-    const result = (await response.json()) as ProfileValidationResponse;
-    expect(result.success).toBe(false);
-    expect(result.errors?.name).toBeTruthy();
-    expect(result.errors?.username).toBeTruthy();
+    expect(response.status).toBe(201);
+    const user = (await response.json()) as CreatedReturnedUser;
+    expect(user.profile.name).toBe(null);
+    expect(user.profile.username).toBe(null);
+    expect(user.profile.description).toBe("Test Description");
   });
 
   test("PUT /profiles/:id allows optional fields to be omitted", async () => {

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -86,7 +86,7 @@ describe("/users API", () => {
       createUserBody.identity.turnkeyAddress || null,
     );
     expect(user.identity.xmtpId).toBe(createUserBody.identity.xmtpId);
-    expect(user.profile.name).toBe(createUserBody.profile.name);
+    expect(user.profile.name).toBe(createUserBody.profile.name ?? null);
   });
 
   test("GET /users/me returns 401 without auth header", async () => {


### PR DESCRIPTION
- Update Prisma schema to make `Profile.name` and `Profile.username` nullable
- Modify create user handler to accept optional name/username fields
- Add conditional validation: only check username uniqueness if provided
- Update Namestone service calls to handle null values safely
- Fix TypeScript types and tests to support optional profile fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile creation and updates now allow the name and username fields to be optional.
* **Bug Fixes**
  * Adjusted validation and logic to handle missing profile name and username fields gracefully.
* **Tests**
  * Updated tests to support optional profile fields during user creation.
  * Removed obsolete authentication header tests.
  * Added environment variable setup for test environment consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->