### PR TITLE
feat: make public assets S3 bucket env variable optional

### DIFF
--- a/src/api/v1/attachments.ts
+++ b/src/api/v1/attachments.ts
@@ -4,6 +4,7 @@ import { Router, type Request, type Response } from "express";
 import mime from "mime-types";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
+import { AppError } from "@/utils/errors";
 
 const envSchema = z.object({
   PUBLIC_ASSETS_BUCKET: z.string().min(1).optional(),
@@ -21,7 +22,7 @@ const s3Client = env.PUBLIC_ASSETS_BUCKET ? new S3Client({}) : null;
 
 const getPresignedURL = async (contentType?: string) => {
   if (!env.PUBLIC_ASSETS_BUCKET || !s3Client) {
-    throw new Error("File uploads not available - S3 not configured");
+    throw new AppError(503, "File uploads not available - S3 not configured");
   }
 
   const objectKey = uuidv4();

--- a/src/api/v1/attachments.ts
+++ b/src/api/v1/attachments.ts
@@ -6,8 +6,8 @@ import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
 const envSchema = z.object({
-  PUBLIC_ASSETS_BUCKET: z.string().min(1),
-  AWS_REGION: z.string().optional(), // Optional - can be inferred from AWS environment
+  PUBLIC_ASSETS_BUCKET: z.string().min(1).optional(),
+  AWS_REGION: z.string().optional(), // Inferred from AWS environment
 });
 
 // Validate environment variables at startup
@@ -15,11 +15,15 @@ const env = envSchema.parse({
   PUBLIC_ASSETS_BUCKET: process.env.PUBLIC_ASSETS_BUCKET,
 });
 
-// Create S3 client once at startup
+// Create S3 client only if bucket is configured
 // No credentials needed - will use IAM role automatically
-const s3Client = new S3Client({});
+const s3Client = env.PUBLIC_ASSETS_BUCKET ? new S3Client({}) : null;
 
 const getPresignedURL = async (contentType?: string) => {
+  if (!env.PUBLIC_ASSETS_BUCKET || !s3Client) {
+    throw new Error("File uploads not available - S3 not configured");
+  }
+
   const objectKey = uuidv4();
   let extension: string | undefined;
   if (contentType && mime.extension(contentType)) {


### PR DESCRIPTION
### Make PUBLIC_ASSETS_BUCKET environment variable optional in attachment handling configuration
The environment schema validation for `PUBLIC_ASSETS_BUCKET` is modified to be optional, and the S3 client initialization becomes conditional based on the presence of this configuration. The `getPresignedURL` function adds error handling to check for S3 availability before attempting to generate presigned URLs, throwing an error when S3 is not configured in [attachments.ts](https://github.com/ephemeraHQ/convos-backend/pull/110/files#diff-0f13891ce77a56429b566f80cf70e253186a2c1e29eb4527bd658ba739d703da).

#### 📍Where to Start
Start with the environment schema validation changes and S3 client initialization logic in [attachments.ts](https://github.com/ephemeraHQ/convos-backend/pull/110/files#diff-0f13891ce77a56429b566f80cf70e253186a2c1e29eb4527bd658ba739d703da).

----

_[Macroscope](https://app.macroscope.com) summarized 338b81c._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when generating presigned URLs by ensuring S3 configuration is validated before proceeding.
  * Prevented attempts to generate presigned URLs if required S3 settings are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->