### PR TITLE
Nmalzieu/invites push

### DIFF
--- a/prisma/migrations/20250808131506_remove_invite_code_request_status/migration.sql
+++ b/prisma/migrations/20250808131506_remove_invite_code_request_status/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `status` on the `InviteCodeRequest` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "InviteCodeRequest_status_idx";
+
+-- AlterTable
+ALTER TABLE "InviteCodeRequest" DROP COLUMN "status";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -212,17 +212,15 @@ model InviteCodeNotificationTarget {
 }
 
 model InviteCodeRequest {
-  id           String                  @id @default(cuid())
+  id           String         @id @default(cuid())
   inviteCodeId String
-  inviteCode   InviteCode              @relation(fields: [inviteCodeId], references: [id], onDelete: Cascade)
+  inviteCode   InviteCode     @relation(fields: [inviteCodeId], references: [id], onDelete: Cascade)
   requesterId  String
-  requester    DeviceIdentity          @relation(fields: [requesterId], references: [id], onDelete: Cascade)
-  status       InviteCodeRequestStatus @default(PENDING)
-  createdAt    DateTime                @default(now())
-  updatedAt    DateTime                @updatedAt
+  requester    DeviceIdentity @relation(fields: [requesterId], references: [id], onDelete: Cascade)
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
 
   @@unique([inviteCodeId, requesterId])
   @@index([inviteCodeId])
   @@index([requesterId])
-  @@index([status])
 }

--- a/src/api/v1/invites/handlers/delete-invite.ts
+++ b/src/api/v1/invites/handlers/delete-invite.ts
@@ -1,0 +1,80 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const deleteInviteParamsSchema = z.object({
+  inviteId: z.string().min(1, "Invite ID is required"),
+});
+
+export type DeleteInviteParams = z.infer<typeof deleteInviteParamsSchema>;
+
+export type DeleteInviteResponse = {
+  id: string;
+  deleted: boolean;
+};
+
+export async function deleteInvite(req: Request, res: Response) {
+  try {
+    const params = await deleteInviteParamsSchema.parseAsync(req.params);
+
+    const { xmtpId } = req.app.locals;
+
+    // Find the authenticated user's identity
+    const identity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId },
+    });
+
+    if (!identity) {
+      res.status(404).json({
+        success: false,
+        message: "Identity not found",
+      });
+      return;
+    }
+
+    // Fetch the invite to ensure it exists and is owned by the user
+    const invite = await prisma.inviteCode.findUnique({
+      where: { id: params.inviteId },
+    });
+
+    if (!invite) {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
+      });
+      return;
+    }
+
+    if (invite.createdById !== identity.id) {
+      res.status(403).json({
+        success: false,
+        message: "Not authorized to delete this invite",
+      });
+      return;
+    }
+
+    await prisma.inviteCode.delete({ where: { id: params.inviteId } });
+
+    const response: DeleteInviteResponse = {
+      id: params.inviteId,
+      deleted: true,
+    };
+
+    res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({
+        success: false,
+        message: "Invalid invite ID",
+        errors: error.errors,
+      });
+      return;
+    }
+
+    req.log.error({ error }, "Error deleting invite");
+    res.status(500).json({
+      success: false,
+      message: "Failed to delete invite",
+    });
+  }
+}

--- a/src/api/v1/invites/handlers/delete-request-to-join.ts
+++ b/src/api/v1/invites/handlers/delete-request-to-join.ts
@@ -20,13 +20,12 @@ export async function deleteRequestToJoin(req: Request, res: Response) {
     const params = await deleteRequestToJoinParams.parseAsync(req.params);
     const { xmtpId } = req.app.locals;
 
-    // Find the requester's identity
-    const requesterIdentity = await prisma.deviceIdentity.findFirst({
+    // Find the authenticated user's identity (by xmtpId)
+    const authenticatedIdentity = await prisma.deviceIdentity.findFirst({
       where: { xmtpId },
-      include: { profile: true },
     });
 
-    if (!requesterIdentity) {
+    if (!authenticatedIdentity) {
       res.status(404).json({
         success: false,
         message: "Identity not found",
@@ -34,14 +33,41 @@ export async function deleteRequestToJoin(req: Request, res: Response) {
       return;
     }
 
-    // Find the request to join with this request id / xmtp id
+    // Load the join request with related entities to check authorization
     const requestToJoin = await prisma.inviteCodeRequest.findUnique({
-      where: { id: params.requestId, requester: { xmtpId } },
+      where: { id: params.requestId },
       include: {
         requester: true,
+        inviteCode: {
+          include: {
+            createdBy: true,
+            notificationTargets: {
+              include: {
+                deviceIdentity: true,
+              },
+            },
+          },
+        },
       },
     });
     if (!requestToJoin) {
+      res.status(404).json({
+        success: false,
+        message: "Request to join not found",
+      });
+      return;
+    }
+
+    // Authorization: requester OR invite creator OR any notification target can delete
+    const isRequester = requestToJoin.requester.xmtpId === xmtpId;
+    const isCreator = requestToJoin.inviteCode.createdBy.xmtpId === xmtpId;
+    const isNotificationTarget =
+      requestToJoin.inviteCode.notificationTargets.some(
+        (target) => target.deviceIdentity.xmtpId === xmtpId,
+      );
+
+    if (!isRequester && !isCreator && !isNotificationTarget) {
+      // Conceal existence if unauthorized
       res.status(404).json({
         success: false,
         message: "Request to join not found",
@@ -61,7 +87,7 @@ export async function deleteRequestToJoin(req: Request, res: Response) {
     if (error instanceof z.ZodError) {
       res.status(400).json({
         success: false,
-        message: "Invalid request body",
+        message: "Invalid request params",
         errors: error.errors,
       });
       return;

--- a/src/api/v1/invites/handlers/delete-request-to-join.ts
+++ b/src/api/v1/invites/handlers/delete-request-to-join.ts
@@ -1,0 +1,76 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const deleteRequestToJoinParams = z.object({
+  requestId: z.string().min(1, "Request ID is required"),
+});
+
+export type DeleteRequestToJoinRequestParams = z.infer<
+  typeof deleteRequestToJoinParams
+>;
+
+export type DeleteRequestToJoinResponse = {
+  id: string;
+  deleted: boolean;
+};
+
+export async function deleteRequestToJoin(req: Request, res: Response) {
+  try {
+    const params = await deleteRequestToJoinParams.parseAsync(req.params);
+    const { xmtpId } = req.app.locals;
+
+    // Find the requester's identity
+    const requesterIdentity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId },
+      include: { profile: true },
+    });
+
+    if (!requesterIdentity) {
+      res.status(404).json({
+        success: false,
+        message: "Identity not found",
+      });
+      return;
+    }
+
+    // Find the request to join with this request id / xmtp id
+    const requestToJoin = await prisma.inviteCodeRequest.findUnique({
+      where: { id: params.requestId, requester: { xmtpId } },
+      include: {
+        requester: true,
+      },
+    });
+    if (!requestToJoin) {
+      res.status(404).json({
+        success: false,
+        message: "Request to join not found",
+      });
+      return;
+    }
+
+    await prisma.inviteCodeRequest.delete({ where: { id: params.requestId } });
+
+    const response: DeleteRequestToJoinResponse = {
+      id: params.requestId,
+      deleted: true,
+    };
+
+    res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({
+        success: false,
+        message: "Invalid request body",
+        errors: error.errors,
+      });
+      return;
+    }
+
+    req.log.error({ error }, "Error deleting join request");
+    res.status(500).json({
+      success: false,
+      message: "Failed to delete join request",
+    });
+  }
+}

--- a/src/api/v1/invites/handlers/get-invite-requests.ts
+++ b/src/api/v1/invites/handlers/get-invite-requests.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { prisma } from "@/utils/prisma";
 
 const querySchema = z.object({
-  status: z.enum(["PENDING", "ACCEPTED", "REJECTED"]).optional(),
   groupId: z.string().optional(),
 });
 
@@ -11,7 +10,6 @@ export type GetInviteRequestsQuery = z.infer<typeof querySchema>;
 
 export interface InviteRequestItem {
   id: string;
-  status: string;
   createdAt: string;
   updatedAt: string;
   requester: {
@@ -64,7 +62,6 @@ export async function getInviteRequests(
         createdById: identity.id,
         ...(query.groupId && { groupId: query.groupId }),
       },
-      ...(query.status && { status: query.status }),
     };
 
     // Get the requests for invite codes created by this user
@@ -93,7 +90,6 @@ export async function getInviteRequests(
     const response: GetInviteRequestsResponse = {
       requests: requests.map((request) => ({
         id: request.id,
-        status: request.status,
         createdAt: request.createdAt.toISOString(),
         updatedAt: request.updatedAt.toISOString(),
         requester: {

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -137,30 +137,30 @@ export async function requestToJoin(
       },
     });
 
-    const payload: InviteRequestNotificationPayload = {
-      id: requestToJoin.id,
-      createdAt: requestToJoin.createdAt.toISOString(),
-      updatedAt: requestToJoin.updatedAt.toISOString(),
-      requester: {
-        id: requestToJoin.requester.id,
-        xmtpId: requestToJoin.requester.xmtpId,
-        profile: requestToJoin.requester.profile
-          ? {
-              name: requestToJoin.requester.profile.name,
-              username: requestToJoin.requester.profile.username,
-              description: requestToJoin.requester.profile.description,
-              avatar: requestToJoin.requester.profile.avatar,
-            }
-          : null,
-      },
-      inviteCode: {
-        id: requestToJoin.inviteCode.id,
-        name: requestToJoin.inviteCode.name,
-        description: requestToJoin.inviteCode.description,
-        groupId: requestToJoin.inviteCode.groupId,
-      },
-      autoApprove: requestToJoin.inviteCode.autoApprove,
-    };
+    // const payload: InviteRequestNotificationPayload = {
+    //   id: requestToJoin.id,
+    //   createdAt: requestToJoin.createdAt.toISOString(),
+    //   updatedAt: requestToJoin.updatedAt.toISOString(),
+    //   requester: {
+    //     id: requestToJoin.requester.id,
+    //     xmtpId: requestToJoin.requester.xmtpId,
+    //     profile: requestToJoin.requester.profile
+    //       ? {
+    //           name: requestToJoin.requester.profile.name,
+    //           username: requestToJoin.requester.profile.username,
+    //           description: requestToJoin.requester.profile.description,
+    //           avatar: requestToJoin.requester.profile.avatar,
+    //         }
+    //       : null,
+    //   },
+    //   inviteCode: {
+    //     id: requestToJoin.inviteCode.id,
+    //     name: requestToJoin.inviteCode.name,
+    //     description: requestToJoin.inviteCode.description,
+    //     groupId: requestToJoin.inviteCode.groupId,
+    //   },
+    //   autoApprove: requestToJoin.inviteCode.autoApprove,
+    // };
 
     // @todo We will send the actual notification here using APNS
 

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -1,3 +1,7 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
@@ -36,6 +40,87 @@ export type InviteRequestNotificationPayload = {
   };
   autoApprove: boolean;
 };
+
+type Logger = {
+  info: (data: unknown, message?: string) => void;
+  warn: (data: unknown, message?: string) => void;
+  error: (data: unknown, message?: string) => void;
+};
+
+async function sendInviteRequestNotification(args: {
+  payload: InviteRequestNotificationPayload;
+  logger: Logger;
+}) {
+  const { payload, logger } = args;
+
+  // Only attempt local simulator push when on macOS and required env vars are set
+  const simId = process.env.IOS_SIMULATOR_ID;
+  const bundleId = process.env.IOS_BUNDLE_ID;
+
+  if (process.platform !== "darwin" || !simId || !bundleId) {
+    logger.info(
+      { configured: Boolean(simId && bundleId), platform: process.platform },
+      "Skipping simulator push (not configured or not macOS)",
+    );
+    return;
+  }
+
+  // Construct a simple APNS payload expected by simctl
+  const title = `${payload.requester.profile?.name || payload.requester.xmtpId} requested to join`;
+  const body = payload.inviteCode.name
+    ? `Group: ${payload.inviteCode.name}`
+    : `Group ID: ${payload.inviteCode.groupId}`;
+
+  const apnsPayload = {
+    aps: {
+      alert: {
+        title,
+        body,
+      },
+      sound: "default",
+      "mutable-content": 1,
+    },
+    type: "invite_request",
+    invite: payload,
+  };
+
+  // Write payload to a temporary file
+  const tmpBase = await mkdtemp(join(tmpdir(), "convos-invite-"));
+  const payloadPath = join(tmpBase, `invite-${payload.id}.apns.json`);
+  console.log({ payloadPath });
+  await writeFile(payloadPath, JSON.stringify(apnsPayload, null, 2), "utf8");
+
+  try {
+    const { stdout, stderr, exitCode } = await new Promise<{
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    }>((resolve) => {
+      execFile(
+        "xcrun",
+        ["simctl", "push", simId, bundleId, payloadPath],
+        (error, stdout, stderr) => {
+          resolve({
+            stdout: String(stdout),
+            stderr: String(stderr),
+            exitCode: error ? 1 : 0,
+          });
+        },
+      );
+    });
+
+    if (exitCode === 0) {
+      logger.info({ stdout }, "Simulator push succeeded");
+    } else {
+      logger.warn({ stderr }, "Simulator push failed");
+    }
+  } catch (error) {
+    logger.error({ error }, "Error running simctl push");
+  } finally {
+    // Best-effort cleanup
+    await rm(tmpBase, { recursive: true, force: true }).catch(() => {});
+  }
+}
 
 export async function requestToJoin(
   req: Request<unknown, unknown, RequestToJoinRequestBody>,
@@ -162,7 +247,7 @@ export async function requestToJoin(
       autoApprove: requestToJoin.inviteCode.autoApprove,
     };
 
-    logRequestNotification({ payload });
+    sendInviteRequestNotification({ payload, logger: req.log });
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,
@@ -189,10 +274,3 @@ export async function requestToJoin(
   }
 }
 
-function logRequestNotification(args: {
-  payload: InviteRequestNotificationPayload;
-}) {
-  const { payload } = args;
-  // Structured log for future integration with notifications pipeline
-  console.log("invite.request.created", JSON.stringify(payload));
-}

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -10,14 +10,12 @@ export type RequestToJoinRequestBody = z.infer<typeof requestToJoinSchema>;
 
 export type RequestToJoinResponse = {
   id: string;
-  status: string;
   inviteId: string;
   createdAt: string;
 };
 
 export type InviteRequestNotificationPayload = {
   id: string;
-  status: string;
   createdAt: string;
   updatedAt: string;
   requester: {
@@ -112,7 +110,7 @@ export async function requestToJoin(
     if (existingRequest) {
       res.status(409).json({
         success: false,
-        message: `You already have a ${existingRequest.status.toLowerCase()} request for this group`,
+        message: `You already have a request for this group`,
       });
       return;
     }
@@ -122,7 +120,6 @@ export async function requestToJoin(
       data: {
         inviteCodeId: body.inviteId,
         requesterId: requesterIdentity.id,
-        status: "PENDING",
       },
       include: {
         requester: {
@@ -142,7 +139,6 @@ export async function requestToJoin(
 
     const payload: InviteRequestNotificationPayload = {
       id: requestToJoin.id,
-      status: requestToJoin.status,
       createdAt: requestToJoin.createdAt.toISOString(),
       updatedAt: requestToJoin.updatedAt.toISOString(),
       requester: {
@@ -170,7 +166,6 @@ export async function requestToJoin(
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,
-      status: requestToJoin.status,
       inviteId: requestToJoin.inviteCodeId,
       createdAt: requestToJoin.createdAt.toISOString(),
     };

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -1,7 +1,3 @@
-import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
@@ -40,87 +36,6 @@ export type InviteRequestNotificationPayload = {
   };
   autoApprove: boolean;
 };
-
-type Logger = {
-  info: (data: unknown, message?: string) => void;
-  warn: (data: unknown, message?: string) => void;
-  error: (data: unknown, message?: string) => void;
-};
-
-async function sendInviteRequestNotification(args: {
-  payload: InviteRequestNotificationPayload;
-  logger: Logger;
-}) {
-  const { payload, logger } = args;
-
-  // Only attempt local simulator push when on macOS and required env vars are set
-  const simId = process.env.IOS_SIMULATOR_ID;
-  const bundleId = process.env.IOS_BUNDLE_ID;
-
-  if (process.platform !== "darwin" || !simId || !bundleId) {
-    logger.info(
-      { configured: Boolean(simId && bundleId), platform: process.platform },
-      "Skipping simulator push (not configured or not macOS)",
-    );
-    return;
-  }
-
-  // Construct a simple APNS payload expected by simctl
-  const title = `${payload.requester.profile?.name || payload.requester.xmtpId} requested to join`;
-  const body = payload.inviteCode.name
-    ? `Group: ${payload.inviteCode.name}`
-    : `Group ID: ${payload.inviteCode.groupId}`;
-
-  const apnsPayload = {
-    aps: {
-      alert: {
-        title,
-        body,
-      },
-      sound: "default",
-      "mutable-content": 1,
-    },
-    type: "invite_request",
-    invite: payload,
-  };
-
-  // Write payload to a temporary file
-  const tmpBase = await mkdtemp(join(tmpdir(), "convos-invite-"));
-  const payloadPath = join(tmpBase, `invite-${payload.id}.apns.json`);
-  console.log({ payloadPath });
-  await writeFile(payloadPath, JSON.stringify(apnsPayload, null, 2), "utf8");
-
-  try {
-    const { stdout, stderr, exitCode } = await new Promise<{
-      stdout: string;
-      stderr: string;
-      exitCode: number;
-    }>((resolve) => {
-      execFile(
-        "xcrun",
-        ["simctl", "push", simId, bundleId, payloadPath],
-        (error, stdout, stderr) => {
-          resolve({
-            stdout: String(stdout),
-            stderr: String(stderr),
-            exitCode: error ? 1 : 0,
-          });
-        },
-      );
-    });
-
-    if (exitCode === 0) {
-      logger.info({ stdout }, "Simulator push succeeded");
-    } else {
-      logger.warn({ stderr }, "Simulator push failed");
-    }
-  } catch (error) {
-    logger.error({ error }, "Error running simctl push");
-  } finally {
-    // Best-effort cleanup
-    await rm(tmpBase, { recursive: true, force: true }).catch(() => {});
-  }
-}
 
 export async function requestToJoin(
   req: Request<unknown, unknown, RequestToJoinRequestBody>,
@@ -247,7 +162,7 @@ export async function requestToJoin(
       autoApprove: requestToJoin.inviteCode.autoApprove,
     };
 
-    sendInviteRequestNotification({ payload, logger: req.log });
+    // @todo We will send the actual notification here using APNS
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,
@@ -273,4 +188,3 @@ export async function requestToJoin(
     });
   }
 }
-

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -15,6 +15,30 @@ export type RequestToJoinResponse = {
   createdAt: string;
 };
 
+export type InviteRequestNotificationPayload = {
+  id: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  requester: {
+    id: string;
+    xmtpId: string;
+    profile: {
+      name: string | null;
+      username: string | null;
+      description: string | null;
+      avatar: string | null;
+    } | null;
+  };
+  inviteCode: {
+    id: string;
+    name: string | null;
+    description: string | null;
+    groupId: string;
+  };
+  autoApprove: boolean;
+};
+
 export async function requestToJoin(
   req: Request<unknown, unknown, RequestToJoinRequestBody>,
   res: Response,
@@ -75,16 +99,6 @@ export async function requestToJoin(
       return;
     }
 
-    // Check if invite requires approval (if autoApprove is true, they should use a different endpoint)
-    if (inviteCode.autoApprove) {
-      res.status(400).json({
-        success: false,
-        message:
-          "This invite does not require approval. You can join directly.",
-      });
-      return;
-    }
-
     // Check if user already has a pending/accepted request
     const existingRequest = await prisma.inviteCodeRequest.findUnique({
       where: {
@@ -103,28 +117,62 @@ export async function requestToJoin(
       return;
     }
 
-    // Create the request
-    const request = await prisma.inviteCodeRequest.create({
+    // Create the request and return populated relations
+    const requestToJoin = await prisma.inviteCodeRequest.create({
       data: {
         inviteCodeId: body.inviteId,
         requesterId: requesterIdentity.id,
         status: "PENDING",
       },
+      include: {
+        requester: {
+          include: { profile: true },
+        },
+        inviteCode: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            groupId: true,
+            autoApprove: true,
+          },
+        },
+      },
     });
 
-    // Log notification info (no actual notifications sent)
-    logRequestNotification({
-      requesterName: requesterIdentity.profile?.name ?? undefined,
-      requesterXmtpId: requesterIdentity.xmtpId,
-      inviteCreatorName: inviteCode.createdBy.profile?.name ?? undefined,
-      groupId: inviteCode.groupId,
-    });
+    const payload: InviteRequestNotificationPayload = {
+      id: requestToJoin.id,
+      status: requestToJoin.status,
+      createdAt: requestToJoin.createdAt.toISOString(),
+      updatedAt: requestToJoin.updatedAt.toISOString(),
+      requester: {
+        id: requestToJoin.requester.id,
+        xmtpId: requestToJoin.requester.xmtpId,
+        profile: requestToJoin.requester.profile
+          ? {
+              name: requestToJoin.requester.profile.name,
+              username: requestToJoin.requester.profile.username,
+              description: requestToJoin.requester.profile.description,
+              avatar: requestToJoin.requester.profile.avatar,
+            }
+          : null,
+      },
+      inviteCode: {
+        id: requestToJoin.inviteCode.id,
+        name: requestToJoin.inviteCode.name,
+        description: requestToJoin.inviteCode.description,
+        groupId: requestToJoin.inviteCode.groupId,
+      },
+      autoApprove: requestToJoin.inviteCode.autoApprove,
+    };
+
+    logRequestNotification({ payload });
 
     const response: RequestToJoinResponse = {
-      id: request.id,
-      status: request.status,
-      inviteId: request.inviteCodeId,
-      createdAt: request.createdAt.toISOString(),
+      id: requestToJoin.id,
+      status: requestToJoin.status,
+      inviteId: requestToJoin.inviteCodeId,
+      createdAt: requestToJoin.createdAt.toISOString(),
     };
 
     res.status(201).json(response);
@@ -147,19 +195,9 @@ export async function requestToJoin(
 }
 
 function logRequestNotification(args: {
-  requesterName?: string;
-  requesterXmtpId: string;
-  inviteCreatorName?: string;
-  groupId: string;
+  payload: InviteRequestNotificationPayload;
 }) {
-  const { requesterName, requesterXmtpId, inviteCreatorName, groupId } = args;
-
-  console.log("🔔 Join Request Created:");
-  console.log(
-    `   📧 Would notify invite creator (${inviteCreatorName || "Unknown"})`,
-  );
-  console.log(
-    `   👤 Request from: ${requesterName || "Unknown"} (${requesterXmtpId})`,
-  );
-  console.log(`   🎫 For group: ${groupId}`);
+  const { payload } = args;
+  // Structured log for future integration with notifications pipeline
+  console.log("invite.request.created", JSON.stringify(payload));
 }

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { getInviteLink } from "@/utils/invites";
 import { prisma } from "@/utils/prisma";
+import { InviteCodeStatusSchema } from "../../../../../prisma/generated/zod";
 
 const paramsSchema = z.object({
   inviteId: z.string().min(1, "Invite ID is required"),
@@ -17,6 +18,7 @@ export const updateInviteCodeRequestBodySchema = z.object({
   expiresAt: z.string().datetime().optional(),
   autoApprove: z.boolean().default(false),
   notificationTargets: z.array(z.string()).default([]),
+  status: InviteCodeStatusSchema.optional(),
 });
 
 export type UpdateInviteCodeRequestBody = z.infer<
@@ -147,6 +149,7 @@ export async function updateInviteCode(
           expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
           autoApprove: body.autoApprove,
           groupId: body.groupId,
+          ...(body.status ? { status: body.status } : {}),
           notificationTargets: {
             create: notificationTargetIds.map((deviceIdentityId) => ({
               deviceIdentityId,

--- a/src/api/v1/invites/invites.router.ts
+++ b/src/api/v1/invites/invites.router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { createInviteCode } from "./handlers/create-invite-code";
+import { deleteInvite } from "./handlers/delete-invite";
 import { deleteRequestToJoin } from "./handlers/delete-request-to-join";
 import { getAuthenticatedInviteDetailsHandler } from "./handlers/get-invite-details";
 import { getInviteRequests } from "./handlers/get-invite-requests";
@@ -14,5 +15,6 @@ invitesRouter.get("/requests", getInviteRequests);
 invitesRouter.delete("/requests/:requestId", deleteRequestToJoin);
 invitesRouter.put("/:inviteId", updateInviteCode);
 invitesRouter.get("/:inviteId", getAuthenticatedInviteDetailsHandler);
+invitesRouter.delete("/:inviteId", deleteInvite);
 
 export default invitesRouter;

--- a/src/api/v1/invites/invites.router.ts
+++ b/src/api/v1/invites/invites.router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { createInviteCode } from "./handlers/create-invite-code";
+import { deleteRequestToJoin } from "./handlers/delete-request-to-join";
 import { getAuthenticatedInviteDetailsHandler } from "./handlers/get-invite-details";
 import { getInviteRequests } from "./handlers/get-invite-requests";
 import { requestToJoin } from "./handlers/request-to-join";
@@ -10,6 +11,7 @@ const invitesRouter = Router();
 invitesRouter.post("/", createInviteCode);
 invitesRouter.post("/request", requestToJoin);
 invitesRouter.get("/requests", getInviteRequests);
+invitesRouter.delete("/requests/:requestId", deleteRequestToJoin);
 invitesRouter.put("/:inviteId", updateInviteCode);
 invitesRouter.get("/:inviteId", getAuthenticatedInviteDetailsHandler);
 

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -9,6 +9,8 @@ import {
   test,
 } from "bun:test";
 import express from "express";
+import type { DeleteRequestToJoinResponse } from "@/api/v1/invites/handlers/delete-request-to-join";
+import type { GetInviteRequestsResponse } from "@/api/v1/invites/handlers/get-invite-requests";
 import type {
   RequestToJoinRequestBody,
   RequestToJoinResponse,
@@ -22,9 +24,13 @@ const app = express();
 app.use(pinoMiddleware);
 app.use(jsonMiddleware);
 
-// Mock authentication by setting the request locals
+// Mock authentication by setting the request locals with optional override
 app.use((req, _res, next) => {
-  req.app.locals.xmtpId = "test-xmtp-id-requester";
+  const overrideXmtpId = req.headers["x-test-xmtp-id"];
+  req.app.locals.xmtpId =
+    typeof overrideXmtpId === "string"
+      ? overrideXmtpId
+      : "test-xmtp-id-requester";
   req.app.locals.xmtpInstallationId = "test-installation-id";
   next();
 });
@@ -297,5 +303,148 @@ describe("/invites/request API", () => {
     } finally {
       testServer.close();
     }
+  });
+
+  test("DELETE /invites/requests/:requestId allows requester to delete and creator sees it removed", async () => {
+    // Arrange: create creator/requester and invite code
+    const inviteCode = await createTestInviteCode();
+
+    // Act: requester creates a join request
+    const createReqRes = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-xmtp-id-requester",
+      },
+      body: JSON.stringify({ inviteId: inviteCode.id }),
+    });
+    expect(createReqRes.status).toBe(201);
+    const joinRequest = (await createReqRes.json()) as RequestToJoinResponse;
+
+    // Assert: creator sees 1 request
+    const listBeforeRes = await fetch(
+      "http://localhost:3011/invites/requests",
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-xmtp-id": "test-creator-xmtp-id",
+        },
+      },
+    );
+    expect(listBeforeRes.status).toBe(200);
+    const listBefore =
+      (await listBeforeRes.json()) as GetInviteRequestsResponse;
+    expect(listBefore.total).toBe(1);
+    expect(listBefore.requests[0].id).toBe(joinRequest.id);
+
+    // Act: requester deletes their request
+    const deleteRes = await fetch(
+      `http://localhost:3011/invites/requests/${joinRequest.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-xmtp-id": "test-xmtp-id-requester",
+        },
+      },
+    );
+    expect(deleteRes.status).toBe(200);
+    const deleted = (await deleteRes.json()) as DeleteRequestToJoinResponse;
+    expect(deleted.id).toBe(joinRequest.id);
+    expect(deleted.deleted).toBe(true);
+
+    // Assert: creator sees 0 requests now
+    const listAfterRes = await fetch("http://localhost:3011/invites/requests", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-creator-xmtp-id",
+      },
+    });
+    expect(listAfterRes.status).toBe(200);
+    const listAfter = (await listAfterRes.json()) as GetInviteRequestsResponse;
+    expect(listAfter.total).toBe(0);
+  });
+
+  test("DELETE /invites/requests/:requestId by non-requester fails", async () => {
+    // Arrange: create creator/requester and invite code
+    const inviteCode = await createTestInviteCode();
+
+    // Ensure we also have a third user (user3) in DB
+    await prisma.user.create({
+      data: {
+        userId: "test-user3",
+        userType: UserType.turnkey,
+        devices: {
+          create: {
+            device: {
+              create: {
+                id: "test-device-id-user3",
+                os: DeviceOS.ios,
+                name: "Test User3 Device",
+              },
+            },
+          },
+        },
+        DeviceIdentity: {
+          create: {
+            xmtpId: "test-user3-xmtp-id",
+            identityAddress: "0x1234user3",
+            profile: {
+              create: {
+                name: "Test User3",
+                username: "testuser3",
+                description: "Test user3",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Act: requester creates a join request
+    const createReqRes = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-xmtp-id-requester",
+      },
+      body: JSON.stringify({ inviteId: inviteCode.id }),
+    });
+    expect(createReqRes.status).toBe(201);
+    const joinRequest = (await createReqRes.json()) as RequestToJoinResponse;
+
+    // Act: user3 attempts to delete the request
+    const deleteRes = await fetch(
+      `http://localhost:3011/invites/requests/${joinRequest.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-xmtp-id": "test-user3-xmtp-id",
+        },
+      },
+    );
+    expect(deleteRes.status).toBe(404);
+    const error = (await deleteRes.json()) as {
+      success: boolean;
+      message: string;
+    };
+    expect(error.success).toBe(false);
+    expect(error.message).toBe("Request to join not found");
+
+    // Assert: creator still sees 1 request
+    const listRes = await fetch("http://localhost:3011/invites/requests", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-creator-xmtp-id",
+      },
+    });
+    expect(listRes.status).toBe(200);
+    const list = (await listRes.json()) as GetInviteRequestsResponse;
+    expect(list.total).toBe(1);
+    expect(list.requests[0].id).toBe(joinRequest.id);
   });
 });

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -342,6 +342,130 @@ describe("/invites/request API", () => {
     expect(listAfter.total).toBe(0);
   });
 
+  test("DELETE /invites/requests/:requestId allows invite creator to delete", async () => {
+    const inviteCode = await createTestInviteCode();
+
+    const createReqRes = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-xmtp-id-requester",
+      },
+      body: JSON.stringify({ inviteId: inviteCode.id }),
+    });
+    expect(createReqRes.status).toBe(201);
+    const joinRequest = (await createReqRes.json()) as RequestToJoinResponse;
+
+    const deleteRes = await fetch(
+      `http://localhost:3011/invites/requests/${joinRequest.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-xmtp-id": "test-creator-xmtp-id",
+        },
+      },
+    );
+    expect(deleteRes.status).toBe(200);
+    const deleted = (await deleteRes.json()) as DeleteRequestToJoinResponse;
+    expect(deleted.id).toBe(joinRequest.id);
+    expect(deleted.deleted).toBe(true);
+
+    // creator sees 0 requests now
+    const listAfterRes = await fetch("http://localhost:3011/invites/requests", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-creator-xmtp-id",
+      },
+    });
+    expect(listAfterRes.status).toBe(200);
+    const listAfter = (await listAfterRes.json()) as GetInviteRequestsResponse;
+    expect(listAfter.total).toBe(0);
+  });
+
+  test("DELETE /invites/requests/:requestId allows notification target to delete", async () => {
+    const inviteCode = await createTestInviteCode();
+
+    // Create a notification target identity and link it to the invite
+    await prisma.user.create({
+      data: {
+        userId: "test-notifier-user",
+        userType: UserType.turnkey,
+        devices: {
+          create: {
+            device: {
+              create: {
+                id: "test-device-id-notifier",
+                os: DeviceOS.ios,
+                name: "Test Notifier Device",
+              },
+            },
+          },
+        },
+        DeviceIdentity: {
+          create: {
+            xmtpId: "test-notifier-xmtp-id",
+            identityAddress: "0x1234notifier",
+            profile: {
+              create: {
+                name: "Test Notifier",
+                username: "testnotifier",
+                description: "Test notifier user",
+              },
+            },
+          },
+        },
+      },
+    });
+    const notifierIdentity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId: "test-notifier-xmtp-id" },
+    });
+    await prisma.inviteCodeNotificationTarget.create({
+      data: {
+        inviteCodeId: inviteCode.id,
+        deviceIdentityId: notifierIdentity!.id,
+      },
+    });
+
+    const createReqRes = await fetch("http://localhost:3011/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-xmtp-id-requester",
+      },
+      body: JSON.stringify({ inviteId: inviteCode.id }),
+    });
+    expect(createReqRes.status).toBe(201);
+    const joinRequest = (await createReqRes.json()) as RequestToJoinResponse;
+
+    const deleteRes = await fetch(
+      `http://localhost:3011/invites/requests/${joinRequest.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-xmtp-id": "test-notifier-xmtp-id",
+        },
+      },
+    );
+    expect(deleteRes.status).toBe(200);
+    const deleted = (await deleteRes.json()) as DeleteRequestToJoinResponse;
+    expect(deleted.id).toBe(joinRequest.id);
+    expect(deleted.deleted).toBe(true);
+
+    const listAfterRes = await fetch("http://localhost:3011/invites/requests", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-creator-xmtp-id",
+      },
+    });
+    expect(listAfterRes.status).toBe(200);
+    const listAfter = (await listAfterRes.json()) as GetInviteRequestsResponse;
+    expect(listAfter.total).toBe(0);
+  });
+
   test("DELETE /invites/requests/:requestId by non-requester fails", async () => {
     // Arrange: create creator/requester and invite code
     const inviteCode = await createTestInviteCode();

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -188,28 +188,6 @@ describe("/invites/request API", () => {
     expect(dbRequest?.status).toBe(InviteCodeRequestStatus.PENDING);
   });
 
-  test("POST /invites/request rejects request for auto-approve invite", async () => {
-    const inviteCode = await createTestInviteCode({ autoApprove: true });
-
-    const requestBody: RequestToJoinRequestBody = {
-      inviteId: inviteCode.id,
-    };
-
-    const response = await fetch("http://localhost:3011/invites/request", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(requestBody),
-    });
-
-    expect(response.status).toBe(400);
-
-    const error = (await response.json()) as ErrorResponse;
-    expect(error.success).toBe(false);
-    expect(error.message).toContain("does not require approval");
-  });
-
   test("POST /invites/request rejects duplicate request", async () => {
     const inviteCode = await createTestInviteCode();
     const requesterIdentity = await prisma.deviceIdentity.findFirst({

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "http";
-import { DeviceOS, InviteCodeRequestStatus, UserType } from "@prisma/client";
+import { DeviceOS, UserType } from "@prisma/client";
 import {
   afterAll,
   beforeAll,
@@ -176,7 +176,6 @@ describe("/invites/request API", () => {
 
     const joinRequest = (await response.json()) as RequestToJoinResponse;
     expect(joinRequest.id).toBeDefined();
-    expect(joinRequest.status).toBe("PENDING");
     expect(joinRequest.inviteId).toBe(inviteCode.id);
     expect(joinRequest.createdAt).toBeDefined();
 
@@ -185,7 +184,6 @@ describe("/invites/request API", () => {
       where: { id: joinRequest.id },
     });
     expect(dbRequest).toBeTruthy();
-    expect(dbRequest?.status).toBe(InviteCodeRequestStatus.PENDING);
   });
 
   test("POST /invites/request rejects duplicate request", async () => {
@@ -199,7 +197,6 @@ describe("/invites/request API", () => {
       data: {
         inviteCodeId: inviteCode.id,
         requesterId: requesterIdentity!.id,
-        status: "PENDING",
       },
     });
 
@@ -219,7 +216,7 @@ describe("/invites/request API", () => {
 
     const error = (await response.json()) as ErrorResponse;
     expect(error.success).toBe(false);
-    expect(error.message).toContain("already have a pending request");
+    expect(error.message).toContain("already have a request");
   });
 
   test("POST /invites/request returns 404 for non-existent invite", async () => {

--- a/tests/invites.test.ts
+++ b/tests/invites.test.ts
@@ -28,7 +28,9 @@ const AUTH_USER_XMTP_ID = "test-invite-xmtp-id";
 
 // Add middleware to simulate authentication for tests
 app.use((req, res, next) => {
-  req.app.locals.xmtpId = AUTH_USER_XMTP_ID;
+  const overrideXmtpId = req.headers["x-test-xmtp-id"];
+  req.app.locals.xmtpId =
+    typeof overrideXmtpId === "string" ? overrideXmtpId : AUTH_USER_XMTP_ID;
   next();
 });
 
@@ -537,6 +539,85 @@ describe("/invites API", () => {
     };
     expect(error.success).toBe(false);
     expect(error.message).toBe("Invite not found");
+  });
+
+  test("DELETE /invites/:inviteId deletes the invite (creator only)", async () => {
+    // Create creator user and invite
+    await createTestUser("-delete-invite-owner");
+
+    const createRes = await fetch("http://localhost:3010/invites", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ groupId: "group-to-delete", name: "To Delete" }),
+    });
+    expect(createRes.status).toBe(201);
+    const invite = (await createRes.json()) as CreateInviteCodeResponse;
+
+    // Fetch details (200)
+    const getBefore = await fetch(
+      `http://localhost:3010/invites/${invite.id}`,
+      {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    expect(getBefore.status).toBe(200);
+
+    // Delete as creator
+    const delRes = await fetch(`http://localhost:3010/invites/${invite.id}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(delRes.status).toBe(200);
+    const del = (await delRes.json()) as { id: string; deleted: boolean };
+    expect(del.id).toBe(invite.id);
+    expect(del.deleted).toBe(true);
+
+    // Fetch again (404)
+    const getAfter = await fetch(`http://localhost:3010/invites/${invite.id}`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(getAfter.status).toBe(404);
+  });
+
+  test("DELETE /invites/:inviteId by non-creator is forbidden", async () => {
+    // Create creator and invite
+    await createTestUser("-delete-invite-owner2");
+    const createRes = await fetch("http://localhost:3010/invites", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        groupId: "group-to-delete2",
+        name: "To Delete 2",
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const invite = (await createRes.json()) as CreateInviteCodeResponse;
+
+    // Create another user
+    const OTHER_XMTP_ID = "delete-invite-other-user";
+    await createTestUser("-delete-invite-other", OTHER_XMTP_ID);
+
+    // Attempt delete as non-creator
+    const delRes = await fetch(`http://localhost:3010/invites/${invite.id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": OTHER_XMTP_ID,
+      },
+    });
+    expect(delRes.status).toBe(403);
+    const err = (await delRes.json()) as { success: boolean; message: string };
+    expect(err.success).toBe(false);
+    expect(err.message).toBe("Not authorized to delete this invite");
+
+    // Ensure invite still exists (creator can fetch)
+    const getRes = await fetch(`http://localhost:3010/invites/${invite.id}`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(getRes.status).toBe(200);
   });
 
   test("POST /invites/:inviteId returns 403 for unauthorized update", async () => {

--- a/tests/invites.test.ts
+++ b/tests/invites.test.ts
@@ -13,10 +13,7 @@ import type {
   CreateInviteCodeRequestBody,
   CreateInviteCodeResponse,
 } from "@/api/v1/invites/handlers/create-invite-code";
-import type { DeleteRequestToJoinResponse } from "@/api/v1/invites/handlers/delete-request-to-join";
 import type { GetInviteDetailsResponse } from "@/api/v1/invites/handlers/get-invite-details";
-import type { GetInviteRequestsResponse } from "@/api/v1/invites/handlers/get-invite-requests";
-import type { RequestToJoinResponse } from "@/api/v1/invites/handlers/request-to-join";
 import invitesRouter from "@/api/v1/invites/invites.router";
 import type { CreatedReturnedUser } from "@/api/v1/users/handlers/create-user";
 import { jsonMiddleware } from "@/middleware/json";
@@ -31,10 +28,7 @@ const AUTH_USER_XMTP_ID = "test-invite-xmtp-id";
 
 // Add middleware to simulate authentication for tests
 app.use((req, res, next) => {
-  // Allow per-request override via header for multi-user scenarios
-  const overrideXmtpId = req.headers["x-test-xmtp-id"];
-  req.app.locals.xmtpId =
-    typeof overrideXmtpId === "string" ? overrideXmtpId : AUTH_USER_XMTP_ID;
+  req.app.locals.xmtpId = AUTH_USER_XMTP_ID;
   next();
 });
 
@@ -762,143 +756,5 @@ describe("/invites API", () => {
     };
     expect(error.success).toBe(false);
     expect(error.message).toBe("Identity not found");
-  });
-
-  test("DELETE /invites/requests/:requestId allows requester to delete and creator sees it removed", async () => {
-    // user1 (creator) setup and create invite
-    await createTestUser("-delete-request-owner");
-
-    const createInviteRes = await fetch("http://localhost:3010/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        groupId: "group-delete-request",
-        name: "Delete Request Group",
-        autoApprove: false,
-      }),
-    });
-    expect(createInviteRes.status).toBe(201);
-    const createdInvite =
-      (await createInviteRes.json()) as CreateInviteCodeResponse;
-
-    // user2 (requester) using header override
-    const USER2_XMTP_ID = "delete-request-user2-xmtp-id";
-    await createTestUser("-delete-request-user2", USER2_XMTP_ID);
-
-    // user2 creates a join request
-    const reqJoinRes = await fetch("http://localhost:3010/invites/request", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-test-xmtp-id": USER2_XMTP_ID,
-      },
-      body: JSON.stringify({ inviteId: createdInvite.id }),
-    });
-    expect(reqJoinRes.status).toBe(201);
-    const joinRequest = (await reqJoinRes.json()) as RequestToJoinResponse;
-
-    // user1 lists requests (should be 1)
-    const listBeforeRes = await fetch(
-      "http://localhost:3010/invites/requests",
-      {
-        method: "GET",
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-    expect(listBeforeRes.status).toBe(200);
-    const listBefore =
-      (await listBeforeRes.json()) as GetInviteRequestsResponse;
-    expect(listBefore.total).toBe(1);
-    expect(listBefore.requests[0].id).toBe(joinRequest.id);
-
-    // user2 deletes their request
-    const deleteRes = await fetch(
-      `http://localhost:3010/invites/requests/${joinRequest.id}`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-xmtp-id": USER2_XMTP_ID,
-        },
-      },
-    );
-    expect(deleteRes.status).toBe(200);
-    const deleted = (await deleteRes.json()) as DeleteRequestToJoinResponse;
-    expect(deleted.id).toBe(joinRequest.id);
-    expect(deleted.deleted).toBe(true);
-
-    // user1 lists again (should be 0)
-    const listAfterRes = await fetch("http://localhost:3010/invites/requests", {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-    });
-    expect(listAfterRes.status).toBe(200);
-    const listAfter = (await listAfterRes.json()) as GetInviteRequestsResponse;
-    expect(listAfter.total).toBe(0);
-  });
-
-  test("DELETE /invites/requests/:requestId by non-requester fails", async () => {
-    // user1 (creator) setup and create invite
-    await createTestUser("-delete-request-nonrequester-owner");
-
-    const createInviteRes = await fetch("http://localhost:3010/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        groupId: "group-delete-request-nonrequester",
-        name: "Delete NonRequester Group",
-        autoApprove: false,
-      }),
-    });
-    expect(createInviteRes.status).toBe(201);
-    const createdInvite =
-      (await createInviteRes.json()) as CreateInviteCodeResponse;
-
-    // user2 (requester) and user3 (non-requester) via header override
-    const USER2_XMTP_ID = "delete-request-user2-xmtp-id-nonrequester";
-    const USER3_XMTP_ID = "delete-request-user3-xmtp-id";
-    await createTestUser("-delete-request-user2-nonrequester", USER2_XMTP_ID);
-    await createTestUser("-delete-request-user3-nonrequester", USER3_XMTP_ID);
-
-    // user2 creates a join request
-    const reqJoinRes = await fetch("http://localhost:3010/invites/request", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-test-xmtp-id": USER2_XMTP_ID,
-      },
-      body: JSON.stringify({ inviteId: createdInvite.id }),
-    });
-    expect(reqJoinRes.status).toBe(201);
-    const joinRequest = (await reqJoinRes.json()) as RequestToJoinResponse;
-
-    // user3 tries to delete user2's request
-    const deleteRes = await fetch(
-      `http://localhost:3010/invites/requests/${joinRequest.id}`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          "x-test-xmtp-id": USER3_XMTP_ID,
-        },
-      },
-    );
-    expect(deleteRes.status).toBe(404);
-    const error = (await deleteRes.json()) as {
-      success: boolean;
-      message: string;
-    };
-    expect(error.success).toBe(false);
-    expect(error.message).toBe("Request to join not found");
-
-    // user1 lists requests (should be still 1)
-    const listAfterRes = await fetch("http://localhost:3010/invites/requests", {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-    });
-    expect(listAfterRes.status).toBe(200);
-    const listBefore = (await listAfterRes.json()) as GetInviteRequestsResponse;
-    expect(listBefore.total).toBe(1);
-    expect(listBefore.requests[0].id).toBe(joinRequest.id);
   });
 });

--- a/tests/invites.test.ts
+++ b/tests/invites.test.ts
@@ -13,7 +13,10 @@ import type {
   CreateInviteCodeRequestBody,
   CreateInviteCodeResponse,
 } from "@/api/v1/invites/handlers/create-invite-code";
+import type { DeleteRequestToJoinResponse } from "@/api/v1/invites/handlers/delete-request-to-join";
 import type { GetInviteDetailsResponse } from "@/api/v1/invites/handlers/get-invite-details";
+import type { GetInviteRequestsResponse } from "@/api/v1/invites/handlers/get-invite-requests";
+import type { RequestToJoinResponse } from "@/api/v1/invites/handlers/request-to-join";
 import invitesRouter from "@/api/v1/invites/invites.router";
 import type { CreatedReturnedUser } from "@/api/v1/users/handlers/create-user";
 import { jsonMiddleware } from "@/middleware/json";
@@ -28,8 +31,10 @@ const AUTH_USER_XMTP_ID = "test-invite-xmtp-id";
 
 // Add middleware to simulate authentication for tests
 app.use((req, res, next) => {
-  // Set xmtpId for testing - this simulates the auth middleware
-  req.app.locals.xmtpId = AUTH_USER_XMTP_ID;
+  // Allow per-request override via header for multi-user scenarios
+  const overrideXmtpId = req.headers["x-test-xmtp-id"];
+  req.app.locals.xmtpId =
+    typeof overrideXmtpId === "string" ? overrideXmtpId : AUTH_USER_XMTP_ID;
   next();
 });
 
@@ -757,5 +762,143 @@ describe("/invites API", () => {
     };
     expect(error.success).toBe(false);
     expect(error.message).toBe("Identity not found");
+  });
+
+  test("DELETE /invites/requests/:requestId allows requester to delete and creator sees it removed", async () => {
+    // user1 (creator) setup and create invite
+    await createTestUser("-delete-request-owner");
+
+    const createInviteRes = await fetch("http://localhost:3010/invites", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        groupId: "group-delete-request",
+        name: "Delete Request Group",
+        autoApprove: false,
+      }),
+    });
+    expect(createInviteRes.status).toBe(201);
+    const createdInvite =
+      (await createInviteRes.json()) as CreateInviteCodeResponse;
+
+    // user2 (requester) using header override
+    const USER2_XMTP_ID = "delete-request-user2-xmtp-id";
+    await createTestUser("-delete-request-user2", USER2_XMTP_ID);
+
+    // user2 creates a join request
+    const reqJoinRes = await fetch("http://localhost:3010/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": USER2_XMTP_ID,
+      },
+      body: JSON.stringify({ inviteId: createdInvite.id }),
+    });
+    expect(reqJoinRes.status).toBe(201);
+    const joinRequest = (await reqJoinRes.json()) as RequestToJoinResponse;
+
+    // user1 lists requests (should be 1)
+    const listBeforeRes = await fetch(
+      "http://localhost:3010/invites/requests",
+      {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    expect(listBeforeRes.status).toBe(200);
+    const listBefore =
+      (await listBeforeRes.json()) as GetInviteRequestsResponse;
+    expect(listBefore.total).toBe(1);
+    expect(listBefore.requests[0].id).toBe(joinRequest.id);
+
+    // user2 deletes their request
+    const deleteRes = await fetch(
+      `http://localhost:3010/invites/requests/${joinRequest.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-xmtp-id": USER2_XMTP_ID,
+        },
+      },
+    );
+    expect(deleteRes.status).toBe(200);
+    const deleted = (await deleteRes.json()) as DeleteRequestToJoinResponse;
+    expect(deleted.id).toBe(joinRequest.id);
+    expect(deleted.deleted).toBe(true);
+
+    // user1 lists again (should be 0)
+    const listAfterRes = await fetch("http://localhost:3010/invites/requests", {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(listAfterRes.status).toBe(200);
+    const listAfter = (await listAfterRes.json()) as GetInviteRequestsResponse;
+    expect(listAfter.total).toBe(0);
+  });
+
+  test("DELETE /invites/requests/:requestId by non-requester fails", async () => {
+    // user1 (creator) setup and create invite
+    await createTestUser("-delete-request-nonrequester-owner");
+
+    const createInviteRes = await fetch("http://localhost:3010/invites", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        groupId: "group-delete-request-nonrequester",
+        name: "Delete NonRequester Group",
+        autoApprove: false,
+      }),
+    });
+    expect(createInviteRes.status).toBe(201);
+    const createdInvite =
+      (await createInviteRes.json()) as CreateInviteCodeResponse;
+
+    // user2 (requester) and user3 (non-requester) via header override
+    const USER2_XMTP_ID = "delete-request-user2-xmtp-id-nonrequester";
+    const USER3_XMTP_ID = "delete-request-user3-xmtp-id";
+    await createTestUser("-delete-request-user2-nonrequester", USER2_XMTP_ID);
+    await createTestUser("-delete-request-user3-nonrequester", USER3_XMTP_ID);
+
+    // user2 creates a join request
+    const reqJoinRes = await fetch("http://localhost:3010/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": USER2_XMTP_ID,
+      },
+      body: JSON.stringify({ inviteId: createdInvite.id }),
+    });
+    expect(reqJoinRes.status).toBe(201);
+    const joinRequest = (await reqJoinRes.json()) as RequestToJoinResponse;
+
+    // user3 tries to delete user2's request
+    const deleteRes = await fetch(
+      `http://localhost:3010/invites/requests/${joinRequest.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-xmtp-id": USER3_XMTP_ID,
+        },
+      },
+    );
+    expect(deleteRes.status).toBe(404);
+    const error = (await deleteRes.json()) as {
+      success: boolean;
+      message: string;
+    };
+    expect(error.success).toBe(false);
+    expect(error.message).toBe("Request to join not found");
+
+    // user1 lists requests (should be still 1)
+    const listAfterRes = await fetch("http://localhost:3010/invites/requests", {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(listAfterRes.status).toBe(200);
+    const listBefore = (await listAfterRes.json()) as GetInviteRequestsResponse;
+    expect(listBefore.total).toBe(1);
+    expect(listBefore.requests[0].id).toBe(joinRequest.id);
   });
 });

--- a/tests/invites.test.ts
+++ b/tests/invites.test.ts
@@ -483,6 +483,7 @@ describe("/invites API", () => {
       name: "Updated Name",
       description: "Updated Description",
       autoApprove: true,
+      status: InviteCodeStatus.DISABLED,
     };
 
     const updateResponse = await fetch(
@@ -506,6 +507,7 @@ describe("/invites API", () => {
     expect(updatedInvite.description).toBe("Updated Description");
     expect(updatedInvite.autoApprove).toBe(true);
     expect(updatedInvite.inviteLinkURL).toBe(originalInvite.inviteLinkURL); // Same URL
+    expect(updatedInvite.status).toBe(InviteCodeStatus.DISABLED);
   });
 
   test("POST /invites/:inviteId returns 404 for non-existent invite", async () => {


### PR DESCRIPTION
Add endpoints to handle invites and invites requests with ability to delete a request after acceptation (or denial)
Add a spawn with xcrun to send notification to simulator. To test you'll need env vars `IOS_SIMULATOR_ID` and `IOS_BUNDLE_ID` setup in your .env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to delete invite requests and invites.

* **Bug Fixes**
  * Improved authorization and error handling for deleting invites and join requests.

* **Refactor**
  * Removed the "status" field from invite requests and related responses/filters.

* **Tests**
  * Added comprehensive tests for invite and invite-request deletion and authorization.
  * Enhanced test middleware for flexible user identity simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->