### PR TITLE
Make docker compose use the local .env file if it exists

### DIFF
--- a/dev/compose
+++ b/dev/compose
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -eou pipefail
 
-docker compose -f dev/compose.yml -p "convos" "$@"
+# Pass the .env file if it exists locally - useful to run tests locally
+if [ -f .env ]; then
+  docker compose --env-file .env -f dev/compose.yml -p "convos" "$@"
+else
+  docker compose -f dev/compose.yml -p "convos" "$@"
+fi

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
     "start": "bun run --preload ./src/instrumentation.ts src/index.ts",
-    "test:notifications-client": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 dev/restart-notification && bun tests/notifications.client.test.ts",
+    "test:notifications-client": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 dev/restart-notification && bun test tests/notifications.client.test.ts",
     "test:push": "bun run scripts/test-push-notification.ts",
     "test:push-simple": "bun run scripts/simple-push-test.ts",
     "typecheck": "tsc"

--- a/tests/notifications.client.test.ts
+++ b/tests/notifications.client.test.ts
@@ -546,7 +546,6 @@ describe("Notifications", () => {
 
       let firstPhaseCount = 0;
       for await (const notification of stream) {
-        console.log("notification1:", notification);
         if (notification === undefined) {
           break;
         }


### PR DESCRIPTION
Tests that were relying on the notifications go server to notify our backend via webhook were failing
Fix in two parts
- this PR forces docker-compose to use the local .env file if it exists so the webhook header secret will be well set
- when running tests you need to have the env variable `TEST_NOTIFICATION_DELIVERY_URL` set to `http://host.docker.internal:8081/` . This is currently done in the `test:notifications-client` command that Thierry had created - this means that running only `bun test` will still result in some the notifications-client tests to fail but I guess that was the case before - do they run well on the CI @lourou or does this need fixing? 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dev environment now automatically uses a local .env file when present for Docker Compose runs.
* **Tests**
  * Corrected test script to use the proper Bun command for running notification client tests.
  * Removed unnecessary console output from a notification test for cleaner logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->