### PR TITLE
Switch to using xmtpId directly when dealing with registering device …

### DIFF
--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -125,27 +125,30 @@ async function handleCurrentRegistration(args: {
     }
 
     // Make sure all the identities being registered belong to the authenticated user
+    let xmtpIdToIdentityIdMap = new Map<string, string>();
     if (body.installations.length > 0) {
-      const identityIdsToVerify = body.installations.map(
-        (inst) => inst.identityId,
-      );
+      const xmtpIdsToVerify = body.installations.map((inst) => inst.identityId);
       const ownedIdentities = await prisma.deviceIdentity.findMany({
         where: {
-          id: { in: identityIdsToVerify },
+          xmtpId: { in: xmtpIdsToVerify },
           userId: deviceIdentityForAuthenticatedUser.userId,
         },
-        select: { id: true },
+        select: { id: true, xmtpId: true },
       });
 
-      if (ownedIdentities.length !== identityIdsToVerify.length) {
+      if (ownedIdentities.length !== xmtpIdsToVerify.length) {
         req.log.warn(
-          `User ${deviceIdentityForAuthenticatedUser.userId} attempt to register with one or more unowned/unknown identities.`,
+          `User ${deviceIdentityForAuthenticatedUser.userId} attempt to register with one or more unowned/unknown identities (by xmtpId).`,
         );
         res.status(403).json({
           error: "Forbidden: Identity access denied for one or more identities",
         });
         return;
       }
+
+      xmtpIdToIdentityIdMap = new Map(
+        ownedIdentities.map((di) => [di.xmtpId, di.id]),
+      );
     }
 
     const identitiesOnDeviceToRemoveFromDb = await prisma.$transaction(
@@ -200,16 +203,31 @@ async function handleCurrentRegistration(args: {
 
         // Upsert the new installations
         for (const installation of body.installations) {
+          const resolvedIdentityId = xmtpIdToIdentityIdMap.get(
+            installation.identityId,
+          );
+          if (!resolvedIdentityId) {
+            // This should not happen due to pre-verification; skip defensively
+            req.log.warn(
+              {
+                xmtpId: installation.identityId,
+                deviceId: body.deviceId,
+              },
+              "Skipping upsert for installation due to unresolved identityId from xmtpId",
+            );
+            continue;
+          }
+
           await tx.identitiesOnDevice.upsert({
             where: {
               deviceId_identityId: {
                 deviceId: body.deviceId,
-                identityId: installation.identityId,
+                identityId: resolvedIdentityId,
               },
             },
             create: {
               deviceId: body.deviceId,
-              identityId: installation.identityId,
+              identityId: resolvedIdentityId,
               xmtpInstallationId: installation.xmtpInstallationId,
             },
             update: {

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -131,7 +131,7 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
           pushTokenType: "apns" as const,
           installations: [
             {
-              identityId: testIdentityId,
+              identityId: AUTH_XMTP_ID,
               xmtpInstallationId: testXmtpInstallationId,
             },
           ],
@@ -187,7 +187,7 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
           pushTokenType: "apns" as const,
           installations: [
             {
-              identityId: testIdentityId,
+              identityId: AUTH_XMTP_ID,
               xmtpInstallationId: "test-installation-id-register",
             },
           ],
@@ -210,7 +210,7 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
           pushTokenType: "apns" as const,
           installations: [
             {
-              identityId: testIdentityId,
+              identityId: AUTH_XMTP_ID,
               xmtpInstallationId: xmtpInstallationIdToTest,
             },
           ],


### PR DESCRIPTION
…for push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved ownership validation during notification device registration using public identity, preventing unauthorized or mismatched registrations.
  - Prevents creation of invalid installations by skipping unresolved identities, reducing registration failures.
  - More accurate error responses when attempting to register devices not owned by the authenticated user.

- Tests
  - Updated registration and unregistration tests to align with public-identity-based validation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->