### PR TITLE
Nmalzieu/notifications types

### DIFF
--- a/scripts/simple-push-test.ts
+++ b/scripts/simple-push-test.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env bun
-import type { Request } from "express";
 import { createApnsService } from "@/api/v1/notifications/services/apns-push.service";
-import type { WebhookNotificationBody } from "@/notifications/client";
 import { prisma } from "@/utils/prisma";
 
 // Simple version - just provide a userId and it will send a basic test notification
@@ -55,40 +53,22 @@ async function quickPushTest(userId: string) {
     return;
   }
 
-  // Mock data
-  const mockNotification: WebhookNotificationBody = {
-    subscription: { is_silent: false },
-    message: {
-      content_topic: "test-topic",
-      message: "test-message",
-      timestamp_ns: Date.now().toString() + "000000",
-    },
-    message_context: { message_type: "test" },
-  } as WebhookNotificationBody;
-
   const messageData = {
     contentTopic: "test-topic",
     messageType: "test",
     encryptedMessage: "Hello from the backend! 👋",
     timestamp: Date.now().toString() + "000000",
-    inboxId: firstDevice.identities[0].identity.xmtpId,
   };
-
-  const mockReq = {
-    log: {
-      info: console.log,
-      error: console.error,
-      warn: console.warn,
-    },
-  } as Request;
 
   console.log("📤 Sending notification...");
 
   const result = await apnsService.sendPushNotification({
     device: firstDevice,
-    notification: mockNotification,
-    messageData,
-    req: mockReq,
+    notification: {
+      inboxId: firstDevice.identities[0].identity.xmtpId,
+      notificationType: "Protocol",
+      notificationData: messageData,
+    },
   });
 
   if (result.success) {

--- a/scripts/simple-push-test.ts
+++ b/scripts/simple-push-test.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import type { Request } from "express";
 import { createApnsService } from "@/api/v1/notifications/services/apns-push.service";
-import type { NotificationResponse } from "@/notifications/client";
+import type { WebhookNotificationBody } from "@/notifications/client";
 import { prisma } from "@/utils/prisma";
 
 // Simple version - just provide a userId and it will send a basic test notification
@@ -56,7 +56,7 @@ async function quickPushTest(userId: string) {
   }
 
   // Mock data
-  const mockNotification: NotificationResponse = {
+  const mockNotification: WebhookNotificationBody = {
     subscription: { is_silent: false },
     message: {
       content_topic: "test-topic",
@@ -64,7 +64,7 @@ async function quickPushTest(userId: string) {
       timestamp_ns: Date.now().toString() + "000000",
     },
     message_context: { message_type: "test" },
-  } as NotificationResponse;
+  } as WebhookNotificationBody;
 
   const messageData = {
     contentTopic: "test-topic",

--- a/scripts/test-push-notification.ts
+++ b/scripts/test-push-notification.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import type { Request } from "express";
 import { createApnsService } from "@/api/v1/notifications/services/apns-push.service";
-import type { NotificationResponse } from "@/notifications/client";
+import type { WebhookNotificationBody } from "@/notifications/client";
 import { prisma } from "@/utils/prisma";
 
 // Mock logger to replace req.log
@@ -86,7 +86,7 @@ async function sendTestPushNotification(args: TestPushArgs) {
   }
 
   // Create mock notification response
-  const mockNotification: NotificationResponse = {
+  const mockNotification: WebhookNotificationBody = {
     subscription: {
       is_silent: isSilent,
     },
@@ -98,7 +98,7 @@ async function sendTestPushNotification(args: TestPushArgs) {
     message_context: {
       message_type: "test",
     },
-  } as NotificationResponse;
+  } as WebhookNotificationBody;
 
   // Create mock message data
   const messageData = {

--- a/scripts/test-push-notification.ts
+++ b/scripts/test-push-notification.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 import { createApnsService } from "@/api/v1/notifications/services/apns-push.service";
-import type {} from "@/notifications/client";
 import { prisma } from "@/utils/prisma";
 
 interface TestPushArgs {

--- a/scripts/test-push-notification.ts
+++ b/scripts/test-push-notification.ts
@@ -1,26 +1,7 @@
 #!/usr/bin/env bun
-import type { Request } from "express";
 import { createApnsService } from "@/api/v1/notifications/services/apns-push.service";
-import type { WebhookNotificationBody } from "@/notifications/client";
+import type {} from "@/notifications/client";
 import { prisma } from "@/utils/prisma";
-
-// Mock logger to replace req.log
-const mockLogger = {
-  info: (data: unknown, message?: string) => {
-    console.log(`[INFO] ${message || ""}`, data);
-  },
-  error: (data: unknown, message?: string) => {
-    console.error(`[ERROR] ${message || ""}`, data);
-  },
-  warn: (data: unknown, message?: string) => {
-    console.warn(`[WARN] ${message || ""}`, data);
-  },
-};
-
-// Mock request object for the APNS service
-const mockRequest = {
-  log: mockLogger,
-} as Request;
 
 interface TestPushArgs {
   userId: string;
@@ -85,28 +66,12 @@ async function sendTestPushNotification(args: TestPushArgs) {
     return;
   }
 
-  // Create mock notification response
-  const mockNotification: WebhookNotificationBody = {
-    subscription: {
-      is_silent: isSilent,
-    },
-    message: {
-      content_topic: "test-topic",
-      message: "encrypted-test-message-data",
-      timestamp_ns: Date.now().toString() + "000000", // Convert to nanoseconds
-    },
-    message_context: {
-      message_type: "test",
-    },
-  } as WebhookNotificationBody;
-
   // Create mock message data
   const messageData = {
     contentTopic: "test-topic",
     messageType: "test",
     encryptedMessage: "encrypted-test-message-data",
     timestamp: Date.now().toString() + "000000",
-    inboxId: "1234567890123456789012345678901234567890", // Mock inbox id
   };
 
   // Send push notification to each device
@@ -129,9 +94,11 @@ async function sendTestPushNotification(args: TestPushArgs) {
     try {
       const result = await apnsService.sendPushNotification({
         device: effectiveDevice,
-        notification: mockNotification,
-        messageData,
-        req: mockRequest,
+        notification: {
+          inboxId: "1234567890123456789012345678901234567890", // Mock inbox id
+          notificationType: "Protocol",
+          notificationData: messageData,
+        },
       });
 
       if (result.success) {

--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -87,9 +87,9 @@ export async function handleXmtpNotification(req: Request, res: Response) {
     const result = await pushNotificationService.sendPushNotification({
       device,
       notification: {
-        notificationType: "Protocol",
         inboxId: identity.xmtpId,
-        data: {
+        notificationType: "Protocol",
+        notificationData: {
           contentTopic: notification.message.content_topic,
           messageType: notification.message_context.message_type,
           encryptedMessage: notification.message.message,

--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import {
   createNotificationClient,
-  type NotificationResponse,
+  type WebhookNotificationBody,
 } from "@/notifications/client";
 import { getHttpDeliveryNotificationAuthHeader } from "@/notifications/utils";
 import { prisma } from "@/utils/prisma";
@@ -28,7 +28,7 @@ export async function handleXmtpNotification(req: Request, res: Response) {
   } | null = null;
 
   try {
-    const notification = req.body as NotificationResponse;
+    const notification = req.body as WebhookNotificationBody;
 
     // Log the notification for debugging
     req.log.info(

--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -83,36 +83,36 @@ export async function handleXmtpNotification(req: Request, res: Response) {
     };
 
     const { device, identity } = identityOnDevice;
-    const pushTokenType = device.pushTokenType;
 
-    // For APNS (new Convos architecture for OTR), use xmtpId - no identityAddress needed
-    if (pushTokenType === "apns") {
-      // Use the unified push notification service - xmtpId used internally
-      const result = await pushNotificationService.sendPushNotification({
-        device,
-        notification,
+    const result = await pushNotificationService.sendPushNotification({
+      device,
+      notification: {
+        notificationType: "Protocol",
         inboxId: identity.xmtpId,
-        req,
-      });
+        data: {
+          contentTopic: notification.message.content_topic,
+          messageType: notification.message_context.message_type,
+          encryptedMessage: notification.message.message,
+          timestamp: notification.message.timestamp_ns,
+        },
+      },
+    });
 
-      if (!result.success && result.shouldCleanup) {
-        req.log.info(
-          `Push notification failed with unrecoverable error for device ${device.id}. Initiating cleanup.`,
-        );
-        if (identityOnDeviceToCleanup.xmtpInstallationId) {
-          await cleanupFailedInstallation({
-            xmtpInstallationId: identityOnDeviceToCleanup.xmtpInstallationId,
-            deviceId: identityOnDeviceToCleanup.deviceId,
-            req,
-          });
-        }
+    if (!result.success && result.shouldCleanup) {
+      req.log.info(
+        `Push notification failed with unrecoverable error for device ${device.id}. Initiating cleanup.`,
+      );
+      if (identityOnDeviceToCleanup.xmtpInstallationId) {
+        await cleanupFailedInstallation({
+          xmtpInstallationId: identityOnDeviceToCleanup.xmtpInstallationId,
+          deviceId: identityOnDeviceToCleanup.deviceId,
+          req,
+        });
       }
-
-      res.status(200).end();
-      return;
     }
 
-    res.status(400).json({ error: "Only APNS notifications supported" });
+    res.status(200).end();
+    return;
   } catch (error) {
     req.log.error({ error }, "Outer error processing notification");
     res.status(500).json({ error: "Internal server error" });

--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { createNotificationClient } from "@/notifications/client";
 import { prisma } from "@/utils/prisma";
+import { ApnsEnvironmentSchema } from "../../../../../prisma/generated/zod";
 
 const installationItemSchema = z.object({
   identityId: z.string(),
@@ -13,6 +14,7 @@ const currentRegistrationSchema = z.object({
   deviceId: z.string(),
   pushToken: z.string(),
   pushTokenType: z.nativeEnum(PushTokenType).optional(),
+  apnsEnv: ApnsEnvironmentSchema.nullable(),
   // List of installations to register
   // We will also check for any other identities on device that don't have any of those installations and delete them
   installations: z.array(installationItemSchema),
@@ -161,6 +163,7 @@ async function handleCurrentRegistration(args: {
           data: {
             pushToken: body.pushToken,
             pushTokenType: body.pushTokenType,
+            apnsEnv: body.apnsEnv,
           },
         });
 

--- a/src/api/v1/notifications/services/apns-push.service.ts
+++ b/src/api/v1/notifications/services/apns-push.service.ts
@@ -1,9 +1,8 @@
 import http2 from "node:http2";
 import type { Device } from "@prisma/client";
-import type { Request } from "express";
 import jwt from "jsonwebtoken";
-import type { WebhookNotificationBody } from "@/notifications/client";
-import type { PushMessageData } from "./push-notification.service";
+import logger from "@/utils/logger";
+import type { NotificationPayload } from "./notifications-types";
 
 export interface ApnsConfig {
   teamId: string;
@@ -12,7 +11,7 @@ export interface ApnsConfig {
   bundleId: string;
 }
 
-export interface ApnsNotificationPayload {
+export type ApnsNotificationPayload = NotificationPayload & {
   aps: {
     alert?: {
       title?: string;
@@ -23,14 +22,7 @@ export interface ApnsNotificationPayload {
     "content-available"?: number;
     "mutable-content"?: number;
   };
-  data: {
-    contentTopic: string;
-    messageType: string;
-    encryptedMessage: string;
-    timestamp: string;
-    ethAddress?: string;
-  };
-}
+};
 
 export class ApnsPushService {
   private config: ApnsConfig;
@@ -80,11 +72,10 @@ export class ApnsPushService {
 
   async sendPushNotification(args: {
     device: Device;
-    notification: WebhookNotificationBody;
-    messageData: PushMessageData;
-    req: Request;
+    notification: NotificationPayload;
+    isSilent?: boolean;
   }): Promise<{ success: boolean; error?: string }> {
-    const { device, notification, messageData, req } = args;
+    const { device, notification, isSilent } = args;
 
     if (!device.pushToken) {
       return { success: false, error: "No APNS push token available" };
@@ -94,12 +85,12 @@ export class ApnsPushService {
       return { success: false, error: "Device is not configured for APNS" };
     }
 
-    const payload: ApnsNotificationPayload = notification.subscription.is_silent
+    const payload: ApnsNotificationPayload = isSilent
       ? {
           aps: {
             "content-available": 1,
           },
-          data: messageData,
+          ...notification,
         }
       : {
           aps: {
@@ -109,7 +100,7 @@ export class ApnsPushService {
             sound: "default",
             "mutable-content": 1,
           },
-          data: messageData,
+          ...notification,
         };
 
     const token = this.getJwtToken();
@@ -125,7 +116,7 @@ export class ApnsPushService {
       });
 
       client.on("error", (error: Error) => {
-        req.log.error(
+        logger.error(
           { error: error.message, stack: error.stack, deviceId: device.id },
           "HTTP/2 connection error",
         );
@@ -138,14 +129,12 @@ export class ApnsPushService {
         ":path": `/3/device/${device.pushToken}`,
         authorization: `bearer ${token}`,
         "apns-topic": this.config.bundleId,
-        "apns-push-type": notification.subscription.is_silent
-          ? "background"
-          : "alert",
-        "apns-priority": notification.subscription.is_silent ? "5" : "10",
+        "apns-push-type": isSilent ? "background" : "alert",
+        "apns-priority": isSilent ? "5" : "10",
         "content-type": "application/json",
       };
 
-      req.log.info(
+      logger.info(
         {
           url: `https://${hostname}/3/device/${device.pushToken}`,
           headers,
@@ -165,7 +154,7 @@ export class ApnsPushService {
       request.on("response", (headers: Record<string, string | number>) => {
         statusCode = headers[":status"] as number;
         responseHeaders = headers;
-        req.log.info(
+        logger.info(
           {
             status: statusCode,
             headers: responseHeaders,
@@ -179,7 +168,7 @@ export class ApnsPushService {
       request.on("data", (chunk: Buffer) => {
         const chunkStr = chunk.toString("utf8");
         responseData += chunkStr;
-        req.log.info(
+        logger.info(
           { chunk: chunkStr, deviceId: device.id, verbose: true },
           "[VERBOSE] APNS response data chunk",
         );
@@ -189,7 +178,7 @@ export class ApnsPushService {
         client.close();
 
         if (statusCode === 200) {
-          req.log.info(
+          logger.info(
             {
               deviceId: device.id,
               apnsEnv: device.apnsEnv,
@@ -212,7 +201,7 @@ export class ApnsPushService {
           // Ignore JSON parse errors
         }
 
-        req.log.error(
+        logger.error(
           {
             status: statusCode,
             error: errorData,
@@ -241,7 +230,7 @@ export class ApnsPushService {
       });
 
       request.on("error", (error: Error) => {
-        req.log.error(
+        logger.error(
           {
             error: error.message,
             stack: error.stack,
@@ -256,7 +245,7 @@ export class ApnsPushService {
 
       // Send the payload
       const payloadStr = JSON.stringify(payload);
-      req.log.info(
+      logger.info(
         {
           payloadLength: payloadStr.length,
           deviceId: device.id,
@@ -268,7 +257,7 @@ export class ApnsPushService {
       request.write(payloadStr);
       request.end();
 
-      req.log.info(
+      logger.info(
         { deviceId: device.id, verbose: true },
         "[VERBOSE] APNS HTTP/2 request stream ended",
       );

--- a/src/api/v1/notifications/services/apns-push.service.ts
+++ b/src/api/v1/notifications/services/apns-push.service.ts
@@ -2,7 +2,7 @@ import http2 from "node:http2";
 import type { Device } from "@prisma/client";
 import type { Request } from "express";
 import jwt from "jsonwebtoken";
-import type { NotificationResponse } from "@/notifications/client";
+import type { WebhookNotificationBody } from "@/notifications/client";
 import type { PushMessageData } from "./push-notification.service";
 
 export interface ApnsConfig {
@@ -80,7 +80,7 @@ export class ApnsPushService {
 
   async sendPushNotification(args: {
     device: Device;
-    notification: NotificationResponse;
+    notification: WebhookNotificationBody;
     messageData: PushMessageData;
     req: Request;
   }): Promise<{ success: boolean; error?: string }> {

--- a/src/api/v1/notifications/services/notifications-types.ts
+++ b/src/api/v1/notifications/services/notifications-types.ts
@@ -18,9 +18,9 @@ export type NotificationTypeToData = {
 };
 
 type NotificationPayloadBase<T extends NotificationType> = {
-  notificationType: T;
   inboxId: string;
-  data: NotificationTypeToData[T];
+  notificationType: T;
+  notificationData: NotificationTypeToData[T];
 };
 
 // Discriminated union over notificationType

--- a/src/api/v1/notifications/services/notifications-types.ts
+++ b/src/api/v1/notifications/services/notifications-types.ts
@@ -1,0 +1,33 @@
+export type NotificationType = "Protocol" | "InviteJoinRequest";
+
+export type ProtocolNotificationData = {
+  contentTopic: string;
+  messageType: string;
+  encryptedMessage: string;
+  timestamp: string;
+};
+
+export type InviteJoinRequestNotificationData = {
+  inviteId: string;
+};
+
+// Mapping from NotificationType to its payload shape
+export type NotificationTypeToData = {
+  Protocol: ProtocolNotificationData;
+  InviteJoinRequest: InviteJoinRequestNotificationData;
+};
+
+type NotificationPayloadBase<T extends NotificationType> = {
+  notificationType: T;
+  inboxId: string;
+  data: NotificationTypeToData[T];
+};
+
+// Discriminated union over notificationType
+export type NotificationPayload = {
+  [K in NotificationType]: NotificationPayloadBase<K>;
+}[NotificationType];
+
+// Helper generic when the type is known at the call-site
+export type NotificationPayloadFor<T extends NotificationType> =
+  NotificationPayloadBase<T>;

--- a/src/api/v1/notifications/services/push-notification.service.ts
+++ b/src/api/v1/notifications/services/push-notification.service.ts
@@ -1,16 +1,14 @@
 import type { Device } from "@prisma/client";
-import type { Request } from "express";
 import type { WebhookNotificationBody } from "@/notifications/client";
+import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 import { createApnsService, type ApnsPushService } from "./apns-push.service";
+import type { NotificationPayload } from "./notifications-types";
 
-export interface PushMessageData extends Record<string, unknown> {
-  contentTopic: string;
-  messageType: string;
-  encryptedMessage: string;
-  timestamp: string;
-  inboxId: string;
-}
+type SendNotificationResult = {
+  success: boolean;
+  shouldCleanup?: boolean;
+};
 
 export class PushNotificationService {
   private apnsService: ApnsPushService | null;
@@ -21,27 +19,17 @@ export class PushNotificationService {
 
   async sendPushNotification(args: {
     device: Device;
-    notification: WebhookNotificationBody;
-    inboxId: string;
-    req: Request;
-  }): Promise<{ success: boolean; shouldCleanup?: boolean }> {
-    const { device, notification, inboxId, req } = args;
+    notification: NotificationPayload;
+  }): Promise<SendNotificationResult> {
+    const { device, notification } = args;
 
     // Check if device has too many push failures
     if (device.pushFailures > 10) {
-      req.log.warn(
+      logger.warn(
         `Device ${device.id} has too many push failures (${device.pushFailures}). Skipping notification.`,
       );
       return { success: false };
     }
-
-    const messageData: PushMessageData = {
-      contentTopic: notification.message.content_topic,
-      messageType: notification.message_context.message_type,
-      encryptedMessage: notification.message.message,
-      timestamp: notification.message.timestamp_ns,
-      inboxId,
-    };
 
     // Determine which push service to use
     const pushTokenType = device.pushTokenType;
@@ -51,34 +39,32 @@ export class PushNotificationService {
     switch (pushTokenType) {
       case "apns":
         if (!this.apnsService) {
-          req.log.error("APNS service not configured");
+          logger.error("APNS service not configured");
           return { success: false };
         }
         result = await this.apnsService.sendPushNotification({
           device,
           notification,
-          messageData,
-          req,
         });
         break;
 
       case "fcm":
-        req.log.warn(
+        logger.warn(
           `FCM push notifications not yet implemented for device ${device.id}`,
         );
         return { success: false };
 
       default:
-        req.log.warn(`No valid push token type for device ${device.id}`);
+        logger.warn(`No valid push token type for device ${device.id}`);
         return { success: false };
     }
 
     // Handle the result
     if (result.success) {
-      await this.updateLastPushSuccess(device.id, req);
+      await this.updateLastPushSuccess(device.id);
       return { success: true };
     } else {
-      await this.incrementPushFailures(device.id, req);
+      await this.incrementPushFailures(device.id);
 
       // Check if we should cleanup the device
       const shouldCleanup =
@@ -89,19 +75,19 @@ export class PushNotificationService {
     }
   }
 
-  private async incrementPushFailures(deviceId: string, req: Request) {
+  private async incrementPushFailures(deviceId: string) {
     try {
       await prisma.device.update({
         where: { id: deviceId },
         data: { pushFailures: { increment: 1 } },
       });
-      req.log.info(`Incremented push failures for device ${deviceId}`);
+      logger.info(`Incremented push failures for device ${deviceId}`);
     } catch (error) {
-      req.log.error({ error, deviceId }, "Failed to increment push failures");
+      logger.error({ error, deviceId }, "Failed to increment push failures");
     }
   }
 
-  private async updateLastPushSuccess(deviceId: string, req: Request) {
+  private async updateLastPushSuccess(deviceId: string) {
     try {
       await prisma.device.update({
         where: { id: deviceId },
@@ -110,9 +96,9 @@ export class PushNotificationService {
           pushFailures: 0, // Reset failures on successful push
         },
       });
-      req.log.info(`Updated last push success for device ${deviceId}`);
+      logger.info(`Updated last push success for device ${deviceId}`);
     } catch (error) {
-      req.log.error({ error, deviceId }, "Failed to update last push success");
+      logger.error({ error, deviceId }, "Failed to update last push success");
     }
   }
 }

--- a/src/api/v1/notifications/services/push-notification.service.ts
+++ b/src/api/v1/notifications/services/push-notification.service.ts
@@ -1,6 +1,6 @@
 import type { Device } from "@prisma/client";
 import type { Request } from "express";
-import type { NotificationResponse } from "@/notifications/client";
+import type { WebhookNotificationBody } from "@/notifications/client";
 import { prisma } from "@/utils/prisma";
 import { createApnsService, type ApnsPushService } from "./apns-push.service";
 
@@ -21,7 +21,7 @@ export class PushNotificationService {
 
   async sendPushNotification(args: {
     device: Device;
-    notification: NotificationResponse;
+    notification: WebhookNotificationBody;
     inboxId: string;
     req: Request;
   }): Promise<{ success: boolean; shouldCleanup?: boolean }> {

--- a/src/api/v1/notifications/services/push-notification.service.ts
+++ b/src/api/v1/notifications/services/push-notification.service.ts
@@ -1,5 +1,4 @@
 import type { Device } from "@prisma/client";
-import type { WebhookNotificationBody } from "@/notifications/client";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 import { createApnsService, type ApnsPushService } from "./apns-push.service";

--- a/src/notifications/client.ts
+++ b/src/notifications/client.ts
@@ -25,7 +25,7 @@ export type Topic = {
   hmacKeys: HmacKey[];
 };
 
-export type NotificationResponse = {
+export type WebhookNotificationBody = {
   idempotency_key: string;
   message: {
     content_topic: string;

--- a/tests/notifications.client.test.ts
+++ b/tests/notifications.client.test.ts
@@ -5,7 +5,7 @@ import { rimrafSync } from "rimraf";
 import { jsonMiddleware } from "@/middleware/json";
 import {
   createNotificationClient,
-  type NotificationResponse,
+  type WebhookNotificationBody,
 } from "@/notifications/client";
 import {
   buildConversationTopic,
@@ -35,12 +35,12 @@ describe("Notifications", () => {
   describe("subscriptions", () => {
     let app: express.Application;
     let server: Server;
-    let stream: AsyncStream<NotificationResponse>;
+    let stream: AsyncStream<WebhookNotificationBody>;
 
     beforeEach(() => {
       app = express();
       app.use(jsonMiddleware);
-      stream = new AsyncStream<NotificationResponse>();
+      stream = new AsyncStream<WebhookNotificationBody>();
       app.post("/", (req: Request, res: Response) => {
         const authHeader = req.headers.authorization;
         const expectedAuthHeader = getHttpDeliveryNotificationAuthHeader();
@@ -51,7 +51,7 @@ describe("Notifications", () => {
           return;
         }
 
-        void stream.callback(null, req.body as NotificationResponse);
+        void stream.callback(null, req.body as WebhookNotificationBody);
         res.status(200).send("OK");
       });
       server = app.listen(8081);
@@ -565,7 +565,7 @@ describe("Notifications", () => {
       });
 
       // Create a new stream for the second phase
-      stream = new AsyncStream<NotificationResponse>();
+      stream = new AsyncStream<WebhookNotificationBody>();
 
       // Send another message - we should NOT receive a notification
       await dm.send("second message after unsubscribe");

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -129,6 +129,7 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
           deviceId: testDeviceId,
           pushToken: "test-push-token-register",
           pushTokenType: "apns" as const,
+          apnsEnv: "sandbox",
           installations: [
             {
               identityId: AUTH_XMTP_ID,
@@ -156,6 +157,7 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
       where: { id: testDeviceId },
     });
     expect(device?.pushToken).toBe("test-push-token-register");
+    expect(device?.apnsEnv).toBe("sandbox");
   });
 
   test("POST /notifications/register validates request body (missing fields)", async () => {
@@ -185,6 +187,7 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
           deviceId: "wrong-device-id",
           pushToken: "test-push-token-forbidden",
           pushTokenType: "apns" as const,
+          apnsEnv: "sandbox",
           installations: [
             {
               identityId: AUTH_XMTP_ID,
@@ -208,6 +211,7 @@ describe("/notifications API - Register/Unregister (Auth Required)", () => {
           deviceId: testDeviceId,
           pushToken: "token-for-unregister-push",
           pushTokenType: "apns" as const,
+          apnsEnv: "sandbox",
           installations: [
             {
               identityId: AUTH_XMTP_ID,


### PR DESCRIPTION
Cleanup the notification payloads - support multiple types of notifications
The payload for a notification on iOS will now be like that

```
{
    "aps": {// APPLE SPECIFIC FIELD},
    "inboxId": string,
    "notificationType": "Protocol" | "InviteJoinRequest" | ... ,
    "notificationData": {
        // Format depends on notificationType
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Device registration now accepts and stores the APNs environment (e.g., sandbox/production).
  - Webhook payloads include a message timestamp and a more structured notification body.
  - Unified push delivery path (no longer restricted to APNs-only branch).

- Refactor
  - Streamlined push notification flow with a simplified, typed payload and centralized logging.

- Tests
  - Added coverage for APNs environment persistence and updated webhook payload expectations.

- Chores
  - Removed obsolete mocks and legacy request-coupled code in test scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->