### PR TITLE
Handle push notifications for invite requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
     "start": "bun run --preload ./src/instrumentation.ts src/index.ts",
+    "test:local": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 dev/restart-notification && bun test",
     "test:notifications-client": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 dev/restart-notification && bun test tests/notifications.client.test.ts",
     "test:push": "bun run scripts/test-push-notification.ts",
     "test:push-simple": "bun run scripts/simple-push-test.ts",

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -198,6 +198,7 @@ export async function requestToJoin(
       });
       return;
     }
+    req.log.warn(`ERROR DEBUGGING : ${error as string}`);
 
     req.log.error({ error }, "Error creating join request");
     res.status(500).json({

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -1,10 +1,14 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
+import type { InviteJoinRequestNotificationData } from "../../notifications/services/notifications-types";
+import { getPushNotificationService } from "../../notifications/services/push-notification.service";
 
 const requestToJoinSchema = z.object({
   inviteId: z.string().min(1, "Invite ID is required"),
 });
+
+const pushNotificationService = getPushNotificationService();
 
 export type RequestToJoinRequestBody = z.infer<typeof requestToJoinSchema>;
 
@@ -12,29 +16,6 @@ export type RequestToJoinResponse = {
   id: string;
   inviteId: string;
   createdAt: string;
-};
-
-export type InviteRequestNotificationPayload = {
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  requester: {
-    id: string;
-    xmtpId: string;
-    profile: {
-      name: string | null;
-      username: string | null;
-      description: string | null;
-      avatar: string | null;
-    } | null;
-  };
-  inviteCode: {
-    id: string;
-    name: string | null;
-    description: string | null;
-    groupId: string;
-  };
-  autoApprove: boolean;
 };
 
 export async function requestToJoin(
@@ -132,37 +113,45 @@ export async function requestToJoin(
             description: true,
             groupId: true,
             autoApprove: true,
+            createdById: true,
           },
         },
       },
     });
 
-    // const payload: InviteRequestNotificationPayload = {
-    //   id: requestToJoin.id,
-    //   createdAt: requestToJoin.createdAt.toISOString(),
-    //   updatedAt: requestToJoin.updatedAt.toISOString(),
-    //   requester: {
-    //     id: requestToJoin.requester.id,
-    //     xmtpId: requestToJoin.requester.xmtpId,
-    //     profile: requestToJoin.requester.profile
-    //       ? {
-    //           name: requestToJoin.requester.profile.name,
-    //           username: requestToJoin.requester.profile.username,
-    //           description: requestToJoin.requester.profile.description,
-    //           avatar: requestToJoin.requester.profile.avatar,
-    //         }
-    //       : null,
-    //   },
-    //   inviteCode: {
-    //     id: requestToJoin.inviteCode.id,
-    //     name: requestToJoin.inviteCode.name,
-    //     description: requestToJoin.inviteCode.description,
-    //     groupId: requestToJoin.inviteCode.groupId,
-    //   },
-    //   autoApprove: requestToJoin.inviteCode.autoApprove,
-    // };
+    const payload: InviteJoinRequestNotificationData = {
+      id: requestToJoin.id,
+      createdAt: requestToJoin.createdAt.toISOString(),
+      updatedAt: requestToJoin.updatedAt.toISOString(),
+      requester: {
+        id: requestToJoin.requester.id,
+        xmtpId: requestToJoin.requester.xmtpId,
+        profile: requestToJoin.requester.profile
+          ? {
+              name: requestToJoin.requester.profile.name,
+              username: requestToJoin.requester.profile.username,
+              description: requestToJoin.requester.profile.description,
+              avatar: requestToJoin.requester.profile.avatar,
+            }
+          : null,
+      },
+      inviteCode: {
+        id: requestToJoin.inviteCode.id,
+        name: requestToJoin.inviteCode.name,
+        description: requestToJoin.inviteCode.description,
+        groupId: requestToJoin.inviteCode.groupId,
+      },
+      autoApprove: requestToJoin.inviteCode.autoApprove,
+    };
 
-    // @todo We will send the actual notification here using APNS
+    await pushNotificationService.sendPushNotificationToXmtpId({
+      xmtpId: requestToJoin.inviteCode.createdById,
+      notification: {
+        inboxId: requestToJoin.inviteCode.createdById,
+        notificationType: "InviteJoinRequest",
+        notificationData: payload,
+      },
+    });
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -8,8 +8,6 @@ const requestToJoinSchema = z.object({
   inviteId: z.string().min(1, "Invite ID is required"),
 });
 
-const pushNotificationService = getPushNotificationService();
-
 export type RequestToJoinRequestBody = z.infer<typeof requestToJoinSchema>;
 
 export type RequestToJoinResponse = {
@@ -25,6 +23,8 @@ export async function requestToJoin(
   try {
     const body = await requestToJoinSchema.parseAsync(req.body);
     const { xmtpId } = req.app.locals;
+
+    const pushNotificationService = getPushNotificationService();
 
     // Find the requester's identity
     const requesterIdentity = await prisma.deviceIdentity.findFirst({
@@ -47,6 +47,11 @@ export async function requestToJoin(
         createdBy: {
           include: {
             profile: true,
+          },
+        },
+        notificationTargets: {
+          include: {
+            deviceIdentity: true,
           },
         },
       },
@@ -148,14 +153,27 @@ export async function requestToJoin(
       autoApprove: requestToJoin.inviteCode.autoApprove,
     };
 
-    await pushNotificationService.sendPushNotificationToXmtpId({
-      xmtpId: requestToJoin.inviteCode.createdBy.xmtpId,
-      notification: {
-        inboxId: requestToJoin.inviteCode.createdBy.xmtpId,
-        notificationType: "InviteJoinRequest",
-        notificationData: payload,
-      },
-    });
+    // Collect all recipients (creator + notification targets)
+    const allRecipients = [
+      requestToJoin.inviteCode.createdBy.xmtpId,
+      ...inviteCode.notificationTargets.map(
+        (target) => target.deviceIdentity.xmtpId,
+      ),
+    ];
+
+    // Send notifications to all recipients
+    const notificationPromises = allRecipients.map((xmtpId) =>
+      pushNotificationService.sendPushNotificationToXmtpId({
+        xmtpId,
+        notification: {
+          inboxId: xmtpId,
+          notificationType: "InviteJoinRequest",
+          notificationData: payload,
+        },
+      }),
+    );
+
+    await Promise.all(notificationPromises);
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -167,18 +167,20 @@ export async function requestToJoin(
     );
 
     // Send notifications to all recipients
-    const notificationPromises = uniqueRecipients.map((xmtpId) =>
-      pushNotificationService.sendPushNotificationToXmtpId({
-        xmtpId,
-        notification: {
-          inboxId: xmtpId,
-          notificationType: "InviteJoinRequest",
-          notificationData: payload,
-        },
-      }),
-    );
-
-    await Promise.all(notificationPromises);
+    uniqueRecipients.forEach((xmtpId) => {
+      pushNotificationService
+        .sendPushNotificationToXmtpId({
+          xmtpId,
+          notification: {
+            inboxId: xmtpId,
+            notificationType: "InviteJoinRequest",
+            notificationData: payload,
+          },
+        })
+        .catch((e: unknown) => {
+          req.log.error({ error: e }, "Error sending push notification");
+        });
+    });
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -154,15 +154,20 @@ export async function requestToJoin(
     };
 
     // Collect all recipients (creator + notification targets)
-    const allRecipients = [
+    const allRecipientIds = [
       requestToJoin.inviteCode.createdBy.xmtpId,
       ...inviteCode.notificationTargets.map(
         (target) => target.deviceIdentity.xmtpId,
       ),
     ];
 
+    // Filter out falsy values and deduplicate while preserving order
+    const uniqueRecipients = Array.from(
+      new Set(allRecipientIds.filter((xmtpId) => xmtpId)),
+    );
+
     // Send notifications to all recipients
-    const notificationPromises = allRecipients.map((xmtpId) =>
+    const notificationPromises = uniqueRecipients.map((xmtpId) =>
       pushNotificationService.sendPushNotificationToXmtpId({
         xmtpId,
         notification: {

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -113,7 +113,11 @@ export async function requestToJoin(
             description: true,
             groupId: true,
             autoApprove: true,
-            createdById: true,
+            createdBy: {
+              select: {
+                xmtpId: true,
+              },
+            },
           },
         },
       },
@@ -145,9 +149,9 @@ export async function requestToJoin(
     };
 
     await pushNotificationService.sendPushNotificationToXmtpId({
-      xmtpId: requestToJoin.inviteCode.createdById,
+      xmtpId: requestToJoin.inviteCode.createdBy.xmtpId,
       notification: {
-        inboxId: requestToJoin.inviteCode.createdById,
+        inboxId: requestToJoin.inviteCode.createdBy.xmtpId,
         notificationType: "InviteJoinRequest",
         notificationData: payload,
       },

--- a/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
+++ b/src/api/v1/notifications/handlers/handle-xmtp-notification.ts
@@ -51,12 +51,6 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       return;
     }
 
-    // Check if this notification should trigger a push
-    if (!notification.message_context.should_push) {
-      res.status(200).end();
-      return;
-    }
-
     const identityOnDevice = await prisma.identitiesOnDevice.findUnique({
       where: {
         xmtpInstallationId: notification.installation.id,

--- a/src/api/v1/notifications/services/notifications-types.ts
+++ b/src/api/v1/notifications/services/notifications-types.ts
@@ -8,7 +8,26 @@ export type ProtocolNotificationData = {
 };
 
 export type InviteJoinRequestNotificationData = {
-  inviteId: string;
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  requester: {
+    id: string;
+    xmtpId: string;
+    profile: {
+      name: string | null;
+      username: string | null;
+      description: string | null;
+      avatar: string | null;
+    } | null;
+  };
+  inviteCode: {
+    id: string;
+    name: string | null;
+    description: string | null;
+    groupId: string;
+  };
+  autoApprove: boolean;
 };
 
 // Mapping from NotificationType to its payload shape

--- a/src/api/v1/notifications/services/push-notification.service.ts
+++ b/src/api/v1/notifications/services/push-notification.service.ts
@@ -23,7 +23,13 @@ export class PushNotificationService {
     const { xmtpId, notification } = args;
     // Right now one xmtp id = one device, we can adapt in the future
     const device = await prisma.device.findFirst({
-      where: { identities: { some: { identityId: xmtpId } } },
+      where: {
+        identities: {
+          some: {
+            identity: { xmtpId: xmtpId },
+          },
+        },
+      },
     });
     if (!device) {
       return { success: false, shouldCleanup: false };

--- a/src/api/v1/notifications/services/push-notification.service.ts
+++ b/src/api/v1/notifications/services/push-notification.service.ts
@@ -16,6 +16,21 @@ export class PushNotificationService {
     this.apnsService = createApnsService();
   }
 
+  async sendPushNotificationToXmtpId(args: {
+    xmtpId: string;
+    notification: NotificationPayload;
+  }): Promise<SendNotificationResult> {
+    const { xmtpId, notification } = args;
+    // Right now one xmtp id = one device, we can adapt in the future
+    const device = await prisma.device.findFirst({
+      where: { identities: { some: { identityId: xmtpId } } },
+    });
+    if (!device) {
+      return { success: false, shouldCleanup: false };
+    }
+    return this.sendPushNotification({ device, notification });
+  }
+
   async sendPushNotification(args: {
     device: Device;
     notification: NotificationPayload;

--- a/src/api/v1/notifications/services/push-notification.service.ts
+++ b/src/api/v1/notifications/services/push-notification.service.ts
@@ -37,7 +37,7 @@ export class PushNotificationService {
     return this.sendPushNotification({ device, notification });
   }
 
-  async sendPushNotification(args: {
+  async _sendPushNotification(args: {
     device: Device;
     notification: NotificationPayload;
   }): Promise<SendNotificationResult> {
@@ -92,6 +92,23 @@ export class PushNotificationService {
         result.error === "BadDeviceToken";
 
       return { success: false, shouldCleanup };
+    }
+  }
+
+  async sendPushNotification(args: {
+    device: Device;
+    notification: NotificationPayload;
+  }): Promise<SendNotificationResult> {
+    try {
+      const notificationResult = await this._sendPushNotification(args);
+      return notificationResult;
+    } catch (error) {
+      logger.error(
+        { error, deviceId: args.device.id },
+        "Unexpected error sending push",
+      );
+      await this.incrementPushFailures(args.device.id);
+      return { success: false };
     }
   }
 

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -6,8 +6,6 @@ import {
   beforeEach,
   describe,
   expect,
-  mock,
-  spyOn,
   test,
 } from "bun:test";
 import express from "express";
@@ -18,19 +16,9 @@ import type {
   RequestToJoinResponse,
 } from "@/api/v1/invites/handlers/request-to-join";
 import invitesRouter from "@/api/v1/invites/invites.router";
-import type { NotificationPayload } from "@/api/v1/notifications/services/notifications-types";
-import * as PushService from "@/api/v1/notifications/services/push-notification.service";
 import { jsonMiddleware } from "@/middleware/json";
 import { pinoMiddleware } from "@/middleware/pino";
 import { prisma } from "@/utils/prisma";
-
-// Mock functions for push notification service
-const mockSendPushNotificationToXmtpId = mock<
-  (args: {
-    xmtpId: string;
-    notification: NotificationPayload;
-  }) => Promise<{ success: boolean }>
->(() => Promise.resolve({ success: true }));
 
 const app = express();
 app.use(pinoMiddleware);
@@ -57,20 +45,9 @@ beforeAll(() => {
 
 afterAll(() => {
   server.close();
-  // Restore all mocks
-  mock.restore();
 });
 
 beforeEach(async () => {
-  // Spy on the specific methods we care about on the actual service
-  const pushService = PushService.getPushNotificationService();
-  spyOn(pushService, "sendPushNotificationToXmtpId").mockImplementation(
-    mockSendPushNotificationToXmtpId,
-  );
-  spyOn(pushService, "sendPushNotification").mockResolvedValue({
-    success: true,
-  });
-
   // Clean up the database before each test
   await prisma.inviteCodeNotificationTarget.deleteMany();
   await prisma.inviteCodeRequest.deleteMany();

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -6,6 +6,8 @@ import {
   beforeEach,
   describe,
   expect,
+  mock,
+  spyOn,
   test,
 } from "bun:test";
 import express from "express";
@@ -16,9 +18,19 @@ import type {
   RequestToJoinResponse,
 } from "@/api/v1/invites/handlers/request-to-join";
 import invitesRouter from "@/api/v1/invites/invites.router";
+import type { NotificationPayload } from "@/api/v1/notifications/services/notifications-types";
+import * as PushService from "@/api/v1/notifications/services/push-notification.service";
 import { jsonMiddleware } from "@/middleware/json";
 import { pinoMiddleware } from "@/middleware/pino";
 import { prisma } from "@/utils/prisma";
+
+// Mock functions for push notification service
+const mockSendPushNotificationToXmtpId = mock<
+  (args: {
+    xmtpId: string;
+    notification: NotificationPayload;
+  }) => Promise<{ success: boolean }>
+>(() => Promise.resolve({ success: true }));
 
 const app = express();
 app.use(pinoMiddleware);
@@ -45,9 +57,20 @@ beforeAll(() => {
 
 afterAll(() => {
   server.close();
+  // Restore all mocks
+  mock.restore();
 });
 
 beforeEach(async () => {
+  // Spy on the specific methods we care about on the actual service
+  const pushService = PushService.getPushNotificationService();
+  spyOn(pushService, "sendPushNotificationToXmtpId").mockImplementation(
+    mockSendPushNotificationToXmtpId,
+  );
+  spyOn(pushService, "sendPushNotification").mockResolvedValue({
+    success: true,
+  });
+
   // Clean up the database before each test
   await prisma.inviteCodeNotificationTarget.deleteMany();
   await prisma.inviteCodeRequest.deleteMany();

--- a/tests/notifications-invites.test.ts
+++ b/tests/notifications-invites.test.ts
@@ -1,0 +1,315 @@
+import type { Server } from "http";
+import { DeviceOS, UserType, type InviteCode } from "@prisma/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import express from "express";
+import { rimrafSync } from "rimraf";
+import type { RequestToJoinRequestBody } from "@/api/v1/invites/handlers/request-to-join";
+import invitesRouter from "@/api/v1/invites/invites.router";
+import type {
+  InviteJoinRequestNotificationData,
+  NotificationPayload,
+} from "@/api/v1/notifications/services/notifications-types";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+
+// Mock the push notification service
+const mockPushNotificationService = {
+  sendPushNotificationToXmtpId: mock<
+    (args: {
+      xmtpId: string;
+      notification: NotificationPayload;
+    }) => Promise<{ success: boolean }>
+  >(() => Promise.resolve({ success: true })),
+};
+
+// Mock the getPushNotificationService function
+void mock.module(
+  "@/api/v1/notifications/services/push-notification.service",
+  () => ({
+    getPushNotificationService: () => mockPushNotificationService,
+    PushNotificationService: class MockPushNotificationService {
+      async sendPushNotificationToXmtpId(args: {
+        xmtpId: string;
+        notification: NotificationPayload;
+      }) {
+        return mockPushNotificationService.sendPushNotificationToXmtpId(args);
+      }
+    },
+  }),
+);
+
+describe("Invite Notifications Integration", () => {
+  let app: express.Application;
+  let server: Server;
+  let inviteCode: InviteCode;
+
+  beforeAll(() => {
+    // Set up Express app
+    app = express();
+    app.use(pinoMiddleware);
+    app.use(jsonMiddleware);
+
+    // Mock authentication middleware
+    app.use((req, _res, next) => {
+      const overrideXmtpId = req.headers["x-test-xmtp-id"];
+      req.app.locals.xmtpId =
+        typeof overrideXmtpId === "string"
+          ? overrideXmtpId
+          : "test-default-xmtp-id";
+      req.app.locals.xmtpInstallationId = "test-installation-id";
+      next();
+    });
+
+    app.use("/invites", invitesRouter);
+    server = app.listen(3015);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+    server.close();
+    rimrafSync("tests/**/*.db3*", { glob: true });
+  });
+
+  beforeEach(async () => {
+    // Reset mocks
+    mockPushNotificationService.sendPushNotificationToXmtpId.mockClear();
+    mockPushNotificationService.sendPushNotificationToXmtpId.mockResolvedValue({
+      success: true,
+    });
+
+    // Create test data
+    inviteCode = await setupTestData();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  const cleanup = async () => {
+    await prisma.inviteCodeNotificationTarget.deleteMany();
+    await prisma.inviteCodeRequest.deleteMany();
+    await prisma.inviteCodeUse.deleteMany();
+    await prisma.inviteCode.deleteMany();
+    await prisma.profile.deleteMany();
+    await prisma.identitiesOnDevice.deleteMany();
+    await prisma.conversationMetadata.deleteMany();
+    await prisma.deviceIdentity.deleteMany();
+    await prisma.device.deleteMany();
+    await prisma.user.deleteMany();
+  };
+
+  const setupTestData = async (): Promise<InviteCode> => {
+    // Create invite creator user
+    await prisma.user.create({
+      data: {
+        userId: "test-creator-user-notifications",
+        userType: UserType.turnkey,
+        devices: {
+          create: {
+            device: {
+              create: {
+                id: "test-device-creator-notifications",
+                os: DeviceOS.ios,
+                name: "Creator Device",
+                pushToken: "creator-push-token",
+                pushTokenType: "apns",
+                apnsEnv: "sandbox",
+              },
+            },
+          },
+        },
+        DeviceIdentity: {
+          create: {
+            xmtpId: "test-creator-xmtp-id-notifications",
+            identityAddress: "0x1234creator",
+            profile: {
+              create: {
+                name: "Test Creator",
+                username: "testcreator",
+                description: "Test creator user",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Create requester user
+    await prisma.user.create({
+      data: {
+        userId: "test-requester-user-notifications",
+        userType: UserType.turnkey,
+        devices: {
+          create: {
+            device: {
+              create: {
+                id: "test-device-requester-notifications",
+                os: DeviceOS.android,
+                name: "Requester Device",
+                pushToken: "requester-push-token",
+                pushTokenType: "apns",
+                apnsEnv: "sandbox",
+              },
+            },
+          },
+        },
+        DeviceIdentity: {
+          create: {
+            xmtpId: "test-requester-xmtp-id-notifications",
+            identityAddress: "0x1234requester",
+            profile: {
+              create: {
+                name: "Test Requester",
+                username: "testrequester",
+                description: "Test requester user",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Create notification target user (someone who should receive notifications)
+    await prisma.user.create({
+      data: {
+        userId: "test-notification-target-user",
+        userType: UserType.turnkey,
+        devices: {
+          create: {
+            device: {
+              create: {
+                id: "test-device-notification-target",
+                os: DeviceOS.ios,
+                name: "Notification Target Device",
+                pushToken: "notification-target-push-token",
+                pushTokenType: "apns",
+                apnsEnv: "sandbox",
+              },
+            },
+          },
+        },
+        DeviceIdentity: {
+          create: {
+            xmtpId: "test-notification-target-xmtp-id",
+            identityAddress: "0x1234notificationtarget",
+            profile: {
+              create: {
+                name: "Test Notification Target",
+                username: "testnotificationtarget",
+                description: "Test notification target user",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Get creator identity for invite creation
+    const creatorIdentity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId: "test-creator-xmtp-id-notifications" },
+    });
+
+    // Create invite code
+    const createdInviteCode = await prisma.inviteCode.create({
+      data: {
+        groupId: "test-group-notifications-123",
+        name: "Test Notification Group Invite",
+        description: "Test invite for notification testing",
+        autoApprove: false, // Require approval to trigger notifications
+        createdById: creatorIdentity!.id,
+      },
+    });
+
+    // Get notification target identity
+    const notificationTargetIdentity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId: "test-notification-target-xmtp-id" },
+    });
+
+    // Add notification target to the invite
+    await prisma.inviteCodeNotificationTarget.create({
+      data: {
+        inviteCodeId: createdInviteCode.id,
+        deviceIdentityId: notificationTargetIdentity!.id,
+      },
+    });
+
+    return createdInviteCode;
+  };
+
+  test("sends push notification when user requests to join invite", async () => {
+    const requestBody: RequestToJoinRequestBody = {
+      inviteId: inviteCode.id,
+    };
+
+    // Make API request as the requester
+    const response = await fetch("http://localhost:3015/invites/request", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-xmtp-id": "test-requester-xmtp-id-notifications",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(201);
+
+    // Verify push notifications were sent to both creator and notification target
+    expect(
+      mockPushNotificationService.sendPushNotificationToXmtpId,
+    ).toHaveBeenCalledTimes(2);
+
+    const calls =
+      mockPushNotificationService.sendPushNotificationToXmtpId.mock.calls;
+    const sentToXmtpIds = calls.map((call) => call[0].xmtpId);
+
+    // Verify notifications were sent to both creator and notification target
+    expect(sentToXmtpIds).toContain("test-creator-xmtp-id-notifications");
+    expect(sentToXmtpIds).toContain("test-notification-target-xmtp-id");
+
+    // Verify notification payload structure (check first call)
+    const firstCall = calls[0][0];
+    const notification = firstCall.notification;
+    expect(notification.notificationType).toBe("InviteJoinRequest");
+
+    // Verify notification data structure
+    const notificationData =
+      notification.notificationData as InviteJoinRequestNotificationData;
+    expect(notificationData.id).toBeDefined();
+    expect(notificationData.createdAt).toBeDefined();
+    expect(notificationData.updatedAt).toBeDefined();
+    expect(notificationData.autoApprove).toBe(false);
+
+    // Verify requester data
+    expect(notificationData.requester.xmtpId).toBe(
+      "test-requester-xmtp-id-notifications",
+    );
+    expect(notificationData.requester.profile?.name).toBe("Test Requester");
+    expect(notificationData.requester.profile?.username).toBe("testrequester");
+    expect(notificationData.requester.profile?.description).toBe(
+      "Test requester user",
+    );
+
+    // Verify invite code data
+    expect(notificationData.inviteCode.id).toBe(inviteCode.id);
+    expect(notificationData.inviteCode.name).toBe(
+      "Test Notification Group Invite",
+    );
+    expect(notificationData.inviteCode.description).toBe(
+      "Test invite for notification testing",
+    );
+    expect(notificationData.inviteCode.groupId).toBe(
+      "test-group-notifications-123",
+    );
+  });
+});

--- a/tests/notifications-invites.test.ts
+++ b/tests/notifications-invites.test.ts
@@ -18,35 +18,18 @@ import type {
   InviteJoinRequestNotificationData,
   NotificationPayload,
 } from "@/api/v1/notifications/services/notifications-types";
+import { getPushNotificationService } from "@/api/v1/notifications/services/push-notification.service";
 import { jsonMiddleware } from "@/middleware/json";
 import { pinoMiddleware } from "@/middleware/pino";
 import { prisma } from "@/utils/prisma";
 
-// Mock the push notification service
-const mockPushNotificationService = {
-  sendPushNotificationToXmtpId: mock<
-    (args: {
-      xmtpId: string;
-      notification: NotificationPayload;
-    }) => Promise<{ success: boolean }>
-  >(() => Promise.resolve({ success: true })),
-};
-
-// Mock the getPushNotificationService function
-void mock.module(
-  "@/api/v1/notifications/services/push-notification.service",
-  () => ({
-    getPushNotificationService: () => mockPushNotificationService,
-    PushNotificationService: class MockPushNotificationService {
-      async sendPushNotificationToXmtpId(args: {
-        xmtpId: string;
-        notification: NotificationPayload;
-      }) {
-        return mockPushNotificationService.sendPushNotificationToXmtpId(args);
-      }
-    },
-  }),
-);
+// Mock only for this test file
+const mockSendPushNotificationToXmtpId = mock<
+  (args: {
+    xmtpId: string;
+    notification: NotificationPayload;
+  }) => Promise<{ success: boolean }>
+>(() => Promise.resolve({ success: true }));
 
 describe("Invite Notifications Integration", () => {
   let app: express.Application;
@@ -85,17 +68,21 @@ describe("Invite Notifications Integration", () => {
   });
 
   beforeEach(async () => {
-    // Reset mocks
-    mockPushNotificationService.sendPushNotificationToXmtpId.mockClear();
-    mockPushNotificationService.sendPushNotificationToXmtpId.mockResolvedValue({
-      success: true,
-    });
+    // Set up spy on the push notification service method
+    const pushService = getPushNotificationService();
+    mockSendPushNotificationToXmtpId.mockClear();
+    mockSendPushNotificationToXmtpId.mockResolvedValue({ success: true });
+
+    // Replace the method with our mock
+    pushService.sendPushNotificationToXmtpId = mockSendPushNotificationToXmtpId;
 
     // Create test data
     inviteCode = await setupTestData();
   });
 
   afterEach(async () => {
+    // Clean up mocks
+    mockSendPushNotificationToXmtpId.mockRestore();
     await cleanup();
   });
 
@@ -268,12 +255,9 @@ describe("Invite Notifications Integration", () => {
     expect(response.status).toBe(201);
 
     // Verify push notifications were sent to both creator and notification target
-    expect(
-      mockPushNotificationService.sendPushNotificationToXmtpId,
-    ).toHaveBeenCalledTimes(2);
+    expect(mockSendPushNotificationToXmtpId).toHaveBeenCalledTimes(2);
 
-    const calls =
-      mockPushNotificationService.sendPushNotificationToXmtpId.mock.calls;
+    const calls = mockSendPushNotificationToXmtpId.mock.calls;
     const sentToXmtpIds = calls.map((call) => call[0].xmtpId);
 
     // Verify notifications were sent to both creator and notification target

--- a/tests/notifications-invites.test.ts
+++ b/tests/notifications-invites.test.ts
@@ -8,6 +8,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 import express from "express";
@@ -18,12 +19,12 @@ import type {
   InviteJoinRequestNotificationData,
   NotificationPayload,
 } from "@/api/v1/notifications/services/notifications-types";
-import { getPushNotificationService } from "@/api/v1/notifications/services/push-notification.service";
+import * as PushService from "@/api/v1/notifications/services/push-notification.service";
 import { jsonMiddleware } from "@/middleware/json";
 import { pinoMiddleware } from "@/middleware/pino";
 import { prisma } from "@/utils/prisma";
 
-// Mock only for this test file
+// Mock functions for push notification service
 const mockSendPushNotificationToXmtpId = mock<
   (args: {
     xmtpId: string;
@@ -62,19 +63,23 @@ describe("Invite Notifications Integration", () => {
     await prisma.$disconnect();
     server.close();
     rimrafSync("tests/**/*.db3*", { glob: true });
-
-    // Restore all mocks to prevent affecting other tests
+    // Restore all mocks
     mock.restore();
   });
 
   beforeEach(async () => {
-    // Set up spy on the push notification service method
-    const pushService = getPushNotificationService();
+    // Clear and reset mocks
     mockSendPushNotificationToXmtpId.mockClear();
     mockSendPushNotificationToXmtpId.mockResolvedValue({ success: true });
 
-    // Replace the method with our mock
-    pushService.sendPushNotificationToXmtpId = mockSendPushNotificationToXmtpId;
+    // Spy on the specific methods we care about on the actual service
+    const pushService = PushService.getPushNotificationService();
+    spyOn(pushService, "sendPushNotificationToXmtpId").mockImplementation(
+      mockSendPushNotificationToXmtpId,
+    );
+    spyOn(pushService, "sendPushNotification").mockResolvedValue({
+      success: true,
+    });
 
     // Create test data
     inviteCode = await setupTestData();
@@ -82,7 +87,8 @@ describe("Invite Notifications Integration", () => {
 
   afterEach(async () => {
     // Clean up mocks
-    mockSendPushNotificationToXmtpId.mockRestore();
+    mockSendPushNotificationToXmtpId.mockClear();
+    mock.restore();
     await cleanup();
   });
 

--- a/tests/notifications-invites.test.ts
+++ b/tests/notifications-invites.test.ts
@@ -79,6 +79,9 @@ describe("Invite Notifications Integration", () => {
     await prisma.$disconnect();
     server.close();
     rimrafSync("tests/**/*.db3*", { glob: true });
+
+    // Restore all mocks to prevent affecting other tests
+    mock.restore();
   });
 
   beforeEach(async () => {

--- a/tests/notifications-invites.test.ts
+++ b/tests/notifications-invites.test.ts
@@ -93,7 +93,6 @@ describe("Invite Notifications Integration", () => {
     await prisma.inviteCode.deleteMany();
     await prisma.profile.deleteMany();
     await prisma.identitiesOnDevice.deleteMany();
-    await prisma.conversationMetadata.deleteMany();
     await prisma.deviceIdentity.deleteMany();
     await prisma.device.deleteMany();
     await prisma.user.deleteMany();

--- a/tests/notifications-service.test.ts
+++ b/tests/notifications-service.test.ts
@@ -20,12 +20,14 @@ import {
 } from "@/api/v1/notifications/services/push-notification.service";
 import { prisma } from "@/utils/prisma";
 
-// Mock only for this test file
-const mockApnsService = {
-  sendPushNotification: mock<
-    () => Promise<{ success: boolean; error?: string }>
-  >(() => Promise.resolve({ success: true })),
-};
+// Mock functions for APNS service
+const mockSendPushNotification = mock<
+  (args: {
+    device: Device;
+    notification: NotificationPayload;
+    isSilent?: boolean;
+  }) => Promise<{ success: boolean; error?: string }>
+>(() => Promise.resolve({ success: true }));
 
 describe("PushNotificationService", () => {
   let testDevice: Device;
@@ -47,13 +49,16 @@ describe("PushNotificationService", () => {
 
   beforeEach(async () => {
     // Reset mocks before each test
-    mockApnsService.sendPushNotification.mockClear();
-    mockApnsService.sendPushNotification.mockResolvedValue({ success: true });
+    mockSendPushNotification.mockClear();
+    mockSendPushNotification.mockResolvedValue({ success: true });
 
-    // Create a fresh service instance
+    // Create a fresh service instance => not breaking the singleton
     pushService = new PushNotificationService();
 
-    // Replace the apnsService with our mock
+    // Mock the APNS service on the instance by replacing the private property
+    const mockApnsService = {
+      sendPushNotification: mockSendPushNotification,
+    };
     // @ts-expect-error - Accessing private property for testing
     pushService.apnsService = mockApnsService;
 
@@ -88,7 +93,7 @@ describe("PushNotificationService", () => {
 
   afterEach(async () => {
     // Clean up mocks
-    mockApnsService.sendPushNotification.mockRestore();
+    mockSendPushNotification.mockClear();
     await cleanup();
   });
 
@@ -109,8 +114,8 @@ describe("PushNotificationService", () => {
       expect(result.shouldCleanup).toBeUndefined();
 
       // Verify APNS service was called
-      expect(mockApnsService.sendPushNotification).toHaveBeenCalledTimes(1);
-      expect(mockApnsService.sendPushNotification).toHaveBeenCalledWith({
+      expect(mockSendPushNotification).toHaveBeenCalledTimes(1);
+      expect(mockSendPushNotification).toHaveBeenCalledWith({
         device: testDevice,
         notification: protocolNotification,
       });
@@ -139,7 +144,7 @@ describe("PushNotificationService", () => {
       expect(result.shouldCleanup).toBeUndefined();
 
       // Verify APNS service was NOT called
-      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
     });
 
     test("handles FCM push token type (not implemented)", async () => {
@@ -154,12 +159,12 @@ describe("PushNotificationService", () => {
       });
 
       expect(result.success).toBe(false);
-      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
     });
 
     test("handles APNS failure and increments push failures", async () => {
       // Mock APNS service to return failure
-      mockApnsService.sendPushNotification.mockResolvedValue({
+      mockSendPushNotification.mockResolvedValue({
         success: false,
         error: "InvalidPayload",
       });
@@ -182,7 +187,7 @@ describe("PushNotificationService", () => {
 
     test("marks device for cleanup on bad device token", async () => {
       // Mock APNS service to return bad device token error
-      mockApnsService.sendPushNotification.mockResolvedValue({
+      mockSendPushNotification.mockResolvedValue({
         success: false,
         error: "BadDeviceToken",
       });
@@ -204,7 +209,7 @@ describe("PushNotificationService", () => {
 
     test("marks device for cleanup on device not registered", async () => {
       // Mock APNS service to return device not registered error
-      mockApnsService.sendPushNotification.mockResolvedValue({
+      mockSendPushNotification.mockResolvedValue({
         success: false,
         error: "DeviceNotRegistered",
       });
@@ -232,7 +237,7 @@ describe("PushNotificationService", () => {
 
       // Should still return success from APNS perspective
       expect(result.success).toBe(true);
-      expect(mockApnsService.sendPushNotification).toHaveBeenCalled();
+      expect(mockSendPushNotification).toHaveBeenCalled();
     });
   });
 
@@ -289,7 +294,7 @@ describe("PushNotificationService", () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockApnsService.sendPushNotification).toHaveBeenCalledTimes(1);
+      expect(mockSendPushNotification).toHaveBeenCalledTimes(1);
     });
 
     test("returns failure when no device found for xmtpId", async () => {
@@ -300,7 +305,7 @@ describe("PushNotificationService", () => {
 
       expect(result.success).toBe(false);
       expect(result.shouldCleanup).toBe(false);
-      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -315,17 +320,19 @@ describe("PushNotificationService", () => {
 
   describe("APNS service not configured", () => {
     test("handles APNS service not configured", async () => {
-      // Set the apnsService to null to simulate APNS not configured
-      // @ts-expect-error - Accessing private property for testing
-      pushService.apnsService = null;
+      // Create a new service instance and set apnsService to null
+      const pushServiceWithoutApns = new PushNotificationService();
 
-      const result = await pushService.sendPushNotification({
+      // @ts-expect-error - Accessing private property for testing
+      pushServiceWithoutApns.apnsService = null;
+
+      const result = await pushServiceWithoutApns.sendPushNotification({
         device: testDevice,
         notification: protocolNotification,
       });
 
       expect(result.success).toBe(false);
-      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+      expect(mockSendPushNotification).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/notifications-service.test.ts
+++ b/tests/notifications-service.test.ts
@@ -50,6 +50,7 @@ describe("PushNotificationService", () => {
     await prisma.$disconnect();
     // Clean up test databases
     rimrafSync("tests/**/*.db3*", { glob: true });
+    mock.restore();
   });
 
   beforeEach(async () => {

--- a/tests/notifications-service.test.ts
+++ b/tests/notifications-service.test.ts
@@ -20,20 +20,12 @@ import {
 } from "@/api/v1/notifications/services/push-notification.service";
 import { prisma } from "@/utils/prisma";
 
+// Mock only for this test file
 const mockApnsService = {
   sendPushNotification: mock<
     () => Promise<{ success: boolean; error?: string }>
   >(() => Promise.resolve({ success: true })),
 };
-
-void mock.module("@/api/v1/notifications/services/apns-push.service", () => ({
-  createApnsService: mock(() => mockApnsService),
-  ApnsPushService: class MockApnsPushService {
-    async sendPushNotification() {
-      return mockApnsService.sendPushNotification();
-    }
-  },
-}));
 
 describe("PushNotificationService", () => {
   let testDevice: Device;
@@ -60,6 +52,10 @@ describe("PushNotificationService", () => {
 
     // Create a fresh service instance
     pushService = new PushNotificationService();
+
+    // Replace the apnsService with our mock
+    // @ts-expect-error - Accessing private property for testing
+    pushService.apnsService = mockApnsService;
 
     // Create test device
     testDevice = await prisma.device.create({
@@ -91,6 +87,8 @@ describe("PushNotificationService", () => {
   });
 
   afterEach(async () => {
+    // Clean up mocks
+    mockApnsService.sendPushNotification.mockRestore();
     await cleanup();
   });
 
@@ -317,21 +315,11 @@ describe("PushNotificationService", () => {
 
   describe("APNS service not configured", () => {
     test("handles APNS service not configured", async () => {
-      // Create a mock that returns null to simulate APNS not configured
-      const mockCreateApnsService = mock(() => null);
+      // Set the apnsService to null to simulate APNS not configured
+      // @ts-expect-error - Accessing private property for testing
+      pushService.apnsService = null;
 
-      // Re-mock the module to return null
-      void mock.module(
-        "@/api/v1/notifications/services/apns-push.service",
-        () => ({
-          createApnsService: mockCreateApnsService,
-        }),
-      );
-
-      // Create a new service instance that will get null from createApnsService
-      const serviceWithoutApns = new PushNotificationService();
-
-      const result = await serviceWithoutApns.sendPushNotification({
+      const result = await pushService.sendPushNotification({
         device: testDevice,
         notification: protocolNotification,
       });

--- a/tests/notifications-service.test.ts
+++ b/tests/notifications-service.test.ts
@@ -1,0 +1,342 @@
+import type { Device } from "@prisma/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { rimrafSync } from "rimraf";
+import type {
+  NotificationPayload,
+  ProtocolNotificationData,
+} from "@/api/v1/notifications/services/notifications-types";
+import {
+  getPushNotificationService,
+  PushNotificationService,
+} from "@/api/v1/notifications/services/push-notification.service";
+import { prisma } from "@/utils/prisma";
+
+const mockApnsService = {
+  sendPushNotification: mock<
+    () => Promise<{ success: boolean; error?: string }>
+  >(() => Promise.resolve({ success: true })),
+};
+
+void mock.module("@/api/v1/notifications/services/apns-push.service", () => ({
+  createApnsService: mock(() => mockApnsService),
+  ApnsPushService: class MockApnsPushService {
+    async sendPushNotification() {
+      return mockApnsService.sendPushNotification();
+    }
+  },
+}));
+
+describe("PushNotificationService", () => {
+  let testDevice: Device;
+  let protocolNotification: NotificationPayload;
+  let pushService: PushNotificationService;
+
+  beforeAll(async () => {
+    // Clean up any existing test data
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+    // Clean up test databases
+    rimrafSync("tests/**/*.db3*", { glob: true });
+  });
+
+  beforeEach(async () => {
+    // Reset mocks before each test
+    mockApnsService.sendPushNotification.mockClear();
+    mockApnsService.sendPushNotification.mockResolvedValue({ success: true });
+
+    // Create a fresh service instance
+    pushService = new PushNotificationService();
+
+    // Create test device
+    testDevice = await prisma.device.create({
+      data: {
+        id: "test-device-notifications",
+        name: "Test Device",
+        os: "ios",
+        pushToken: "test-apns-token",
+        pushTokenType: "apns",
+        apnsEnv: "sandbox",
+        pushFailures: 0,
+        lastPushSuccessAt: null,
+      },
+    });
+
+    // Create test protocol notification
+    const protocolData: ProtocolNotificationData = {
+      contentTopic: "/xmtp/mls/1/g-test-group/proto",
+      messageType: "v3-conversation",
+      encryptedMessage: "encrypted-message-content",
+      timestamp: new Date().toISOString(),
+    };
+
+    protocolNotification = {
+      inboxId: "test-inbox-id",
+      notificationType: "Protocol",
+      notificationData: protocolData,
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  const cleanup = async () => {
+    await prisma.device.deleteMany({
+      where: { id: { contains: "test" } },
+    });
+  };
+
+  describe("sendPushNotification", () => {
+    test("successfully sends notification to APNS device", async () => {
+      const result = await pushService.sendPushNotification({
+        device: testDevice,
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.shouldCleanup).toBeUndefined();
+
+      // Verify APNS service was called
+      expect(mockApnsService.sendPushNotification).toHaveBeenCalledTimes(1);
+      expect(mockApnsService.sendPushNotification).toHaveBeenCalledWith({
+        device: testDevice,
+        notification: protocolNotification,
+      });
+
+      // Verify database was updated - device should have success timestamp and reset failures
+      const updatedDevice = await prisma.device.findUnique({
+        where: { id: testDevice.id },
+      });
+      expect(updatedDevice?.pushFailures).toBe(0);
+      expect(updatedDevice?.lastPushSuccessAt).not.toBeNull();
+    });
+
+    test("skips notification for device with too many failures", async () => {
+      // Update device to have too many failures
+      await prisma.device.update({
+        where: { id: testDevice.id },
+        data: { pushFailures: 15 },
+      });
+
+      const result = await pushService.sendPushNotification({
+        device: { ...testDevice, pushFailures: 15 },
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.shouldCleanup).toBeUndefined();
+
+      // Verify APNS service was NOT called
+      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+    });
+
+    test("handles FCM push token type (not implemented)", async () => {
+      const fcmDevice = {
+        ...testDevice,
+        pushTokenType: "fcm" as const,
+      };
+
+      const result = await pushService.sendPushNotification({
+        device: fcmDevice,
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+    });
+
+    test("handles APNS failure and increments push failures", async () => {
+      // Mock APNS service to return failure
+      mockApnsService.sendPushNotification.mockResolvedValue({
+        success: false,
+        error: "InvalidPayload",
+      });
+
+      const result = await pushService.sendPushNotification({
+        device: testDevice,
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.shouldCleanup).toBe(false);
+
+      // Verify database was updated - failures should be incremented
+      const updatedDevice = await prisma.device.findUnique({
+        where: { id: testDevice.id },
+      });
+      expect(updatedDevice?.pushFailures).toBe(1);
+      expect(updatedDevice?.lastPushSuccessAt).toBeNull();
+    });
+
+    test("marks device for cleanup on bad device token", async () => {
+      // Mock APNS service to return bad device token error
+      mockApnsService.sendPushNotification.mockResolvedValue({
+        success: false,
+        error: "BadDeviceToken",
+      });
+
+      const result = await pushService.sendPushNotification({
+        device: testDevice,
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.shouldCleanup).toBe(true);
+
+      // Verify failures were still incremented
+      const updatedDevice = await prisma.device.findUnique({
+        where: { id: testDevice.id },
+      });
+      expect(updatedDevice?.pushFailures).toBe(1);
+    });
+
+    test("marks device for cleanup on device not registered", async () => {
+      // Mock APNS service to return device not registered error
+      mockApnsService.sendPushNotification.mockResolvedValue({
+        success: false,
+        error: "DeviceNotRegistered",
+      });
+
+      const result = await pushService.sendPushNotification({
+        device: testDevice,
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.shouldCleanup).toBe(true);
+    });
+
+    test("handles database update errors gracefully", async () => {
+      // Create device with invalid ID that will cause database error
+      const invalidDevice = {
+        ...testDevice,
+        id: "non-existent-device-id",
+      };
+
+      const result = await pushService.sendPushNotification({
+        device: invalidDevice,
+        notification: protocolNotification,
+      });
+
+      // Should still return success from APNS perspective
+      expect(result.success).toBe(true);
+      expect(mockApnsService.sendPushNotification).toHaveBeenCalled();
+    });
+  });
+
+  describe("sendPushNotificationToXmtpId", () => {
+    let testUser: { id: string; userId: string };
+    let testIdentity: { id: string; xmtpId: string };
+
+    beforeEach(async () => {
+      // Create test user and identity
+      testUser = await prisma.user.create({
+        data: {
+          userId: "test-user-notifications",
+          userType: "turnkey",
+        },
+      });
+
+      testIdentity = await prisma.deviceIdentity.create({
+        data: {
+          userId: testUser.id,
+          xmtpId: "test-xmtp-id-notifications",
+          identityAddress: "0x1234567890",
+        },
+      });
+
+      // Link device to user
+      await prisma.usersOnDevice.create({
+        data: {
+          userId: testUser.id,
+          deviceId: testDevice.id,
+        },
+      });
+
+      // Link identity to device
+      await prisma.identitiesOnDevice.create({
+        data: {
+          deviceId: testDevice.id,
+          identityId: testIdentity.id,
+          xmtpInstallationId: "test-installation-id",
+        },
+      });
+    });
+
+    afterEach(async () => {
+      await prisma.identitiesOnDevice.deleteMany();
+      await prisma.usersOnDevice.deleteMany();
+      await prisma.deviceIdentity.deleteMany();
+      await prisma.user.deleteMany();
+    });
+
+    test("successfully sends notification to device by xmtpId", async () => {
+      const result = await pushService.sendPushNotificationToXmtpId({
+        xmtpId: "test-xmtp-id-notifications",
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockApnsService.sendPushNotification).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns failure when no device found for xmtpId", async () => {
+      const result = await pushService.sendPushNotificationToXmtpId({
+        xmtpId: "non-existent-xmtp-id",
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.shouldCleanup).toBe(false);
+      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("singleton service", () => {
+    test("getPushNotificationService returns same instance", () => {
+      const service1 = getPushNotificationService();
+      const service2 = getPushNotificationService();
+
+      expect(service1).toBe(service2);
+    });
+  });
+
+  describe("APNS service not configured", () => {
+    test("handles APNS service not configured", async () => {
+      // Create a mock that returns null to simulate APNS not configured
+      const mockCreateApnsService = mock(() => null);
+
+      // Re-mock the module to return null
+      void mock.module(
+        "@/api/v1/notifications/services/apns-push.service",
+        () => ({
+          createApnsService: mockCreateApnsService,
+        }),
+      );
+
+      // Create a new service instance that will get null from createApnsService
+      const serviceWithoutApns = new PushNotificationService();
+
+      const result = await serviceWithoutApns.sendPushNotification({
+        device: testDevice,
+        notification: protocolNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockApnsService.sendPushNotification).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
### Send push notifications to invite creators when users request to join their invites
- The `requestToJoin` handler in [request-to-join.ts](https://github.com/ephemeraHQ/convos-backend/pull/120/files#diff-cf71af42c7db7b44ac40a54cbea5a69ba186368416c84cd2884c191796102ebe) now sends push notifications to invite creators using their XMTP ID when join requests are submitted
- A new `sendPushNotificationToXmtpId` method is added to `PushNotificationService` in [push-notification.service.ts](https://github.com/ephemeraHQ/convos-backend/pull/120/files#diff-20713748a18cf334782da4556ebf5d9054f6f77e274ebcab7b1dfb8f6ace9220) to enable sending notifications by XMTP identity
- The `InviteJoinRequestNotificationData` type in [notifications-types.ts](https://github.com/ephemeraHQ/convos-backend/pull/120/files#diff-ea3948e109d926a548317931116a3fcaa9cfc20fd25c9bb799bc7d860df7be78) is updated to include detailed request and invite information
- The XMTP notification handler in [handle-xmtp-notification.ts](https://github.com/ephemeraHQ/convos-backend/pull/120/files#diff-5e68d80d2d4bcf38d79f23de529a3d6dd023eb809a0ffb452350874ec493e29e) removes the early return for notifications with `should_push` set to false

#### 📍Where to Start
Start with the `requestToJoin` handler in [request-to-join.ts](https://github.com/ephemeraHQ/convos-backend/pull/120/files#diff-cf71af42c7db7b44ac40a54cbea5a69ba186368416c84cd2884c191796102ebe) where the push notification logic is integrated into the join request flow.

----

_[Macroscope](https://app.macroscope.com) summarized 7af6e60._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Invite join requests now send push notifications to multiple recipients (creator + configured notification targets) with per-recipient routing.

- **Bug Fixes**
  - Notification processing no longer exits early, improving delivery attempts and reliability.

- **Chores**
  - Invite notification payload enriched with requester and invite metadata; push service gains per-identity targeting and delivery handling; added a local test script.

- **Tests**
  - New unit and integration tests covering multi-recipient delivery and push service behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->