### PR TITLE
Return full invite from request to join

### DIFF
--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -41,21 +41,9 @@ export async function requestToJoin(
       return;
     }
 
-    // Find the invite code
+    // Find the invite code, without include because we return it
     const inviteCode = await prisma.inviteCode.findUnique({
       where: { id: body.inviteId },
-      include: {
-        createdBy: {
-          include: {
-            profile: true,
-          },
-        },
-        notificationTargets: {
-          include: {
-            deviceIdentity: true,
-          },
-        },
-      },
     });
 
     if (!inviteCode) {
@@ -113,9 +101,21 @@ export async function requestToJoin(
           include: { profile: true },
         },
         inviteCode: {
-          include: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            groupId: true,
+            autoApprove: true,
             createdBy: {
-              select: { xmtpId: true },
+              select: {
+                xmtpId: true,
+              },
+            },
+            notificationTargets: {
+              include: {
+                deviceIdentity: true,
+              },
             },
           },
         },
@@ -150,7 +150,7 @@ export async function requestToJoin(
     // Collect all recipients (creator + notification targets)
     const allRecipientIds = [
       requestToJoin.inviteCode.createdBy.xmtpId,
-      ...inviteCode.notificationTargets.map(
+      ...requestToJoin.inviteCode.notificationTargets.map(
         (target) => target.deviceIdentity.xmtpId,
       ),
     ];
@@ -178,7 +178,7 @@ export async function requestToJoin(
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,
-      invite: requestToJoin.inviteCode,
+      invite: inviteCode,
       createdAt: requestToJoin.createdAt.toISOString(),
     };
 

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -1,3 +1,4 @@
+import type { InviteCode } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
@@ -12,7 +13,7 @@ export type RequestToJoinRequestBody = z.infer<typeof requestToJoinSchema>;
 
 export type RequestToJoinResponse = {
   id: string;
-  inviteId: string;
+  invite: InviteCode;
   createdAt: string;
 };
 
@@ -112,16 +113,9 @@ export async function requestToJoin(
           include: { profile: true },
         },
         inviteCode: {
-          select: {
-            id: true,
-            name: true,
-            description: true,
-            groupId: true,
-            autoApprove: true,
+          include: {
             createdBy: {
-              select: {
-                xmtpId: true,
-              },
+              select: { xmtpId: true },
             },
           },
         },
@@ -184,7 +178,7 @@ export async function requestToJoin(
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,
-      inviteId: requestToJoin.inviteCodeId,
+      invite: requestToJoin.inviteCode,
       createdAt: requestToJoin.createdAt.toISOString(),
     };
 

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -1,6 +1,7 @@
 import type { InviteCode } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { getInviteLink } from "@/utils/invites";
 import { prisma } from "@/utils/prisma";
 import type { InviteJoinRequestNotificationData } from "../../notifications/services/notifications-types";
 import { getPushNotificationService } from "../../notifications/services/push-notification.service";
@@ -13,7 +14,9 @@ export type RequestToJoinRequestBody = z.infer<typeof requestToJoinSchema>;
 
 export type RequestToJoinResponse = {
   id: string;
-  invite: InviteCode;
+  invite: InviteCode & {
+    inviteLinkURL: string;
+  };
   createdAt: string;
 };
 
@@ -178,7 +181,10 @@ export async function requestToJoin(
 
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,
-      invite: inviteCode,
+      invite: {
+        ...inviteCode,
+        inviteLinkURL: getInviteLink(inviteCode.id),
+      },
       createdAt: requestToJoin.createdAt.toISOString(),
     };
 

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -175,7 +175,7 @@ describe("/invites/request API", () => {
 
     const joinRequest = (await response.json()) as RequestToJoinResponse;
     expect(joinRequest.id).toBeDefined();
-    expect(joinRequest.inviteId).toBe(inviteCode.id);
+    expect(joinRequest.invite.id).toBe(inviteCode.id);
     expect(joinRequest.createdAt).toBeDefined();
 
     // Verify the request was created in the database


### PR DESCRIPTION
### Return full invite object instead of inviteId string from request-to-join API endpoint
The `RequestToJoinResponse` type alias changes from returning an `inviteId` string to returning a full `invite` object, and the `requestToJoin` handler in [src/api/v1/invites/handlers/request-to-join.ts](https://github.com/ephemeraHQ/convos-backend/pull/123/files#diff-cf71af42c7db7b44ac40a54cbea5a69ba186368416c84cd2884c191796102ebe) modifies its Prisma query to include the full invite entity with `createdBy.xmtpId` instead of selecting specific fields. The corresponding test in [tests/invite-requests.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/123/files#diff-14c308b5731fb0687bf93a14d5b3a7066f7b35360ec7d3a7ca5fc0948aac898c) updates its assertion to expect `joinRequest.invite.id` instead of `joinRequest.inviteId`.

#### 📍Where to Start
Start with the `requestToJoin` handler function in [src/api/v1/invites/handlers/request-to-join.ts](https://github.com/ephemeraHQ/convos-backend/pull/123/files#diff-cf71af42c7db7b44ac40a54cbea5a69ba186368416c84cd2884c191796102ebe) to understand how the response structure changes from returning an invite ID to the full invite object.

----

_[Macroscope](https://app.macroscope.com) summarized ea46f46._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Join request API now returns an invite object (with id, details and a computed invite link URL) instead of a plain inviteId, allowing clients to access invite information and link directly.
  - Breaking change: integrations expecting inviteId must be updated to read invite.id and invite.inviteLinkURL.

- Tests
  - Updated tests to assert the nested invite.id and presence of invite details in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->