### PR TITLE
Added `/with-group` endpoint + renamed invite handlers for clarity

### DIFF
--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -29,9 +29,13 @@ export type GetPublicInviteDetailsResponse = {
   description: string | null;
   imageUrl: string | null;
   inviteLinkURL: string;
+  groupId: string;
 };
 
-export const getInviteDetailsHandler = async (req: Request, res: Response) => {
+export const getPublicInviteDetailsHandler = async (
+  req: Request,
+  res: Response,
+) => {
   try {
     const { inviteId } = await paramsSchema.parseAsync(req.params);
 
@@ -71,6 +75,7 @@ export const getInviteDetailsHandler = async (req: Request, res: Response) => {
       description: inviteCode.description,
       imageUrl: inviteCode.imageUrl,
       inviteLinkURL: getInviteLink(inviteCode.id),
+      groupId: inviteCode.groupId,
     };
 
     res.status(200).json(response);
@@ -92,7 +97,7 @@ export const getInviteDetailsHandler = async (req: Request, res: Response) => {
   }
 };
 
-export const getAuthenticatedInviteDetailsHandler = async (
+export const getOwnerInviteDetailsHandler = async (
   req: Request,
   res: Response,
 ) => {
@@ -162,6 +167,87 @@ export const getAuthenticatedInviteDetailsHandler = async (
     }
 
     req.log.error({ error }, "Error fetching invite details");
+    res.status(500).json({
+      success: false,
+      message: "Failed to fetch invite details",
+    });
+  }
+};
+
+export const getAuthenticatedInviteDetailsHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { inviteId } = await paramsSchema.parseAsync(req.params);
+
+    // Get the authenticated user's identity from the JWT (for auth validation)
+    const { xmtpId } = req.app.locals;
+
+    const identity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId },
+    });
+
+    if (!identity) {
+      res.status(404).json({
+        success: false,
+        message: "Identity not found",
+      });
+      return;
+    }
+
+    const inviteCode = await prisma.inviteCode.findUnique({
+      where: { id: inviteId },
+    });
+
+    if (!inviteCode) {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
+      });
+      return;
+    }
+
+    // Check if invite is active
+    if (inviteCode.status !== "ACTIVE") {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
+      });
+      return;
+    }
+
+    // Check if invite is expired
+    if (inviteCode.expiresAt && inviteCode.expiresAt < new Date()) {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
+      });
+      return;
+    }
+
+    // Return the same data as public endpoint (including groupId)
+    const response: GetPublicInviteDetailsResponse = {
+      id: inviteCode.id,
+      name: inviteCode.name,
+      description: inviteCode.description,
+      imageUrl: inviteCode.imageUrl,
+      inviteLinkURL: getInviteLink(inviteCode.id),
+      groupId: inviteCode.groupId,
+    };
+
+    res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({
+        success: false,
+        message: "Invalid invite ID",
+        errors: error.errors,
+      });
+      return;
+    }
+
+    req.log.error({ error }, "Error fetching authenticated invite details");
     res.status(500).json({
       success: false,
       message: "Failed to fetch invite details",

--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -29,7 +29,35 @@ export type GetPublicInviteDetailsResponse = {
   description: string | null;
   imageUrl: string | null;
   inviteLinkURL: string;
+};
+
+export type GetAuthenticatedInviteDetailsResponse = {
+  id: string;
+  name: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  inviteLinkURL: string;
   groupId: string;
+};
+
+/**
+ * Fetches an active, non-expired invite with public fields
+ */
+const fetchActiveInvite = async (inviteId: string) => {
+  return await prisma.inviteCode.findFirst({
+    where: {
+      id: inviteId,
+      status: "ACTIVE",
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      imageUrl: true,
+      groupId: true,
+    },
+  });
 };
 
 export const getPublicInviteDetailsHandler = async (
@@ -39,29 +67,9 @@ export const getPublicInviteDetailsHandler = async (
   try {
     const { inviteId } = await paramsSchema.parseAsync(req.params);
 
-    const inviteCode = await prisma.inviteCode.findUnique({
-      where: { id: inviteId },
-    });
+    const invite = await fetchActiveInvite(inviteId);
 
-    if (!inviteCode) {
-      res.status(404).json({
-        success: false,
-        message: "Invite not found",
-      });
-      return;
-    }
-
-    // Check if invite is active
-    if (inviteCode.status !== "ACTIVE") {
-      res.status(404).json({
-        success: false,
-        message: "Invite not found",
-      });
-      return;
-    }
-
-    // Check if invite is expired
-    if (inviteCode.expiresAt && inviteCode.expiresAt < new Date()) {
+    if (!invite) {
       res.status(404).json({
         success: false,
         message: "Invite not found",
@@ -70,12 +78,11 @@ export const getPublicInviteDetailsHandler = async (
     }
 
     const response: GetPublicInviteDetailsResponse = {
-      id: inviteCode.id,
-      name: inviteCode.name,
-      description: inviteCode.description,
-      imageUrl: inviteCode.imageUrl,
-      inviteLinkURL: getInviteLink(inviteCode.id),
-      groupId: inviteCode.groupId,
+      id: invite.id,
+      name: invite.name,
+      description: invite.description,
+      imageUrl: invite.imageUrl,
+      inviteLinkURL: getInviteLink(invite.id),
     };
 
     res.status(200).json(response);
@@ -119,11 +126,11 @@ export const getOwnerInviteDetailsHandler = async (
       return;
     }
 
-    const inviteCode = await prisma.inviteCode.findUnique({
+    const invite = await prisma.inviteCode.findUnique({
       where: { id: inviteId },
     });
 
-    if (!inviteCode) {
+    if (!invite) {
       res.status(404).json({
         success: false,
         message: "Invite not found",
@@ -132,7 +139,7 @@ export const getOwnerInviteDetailsHandler = async (
     }
 
     // Only allow the invite creator to see full details
-    if (inviteCode.createdById !== identity.id) {
+    if (invite.createdById !== identity.id) {
       res.status(403).json({
         success: false,
         message: "Forbidden: you don't have access to this invite",
@@ -141,18 +148,18 @@ export const getOwnerInviteDetailsHandler = async (
     }
 
     const response: GetInviteDetailsResponse = {
-      id: inviteCode.id,
-      name: inviteCode.name,
-      description: inviteCode.description,
-      imageUrl: inviteCode.imageUrl,
-      maxUses: inviteCode.maxUses,
-      usesCount: inviteCode.usesCount,
-      status: inviteCode.status,
-      expiresAt: inviteCode.expiresAt?.toISOString() || null,
-      autoApprove: inviteCode.autoApprove,
-      groupId: inviteCode.groupId,
-      createdAt: inviteCode.createdAt.toISOString(),
-      inviteLinkURL: getInviteLink(inviteCode.id),
+      id: invite.id,
+      name: invite.name,
+      description: invite.description,
+      imageUrl: invite.imageUrl,
+      maxUses: invite.maxUses,
+      usesCount: invite.usesCount,
+      status: invite.status,
+      expiresAt: invite.expiresAt?.toISOString() || null,
+      autoApprove: invite.autoApprove,
+      groupId: invite.groupId,
+      createdAt: invite.createdAt.toISOString(),
+      inviteLinkURL: getInviteLink(invite.id),
     };
 
     res.status(200).json(response);
@@ -181,8 +188,16 @@ export const getAuthenticatedInviteDetailsHandler = async (
   try {
     const { inviteId } = await paramsSchema.parseAsync(req.params);
 
-    // Get the authenticated user's identity from the JWT (for auth validation)
-    const { xmtpId } = req.app.locals;
+    // Get the authenticated user's identity from the JWT
+    const xmtpId = req.app.locals.xmtpId;
+
+    if (!xmtpId) {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
+      });
+      return;
+    }
 
     const identity = await prisma.deviceIdentity.findFirst({
       where: { xmtpId },
@@ -191,16 +206,14 @@ export const getAuthenticatedInviteDetailsHandler = async (
     if (!identity) {
       res.status(404).json({
         success: false,
-        message: "Identity not found",
+        message: "Invite not found",
       });
       return;
     }
 
-    const inviteCode = await prisma.inviteCode.findUnique({
-      where: { id: inviteId },
-    });
+    const invite = await fetchActiveInvite(inviteId);
 
-    if (!inviteCode) {
+    if (!invite) {
       res.status(404).json({
         success: false,
         message: "Invite not found",
@@ -208,32 +221,13 @@ export const getAuthenticatedInviteDetailsHandler = async (
       return;
     }
 
-    // Check if invite is active
-    if (inviteCode.status !== "ACTIVE") {
-      res.status(404).json({
-        success: false,
-        message: "Invite not found",
-      });
-      return;
-    }
-
-    // Check if invite is expired
-    if (inviteCode.expiresAt && inviteCode.expiresAt < new Date()) {
-      res.status(404).json({
-        success: false,
-        message: "Invite not found",
-      });
-      return;
-    }
-
-    // Return the same data as public endpoint (including groupId)
-    const response: GetPublicInviteDetailsResponse = {
-      id: inviteCode.id,
-      name: inviteCode.name,
-      description: inviteCode.description,
-      imageUrl: inviteCode.imageUrl,
-      inviteLinkURL: getInviteLink(inviteCode.id),
-      groupId: inviteCode.groupId,
+    const response: GetAuthenticatedInviteDetailsResponse = {
+      id: invite.id,
+      name: invite.name,
+      description: invite.description,
+      imageUrl: invite.imageUrl,
+      inviteLinkURL: getInviteLink(invite.id),
+      groupId: invite.groupId,
     };
 
     res.status(200).json(response);
@@ -247,7 +241,7 @@ export const getAuthenticatedInviteDetailsHandler = async (
       return;
     }
 
-    req.log.error({ error }, "Error fetching authenticated invite details");
+    req.log.error({ error }, "Authenticated invite details fetch failed");
     res.status(500).json({
       success: false,
       message: "Failed to fetch invite details",

--- a/src/api/v1/invites/invites-public.router.ts
+++ b/src/api/v1/invites/invites-public.router.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
-import { getInviteDetailsHandler } from "./handlers/get-invite-details";
+import { getPublicInviteDetailsHandler } from "./handlers/get-invite-details";
 
 const publicInvitesRouter = Router();
 
-publicInvitesRouter.get("/:inviteId", getInviteDetailsHandler);
+publicInvitesRouter.get("/:inviteId", getPublicInviteDetailsHandler);
 
 export default publicInvitesRouter;

--- a/src/api/v1/invites/invites.router.ts
+++ b/src/api/v1/invites/invites.router.ts
@@ -2,7 +2,10 @@ import { Router } from "express";
 import { createInviteCode } from "./handlers/create-invite-code";
 import { deleteInvite } from "./handlers/delete-invite";
 import { deleteRequestToJoin } from "./handlers/delete-request-to-join";
-import { getAuthenticatedInviteDetailsHandler } from "./handlers/get-invite-details";
+import {
+  getAuthenticatedInviteDetailsHandler,
+  getOwnerInviteDetailsHandler,
+} from "./handlers/get-invite-details";
 import { getInviteRequests } from "./handlers/get-invite-requests";
 import { requestToJoin } from "./handlers/request-to-join";
 import { updateInviteCode } from "./handlers/update-invite-code";
@@ -14,7 +17,11 @@ invitesRouter.post("/request", requestToJoin);
 invitesRouter.get("/requests", getInviteRequests);
 invitesRouter.delete("/requests/:requestId", deleteRequestToJoin);
 invitesRouter.put("/:inviteId", updateInviteCode);
-invitesRouter.get("/:inviteId", getAuthenticatedInviteDetailsHandler);
+invitesRouter.get(
+  "/:inviteId/with-group",
+  getAuthenticatedInviteDetailsHandler,
+);
+invitesRouter.get("/:inviteId", getOwnerInviteDetailsHandler);
 invitesRouter.delete("/:inviteId", deleteInvite);
 
 export default invitesRouter;


### PR DESCRIPTION
Add `/with-group` endpoint and rename invite detail handlers.
Handler renamed to remove confusing "authenticated AND public" naming and indicate access level and purpose.

Added new authenticated endpoint and renamed handlers for better clarity:
- `GET /api/v1/invites/public/:inviteId` - Public invite details (no auth)
- `GET /api/v1/invites/:inviteId` - Inviter-only full invite details (auth + ownership check)  
- `GET /api/v1/invites/:inviteId/with-group` - **NEW:** Basic invite details (auth required). Example:
```
{
  id: "cmemtde8v000p04rpsmsvbkin",
  name: null,
  description: null,
  imageUrl: null,
  inviteLinkURL: "https://otr-preview.convos.org/join/cmemtde8v000p04rpsmsvbkin",
  groupId: "b52cbe1a1cc1ae15175766725ca65419"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added authenticated endpoint GET /invites/:inviteId/with-group to fetch invite details including groupId.
  - Added an owner-only invite details endpoint GET /invites/:inviteId (authentication required) returning full invite metadata.

- Refactor
  - Public invite GET /invites/:inviteId continues to return public-facing fields and 404 for inactive/expired invites.
  - Owner route now serves full-detail responses; authenticated-with-group route returns a slim view plus groupId.

- Chores
  - Improved error handling and logging for public, authenticated, and owner invite detail fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->