### PR TITLE
Add inviter inboxId

### DIFF
--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -225,7 +225,7 @@ export const getAuthenticatedInviteDetailsHandler = async (
       },
     });
 
-    if (!invite) {
+    if (!invite || !invite.createdBy?.xmtpId) {
       res.status(404).json({
         success: false,
         message: "Invite not found",

--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -38,26 +38,7 @@ export type GetAuthenticatedInviteDetailsResponse = {
   imageUrl: string | null;
   inviteLinkURL: string;
   groupId: string;
-};
-
-/**
- * Fetches an active, non-expired invite with public fields
- */
-const fetchActiveInvite = async (inviteId: string) => {
-  return await prisma.inviteCode.findFirst({
-    where: {
-      id: inviteId,
-      status: "ACTIVE",
-      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
-    },
-    select: {
-      id: true,
-      name: true,
-      description: true,
-      imageUrl: true,
-      groupId: true,
-    },
-  });
+  inviterInboxId: string;
 };
 
 export const getPublicInviteDetailsHandler = async (
@@ -67,7 +48,20 @@ export const getPublicInviteDetailsHandler = async (
   try {
     const { inviteId } = await paramsSchema.parseAsync(req.params);
 
-    const invite = await fetchActiveInvite(inviteId);
+    const invite = await prisma.inviteCode.findFirst({
+      where: {
+        id: inviteId,
+        status: "ACTIVE",
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        imageUrl: true,
+        groupId: true,
+      },
+    });
 
     if (!invite) {
       res.status(404).json({
@@ -211,7 +205,25 @@ export const getAuthenticatedInviteDetailsHandler = async (
       return;
     }
 
-    const invite = await fetchActiveInvite(inviteId);
+    const invite = await prisma.inviteCode.findFirst({
+      where: {
+        id: inviteId,
+        status: "ACTIVE",
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        imageUrl: true,
+        groupId: true,
+        createdBy: {
+          select: {
+            xmtpId: true,
+          },
+        },
+      },
+    });
 
     if (!invite) {
       res.status(404).json({
@@ -228,6 +240,7 @@ export const getAuthenticatedInviteDetailsHandler = async (
       imageUrl: invite.imageUrl,
       inviteLinkURL: getInviteLink(invite.id),
       groupId: invite.groupId,
+      inviterInboxId: invite.createdBy.xmtpId,
     };
 
     res.status(200).json(response);


### PR DESCRIPTION
### Include inviterInboxId in `getAuthenticatedInviteDetailsHandler` responses in [get-invite-details.ts](https://github.com/ephemeraHQ/convos-backend/pull/127/files#diff-a77d923f3633e8caa7168084db3453c2fed7b5e5160d9966c95b272d048eada8) to add inviter inboxId
- Add `inviterInboxId: string` to `types.GetAuthenticatedInviteDetailsResponse`.
- Update `getAuthenticatedInviteDetailsHandler` in [get-invite-details.ts](https://github.com/ephemeraHQ/convos-backend/pull/127/files#diff-a77d923f3633e8caa7168084db3453c2fed7b5e5160d9966c95b272d048eada8) to select `createdBy.xmtpId` via `prisma.inviteCode.findFirst` and return it as `inviterInboxId`.
- Replace `fetchActiveInvite` with inline `prisma.inviteCode.findFirst` in `getAuthenticatedInviteDetailsHandler` and `getPublicInviteDetailsHandler`; the public handler now selects `id`, `name`, `description`, `imageUrl`, and `groupId` under ACTIVE and non-expired constraints.
- Remove the `fetchActiveInvite` helper.

#### 📍Where to Start
Start with `getAuthenticatedInviteDetailsHandler` in [get-invite-details.ts](https://github.com/ephemeraHQ/convos-backend/pull/127/files#diff-a77d923f3633e8caa7168084db3453c2fed7b5e5160d9966c95b272d048eada8), focusing on the `prisma.inviteCode.findFirst` selection and response mapping.

----

_[Macroscope](https://app.macroscope.com) summarized c1fa4c3._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Authenticated invite details responses now include inviterInboxId so clients can identify the inviter’s messaging inbox.

- Bug Fixes / Behavior Changes
  - Invite detail endpoints return 404 when an invite or required inviter information is missing, enforcing stricter not-found handling.
  - Improved error logging message for authenticated invite detail fetch failures.

- Documentation
  - API response docs updated to include inviterInboxId for authenticated invite details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->