### PR TITLE
Stop cleaning stale installations as we will implement explode

### DIFF
--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -225,7 +225,7 @@ export const getAuthenticatedInviteDetailsHandler = async (
       },
     });
 
-    if (!invite || !invite.createdBy?.xmtpId) {
+    if (!invite || !invite.createdBy.xmtpId) {
       res.status(404).json({
         success: false,
         message: "Invite not found",

--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -153,174 +153,79 @@ async function handleCurrentRegistration(args: {
       );
     }
 
-    const identitiesOnDeviceToRemoveFromDb = await prisma.$transaction(
-      async (tx) => {
-        // Update the device with the new push token
-        await tx.device.update({
-          where: {
-            id: body.deviceId,
-          },
-          data: {
-            pushToken: body.pushToken,
-            pushTokenType: body.pushTokenType,
-            apnsEnv: body.apnsEnv,
-          },
-        });
+    await prisma.$transaction(async (tx) => {
+      // Update the device with the new push token
+      await tx.device.update({
+        where: {
+          id: body.deviceId,
+        },
+        data: {
+          pushToken: body.pushToken,
+          pushTokenType: body.pushTokenType,
+          apnsEnv: body.apnsEnv,
+        },
+      });
 
-        // Find all existing identities on the device for logging
-        const allExistingIdentitiesOnDevice =
-          await tx.identitiesOnDevice.findMany({
-            where: {
-              deviceId: body.deviceId,
-              xmtpInstallationId: { not: null },
-            },
-            select: { xmtpInstallationId: true, identityId: true },
-          });
-
-        const incomingInstallationIds = body.installations.map(
-          (inst) => inst.xmtpInstallationId,
-        );
-
-        req.log.info(
-          {
-            deviceId: body.deviceId,
-            existingInstallations: allExistingIdentitiesOnDevice.map(
-              (i) => i.xmtpInstallationId,
-            ),
-            incomingInstallations: incomingInstallationIds,
-          },
-          "Registration update: comparing existing vs incoming installations",
-        );
-
-        // Find all the identities on the device that are not in the new installations
-        const staleIdentitiesOnDevice = await tx.identitiesOnDevice.findMany({
+      // Find all existing identities on the device for logging
+      const allExistingIdentitiesOnDevice =
+        await tx.identitiesOnDevice.findMany({
           where: {
             deviceId: body.deviceId,
-            AND: [
-              {
-                xmtpInstallationId: {
-                  not: {
-                    in: incomingInstallationIds,
-                  },
-                },
-              },
-              {
-                xmtpInstallationId: {
-                  not: null,
-                },
-              },
-            ],
+            xmtpInstallationId: { not: null },
           },
           select: { xmtpInstallationId: true, identityId: true },
         });
 
-        if (staleIdentitiesOnDevice.length > 0) {
-          req.log.warn(
-            {
-              deviceId: body.deviceId,
-              staleInstallations: staleIdentitiesOnDevice.map(
-                (i) => i.xmtpInstallationId,
-              ),
-              staleIdentityIds: staleIdentitiesOnDevice.map(
-                (i) => i.identityId,
-              ),
-              incomingInstallations: incomingInstallationIds,
-              totalExistingInstallations: allExistingIdentitiesOnDevice.length,
-            },
-            "POTENTIAL BUG: About to delete installations that may still be active",
-          );
-        }
+      const incomingInstallationIds = body.installations.map(
+        (inst) => inst.xmtpInstallationId,
+      );
 
-        // SAFER APPROACH: Instead of automatically deleting "stale" installations,
-        // only delete them if they meet stricter criteria to avoid deleting active installations
-        //
-        // For now, we'll disable automatic cleanup to prevent the bug where active
-        // installations get deleted. This needs to be replaced with a more sophisticated
-        // cleanup strategy that can distinguish truly stale installations from active ones.
-        //
-        // TODO: Implement proper cleanup logic that:
-        // 1. Checks installation age/last activity
-        // 2. Verifies with XMTP server before deletion
-        // 3. Uses explicit cleanup requests rather than inference
-
-        if (staleIdentitiesOnDevice.length > 0) {
-          req.log.warn(
-            {
-              deviceId: body.deviceId,
-              potentialStaleCount: staleIdentitiesOnDevice.length,
-              staleInstallations: staleIdentitiesOnDevice.map(
-                (i) => i.xmtpInstallationId,
-              ),
-            },
-            "CLEANUP DISABLED: Found installations not in current request, but skipping deletion to prevent breaking active notifications",
-          );
-
-          // COMMENTED OUT to prevent bug - do not delete installations automatically
-          // const staleIdentityIds = staleIdentitiesOnDevice.map((r) => r.identityId);
-          // await tx.identitiesOnDevice.deleteMany({
-          //   where: {
-          //     deviceId: body.deviceId,
-          //     identityId: { in: staleIdentityIds },
-          //   },
-          // });
-        }
-
-        // Upsert the new installations
-        for (const installation of body.installations) {
-          const resolvedIdentityId = xmtpIdToIdentityIdMap.get(
-            installation.identityId,
-          );
-          if (!resolvedIdentityId) {
-            // This should not happen due to pre-verification; skip defensively
-            req.log.warn(
-              {
-                xmtpId: installation.identityId,
-                deviceId: body.deviceId,
-              },
-              "Skipping upsert for installation due to unresolved identityId from xmtpId",
-            );
-            continue;
-          }
-
-          await tx.identitiesOnDevice.upsert({
-            where: {
-              deviceId_identityId: {
-                deviceId: body.deviceId,
-                identityId: resolvedIdentityId,
-              },
-            },
-            create: {
-              deviceId: body.deviceId,
-              identityId: resolvedIdentityId,
-              xmtpInstallationId: installation.xmtpInstallationId,
-            },
-            update: {
-              xmtpInstallationId: installation.xmtpInstallationId,
-            },
-          });
-        }
-
-        // Return empty array since we're not deleting installations anymore
-        return [];
-      },
-    );
-
-    // CLEANUP DISABLED: No longer automatically deleting "stale" installations
-    // This prevents the bug where active installations get incorrectly deleted
-    //
-    // The previous logic would delete installations from XMTP server here,
-    // but since we're not removing them from our DB, we shouldn't delete them
-    // from XMTP either.
-
-    if (identitiesOnDeviceToRemoveFromDb.length > 0) {
       req.log.info(
         {
           deviceId: body.deviceId,
-          skippedDeletions: identitiesOnDeviceToRemoveFromDb.length,
+          existingInstallations: allExistingIdentitiesOnDevice.map(
+            (i) => i.xmtpInstallationId,
+          ),
+          incomingInstallations: incomingInstallationIds,
         },
-        "Skipped deleting installations from XMTP server to prevent breaking active notifications",
+        "Registration update: comparing existing vs incoming installations",
       );
-    }
+
+      // Upsert the new installations
+      for (const installation of body.installations) {
+        const resolvedIdentityId = xmtpIdToIdentityIdMap.get(
+          installation.identityId,
+        );
+        if (!resolvedIdentityId) {
+          // This should not happen due to pre-verification; skip defensively
+          req.log.warn(
+            {
+              xmtpId: installation.identityId,
+              deviceId: body.deviceId,
+            },
+            "Skipping upsert for installation due to unresolved identityId from xmtpId",
+          );
+          continue;
+        }
+
+        await tx.identitiesOnDevice.upsert({
+          where: {
+            deviceId_identityId: {
+              deviceId: body.deviceId,
+              identityId: resolvedIdentityId,
+            },
+          },
+          create: {
+            deviceId: body.deviceId,
+            identityId: resolvedIdentityId,
+            xmtpInstallationId: installation.xmtpInstallationId,
+          },
+          update: {
+            xmtpInstallationId: installation.xmtpInstallationId,
+          },
+        });
+      }
+    });
 
     // Register the new installations with XMTP
     // Process registrations in parallel for better performance


### PR DESCRIPTION
### Stop cleaning stale installations in `src/api/v1/notifications/handlers/register-installation.ts` `handleCurrentRegistration` to implement explode
- Rework the registration transaction in `handleCurrentRegistration` to only update device push token data, log existing vs incoming installations, and upsert the provided installations, removing stale installation detection and related logs in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/128/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd).
- Change the invite creator null-check in `getAuthenticatedInviteDetailsHandler` to directly access `createdBy.xmtpId`, replacing optional chaining in [get-invite-details.ts](https://github.com/ephemeraHQ/convos-backend/pull/128/files#diff-a77d923f3633e8caa7168084db3453c2fed7b5e5160d9966c95b272d048eada8).

#### 📍Where to Start
Start with the `handleCurrentRegistration` handler in [register-installation.ts](https://github.com/ephemeraHQ/convos-backend/pull/128/files#diff-e832655c5ccce7cf8a4f8bb66174d34d4b8cb2b3df82b73532ce96f27b2b5dcd).

----

_[Macroscope](https://app.macroscope.com) summarized fd35c0e._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Streamlined push notification registration to improve reliability and performance; installations are now processed individually to ensure consistent updates.

- Bug Fixes
  - Updated invite details handling; in rare cases, requests may now return a server error instead of “not found,” improving visibility into underlying issues.

- Chores
  - Reduced unnecessary background cleanup during registration and improved diagnostic logging (no user action required).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->