### PR TITLE
Add production deployment pipeline configuration

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -8,6 +8,7 @@ on:
       - main
       - dev
       - otr-dev
+      - otr-prod
   pull_request:
   repository_dispatch:
     types: [deploy-main]
@@ -102,6 +103,26 @@ jobs:
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
           terraform-org: xmtp
           terraform-workspace: convos_otr_dev
+          variable-name: api_image
+          variable-value: "ghcr.io/ephemerahq/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
+          variable-value-required-prefix: "ghcr.io/ephemerahq/convos-backend@sha256:"
+
+  deploy_otr_prod:
+    name: Deploy to OTR Production
+    runs-on: ubuntu-latest
+    needs: push_to_registry
+    if: (inputs.ref == 'otr-prod') || (github.ref == 'refs/heads/otr-prod' && !inputs.ref)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy to OTR Production Environment
+        uses: xmtp-labs/terraform-deployer@v1
+        timeout-minutes: 20
+        with:
+          timeout: 20m
+          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
+          terraform-org: xmtp
+          terraform-workspace: convos-otr-prod
           variable-name: api_image
           variable-value: "ghcr.io/ephemerahq/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
           variable-value-required-prefix: "ghcr.io/ephemerahq/convos-backend@sha256:"


### PR DESCRIPTION
### Add `otr-prod` branch trigger and `deploy_otr_prod` job in [deploy-aws.yml](https://github.com/ephemeraHQ/convos-backend/pull/129/files#diff-0d3289eb372cc20ad90cd149a511773611be96818d075262367aee3ec4d77a69) to configure the production deployment pipeline targeting Terraform workspace `convos-otr-prod` with a sha256-prefixed image digest from `push_to_registry`
- Add job `deploy_otr_prod` in [deploy-aws.yml](https://github.com/ephemeraHQ/convos-backend/pull/129/files#diff-0d3289eb372cc20ad90cd149a511773611be96818d075262367aee3ec4d77a69) that depends on `push_to_registry`, conditionally runs on `otr-prod` (branch or input), checks out the repository, runs `xmtp-labs/terraform-deployer@v1` against workspace `convos-otr-prod`, sets `api_image` to the built image digest, and enforces a `sha256`-prefixed image reference.
- Update `on.push.branches` in [deploy-aws.yml](https://github.com/ephemeraHQ/convos-backend/pull/129/files#diff-0d3289eb372cc20ad90cd149a511773611be96818d075262367aee3ec4d77a69) to include `otr-prod`.

#### 📍Where to Start
Start with the `jobs.deploy_otr_prod` block in [deploy-aws.yml](https://github.com/ephemeraHQ/convos-backend/pull/129/files#diff-0d3289eb372cc20ad90cd149a511773611be96818d075262367aee3ec4d77a69), reviewing its `if` condition and the `xmtp-labs/terraform-deployer@v1` step.

----

_[Macroscope](https://app.macroscope.com) summarized 0bfbdb6._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated deployment path for the OTR Production environment, triggered on the OTR production branch.
  * Aligns production deployment with the existing dev flow for consistency and faster releases.
  * Ensures precise, reproducible deployments by using an image digest from the registry.
  * Adds timeout safeguards to prevent stalled runs.
  * No user-facing changes; improves release reliability and deployment confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->