### PR TITLE
Update `xmtp/node-go` image

### DIFF
--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -7,7 +7,7 @@ services:
       - 5432:5432
 
   node:
-    image: xmtp/node-go:latest
+    image: ghcr.io/xmtp/node-go:main
     platform: linux/amd64
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67


### PR DESCRIPTION
### Update docker-compose `node` service to use `ghcr.io/xmtp/node-go:main` image
Change the `image` reference for the `node` service in [dev/compose.yml](https://github.com/ephemeraHQ/convos-backend/pull/131/files#diff-179aaaa54e90c327e1f24333cdd54163b98fd92fdcdf94a383ae7a2e709748a9) from `xmtp/node-go:latest` to `ghcr.io/xmtp/node-go:main`.

#### 📍Where to Start
Start with the `node` service definition in [dev/compose.yml](https://github.com/ephemeraHQ/convos-backend/pull/131/files#diff-179aaaa54e90c327e1f24333cdd54163b98fd92fdcdf94a383ae7a2e709748a9).

----

_[Macroscope](https://app.macroscope.com) summarized e90de3b._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the development environment to pull the Node service image from ghcr.io/xmtp/node-go:main instead of the previous registry/tag.
  - Service configuration remains unchanged; only the image source and tag were updated.
  - This change applies to local/dev setups and does not alter production behavior.
  - No user-facing functionality is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->