### PR TITLE
Use res.locals, not app.locals, to avoid leaking xmtp id between requ…

### DIFF
--- a/src/api/v1/devices/handlers/create-device.handler.ts
+++ b/src/api/v1/devices/handlers/create-device.handler.ts
@@ -27,7 +27,7 @@ export async function createDeviceHandler(
   res: Response,
 ) {
   try {
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     // Verify the authenticated identity exists
     const identity = await prisma.deviceIdentity.findFirst({

--- a/src/api/v1/devices/handlers/get-device.handler.ts
+++ b/src/api/v1/devices/handlers/get-device.handler.ts
@@ -12,7 +12,7 @@ export async function getDeviceHandler(
 ) {
   try {
     const { deviceId } = req.params;
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     // Verify authenticated identity exists
     const identity = await prisma.deviceIdentity.findFirst({
@@ -67,7 +67,7 @@ export async function getDeviceHandler(
   } catch (error) {
     logError(error, {
       deviceId: req.params.deviceId,
-      xmtpId: req.app.locals.xmtpId,
+      xmtpId: res.locals.xmtpId,
     });
 
     if (error instanceof AppError) {

--- a/src/api/v1/devices/handlers/list-devices.handler.ts
+++ b/src/api/v1/devices/handlers/list-devices.handler.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/utils/prisma";
 
 export async function listDevicesHandler(req: Request, res: Response) {
   try {
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     // Verify authenticated identity exists
     const identity = await prisma.deviceIdentity.findFirst({

--- a/src/api/v1/devices/handlers/update-device.handler.ts
+++ b/src/api/v1/devices/handlers/update-device.handler.ts
@@ -26,7 +26,7 @@ export async function updateDeviceHandler(
 ) {
   try {
     const { deviceId } = req.params;
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     // Verify the authenticated identity exists
     const identity = await prisma.deviceIdentity.findFirst({
@@ -109,7 +109,7 @@ export async function updateDeviceHandler(
   } catch (error) {
     logError(error, {
       deviceId: req.params.deviceId,
-      xmtpId: req.app.locals.xmtpId,
+      xmtpId: res.locals.xmtpId,
       requestBodyMetadata: {
         hasPushToken: Boolean(req.body.pushToken),
         pushTokenType: typeof req.body.pushTokenType,

--- a/src/api/v1/invites/handlers/create-invite-code.ts
+++ b/src/api/v1/invites/handlers/create-invite-code.ts
@@ -56,7 +56,7 @@ export async function createInviteCode(
     }
 
     // Get the authenticated user's identity from the JWT
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     const identity = await prisma.deviceIdentity.findFirst({
       where: { xmtpId },

--- a/src/api/v1/invites/handlers/delete-invite.ts
+++ b/src/api/v1/invites/handlers/delete-invite.ts
@@ -17,7 +17,7 @@ export async function deleteInvite(req: Request, res: Response) {
   try {
     const params = await deleteInviteParamsSchema.parseAsync(req.params);
 
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     // Find the authenticated user's identity
     const identity = await prisma.deviceIdentity.findFirst({

--- a/src/api/v1/invites/handlers/delete-request-to-join.ts
+++ b/src/api/v1/invites/handlers/delete-request-to-join.ts
@@ -18,7 +18,7 @@ export type DeleteRequestToJoinResponse = {
 export async function deleteRequestToJoin(req: Request, res: Response) {
   try {
     const params = await deleteRequestToJoinParams.parseAsync(req.params);
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     // Find the authenticated user's identity (by xmtpId)
     const authenticatedIdentity = await prisma.deviceIdentity.findFirst({

--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -106,7 +106,7 @@ export const getOwnerInviteDetailsHandler = async (
     const { inviteId } = await paramsSchema.parseAsync(req.params);
 
     // Get the authenticated user's identity from the JWT
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     const identity = await prisma.deviceIdentity.findFirst({
       where: { xmtpId },
@@ -183,7 +183,7 @@ export const getAuthenticatedInviteDetailsHandler = async (
     const { inviteId } = await paramsSchema.parseAsync(req.params);
 
     // Get the authenticated user's identity from the JWT
-    const xmtpId = req.app.locals.xmtpId;
+    const xmtpId = res.locals.xmtpId;
 
     if (!xmtpId) {
       res.status(404).json({

--- a/src/api/v1/invites/handlers/get-invite-requests.ts
+++ b/src/api/v1/invites/handlers/get-invite-requests.ts
@@ -41,7 +41,7 @@ export async function getInviteRequests(
 ) {
   try {
     const query = await querySchema.parseAsync(req.query);
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     // Find the authenticated user's identity
     const identity = await prisma.deviceIdentity.findFirst({

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -26,7 +26,7 @@ export async function requestToJoin(
 ) {
   try {
     const body = await requestToJoinSchema.parseAsync(req.body);
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     const pushNotificationService = getPushNotificationService();
 

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -66,7 +66,7 @@ export async function updateInviteCode(
     }
 
     // Get the authenticated user's identity from the JWT
-    const { xmtpId } = req.app.locals;
+    const { xmtpId } = res.locals;
 
     const identity = await prisma.deviceIdentity.findFirst({
       where: { xmtpId },

--- a/src/api/v1/notifications/handlers/register-installation.ts
+++ b/src/api/v1/notifications/handlers/register-installation.ts
@@ -91,7 +91,7 @@ async function handleCurrentRegistration(args: {
   const { req, res, body } = args;
 
   try {
-    const authenticatedXmtpId = req.app.locals.xmtpId;
+    const authenticatedXmtpId = res.locals.xmtpId;
 
     // Ensure the authenticated identity exists
     const deviceIdentityForAuthenticatedUser =

--- a/src/api/v1/notifications/handlers/unregister-installation.ts
+++ b/src/api/v1/notifications/handlers/unregister-installation.ts
@@ -17,7 +17,7 @@ export async function unregisterInstallation(
   res: Response,
 ) {
   try {
-    const authenticatedXmtpId = req.app.locals.xmtpId;
+    const authenticatedXmtpId = res.locals.xmtpId;
 
     const { xmtpInstallationId } = unregisterRequestParamsSchema.parse(
       req.params,

--- a/src/api/v1/profiles/handlers/update-profile.ts
+++ b/src/api/v1/profiles/handlers/update-profile.ts
@@ -22,7 +22,7 @@ export async function updateProfile(
 ) {
   try {
     const { xmtpId: targetXmtpId } = req.params;
-    const { xmtpId: authenticatedXmtpId } = req.app.locals;
+    const { xmtpId: authenticatedXmtpId } = res.locals;
 
     if (!targetXmtpId) {
       res.status(400).json({ error: "Invalid request parameters" });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -24,8 +24,8 @@ export const authMiddleware = async (
     );
 
     // So we can use them in request handlers
-    req.app.locals.xmtpId = payload.inboxId;
-    req.app.locals.xmtpInstallationId = payload.xmtpInstallationId;
+    res.locals.xmtpId = payload.inboxId;
+    res.locals.xmtpInstallationId = payload.xmtpInstallationId;
 
     next();
   } catch {

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -27,7 +27,7 @@ app.use(jsonMiddleware);
 // Add middleware to simulate authentication for tests
 app.use((req, res, next) => {
   // Set xmtpId for testing - this simulates the auth middleware
-  req.app.locals.xmtpId = AUTH_XMTP_ID;
+  res.locals.xmtpId = AUTH_XMTP_ID;
   next();
 });
 

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -27,11 +27,11 @@ app.use(jsonMiddleware);
 // Mock authentication by setting the request locals with optional override
 app.use((req, _res, next) => {
   const overrideXmtpId = req.headers["x-test-xmtp-id"];
-  req.app.locals.xmtpId =
+  _res.locals.xmtpId =
     typeof overrideXmtpId === "string"
       ? overrideXmtpId
       : "test-xmtp-id-requester";
-  req.app.locals.xmtpInstallationId = "test-installation-id";
+  _res.locals.xmtpInstallationId = "test-installation-id";
   next();
 });
 
@@ -213,7 +213,7 @@ describe("/invites/request API", () => {
     testApp.use(pinoMiddleware);
     testApp.use(jsonMiddleware);
     testApp.use((req, _res, next) => {
-      req.app.locals.xmtpId = "non-existent-xmtp-id";
+      _res.locals.xmtpId = "non-existent-xmtp-id";
       next();
     });
     testApp.use("/invites", invitesRouter);

--- a/tests/invites.test.ts
+++ b/tests/invites.test.ts
@@ -29,7 +29,7 @@ const AUTH_USER_XMTP_ID = "test-invite-xmtp-id";
 // Add middleware to simulate authentication for tests
 app.use((req, res, next) => {
   const overrideXmtpId = req.headers["x-test-xmtp-id"];
-  req.app.locals.xmtpId =
+  res.locals.xmtpId =
     typeof overrideXmtpId === "string" ? overrideXmtpId : AUTH_USER_XMTP_ID;
   next();
 });
@@ -622,8 +622,8 @@ describe("/invites API", () => {
     secondUserApp.use(pinoMiddleware);
     secondUserApp.use(jsonMiddleware);
     secondUserApp.use((req, _res, next) => {
-      req.app.locals.xmtpId = "different-user-xmtp-id";
-      req.app.locals.xmtpInstallationId = "different-installation-id";
+      _res.locals.xmtpId = "different-user-xmtp-id";
+      _res.locals.xmtpInstallationId = "different-installation-id";
       next();
     });
     secondUserApp.use("/invites", invitesRouter);
@@ -737,8 +737,8 @@ describe("/invites API", () => {
     secondUserApp.use(pinoMiddleware);
     secondUserApp.use(jsonMiddleware);
     secondUserApp.use((req, _res, next) => {
-      req.app.locals.xmtpId = "different-user-get-details-xmtp-id";
-      req.app.locals.xmtpInstallationId = "different-installation-id";
+      _res.locals.xmtpId = "different-user-get-details-xmtp-id";
+      _res.locals.xmtpInstallationId = "different-installation-id";
       next();
     });
     secondUserApp.use("/invites", invitesRouter);

--- a/tests/notifications-invites.test.ts
+++ b/tests/notifications-invites.test.ts
@@ -46,11 +46,11 @@ describe("Invite Notifications Integration", () => {
     // Mock authentication middleware
     app.use((req, _res, next) => {
       const overrideXmtpId = req.headers["x-test-xmtp-id"];
-      req.app.locals.xmtpId =
+      _res.locals.xmtpId =
         typeof overrideXmtpId === "string"
           ? overrideXmtpId
           : "test-default-xmtp-id";
-      req.app.locals.xmtpInstallationId = "test-installation-id";
+      _res.locals.xmtpInstallationId = "test-installation-id";
       next();
     });
 

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -28,7 +28,7 @@ app.use(pinoMiddleware);
 const AUTH_XMTP_ID = "test-auth-xmtp-id";
 
 app.use((req, res, next) => {
-  req.app.locals.xmtpId = AUTH_XMTP_ID;
+  res.locals.xmtpId = AUTH_XMTP_ID;
   next();
 });
 

--- a/tests/profiles-batch.test.ts
+++ b/tests/profiles-batch.test.ts
@@ -35,8 +35,13 @@ let baseUrl: string;
 
 describe("Batch Profile endpoints", () => {
   const testProfiles: (Profile & { deviceIdentity: DeviceIdentity })[] = [];
-  const xmtpIds = ["test-xmtp-id-1", "test-xmtp-id-2", "test-xmtp-id-3"];
-  const testIdentityId = "test-user-id-batch-profiles";
+  const testRunId = `${Date.now()}-${Math.random().toString(36).substring(7)}`;
+  const xmtpIds = [
+    `test-xmtp-id-1-${testRunId}`,
+    `test-xmtp-id-2-${testRunId}`,
+    `test-xmtp-id-3-${testRunId}`,
+  ];
+  const testIdentityId = `test-user-id-batch-profiles-${testRunId}`;
 
   beforeAll(async () => {
     // Wait a bit in CI environments
@@ -50,7 +55,7 @@ describe("Batch Profile endpoints", () => {
       await prisma.deviceIdentity.create({
         data: {
           id: testIdentityId,
-          xmtpId: "test-turnkey-user-id-batch-profiles",
+          xmtpId: `test-turnkey-user-id-batch-profiles-${testRunId}`,
         },
       });
 

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -29,7 +29,7 @@ app.use(pinoMiddleware);
 app.use((req, _res, next) => {
   const overrideXmtpId = req.headers["x-test-xmtp-id"];
   if (typeof overrideXmtpId === "string") {
-    req.app.locals.xmtpId = overrideXmtpId;
+    _res.locals.xmtpId = overrideXmtpId;
   }
   next();
 });


### PR DESCRIPTION
…ests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Moved authentication context from app-scoped storage to response-scoped per-request storage across device, invite, notification, and profile endpoints.
- Tests
  - Updated test middleware and scenarios to reflect per-request response-scoped authentication.
- Bug Fixes
  - Reduces risk of cross-request leakage of authentication identifiers, improving reliability for concurrent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->