### PR TITLE
Change join invite URL scheme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ NAMESTONE_API_KEY=
 NAMESTONE_DOMAIN=convosapp.eth|convos.org
 
 # Website URL
-WEBSITE_URL=https://convos.org
+WEBSITE_URL=https://popup.convos.org
 
 # APNS - Apple Push Notifications Service
 APNS_KEY=

--- a/src/utils/invites.ts
+++ b/src/utils/invites.ts
@@ -1,4 +1,4 @@
 export const getInviteLink = (inviteId: string): string => {
   const baseUrl = process.env.WEBSITE_URL || "";
-  return `${baseUrl}/join/${inviteId}`;
+  return `${baseUrl}/${inviteId}`;
 };

--- a/tests/invites.test.ts
+++ b/tests/invites.test.ts
@@ -169,7 +169,7 @@ describe("/invites API", () => {
     expect(inviteCode.autoApprove).toBe(false);
     expect(inviteCode.createdAt).toBeDefined();
     expect(inviteCode.inviteLinkURL).toBeDefined();
-    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/join\/c[a-z0-9]{24}$/);
+    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/c[a-z0-9]{24}$/);
   });
 
   test("POST /invites creates a new invite code with all optional fields", async () => {
@@ -211,7 +211,7 @@ describe("/invites API", () => {
     expect(inviteCode.autoApprove).toBe(true);
     expect(inviteCode.createdAt).toBeDefined();
     expect(inviteCode.inviteLinkURL).toBeDefined();
-    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/join\/c[a-z0-9]{24}$/);
+    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/c[a-z0-9]{24}$/);
   });
 
   test("POST /invites validates required fields", async () => {
@@ -374,7 +374,7 @@ describe("/invites API", () => {
     // CUID should be 25 characters long and start with 'c'
     expect(inviteCode.id).toMatch(/^c[a-z0-9]{24}$/);
     expect(inviteCode.inviteLinkURL).toBeDefined();
-    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/join\/c[a-z0-9]{24}$/);
+    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/c[a-z0-9]{24}$/);
   });
 
   test("POST /invites stores correct createdById", async () => {
@@ -430,7 +430,7 @@ describe("/invites API", () => {
     expect(inviteCode.status).toBe(InviteCodeStatus.ACTIVE); // Default value
     expect(inviteCode.usesCount).toBe(0); // Default value
     expect(inviteCode.inviteLinkURL).toBeDefined();
-    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/join\/c[a-z0-9]{24}$/);
+    expect(inviteCode.inviteLinkURL).toMatch(/^.*\/c[a-z0-9]{24}$/);
   });
 
   test("POST /invites/:inviteId updates existing invite code", async () => {


### PR DESCRIPTION
### Change invite link generation in `src/utils/invites.ts.getInviteLink` to remove the '/join' path segment for the join invite URL scheme
- Update `getInviteLink` to return `${baseUrl}/${inviteId}` instead of `${baseUrl}/join/${inviteId}` in [invites.ts](https://github.com/ephemeraHQ/convos-backend/pull/136/files#diff-6c1ef73009268222ef2b21b835b8a280093ac2e50d2443e1caa3cee71b7859af)
- Update example `WEBSITE_URL` to `https://popup.convos.org` in [.env.example](https://github.com/ephemeraHQ/convos-backend/pull/136/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c)

#### 📍Where to Start
Start with the `getInviteLink` function in [invites.ts](https://github.com/ephemeraHQ/convos-backend/pull/136/files#diff-6c1ef73009268222ef2b21b835b8a280093ac2e50d2443e1caa3cee71b7859af).

----

_[Macroscope](https://app.macroscope.com) summarized b07fc95._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified invite links: invite URLs now use the site base URL directly followed by the invite ID (the previous extra path segment has been removed).

* **Documentation**
  * Updated sample environment configuration: default WEBSITE_URL in the example env file changed to https://popup.convos.org.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->