### PR TITLE
Shared group metadata for invites, adds join requests acceptance tracking

### DIFF
--- a/prisma/migrations/20250919000000_shared_invite_metadata/migration.sql
+++ b/prisma/migrations/20250919000000_shared_invite_metadata/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "GroupMetadata" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "description" TEXT,
+    "imageUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GroupMetadata_pkey" PRIMARY KEY ("id")
+);
+
+-- Insert empty metadata entries for all existing groupIds
+INSERT INTO "GroupMetadata" ("id", "updatedAt")
+SELECT DISTINCT "groupId", CURRENT_TIMESTAMP
+FROM "InviteCode"
+WHERE "groupId" IS NOT NULL;
+
+-- Remove old metadata fields from InviteCode
+ALTER TABLE "InviteCode" DROP COLUMN "name";
+ALTER TABLE "InviteCode" DROP COLUMN "description";
+ALTER TABLE "InviteCode" DROP COLUMN "imageUrl";
+
+-- AddForeignKey
+ALTER TABLE "InviteCode" ADD CONSTRAINT "InviteCode_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "GroupMetadata"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250919000002_remove_cascade_from_group_metadata/migration.sql
+++ b/prisma/migrations/20250919000002_remove_cascade_from_group_metadata/migration.sql
@@ -1,0 +1,6 @@
+-- Remove CASCADE from the foreign key constraint
+-- First drop the existing constraint
+ALTER TABLE "InviteCode" DROP CONSTRAINT "InviteCode_groupId_fkey";
+
+-- Add the constraint back without CASCADE
+ALTER TABLE "InviteCode" ADD CONSTRAINT "InviteCode_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "GroupMetadata"("id");

--- a/prisma/migrations/20250923131751_add_composite_indexes/migration.sql
+++ b/prisma/migrations/20250923131751_add_composite_indexes/migration.sql
@@ -1,0 +1,14 @@
+-- DropForeignKey
+ALTER TABLE "InviteCode" DROP CONSTRAINT "InviteCode_groupId_fkey";
+
+-- CreateIndex
+CREATE INDEX "InviteCode_status_expiresAt_idx" ON "InviteCode"("status", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "InviteCode_createdById_groupId_idx" ON "InviteCode"("createdById", "groupId");
+
+-- CreateIndex
+CREATE INDEX "InviteCodeRequest_inviteCodeId_createdAt_idx" ON "InviteCodeRequest"("inviteCodeId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "InviteCode" ADD CONSTRAINT "InviteCode_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "GroupMetadata"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,8 @@ model InviteCode {
   @@index([status])
   @@index([createdById])
   @@index([groupId])
+  @@index([status, expiresAt])
+  @@index([createdById, groupId])
 }
 
 model InviteCodeUse {
@@ -187,4 +189,5 @@ model InviteCodeRequest {
   @@unique([inviteCodeId, requesterId])
   @@index([inviteCodeId])
   @@index([requesterId])
+  @@index([inviteCodeId, createdAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,11 +108,20 @@ enum InviteCodeRequestStatus {
   REJECTED
 }
 
-model InviteCode {
-  id          String           @id @default(cuid())
+model GroupMetadata {
+  id          String   @id // This is the groupId
   name        String?
   description String?
   imageUrl    String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  inviteCodes InviteCode[]
+}
+
+model InviteCode {
+  id          String           @id @default(cuid())
   maxUses     Int? // null = unlimited uses
   usesCount   Int              @default(0)
   status      InviteCodeStatus @default(ACTIVE)
@@ -121,6 +130,9 @@ model InviteCode {
 
   // Group ID to identify which group this invite code is for
   groupId String
+
+  // Shared metadata reference
+  groupMetadata GroupMetadata @relation(fields: [groupId], references: [id], onDelete: Cascade)
 
   // Keep track of who created it for admin purposes
   createdById String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,7 +132,7 @@ model InviteCode {
   groupId String
 
   // Shared metadata reference
-  groupMetadata GroupMetadata @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupMetadata GroupMetadata @relation(fields: [groupId], references: [id])
 
   // Keep track of who created it for admin purposes
   createdById String

--- a/src/api/v1/invites/handlers/accept-request-to-join.ts
+++ b/src/api/v1/invites/handlers/accept-request-to-join.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
@@ -65,7 +66,23 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       return;
     }
 
+    // Authorization: only invite creator OR notification targets can accept
+    const isCreator = requestToJoin.inviteCode.createdBy.xmtpId === xmtpId;
+    const isNotificationTarget =
+      requestToJoin.inviteCode.notificationTargets.some(
+        (target) => target.deviceIdentity.xmtpId === xmtpId,
+      );
+
+    if (!isCreator && !isNotificationTarget) {
+      res.status(404).json({
+        success: false,
+        message: "Request not found",
+      });
+      return;
+    }
+
     // Check if user has already been accepted (has InviteCodeUse record)
+    // This check is done AFTER authorization to prevent information disclosure
     const existingUse = await prisma.inviteCodeUse.findUnique({
       where: {
         inviteCodeId_usedById: {
@@ -85,21 +102,6 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
           id: existingUse.id,
           usedAt: existingUse.usedAt.toISOString(),
         },
-      });
-      return;
-    }
-
-    // Authorization: only invite creator OR notification targets can accept
-    const isCreator = requestToJoin.inviteCode.createdBy.xmtpId === xmtpId;
-    const isNotificationTarget =
-      requestToJoin.inviteCode.notificationTargets.some(
-        (target) => target.deviceIdentity.xmtpId === xmtpId,
-      );
-
-    if (!isCreator && !isNotificationTarget) {
-      res.status(404).json({
-        success: false,
-        message: "Request not found",
       });
       return;
     }
@@ -211,6 +213,59 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
         message: "Invite not found",
       });
       return;
+    }
+
+    // Handle race condition where another request already created the InviteCodeUse
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002" &&
+      Array.isArray(error.meta?.target) &&
+      (error.meta.target as string[]).some((field) =>
+        ["inviteCodeId_usedById", "inviteCodeId", "usedById"].includes(field),
+      )
+    ) {
+      // Another request already created the InviteCodeUse - fetch it for idempotent response
+      // We need the original request data to look up the correct record
+      const requestId = req.params.requestId;
+      const requestData = await prisma.inviteCodeRequest.findUnique({
+        where: { id: requestId },
+      });
+
+      if (!requestData) {
+        // Request was already deleted, which means it was processed successfully
+        // Return success for idempotency
+        res.status(200).json({
+          id: requestId,
+          accepted: true,
+          inviteCodeUse: {
+            id: "unknown",
+            usedAt: new Date().toISOString(),
+          },
+        });
+        return;
+      }
+
+      const existingUse = await prisma.inviteCodeUse.findUnique({
+        where: {
+          inviteCodeId_usedById: {
+            inviteCodeId: requestData.inviteCodeId,
+            usedById: requestData.requesterId,
+          },
+        },
+      });
+
+      if (existingUse) {
+        const response: AcceptRequestToJoinResponse = {
+          id: requestId,
+          accepted: true,
+          inviteCodeUse: {
+            id: existingUse.id,
+            usedAt: existingUse.usedAt.toISOString(),
+          },
+        };
+        res.status(200).json(response);
+        return;
+      }
     }
 
     req.log.error({ error }, "Error accepting request to join");

--- a/src/api/v1/invites/handlers/accept-request-to-join.ts
+++ b/src/api/v1/invites/handlers/accept-request-to-join.ts
@@ -76,9 +76,15 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
     });
 
     if (existingUse) {
-      res.status(400).json({
-        success: false,
-        message: "Request has already been accepted",
+      // Return success for idempotency - request was already processed
+      res.status(200).json({
+        id: params.requestId,
+        accepted: true,
+        alreadyAccepted: true,
+        inviteCodeUse: {
+          id: existingUse.id,
+          usedAt: existingUse.usedAt.toISOString(),
+        },
       });
       return;
     }

--- a/src/api/v1/invites/handlers/accept-request-to-join.ts
+++ b/src/api/v1/invites/handlers/accept-request-to-join.ts
@@ -1,4 +1,3 @@
-import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
@@ -93,15 +92,10 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
     });
 
     if (existingUse) {
-      // Return success for idempotency - request was already processed
-      res.status(200).json({
-        id: params.requestId,
-        accepted: true,
-        alreadyAccepted: true,
-        inviteCodeUse: {
-          id: existingUse.id,
-          usedAt: existingUse.usedAt.toISOString(),
-        },
+      // User already accepted - this should not happen with proper client flow
+      res.status(409).json({
+        success: false,
+        message: "Request has already been processed",
       });
       return;
     }
@@ -216,25 +210,6 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       res.status(404).json({
         success: false,
         message: "Invite not found",
-      });
-      return;
-    }
-
-    // Handle race condition where another request already created the InviteCodeUse
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002"
-    ) {
-      // Duplicate key error - likely another request processed this already
-      // Return success for idempotency
-      res.status(200).json({
-        id: req.params.requestId,
-        accepted: true,
-        alreadyAccepted: true,
-        inviteCodeUse: {
-          id: "race-condition-handled",
-          usedAt: new Date().toISOString(),
-        },
       });
       return;
     }

--- a/src/api/v1/invites/handlers/accept-request-to-join.ts
+++ b/src/api/v1/invites/handlers/accept-request-to-join.ts
@@ -118,14 +118,30 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
 
     // Accept the request and create InviteCodeUse in a transaction
     const result = await prisma.$transaction(async (tx) => {
+      // First fetch the current invite to get maxUses value
+      const currentInvite = await tx.inviteCode.findUnique({
+        where: { id: requestToJoin.inviteCodeId },
+        select: { maxUses: true, usesCount: true },
+      });
+
+      if (!currentInvite) {
+        throw new Error("INVITE_NOT_FOUND");
+      }
+
       // Atomically claim a slot by incrementing uses count with a guard
+      const whereConditions: Array<
+        { maxUses: null } | { usesCount: { lt: number } }
+      > = [{ maxUses: null }];
+
+      // Only add the usesCount comparison if maxUses is not null
+      if (currentInvite.maxUses !== null) {
+        whereConditions.push({ usesCount: { lt: currentInvite.maxUses } });
+      }
+
       const updateResult = await tx.inviteCode.updateMany({
         where: {
           id: requestToJoin.inviteCodeId,
-          OR: [
-            { maxUses: null },
-            { usesCount: { lt: prisma.inviteCode.fields.maxUses } },
-          ],
+          OR: whereConditions,
         },
         data: {
           usesCount: {
@@ -179,6 +195,14 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       res.status(400).json({
         success: false,
         message: "Invite has reached maximum uses",
+      });
+      return;
+    }
+
+    if (error instanceof Error && error.message === "INVITE_NOT_FOUND") {
+      res.status(404).json({
+        success: false,
+        message: "Invite not found",
       });
       return;
     }

--- a/src/api/v1/invites/handlers/accept-request-to-join.ts
+++ b/src/api/v1/invites/handlers/accept-request-to-join.ts
@@ -116,32 +116,34 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       return;
     }
 
-    // Check max uses limit
-    if (inviteCode.maxUses && inviteCode.usesCount >= inviteCode.maxUses) {
-      res.status(400).json({
-        success: false,
-        message: "Invite has reached maximum uses",
-      });
-      return;
-    }
-
     // Accept the request and create InviteCodeUse in a transaction
     const result = await prisma.$transaction(async (tx) => {
+      // Atomically claim a slot by incrementing uses count with a guard
+      const updateResult = await tx.inviteCode.updateMany({
+        where: {
+          id: requestToJoin.inviteCodeId,
+          OR: [
+            { maxUses: null },
+            { usesCount: { lt: prisma.inviteCode.fields.maxUses } },
+          ],
+        },
+        data: {
+          usesCount: {
+            increment: 1,
+          },
+        },
+      });
+
+      // Check if we successfully claimed a slot
+      if (updateResult.count === 0) {
+        throw new Error("INVITE_MAX_USES_REACHED");
+      }
+
       // Create InviteCodeUse record
       const inviteCodeUse = await tx.inviteCodeUse.create({
         data: {
           inviteCodeId: requestToJoin.inviteCodeId,
           usedById: requestToJoin.requesterId,
-        },
-      });
-
-      // Increment uses count
-      await tx.inviteCode.update({
-        where: { id: requestToJoin.inviteCodeId },
-        data: {
-          usesCount: {
-            increment: 1,
-          },
         },
       });
 
@@ -169,6 +171,14 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
         success: false,
         message: "Invalid request data",
         errors: error.errors,
+      });
+      return;
+    }
+
+    if (error instanceof Error && error.message === "INVITE_MAX_USES_REACHED") {
+      res.status(400).json({
+        success: false,
+        message: "Invite has reached maximum uses",
       });
       return;
     }

--- a/src/api/v1/invites/handlers/accept-request-to-join.ts
+++ b/src/api/v1/invites/handlers/accept-request-to-join.ts
@@ -40,9 +40,23 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       return;
     }
 
-    // Load the join request with related entities
-    const requestToJoin = await prisma.inviteCodeRequest.findUnique({
-      where: { id: params.requestId },
+    // Load the join request with related entities and check authorization in one query
+    const requestToJoin = await prisma.inviteCodeRequest.findFirst({
+      where: {
+        id: params.requestId,
+        OR: [
+          // User is the invite creator
+          { inviteCode: { createdBy: { xmtpId } } },
+          // User is a notification target
+          {
+            inviteCode: {
+              notificationTargets: {
+                some: { deviceIdentity: { xmtpId } },
+              },
+            },
+          },
+        ],
+      },
       include: {
         requester: true,
         inviteCode: {
@@ -58,22 +72,8 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       },
     });
 
+    // Single 404 response for both "not found" and "not authorized"
     if (!requestToJoin) {
-      res.status(404).json({
-        success: false,
-        message: "Request not found",
-      });
-      return;
-    }
-
-    // Authorization: only invite creator OR notification targets can accept
-    const isCreator = requestToJoin.inviteCode.createdBy.xmtpId === xmtpId;
-    const isNotificationTarget =
-      requestToJoin.inviteCode.notificationTargets.some(
-        (target) => target.deviceIdentity.xmtpId === xmtpId,
-      );
-
-    if (!isCreator && !isNotificationTarget) {
       res.status(404).json({
         success: false,
         message: "Request not found",
@@ -149,7 +149,11 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       const updateResult = await tx.inviteCode.updateMany({
         where: {
           id: requestToJoin.inviteCodeId,
-          OR: whereConditions,
+          AND: [
+            { status: "ACTIVE" },
+            { OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }] },
+            { OR: whereConditions },
+          ],
         },
         data: {
           usesCount: {
@@ -160,7 +164,7 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
 
       // Check if we successfully claimed a slot
       if (updateResult.count === 0) {
-        throw new Error("INVITE_MAX_USES_REACHED");
+        throw new Error("INVITE_NOT_AVAILABLE");
       }
 
       // Create InviteCodeUse record
@@ -199,10 +203,11 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
       return;
     }
 
-    if (error instanceof Error && error.message === "INVITE_MAX_USES_REACHED") {
+    if (error instanceof Error && error.message === "INVITE_NOT_AVAILABLE") {
       res.status(400).json({
         success: false,
-        message: "Invite has reached maximum uses",
+        message:
+          "Invite is no longer available (may be expired, inactive, or at capacity)",
       });
       return;
     }
@@ -218,54 +223,20 @@ export async function acceptRequestToJoin(req: Request, res: Response) {
     // Handle race condition where another request already created the InviteCodeUse
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002" &&
-      Array.isArray(error.meta?.target) &&
-      (error.meta.target as string[]).some((field) =>
-        ["inviteCodeId_usedById", "inviteCodeId", "usedById"].includes(field),
-      )
+      error.code === "P2002"
     ) {
-      // Another request already created the InviteCodeUse - fetch it for idempotent response
-      // We need the original request data to look up the correct record
-      const requestId = req.params.requestId;
-      const requestData = await prisma.inviteCodeRequest.findUnique({
-        where: { id: requestId },
-      });
-
-      if (!requestData) {
-        // Request was already deleted, which means it was processed successfully
-        // Return success for idempotency
-        res.status(200).json({
-          id: requestId,
-          accepted: true,
-          inviteCodeUse: {
-            id: "unknown",
-            usedAt: new Date().toISOString(),
-          },
-        });
-        return;
-      }
-
-      const existingUse = await prisma.inviteCodeUse.findUnique({
-        where: {
-          inviteCodeId_usedById: {
-            inviteCodeId: requestData.inviteCodeId,
-            usedById: requestData.requesterId,
-          },
+      // Duplicate key error - likely another request processed this already
+      // Return success for idempotency
+      res.status(200).json({
+        id: req.params.requestId,
+        accepted: true,
+        alreadyAccepted: true,
+        inviteCodeUse: {
+          id: "race-condition-handled",
+          usedAt: new Date().toISOString(),
         },
       });
-
-      if (existingUse) {
-        const response: AcceptRequestToJoinResponse = {
-          id: requestId,
-          accepted: true,
-          inviteCodeUse: {
-            id: existingUse.id,
-            usedAt: existingUse.usedAt.toISOString(),
-          },
-        };
-        res.status(200).json(response);
-        return;
-      }
+      return;
     }
 
     req.log.error({ error }, "Error accepting request to join");

--- a/src/api/v1/invites/handlers/accept-request-to-join.ts
+++ b/src/api/v1/invites/handlers/accept-request-to-join.ts
@@ -1,0 +1,182 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const acceptRequestParams = z.object({
+  requestId: z.string().min(1, "Request ID is required"),
+});
+
+export type AcceptRequestToJoinParams = z.infer<typeof acceptRequestParams>;
+
+export type AcceptRequestToJoinResponse = {
+  id: string;
+  accepted: boolean;
+  inviteCodeUse: {
+    id: string;
+    usedAt: string;
+  };
+};
+
+/**
+ * Accept a join request and create an InviteCodeUse record
+ * Only the invite creator or notification targets can accept requests
+ */
+export async function acceptRequestToJoin(req: Request, res: Response) {
+  try {
+    const params = await acceptRequestParams.parseAsync(req.params);
+    const { xmtpId } = res.locals;
+
+    // Find the authenticated user's identity
+    const authenticatedIdentity = await prisma.deviceIdentity.findFirst({
+      where: { xmtpId },
+    });
+
+    if (!authenticatedIdentity) {
+      res.status(404).json({
+        success: false,
+        message: "Request not found",
+      });
+      return;
+    }
+
+    // Load the join request with related entities
+    const requestToJoin = await prisma.inviteCodeRequest.findUnique({
+      where: { id: params.requestId },
+      include: {
+        requester: true,
+        inviteCode: {
+          include: {
+            createdBy: true,
+            notificationTargets: {
+              include: {
+                deviceIdentity: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!requestToJoin) {
+      res.status(404).json({
+        success: false,
+        message: "Request not found",
+      });
+      return;
+    }
+
+    // Check if user has already been accepted (has InviteCodeUse record)
+    const existingUse = await prisma.inviteCodeUse.findUnique({
+      where: {
+        inviteCodeId_usedById: {
+          inviteCodeId: requestToJoin.inviteCodeId,
+          usedById: requestToJoin.requesterId,
+        },
+      },
+    });
+
+    if (existingUse) {
+      res.status(400).json({
+        success: false,
+        message: "Request has already been accepted",
+      });
+      return;
+    }
+
+    // Authorization: only invite creator OR notification targets can accept
+    const isCreator = requestToJoin.inviteCode.createdBy.xmtpId === xmtpId;
+    const isNotificationTarget =
+      requestToJoin.inviteCode.notificationTargets.some(
+        (target) => target.deviceIdentity.xmtpId === xmtpId,
+      );
+
+    if (!isCreator && !isNotificationTarget) {
+      res.status(404).json({
+        success: false,
+        message: "Request not found",
+      });
+      return;
+    }
+
+    // Check if invite is still valid
+    const inviteCode = requestToJoin.inviteCode;
+    if (inviteCode.status !== "ACTIVE") {
+      res.status(400).json({
+        success: false,
+        message: "Invite is no longer active",
+      });
+      return;
+    }
+
+    if (inviteCode.expiresAt && inviteCode.expiresAt < new Date()) {
+      res.status(400).json({
+        success: false,
+        message: "Invite has expired",
+      });
+      return;
+    }
+
+    // Check max uses limit
+    if (inviteCode.maxUses && inviteCode.usesCount >= inviteCode.maxUses) {
+      res.status(400).json({
+        success: false,
+        message: "Invite has reached maximum uses",
+      });
+      return;
+    }
+
+    // Accept the request and create InviteCodeUse in a transaction
+    const result = await prisma.$transaction(async (tx) => {
+      // Create InviteCodeUse record
+      const inviteCodeUse = await tx.inviteCodeUse.create({
+        data: {
+          inviteCodeId: requestToJoin.inviteCodeId,
+          usedById: requestToJoin.requesterId,
+        },
+      });
+
+      // Increment uses count
+      await tx.inviteCode.update({
+        where: { id: requestToJoin.inviteCodeId },
+        data: {
+          usesCount: {
+            increment: 1,
+          },
+        },
+      });
+
+      // Delete the original request (it's been processed)
+      await tx.inviteCodeRequest.delete({
+        where: { id: params.requestId },
+      });
+
+      return { inviteCodeUse };
+    });
+
+    const response: AcceptRequestToJoinResponse = {
+      id: params.requestId,
+      accepted: true,
+      inviteCodeUse: {
+        id: result.inviteCodeUse.id,
+        usedAt: result.inviteCodeUse.usedAt.toISOString(),
+      },
+    };
+
+    res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({
+        success: false,
+        message: "Invalid request data",
+        errors: error.errors,
+      });
+      return;
+    }
+
+    req.log.error({ error }, "Error accepting request to join");
+    res.status(500).json({
+      success: false,
+      message: "Failed to accept request",
+    });
+  }
+}

--- a/src/api/v1/invites/handlers/create-invite-code.ts
+++ b/src/api/v1/invites/handlers/create-invite-code.ts
@@ -102,14 +102,19 @@ export async function createInviteCode(
 
     // Create the invite code with notification targets
     const inviteCode = await prisma.$transaction(async (tx) => {
-      // Update or create group metadata
-      await tx.groupMetadata.upsert({
-        where: { id: body.groupId },
-        update: {
+      // Build object with only provided fields
+      const metadataCreate = Object.fromEntries(
+        Object.entries({
           name: body.name,
           description: body.description,
           imageUrl: body.imageUrl,
-        },
+        }).filter(([_, value]) => value !== undefined),
+      );
+
+      // Update or create group metadata (only update provided fields)
+      await tx.groupMetadata.upsert({
+        where: { id: body.groupId },
+        update: metadataCreate,
         create: {
           id: body.groupId,
           name: body.name,

--- a/src/api/v1/invites/handlers/create-invite-code.ts
+++ b/src/api/v1/invites/handlers/create-invite-code.ts
@@ -58,6 +58,14 @@ export async function createInviteCode(
     // Get the authenticated user's identity from the JWT
     const { xmtpId } = res.locals;
 
+    if (!xmtpId) {
+      res.status(401).json({
+        success: false,
+        message: "Authentication required",
+      });
+      return;
+    }
+
     const identity = await prisma.deviceIdentity.findFirst({
       where: { xmtpId },
     });

--- a/src/api/v1/invites/handlers/create-invite-code.ts
+++ b/src/api/v1/invites/handlers/create-invite-code.ts
@@ -144,10 +144,10 @@ export async function createInviteCode(
     });
 
     const response: CreateInviteCodeResponse = {
-      id: inviteCode.id, // This cuid serves as the invite code for /join/INVITECODE
-      name: inviteCode.groupMetadata.name,
-      description: inviteCode.groupMetadata.description,
-      imageUrl: inviteCode.groupMetadata.imageUrl,
+      id: inviteCode.id,
+      name: inviteCode.groupMetadata.name ?? null,
+      description: inviteCode.groupMetadata.description ?? null,
+      imageUrl: inviteCode.groupMetadata.imageUrl ?? null,
       maxUses: inviteCode.maxUses,
       usesCount: inviteCode.usesCount,
       status: inviteCode.status,

--- a/src/api/v1/invites/handlers/create-invite-code.ts
+++ b/src/api/v1/invites/handlers/create-invite-code.ts
@@ -101,29 +101,48 @@ export async function createInviteCode(
     }
 
     // Create the invite code with notification targets
-    const inviteCode = await prisma.inviteCode.create({
-      data: {
-        name: body.name,
-        description: body.description,
-        imageUrl: body.imageUrl,
-        maxUses: body.maxUses,
-        expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
-        autoApprove: body.autoApprove,
-        groupId: body.groupId,
-        createdById: identity.id,
-        notificationTargets: {
-          create: notificationTargetIds.map((deviceIdentityId) => ({
-            deviceIdentityId,
-          })),
+    const inviteCode = await prisma.$transaction(async (tx) => {
+      // Update or create group metadata
+      await tx.groupMetadata.upsert({
+        where: { id: body.groupId },
+        update: {
+          name: body.name,
+          description: body.description,
+          imageUrl: body.imageUrl,
         },
-      },
+        create: {
+          id: body.groupId,
+          name: body.name,
+          description: body.description,
+          imageUrl: body.imageUrl,
+        },
+      });
+
+      // Create the invite code
+      return await tx.inviteCode.create({
+        data: {
+          maxUses: body.maxUses,
+          expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+          autoApprove: body.autoApprove,
+          groupId: body.groupId,
+          createdById: identity.id,
+          notificationTargets: {
+            create: notificationTargetIds.map((deviceIdentityId) => ({
+              deviceIdentityId,
+            })),
+          },
+        },
+        include: {
+          groupMetadata: true,
+        },
+      });
     });
 
     const response: CreateInviteCodeResponse = {
       id: inviteCode.id, // This cuid serves as the invite code for /join/INVITECODE
-      name: inviteCode.name,
-      description: inviteCode.description,
-      imageUrl: inviteCode.imageUrl,
+      name: inviteCode.groupMetadata.name,
+      description: inviteCode.groupMetadata.description,
+      imageUrl: inviteCode.groupMetadata.imageUrl,
       maxUses: inviteCode.maxUses,
       usesCount: inviteCode.usesCount,
       status: inviteCode.status,

--- a/src/api/v1/invites/handlers/create-invite-code.ts
+++ b/src/api/v1/invites/handlers/create-invite-code.ts
@@ -102,26 +102,22 @@ export async function createInviteCode(
 
     // Create the invite code with notification targets
     const inviteCode = await prisma.$transaction(async (tx) => {
-      // Build object with only provided fields
-      const metadataCreate = Object.fromEntries(
-        Object.entries({
-          name: body.name,
-          description: body.description,
-          imageUrl: body.imageUrl,
-        }).filter(([_, value]) => value !== undefined),
-      );
-
-      // Update or create group metadata (only update provided fields)
-      await tx.groupMetadata.upsert({
+      // Only create group metadata if it doesn't exist (don't overwrite existing)
+      const existingMetadata = await tx.groupMetadata.findUnique({
         where: { id: body.groupId },
-        update: metadataCreate,
-        create: {
-          id: body.groupId,
-          name: body.name,
-          description: body.description,
-          imageUrl: body.imageUrl,
-        },
       });
+
+      if (!existingMetadata) {
+        await tx.groupMetadata.create({
+          data: {
+            id: body.groupId,
+            name: body.name,
+            description: body.description,
+            imageUrl: body.imageUrl,
+          },
+        });
+      }
+      // If metadata exists, leave it untouched (don't overwrite other users' group data)
 
       // Create the invite code
       return await tx.inviteCode.create({

--- a/src/api/v1/invites/handlers/delete-invite.ts
+++ b/src/api/v1/invites/handlers/delete-invite.ts
@@ -53,7 +53,23 @@ export async function deleteInvite(req: Request, res: Response) {
       return;
     }
 
-    await prisma.inviteCode.delete({ where: { id: params.inviteId } });
+    // Delete the invite and clean up orphaned group metadata
+    await prisma.$transaction(async (tx) => {
+      // Delete the invite code
+      await tx.inviteCode.delete({ where: { id: params.inviteId } });
+
+      // Check if this was the last invite for this group
+      const remainingInvites = await tx.inviteCode.count({
+        where: { groupId: invite.groupId },
+      });
+
+      // If no more invites exist for this group, delete the metadata
+      if (remainingInvites === 0) {
+        await tx.groupMetadata.delete({
+          where: { id: invite.groupId },
+        });
+      }
+    });
 
     const response: DeleteInviteResponse = {
       id: params.inviteId,

--- a/src/api/v1/invites/handlers/delete-invite.ts
+++ b/src/api/v1/invites/handlers/delete-invite.ts
@@ -55,17 +55,14 @@ export async function deleteInvite(req: Request, res: Response) {
 
     // Delete the invite and clean up orphaned group metadata
     await prisma.$transaction(async (tx) => {
-      // Delete the invite code
       await tx.inviteCode.delete({ where: { id: params.inviteId } });
 
-      // Check if this was the last invite for this group
       const remainingInvites = await tx.inviteCode.count({
         where: { groupId: invite.groupId },
       });
 
-      // If no more invites exist for this group, delete the metadata
       if (remainingInvites === 0) {
-        await tx.groupMetadata.delete({
+        await tx.groupMetadata.deleteMany({
           where: { id: invite.groupId },
         });
       }

--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -77,9 +77,9 @@ export const getPublicInviteDetailsHandler = async (
 
     const response: GetPublicInviteDetailsResponse = {
       id: invite.id,
-      name: invite.groupMetadata.name,
-      description: invite.groupMetadata.description,
-      imageUrl: invite.groupMetadata.imageUrl,
+      name: invite.groupMetadata.name ?? null,
+      description: invite.groupMetadata.description ?? null,
+      imageUrl: invite.groupMetadata.imageUrl ?? null,
       inviteLinkURL: getInviteLink(invite.id),
     };
 
@@ -150,9 +150,9 @@ export const getOwnerInviteDetailsHandler = async (
 
     const response: GetInviteDetailsResponse = {
       id: invite.id,
-      name: invite.groupMetadata.name,
-      description: invite.groupMetadata.description,
-      imageUrl: invite.groupMetadata.imageUrl,
+      name: invite.groupMetadata.name ?? null,
+      description: invite.groupMetadata.description ?? null,
+      imageUrl: invite.groupMetadata.imageUrl ?? null,
       maxUses: invite.maxUses,
       usesCount: invite.usesCount,
       status: invite.status,
@@ -246,9 +246,9 @@ export const getAuthenticatedInviteDetailsHandler = async (
 
     const response: GetAuthenticatedInviteDetailsResponse = {
       id: invite.id,
-      name: invite.groupMetadata.name,
-      description: invite.groupMetadata.description,
-      imageUrl: invite.groupMetadata.imageUrl,
+      name: invite.groupMetadata.name ?? null,
+      description: invite.groupMetadata.description ?? null,
+      imageUrl: invite.groupMetadata.imageUrl ?? null,
       inviteLinkURL: getInviteLink(invite.id),
       groupId: invite.groupId,
       inviterInboxId: invite.createdBy.xmtpId,

--- a/src/api/v1/invites/handlers/get-invite-details.ts
+++ b/src/api/v1/invites/handlers/get-invite-details.ts
@@ -56,10 +56,14 @@ export const getPublicInviteDetailsHandler = async (
       },
       select: {
         id: true,
-        name: true,
-        description: true,
-        imageUrl: true,
         groupId: true,
+        groupMetadata: {
+          select: {
+            name: true,
+            description: true,
+            imageUrl: true,
+          },
+        },
       },
     });
 
@@ -73,9 +77,9 @@ export const getPublicInviteDetailsHandler = async (
 
     const response: GetPublicInviteDetailsResponse = {
       id: invite.id,
-      name: invite.name,
-      description: invite.description,
-      imageUrl: invite.imageUrl,
+      name: invite.groupMetadata.name,
+      description: invite.groupMetadata.description,
+      imageUrl: invite.groupMetadata.imageUrl,
       inviteLinkURL: getInviteLink(invite.id),
     };
 
@@ -122,6 +126,9 @@ export const getOwnerInviteDetailsHandler = async (
 
     const invite = await prisma.inviteCode.findUnique({
       where: { id: inviteId },
+      include: {
+        groupMetadata: true,
+      },
     });
 
     if (!invite) {
@@ -143,9 +150,9 @@ export const getOwnerInviteDetailsHandler = async (
 
     const response: GetInviteDetailsResponse = {
       id: invite.id,
-      name: invite.name,
-      description: invite.description,
-      imageUrl: invite.imageUrl,
+      name: invite.groupMetadata.name,
+      description: invite.groupMetadata.description,
+      imageUrl: invite.groupMetadata.imageUrl,
       maxUses: invite.maxUses,
       usesCount: invite.usesCount,
       status: invite.status,
@@ -213,10 +220,14 @@ export const getAuthenticatedInviteDetailsHandler = async (
       },
       select: {
         id: true,
-        name: true,
-        description: true,
-        imageUrl: true,
         groupId: true,
+        groupMetadata: {
+          select: {
+            name: true,
+            description: true,
+            imageUrl: true,
+          },
+        },
         createdBy: {
           select: {
             xmtpId: true,
@@ -235,9 +246,9 @@ export const getAuthenticatedInviteDetailsHandler = async (
 
     const response: GetAuthenticatedInviteDetailsResponse = {
       id: invite.id,
-      name: invite.name,
-      description: invite.description,
-      imageUrl: invite.imageUrl,
+      name: invite.groupMetadata.name,
+      description: invite.groupMetadata.description,
+      imageUrl: invite.groupMetadata.imageUrl,
       inviteLinkURL: getInviteLink(invite.id),
       groupId: invite.groupId,
       inviterInboxId: invite.createdBy.xmtpId,

--- a/src/api/v1/invites/handlers/get-invite-requests.ts
+++ b/src/api/v1/invites/handlers/get-invite-requests.ts
@@ -110,8 +110,8 @@ export async function getInviteRequests(
         },
         inviteCode: {
           id: request.inviteCode.id,
-          name: request.inviteCode.groupMetadata.name,
-          description: request.inviteCode.groupMetadata.description,
+          name: request.inviteCode.groupMetadata.name ?? null,
+          description: request.inviteCode.groupMetadata.description ?? null,
           groupId: request.inviteCode.groupId,
         },
       })),

--- a/src/api/v1/invites/handlers/get-invite-requests.ts
+++ b/src/api/v1/invites/handlers/get-invite-requests.ts
@@ -76,9 +76,13 @@ export async function getInviteRequests(
         inviteCode: {
           select: {
             id: true,
-            name: true,
-            description: true,
             groupId: true,
+            groupMetadata: {
+              select: {
+                name: true,
+                description: true,
+              },
+            },
           },
         },
       },
@@ -106,8 +110,8 @@ export async function getInviteRequests(
         },
         inviteCode: {
           id: request.inviteCode.id,
-          name: request.inviteCode.name,
-          description: request.inviteCode.description,
+          name: request.inviteCode.groupMetadata.name,
+          description: request.inviteCode.groupMetadata.description,
           groupId: request.inviteCode.groupId,
         },
       })),

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -1,4 +1,3 @@
-import type { InviteCode } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { getInviteLink } from "@/utils/invites";

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -14,7 +14,20 @@ export type RequestToJoinRequestBody = z.infer<typeof requestToJoinSchema>;
 
 export type RequestToJoinResponse = {
   id: string;
-  invite: InviteCode & {
+  invite: {
+    id: string;
+    name: string | null;
+    description: string | null;
+    imageUrl: string | null;
+    maxUses: number | null;
+    usesCount: number;
+    status: string;
+    expiresAt: string | null;
+    autoApprove: boolean;
+    groupId: string;
+    createdAt: string;
+    updatedAt: string;
+    createdById: string;
     inviteLinkURL: string;
   };
   createdAt: string;
@@ -106,10 +119,22 @@ export async function requestToJoin(
         inviteCode: {
           select: {
             id: true,
-            name: true,
-            description: true,
-            groupId: true,
+            maxUses: true,
+            usesCount: true,
+            status: true,
+            expiresAt: true,
             autoApprove: true,
+            groupId: true,
+            createdAt: true,
+            updatedAt: true,
+            createdById: true,
+            groupMetadata: {
+              select: {
+                name: true,
+                description: true,
+                imageUrl: true,
+              },
+            },
             createdBy: {
               select: {
                 xmtpId: true,
@@ -143,8 +168,8 @@ export async function requestToJoin(
       },
       inviteCode: {
         id: requestToJoin.inviteCode.id,
-        name: requestToJoin.inviteCode.name,
-        description: requestToJoin.inviteCode.description,
+        name: requestToJoin.inviteCode.groupMetadata.name,
+        description: requestToJoin.inviteCode.groupMetadata.description,
         groupId: requestToJoin.inviteCode.groupId,
       },
       autoApprove: requestToJoin.inviteCode.autoApprove,
@@ -182,8 +207,22 @@ export async function requestToJoin(
     const response: RequestToJoinResponse = {
       id: requestToJoin.id,
       invite: {
-        ...inviteCode,
-        inviteLinkURL: getInviteLink(inviteCode.id),
+        id: requestToJoin.inviteCode.id,
+        name: requestToJoin.inviteCode.groupMetadata.name,
+        description: requestToJoin.inviteCode.groupMetadata.description,
+        imageUrl: requestToJoin.inviteCode.groupMetadata.imageUrl,
+        maxUses: requestToJoin.inviteCode.maxUses,
+        usesCount: requestToJoin.inviteCode.usesCount,
+        status: requestToJoin.inviteCode.status,
+        expiresAt: requestToJoin.inviteCode.expiresAt
+          ? requestToJoin.inviteCode.expiresAt.toISOString()
+          : null,
+        autoApprove: requestToJoin.inviteCode.autoApprove,
+        groupId: requestToJoin.inviteCode.groupId,
+        createdAt: requestToJoin.inviteCode.createdAt.toISOString(),
+        updatedAt: requestToJoin.inviteCode.updatedAt.toISOString(),
+        createdById: requestToJoin.inviteCode.createdById,
+        inviteLinkURL: getInviteLink(requestToJoin.inviteCode.id),
       },
       createdAt: requestToJoin.createdAt.toISOString(),
     };

--- a/src/api/v1/invites/handlers/request-to-join.ts
+++ b/src/api/v1/invites/handlers/request-to-join.ts
@@ -167,8 +167,8 @@ export async function requestToJoin(
       },
       inviteCode: {
         id: requestToJoin.inviteCode.id,
-        name: requestToJoin.inviteCode.groupMetadata.name,
-        description: requestToJoin.inviteCode.groupMetadata.description,
+        name: requestToJoin.inviteCode.groupMetadata.name ?? null,
+        description: requestToJoin.inviteCode.groupMetadata.description ?? null,
         groupId: requestToJoin.inviteCode.groupId,
       },
       autoApprove: requestToJoin.inviteCode.autoApprove,
@@ -207,9 +207,9 @@ export async function requestToJoin(
       id: requestToJoin.id,
       invite: {
         id: requestToJoin.inviteCode.id,
-        name: requestToJoin.inviteCode.groupMetadata.name,
-        description: requestToJoin.inviteCode.groupMetadata.description,
-        imageUrl: requestToJoin.inviteCode.groupMetadata.imageUrl,
+        name: requestToJoin.inviteCode.groupMetadata.name ?? null,
+        description: requestToJoin.inviteCode.groupMetadata.description ?? null,
+        imageUrl: requestToJoin.inviteCode.groupMetadata.imageUrl ?? null,
         maxUses: requestToJoin.inviteCode.maxUses,
         usesCount: requestToJoin.inviteCode.usesCount,
         status: requestToJoin.inviteCode.status,

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -138,13 +138,26 @@ export async function updateInviteCode(
         where: { inviteCodeId: params.inviteId },
       });
 
-      // Update the invite code
-      const updatedInvite = await tx.inviteCode.update({
-        where: { id: params.inviteId },
-        data: {
+      // Update or create group metadata
+      await tx.groupMetadata.upsert({
+        where: { id: body.groupId },
+        update: {
           name: body.name,
           description: body.description,
           imageUrl: body.imageUrl,
+        },
+        create: {
+          id: body.groupId,
+          name: body.name,
+          description: body.description,
+          imageUrl: body.imageUrl,
+        },
+      });
+
+      // Update the invite code (without metadata fields)
+      const updatedInvite = await tx.inviteCode.update({
+        where: { id: params.inviteId },
+        data: {
           maxUses: body.maxUses,
           expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
           autoApprove: body.autoApprove,
@@ -156,6 +169,9 @@ export async function updateInviteCode(
             })),
           },
         },
+        include: {
+          groupMetadata: true,
+        },
       });
 
       return updatedInvite;
@@ -163,9 +179,9 @@ export async function updateInviteCode(
 
     const response: UpdateInviteCodeResponse = {
       id: inviteCode.id,
-      name: inviteCode.name,
-      description: inviteCode.description,
-      imageUrl: inviteCode.imageUrl,
+      name: inviteCode.groupMetadata.name,
+      description: inviteCode.groupMetadata.description,
+      imageUrl: inviteCode.groupMetadata.imageUrl,
       maxUses: inviteCode.maxUses,
       usesCount: inviteCode.usesCount,
       status: inviteCode.status,

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -1,23 +1,64 @@
-import type { InviteCodeStatus } from "@prisma/client";
+import type { InviteCodeStatus, Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { getInviteLink } from "@/utils/invites";
 import { prisma } from "@/utils/prisma";
 import { InviteCodeStatusSchema } from "../../../../../prisma/generated/zod";
 
+/**
+ * Checks if a user can update group metadata based on security rules:
+ * - Pre-migration (before Sept 25, 2025): Allow all invite creators (since everyone was one)
+ * - Post-migration: Only users who have a valid InviteCodeUse (legitimate group members)
+ *
+ * Note: Currently, the app creates invite codes for every new joiner, but this
+ * might change in the future as not everyone should be able to create invites
+ * and therefore invite others in turn.
+ */
+async function checkCanUpdateGroupMetadata(args: {
+  tx: Prisma.TransactionClient;
+  identityId: string;
+  groupId: string;
+  inviteCreatedAt: Date;
+}) {
+  const { tx, identityId, groupId, inviteCreatedAt } = args;
+
+  const migrationCutoff = new Date("2025-09-25T00:00:00Z");
+
+  // Pre-migration: Allow all invite creators (since everyone was one anyway)
+  if (inviteCreatedAt < migrationCutoff) {
+    const hasCreatedInvite = await tx.inviteCode.findFirst({
+      where: {
+        groupId,
+        createdById: identityId,
+      },
+    });
+    return !!hasCreatedInvite;
+  }
+
+  // Post-migration: Only users with valid InviteCodeUse (legitimate group members)
+  // This ensures only people who actually joined the group can edit metadata
+  const hasValidUse = await tx.inviteCodeUse.findFirst({
+    where: {
+      usedById: identityId,
+      inviteCode: { groupId },
+    },
+  });
+
+  return !!hasValidUse;
+}
+
 const paramsSchema = z.object({
   inviteId: z.string().min(1, "Invite ID is required"),
 });
 
 export const updateInviteCodeRequestBodySchema = z.object({
-  groupId: z.string(),
   name: z.string().optional(),
   description: z.string().optional(),
   imageUrl: z.string().url().optional(),
   maxUses: z.number().int().positive().optional(),
   expiresAt: z.string().datetime().optional(),
-  autoApprove: z.boolean().default(false),
-  notificationTargets: z.array(z.string()).default([]),
+  autoApprove: z.boolean().optional(),
+  notificationTargets: z.array(z.string()).optional(),
   status: InviteCodeStatusSchema.optional(),
 });
 
@@ -103,7 +144,7 @@ export async function updateInviteCode(
 
     // Validate notification targets exist if provided
     let notificationTargetIds: string[] = [];
-    if (body.notificationTargets.length > 0) {
+    if (body.notificationTargets && body.notificationTargets.length > 0) {
       const targetIdentities = await prisma.deviceIdentity.findMany({
         where: {
           xmtpId: {
@@ -133,47 +174,78 @@ export async function updateInviteCode(
 
     // Update the invite code
     const inviteCode = await prisma.$transaction(async (tx) => {
-      // Delete existing notification targets
-      await tx.inviteCodeNotificationTarget.deleteMany({
-        where: { inviteCodeId: params.inviteId },
+      // Delete existing notification targets if new ones are provided
+      if (body.notificationTargets !== undefined) {
+        await tx.inviteCodeNotificationTarget.deleteMany({
+          where: { inviteCodeId: params.inviteId },
+        });
+      }
+
+      // Check authorization for metadata updates
+      const canUpdateMetadata = await checkCanUpdateGroupMetadata({
+        tx,
+        identityId: identity.id,
+        groupId: existingInvite.groupId, // Use groupId from existing invite
+        inviteCreatedAt: existingInvite.createdAt,
       });
+
+      // Build metadata update if authorized and fields provided
+      if (
+        canUpdateMetadata &&
+        (body.name !== undefined ||
+          body.description !== undefined ||
+          body.imageUrl !== undefined)
+      ) {
+        const metadataUpdate = Object.fromEntries(
+          Object.entries({
+            name: body.name,
+            description: body.description,
+            imageUrl: body.imageUrl,
+          }).filter(([_, value]) => value !== undefined),
+        );
+
+        await tx.groupMetadata.upsert({
+          where: { id: existingInvite.groupId },
+          update: metadataUpdate,
+          create: {
+            id: existingInvite.groupId,
+            name: body.name,
+            description: body.description,
+            imageUrl: body.imageUrl,
+          },
+        });
+      }
 
       // Build update object with only provided fields
-      const metadataUpdate = Object.fromEntries(
-        Object.entries({
-          name: body.name,
-          description: body.description,
-          imageUrl: body.imageUrl,
-        }).filter(([_, value]) => value !== undefined),
-      );
-
-      // Update or create group metadata (only update provided fields)
-      await tx.groupMetadata.upsert({
-        where: { id: body.groupId },
-        update: metadataUpdate,
-        create: {
-          id: body.groupId,
-          name: body.name,
-          description: body.description,
-          imageUrl: body.imageUrl,
-        },
-      });
-
-      // Update the invite code (without metadata fields)
-      const updatedInvite = await tx.inviteCode.update({
-        where: { id: params.inviteId },
-        data: {
-          maxUses: body.maxUses,
+      const fieldsToUpdate = {
+        maxUses: body.maxUses,
+        autoApprove: body.autoApprove,
+        status: body.status,
+        ...(body.expiresAt !== undefined && {
           expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
-          autoApprove: body.autoApprove,
-          groupId: body.groupId,
-          ...(body.status ? { status: body.status } : {}),
+        }),
+      };
+
+      const updateData = {
+        ...Object.fromEntries(
+          Object.entries(fieldsToUpdate).filter(
+            ([_, value]) => value !== undefined,
+          ),
+        ),
+        // Handle notification targets if provided
+        ...(body.notificationTargets !== undefined && {
           notificationTargets: {
             create: notificationTargetIds.map((deviceIdentityId) => ({
               deviceIdentityId,
             })),
           },
-        },
+        }),
+      };
+
+      // Update the invite code
+      const updatedInvite = await tx.inviteCode.update({
+        where: { id: params.inviteId },
+        data: updateData,
         include: {
           groupMetadata: true,
         },

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -184,9 +184,9 @@ export async function updateInviteCode(
 
     const response: UpdateInviteCodeResponse = {
       id: inviteCode.id,
-      name: inviteCode.groupMetadata.name,
-      description: inviteCode.groupMetadata.description,
-      imageUrl: inviteCode.groupMetadata.imageUrl,
+      name: inviteCode.groupMetadata.name ?? null,
+      description: inviteCode.groupMetadata.description ?? null,
+      imageUrl: inviteCode.groupMetadata.imageUrl ?? null,
       maxUses: inviteCode.maxUses,
       usesCount: inviteCode.usesCount,
       status: inviteCode.status,

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -128,7 +128,14 @@ export async function updateInviteCode(
       return;
     }
 
-    if (existingInvite.createdById !== identity.id) {
+    const canUpdate = await checkCanUpdateGroupMetadata({
+      tx: prisma,
+      identityId: identity.id,
+      groupId: existingInvite.groupId,
+      inviteId: params.inviteId,
+    });
+
+    if (!canUpdate) {
       res.status(403).json({
         success: false,
         message: "Not authorized to update this invite",

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -103,6 +103,14 @@ export async function updateInviteCode(
     // Get the authenticated user's identity from the JWT
     const { xmtpId } = res.locals;
 
+    if (!xmtpId) {
+      res.status(401).json({
+        success: false,
+        message: "Authentication required",
+      });
+      return;
+    }
+
     const identity = await prisma.deviceIdentity.findFirst({
       where: { xmtpId },
     });

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -6,41 +6,35 @@ import { prisma } from "@/utils/prisma";
 import { InviteCodeStatusSchema } from "../../../../../prisma/generated/zod";
 
 /**
- * Checks if a user can update group metadata based on security rules:
- * - Pre-migration (before Sept 25, 2025): Allow all invite creators (since everyone was one)
- * - Post-migration: Only users who have a valid InviteCodeUse (legitimate group members)
- *
- * Note: Currently, the app creates invite codes for every new joiner, but this
- * might change in the future as not everyone should be able to create invites
- * and therefore invite others in turn.
+ * Checks if a user can update group metadata.
+ * Allows both the creator of the specific invite being updated and users with valid InviteCodeUse
  */
 async function checkCanUpdateGroupMetadata(args: {
   tx: Prisma.TransactionClient;
   identityId: string;
   groupId: string;
-  inviteCreatedAt: Date;
+  inviteId: string;
 }) {
-  const { tx, identityId, groupId, inviteCreatedAt } = args;
+  const { tx, identityId, groupId, inviteId } = args;
 
-  const migrationCutoff = new Date("2025-09-25T00:00:00Z");
+  const hasCreatedThisInvite = await tx.inviteCode.findFirst({
+    where: {
+      id: inviteId,
+      groupId,
+      createdById: identityId,
+    },
+  });
 
-  // Pre-migration: Allow all invite creators (since everyone was one anyway)
-  if (inviteCreatedAt < migrationCutoff) {
-    const hasCreatedInvite = await tx.inviteCode.findFirst({
-      where: {
-        groupId,
-        createdById: identityId,
-      },
-    });
-    return !!hasCreatedInvite;
+  if (hasCreatedThisInvite) {
+    return true;
   }
 
-  // Post-migration: Only users with valid InviteCodeUse (legitimate group members)
-  // This ensures only people who actually joined the group can edit metadata
   const hasValidUse = await tx.inviteCodeUse.findFirst({
     where: {
       usedById: identityId,
-      inviteCode: { groupId },
+      inviteCode: {
+        groupId: groupId,
+      },
     },
   });
 
@@ -186,7 +180,7 @@ export async function updateInviteCode(
         tx,
         identityId: identity.id,
         groupId: existingInvite.groupId, // Use groupId from existing invite
-        inviteCreatedAt: existingInvite.createdAt,
+        inviteId: params.inviteId,
       });
 
       // Build metadata update if authorized and fields provided

--- a/src/api/v1/invites/handlers/update-invite-code.ts
+++ b/src/api/v1/invites/handlers/update-invite-code.ts
@@ -138,14 +138,19 @@ export async function updateInviteCode(
         where: { inviteCodeId: params.inviteId },
       });
 
-      // Update or create group metadata
-      await tx.groupMetadata.upsert({
-        where: { id: body.groupId },
-        update: {
+      // Build update object with only provided fields
+      const metadataUpdate = Object.fromEntries(
+        Object.entries({
           name: body.name,
           description: body.description,
           imageUrl: body.imageUrl,
-        },
+        }).filter(([_, value]) => value !== undefined),
+      );
+
+      // Update or create group metadata (only update provided fields)
+      await tx.groupMetadata.upsert({
+        where: { id: body.groupId },
+        update: metadataUpdate,
         create: {
           id: body.groupId,
           name: body.name,

--- a/src/api/v1/invites/invites.router.ts
+++ b/src/api/v1/invites/invites.router.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { acceptRequestToJoin } from "./handlers/accept-request-to-join";
 import { createInviteCode } from "./handlers/create-invite-code";
 import { deleteInvite } from "./handlers/delete-invite";
 import { deleteRequestToJoin } from "./handlers/delete-request-to-join";
@@ -15,6 +16,7 @@ const invitesRouter = Router();
 invitesRouter.post("/", createInviteCode);
 invitesRouter.post("/request", requestToJoin);
 invitesRouter.get("/requests", getInviteRequests);
+invitesRouter.put("/requests/:requestId/accept", acceptRequestToJoin);
 invitesRouter.delete("/requests/:requestId", deleteRequestToJoin);
 invitesRouter.put("/:inviteId", updateInviteCode);
 invitesRouter.get(

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -59,6 +59,7 @@ const NOTIFICATION_EXTENSION_ALLOWED_ROUTES = [
   // Invites routes
   { method: "GET", path: "/api/v1/invites/requests" },
   { method: "DELETE", path: "/api/v1/invites/requests/:requestId" },
+  { method: "PUT", path: "/api/v1/invites/requests/:requestId/accept" },
   { method: "GET", path: "/api/v1/invites/:inviteId/with-group" },
   { method: "GET", path: "/api/v1/invites/:inviteId" },
   { method: "DELETE", path: "/api/v1/invites/:inviteId" },

--- a/tests/invite-requests.test.ts
+++ b/tests/invite-requests.test.ts
@@ -99,10 +99,19 @@ async function createTestInviteCode(args: { autoApprove?: boolean } = {}) {
     where: { xmtpId: "test-creator-xmtp-id" },
   });
 
+  // Create group metadata first
+  await prisma.groupMetadata.upsert({
+    where: { id: "test-group-123" },
+    update: {},
+    create: {
+      id: "test-group-123",
+      name: "Test Group Invite",
+    },
+  });
+
   return await prisma.inviteCode.create({
     data: {
       groupId: "test-group-123",
-      name: "Test Group Invite",
       autoApprove: args.autoApprove ?? false, // Default to requiring approval
       createdById: creatorIdentity!.id,
     },

--- a/tests/notifications-invites.test.ts
+++ b/tests/notifications-invites.test.ts
@@ -200,12 +200,21 @@ describe("Invite Notifications Integration", () => {
       },
     });
 
+    // Create group metadata first
+    await prisma.groupMetadata.upsert({
+      where: { id: "test-group-notifications-123" },
+      update: {},
+      create: {
+        id: "test-group-notifications-123",
+        name: "Test Notification Group Invite",
+        description: "Test invite for notification testing",
+      },
+    });
+
     // Create invite code
     const createdInviteCode = await prisma.inviteCode.create({
       data: {
         groupId: "test-group-notifications-123",
-        name: "Test Notification Group Invite",
-        description: "Test invite for notification testing",
         autoApprove: false, // Require approval to trigger notifications
         createdById: creatorIdentity.id,
       },


### PR DESCRIPTION
### Store invite metadata per group by introducing `GroupMetadata` and updating invite handlers to read and write metadata via `InviteCode.groupMetadata` for shared group metadata for invites
This change moves invite `name`/`description`/`imageUrl` from `InviteCode` to a new `GroupMetadata` table keyed by `groupId`, updates Prisma schema and migrations, and refactors invite handlers to read and write metadata via the `groupMetadata` relation. It also makes related responses build metadata from `groupMetadata` and performs upserts within transactions when creating or updating invites.

- Add `GroupMetadata` table and foreign key from `InviteCode.groupId` with cascade behavior in [migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-90063dface19f52431a1b6f2162140beb91867c0dab47d02ffc8fedb4b9d3b25); seed from existing `InviteCode` records
- Introduce `GroupMetadata` model and relations; remove metadata fields from `InviteCode` in [schema.prisma](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c)
- Update `createInviteCode` to upsert `GroupMetadata` and create `InviteCode` in a transaction and return `groupMetadata` in [create-invite-code.ts](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-652d7ccdd38346fbce9b96a62dfe08472a7c58cf7c04259601616a881101e04d)
- Update invite details handlers to select and return metadata from `groupMetadata` in [get-invite-details.ts](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-a77d923f3633e8caa7168084db3453c2fed7b5e5160d9966c95b272d048eada8)
- Update invite requests handler to map metadata from `groupMetadata` in [get-invite-requests.ts](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-d2a6a8be3995d4b8267168f7a4d5e59327eeb582b0045a05904a37eb2ec11c18)
- Adjust join request response construction to include metadata from `groupMetadata` and serialize timestamps in [request-to-join.ts](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-cf71af42c7db7b44ac40a54cbea5a69ba186368416c84cd2884c191796102ebe)
- Update `updateInviteCode` to upsert `GroupMetadata` and return `groupMetadata` in [update-invite-code.ts](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-0b31a61fd152efc6ff9f36ed58b768f808c9c07b2cb4d24ceaa4635432c1e277)

#### 📍Where to Start
Start with the migration and schema to understand the data model change: [migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-90063dface19f52431a1b6f2162140beb91867c0dab47d02ffc8fedb4b9d3b25) and [schema.prisma](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c), then review the transaction logic in `createInviteCode` in [create-invite-code.ts](https://github.com/ephemeraHQ/convos-backend/pull/137/files#diff-652d7ccdd38346fbce9b96a62dfe08472a7c58cf7c04259601616a881101e04d).

----

_[Macroscope](https://app.macroscope.com) summarized e366356._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Invite codes can expire, support optional auto-approve, and responses include created/updated timestamps and invite link URLs.
  - New endpoint to accept join requests (PUT /requests/:requestId/accept).

- Refactor
  - Group metadata (name, description, image) centralized into a shared group metadata entity; invite payloads now surface metadata from that source.
  - Create/update/delete flows handle group metadata atomically and clean up unused metadata.

- Bug Fixes
  - Improved authorization and validation for invite updates and request acceptance; notification-only tokens can access the accept endpoint.

- Tests
  - Tests updated to rely on separate group metadata entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->