### PR TITLE
Fix device registration

### DIFF
--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -142,10 +142,17 @@ export async function register(
       "code" in error &&
       error.code === "P2002"
     ) {
-      const deviceId = req.body.deviceId;
-      const pushToken = req.body.pushToken;
-      const pushTokenType = req.body.pushTokenType;
-      const apnsEnv = req.body.apnsEnv;
+      // Re-parse the request body to ensure data integrity
+      const parsed = registerRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        req.log.warn(
+          { errors: parsed.error.errors },
+          "Invalid request body during conflict path",
+        );
+        res.status(400).json({ error: "Invalid request body" });
+        return;
+      }
+      const { deviceId, pushToken, pushTokenType, apnsEnv } = parsed.data;
 
       req.log.info(
         { deviceId, hasPushToken: !!pushToken },
@@ -153,7 +160,7 @@ export async function register(
       );
 
       try {
-        // Build update data from the request body
+        // Build update data from validated request body
         const conflictUpdateData: {
           pushTokenType?: PushTokenType;
           apnsEnv?: ApnsEnvironment | null;
@@ -171,17 +178,16 @@ export async function register(
         }
 
         await prisma.$transaction(async (tx) => {
-          // If pushToken conflict: clear it from other devices first
+          // If pushToken conflict: clear it from other devices first (same type/env only)
           if (pushToken) {
             await tx.deviceRegistration.updateMany({
               where: {
-                pushToken,
                 deviceId: { not: deviceId },
+                pushToken,
+                pushTokenType: pushTokenType ?? "apns",
+                apnsEnv: apnsEnv ?? null,
               },
-              data: {
-                pushToken: null,
-                apnsEnv: null,
-              },
+              data: { pushToken: null },
             });
           }
 

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -170,24 +170,26 @@ export async function register(
           conflictUpdateData.apnsEnv = apnsEnv;
         }
 
-        // If pushToken conflict: clear it from other devices first
-        if (pushToken) {
-          await prisma.deviceRegistration.updateMany({
-            where: {
-              pushToken,
-              deviceId: { not: deviceId },
-            },
-            data: {
-              pushToken: null,
-              apnsEnv: null,
-            },
-          });
-        }
+        await prisma.$transaction(async (tx) => {
+          // If pushToken conflict: clear it from other devices first
+          if (pushToken) {
+            await tx.deviceRegistration.updateMany({
+              where: {
+                pushToken,
+                deviceId: { not: deviceId },
+              },
+              data: {
+                pushToken: null,
+                apnsEnv: null,
+              },
+            });
+          }
 
-        // Update this device
-        await prisma.deviceRegistration.update({
-          where: { deviceId },
-          data: conflictUpdateData,
+          // Update this device
+          await tx.deviceRegistration.update({
+            where: { deviceId },
+            data: conflictUpdateData,
+          });
         });
 
         req.log.info(

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -16,6 +16,75 @@ const registerRequestSchema = z.object({
 
 export type IRegisterRequestBody = z.infer<typeof registerRequestSchema>;
 
+/**
+ * Helper function to perform the device registration transaction.
+ * This handles clearing conflicting push tokens and upserting the device registration.
+ */
+async function performDeviceRegistration(
+  deviceId: string,
+  pushToken: string | undefined,
+  pushTokenType: PushTokenType | undefined,
+  apnsEnv: ApnsEnvironment | null | undefined,
+  updateData: {
+    pushTokenType?: PushTokenType;
+    apnsEnv?: ApnsEnvironment | null;
+    pushToken?: string | null;
+  },
+  logger: Request["log"],
+) {
+  await prisma.$transaction(async (tx) => {
+    // If a push token is provided, clear it from any other devices
+    if (pushToken) {
+      const tokenType = pushTokenType ?? "apns";
+      const environment = apnsEnv ?? null;
+
+      // Find any other device with the same push token combination
+      const existingDevice = await tx.deviceRegistration.findFirst({
+        where: {
+          pushToken,
+          pushTokenType: tokenType,
+          apnsEnv: environment,
+          deviceId: { not: deviceId },
+        },
+      });
+
+      if (existingDevice) {
+        logger.info(
+          {
+            oldDeviceId: existingDevice.deviceId,
+            newDeviceId: deviceId,
+            hasPushToken: !!pushToken,
+          },
+          "Push token moving from old device to new device - clearing old registration",
+        );
+
+        // Clear the push token from all devices with the same token combination
+        await tx.deviceRegistration.updateMany({
+          where: {
+            deviceId: { not: deviceId },
+            pushToken,
+            pushTokenType: tokenType,
+            apnsEnv: environment,
+          },
+          data: { pushToken: null },
+        });
+      }
+    }
+
+    // Now upsert the device registration
+    await tx.deviceRegistration.upsert({
+      where: { deviceId },
+      create: {
+        deviceId,
+        pushToken: pushToken ?? null,
+        pushTokenType: pushTokenType ?? "apns",
+        apnsEnv: apnsEnv ?? null,
+      },
+      update: updateData,
+    });
+  });
+}
+
 export async function register(
   req: Request<unknown, unknown, IRegisterRequestBody>,
   res: Response,
@@ -67,57 +136,14 @@ export async function register(
     // Use transaction to handle push token conflicts
     // If this push token is already registered to a different device,
     // we need to transfer ownership to the new device
-    await prisma.$transaction(async (tx) => {
-      // If a push token is provided, check if it's registered to another device
-      if (body.pushToken) {
-        const pushTokenType = body.pushTokenType ?? "apns";
-        const apnsEnv = body.apnsEnv ?? null;
-
-        // Find any other device with the same push token combination
-        const existingDevice = await tx.deviceRegistration.findFirst({
-          where: {
-            pushToken: body.pushToken,
-            pushTokenType,
-            apnsEnv,
-            deviceId: { not: body.deviceId },
-          },
-        });
-
-        if (existingDevice) {
-          req.log.info(
-            {
-              oldDeviceId: existingDevice.deviceId,
-              newDeviceId: body.deviceId,
-              hasPushToken: !!body.pushToken,
-            },
-            "Push token moving from old device to new device - clearing old registration",
-          );
-
-          // Clear the push token from all devices with the same token combination
-          await tx.deviceRegistration.updateMany({
-            where: {
-              deviceId: { not: body.deviceId },
-              pushToken: body.pushToken,
-              pushTokenType,
-              apnsEnv,
-            },
-            data: { pushToken: null },
-          });
-        }
-      }
-
-      // Now upsert the new device registration
-      await tx.deviceRegistration.upsert({
-        where: { deviceId: body.deviceId },
-        create: {
-          deviceId: body.deviceId,
-          pushToken: body.pushToken ?? null,
-          pushTokenType: body.pushTokenType ?? "apns",
-          apnsEnv: body.apnsEnv ?? null,
-        },
-        update: updateData,
-      });
-    });
+    await performDeviceRegistration(
+      body.deviceId,
+      body.pushToken,
+      body.pushTokenType,
+      body.apnsEnv,
+      updateData,
+      req.log,
+    );
 
     req.log.info(
       { deviceId: body.deviceId, hasPushToken: !!body.pushToken },
@@ -134,92 +160,6 @@ export async function register(
       );
       res.status(400).json({ error: "Invalid request body" });
       return;
-    }
-
-    // Handle unique constraint violations - just update with latest data (idempotent)
-    if (
-      error &&
-      typeof error === "object" &&
-      "code" in error &&
-      error.code === "P2002"
-    ) {
-      // Re-parse the request body to ensure data integrity
-      const parsed = registerRequestSchema.safeParse(req.body);
-      if (!parsed.success) {
-        req.log.warn(
-          { errors: parsed.error.errors },
-          "Invalid request body during conflict path",
-        );
-        res.status(400).json({ error: "Invalid request body" });
-        return;
-      }
-      const { deviceId, pushToken, pushTokenType, apnsEnv } = parsed.data;
-
-      req.log.info(
-        { deviceId, hasPushToken: !!pushToken },
-        "Conflict detected - updating device with latest data (idempotent)",
-      );
-
-      try {
-        // Build update data from validated request body
-        const conflictUpdateData: {
-          pushTokenType?: PushTokenType;
-          apnsEnv?: ApnsEnvironment | null;
-          pushToken?: string | null;
-        } = {};
-
-        if (pushToken !== undefined) {
-          conflictUpdateData.pushToken = pushToken || null;
-        }
-        if (pushTokenType !== undefined) {
-          conflictUpdateData.pushTokenType = pushTokenType;
-        }
-        if (apnsEnv !== undefined) {
-          conflictUpdateData.apnsEnv = apnsEnv;
-        }
-
-        await prisma.$transaction(async (tx) => {
-          // If pushToken conflict: clear it from other devices first (same type/env only)
-          if (pushToken) {
-            await tx.deviceRegistration.updateMany({
-              where: {
-                deviceId: { not: deviceId },
-                pushToken,
-                pushTokenType: pushTokenType ?? "apns",
-                apnsEnv: apnsEnv ?? null,
-              },
-              data: { pushToken: null },
-            });
-          }
-
-          // Upsert this device
-          await tx.deviceRegistration.upsert({
-            where: { deviceId },
-            create: {
-              deviceId,
-              pushToken: pushToken ?? null,
-              pushTokenType: pushTokenType ?? "apns",
-              apnsEnv: apnsEnv ?? null,
-            },
-            update: conflictUpdateData,
-          });
-        });
-
-        req.log.info(
-          { deviceId, hasPushToken: !!pushToken },
-          "Device updated successfully",
-        );
-
-        res.status(200).send();
-        return;
-      } catch (updateError) {
-        req.log.error(
-          { error: updateError, deviceId },
-          "Failed to update device after conflict",
-        );
-        res.status(500).json({ error: "Failed to register device" });
-        return;
-      }
     }
 
     req.log.error({ error }, "Failed to register device");

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -135,22 +135,76 @@ export async function register(
       return;
     }
 
-    // Handle unexpected Prisma unique constraint violations (should be rare due to transaction logic)
+    // Handle unique constraint violations - just update with latest data (idempotent)
     if (
       error &&
       typeof error === "object" &&
       "code" in error &&
       error.code === "P2002"
     ) {
-      req.log.error(
-        { deviceId: req.body.deviceId, error },
-        "Unexpected unique constraint violation - possible race condition",
+      const deviceId = req.body.deviceId;
+      const pushToken = req.body.pushToken;
+      const pushTokenType = req.body.pushTokenType;
+      const apnsEnv = req.body.apnsEnv;
+
+      req.log.info(
+        { deviceId, hasPushToken: !!pushToken },
+        "Conflict detected - updating device with latest data (idempotent)",
       );
-      res.status(409).json({
-        error:
-          "Push token already registered. Please retry or contact support.",
-      });
-      return;
+
+      try {
+        // Build update data from the request body
+        const conflictUpdateData: {
+          pushTokenType?: PushTokenType;
+          apnsEnv?: ApnsEnvironment | null;
+          pushToken?: string | null;
+        } = {};
+
+        if (pushToken !== undefined) {
+          conflictUpdateData.pushToken = pushToken || null;
+        }
+        if (pushTokenType !== undefined) {
+          conflictUpdateData.pushTokenType = pushTokenType;
+        }
+        if (apnsEnv !== undefined) {
+          conflictUpdateData.apnsEnv = apnsEnv;
+        }
+
+        // If pushToken conflict: clear it from other devices first
+        if (pushToken) {
+          await prisma.deviceRegistration.updateMany({
+            where: {
+              pushToken,
+              deviceId: { not: deviceId },
+            },
+            data: {
+              pushToken: null,
+              apnsEnv: null,
+            },
+          });
+        }
+
+        // Update this device
+        await prisma.deviceRegistration.update({
+          where: { deviceId },
+          data: conflictUpdateData,
+        });
+
+        req.log.info(
+          { deviceId, hasPushToken: !!pushToken },
+          "Device updated successfully",
+        );
+
+        res.status(200).send();
+        return;
+      } catch (updateError) {
+        req.log.error(
+          { error: updateError, deviceId },
+          "Failed to update device after conflict",
+        );
+        res.status(500).json({ error: "Failed to register device" });
+        return;
+      }
     }
 
     req.log.error({ error }, "Failed to register device");

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -191,10 +191,16 @@ export async function register(
             });
           }
 
-          // Update this device
-          await tx.deviceRegistration.update({
+          // Upsert this device
+          await tx.deviceRegistration.upsert({
             where: { deviceId },
-            data: conflictUpdateData,
+            create: {
+              deviceId,
+              pushToken: pushToken ?? null,
+              pushTokenType: pushTokenType ?? "apns",
+              apnsEnv: apnsEnv ?? null,
+            },
+            update: conflictUpdateData,
           });
         });
 

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -88,19 +88,20 @@ export async function register(
             {
               oldDeviceId: existingDevice.deviceId,
               newDeviceId: body.deviceId,
-              pushToken: body.pushToken,
+              hasPushToken: !!body.pushToken,
             },
             "Push token moving from old device to new device - clearing old registration",
           );
 
-          // Clear the push token from the old device to avoid unique constraint violation
-          await tx.deviceRegistration.update({
-            where: { deviceId: existingDevice.deviceId },
-            data: {
-              pushToken: null,
-              pushTokenType: "apns",
-              apnsEnv: null,
+          // Clear the push token from all devices with the same token combination
+          await tx.deviceRegistration.updateMany({
+            where: {
+              deviceId: { not: body.deviceId },
+              pushToken: body.pushToken,
+              pushTokenType,
+              apnsEnv,
             },
+            data: { pushToken: null },
           });
         }
       }

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -148,6 +148,7 @@ export async function subscribe(
       "Subscribed successfully",
     );
     res.status(200).send();
+    return;
   } catch (error) {
     if (error instanceof z.ZodError) {
       req.log.warn(

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -63,15 +63,6 @@ export async function subscribe(
       return;
     }
 
-    if (!device.pushToken) {
-      req.log.warn(
-        { deviceId: body.deviceId },
-        "Device has no push token registered",
-      );
-      res.status(400).json({ error: "Device has no push token registered" });
-      return;
-    }
-
     // Convert HMAC keys to Uint8Array
     const subscriptions = body.topics.map((topic) => ({
       topic: topic.topic,
@@ -82,39 +73,46 @@ export async function subscribe(
       })),
     }));
 
-    // Register installation with notification server
-    try {
-      await notificationClient.registerInstallation({
-        installationId: body.clientId,
-        deliveryMechanism: {
-          deliveryMechanismType: {
-            case:
-              device.pushTokenType === "apns"
-                ? "apnsDeviceToken"
-                : "firebaseDeviceToken",
-            value: device.pushToken,
-          },
-        },
-      });
-
-      // Subscribe to topics
-      await notificationClient.subscribeWithMetadata({
-        installationId: body.clientId,
-        subscriptions,
-      });
-    } catch (remoteErr) {
-      // Compensate: best-effort delete installation to avoid orphaned state
+    // Register installation with notification server (only if pushToken exists)
+    if (!device.pushToken) {
+      req.log.info(
+        { deviceId: body.deviceId, clientId: body.clientId },
+        "Device has no push token yet - subscription will be activated once token is registered",
+      );
+    } else {
       try {
-        await notificationClient.deleteInstallation({
+        await notificationClient.registerInstallation({
           installationId: body.clientId,
+          deliveryMechanism: {
+            deliveryMechanismType: {
+              case:
+                device.pushTokenType === "apns"
+                  ? "apnsDeviceToken"
+                  : "firebaseDeviceToken",
+              value: device.pushToken,
+            },
+          },
         });
-      } catch (cleanupErr) {
-        req.log.warn(
-          { error: cleanupErr, installationId: body.clientId },
-          "Failed to cleanup installation after subscription failure",
-        );
+
+        // Subscribe to topics
+        await notificationClient.subscribeWithMetadata({
+          installationId: body.clientId,
+          subscriptions,
+        });
+      } catch (remoteErr) {
+        // Compensate: best-effort delete installation to avoid orphaned state
+        try {
+          await notificationClient.deleteInstallation({
+            installationId: body.clientId,
+          });
+        } catch (cleanupErr) {
+          req.log.warn(
+            { error: cleanupErr, installationId: body.clientId },
+            "Failed to cleanup installation after subscription failure",
+          );
+        }
+        throw remoteErr;
       }
-      throw remoteErr;
     }
 
     // Create or update client identifier record
@@ -129,16 +127,18 @@ export async function subscribe(
         update: { deviceId: body.deviceId },
       });
     } catch (dbErr) {
-      // Compensate: delete installation to maintain consistency
-      try {
-        await notificationClient.deleteInstallation({
-          installationId: body.clientId,
-        });
-      } catch (cleanupErr) {
-        req.log.warn(
-          { error: cleanupErr, installationId: body.clientId },
-          "Failed to cleanup installation after DB failure",
-        );
+      // Compensate: delete installation to maintain consistency (only if we created one)
+      if (device.pushToken) {
+        try {
+          await notificationClient.deleteInstallation({
+            installationId: body.clientId,
+          });
+        } catch (cleanupErr) {
+          req.log.warn(
+            { error: cleanupErr, installationId: body.clientId },
+            "Failed to cleanup installation after DB failure",
+          );
+        }
       }
       throw dbErr;
     }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix device registration by clearing duplicate push tokens across existing registrations in `src/api/v2/device/handlers/register.ts` and allowing subscription without a push token in `src/api/v2/notifications/handlers/subscribe.ts`
This pull request introduces a helper to wrap the device registration transaction and updates the registration and subscription handlers to align with new push token handling behavior. It centralizes the clearing of duplicate push tokens during registration and adjusts the subscription flow to proceed without requiring a push token.

- Add `performDeviceRegistration` helper in [register.ts](https://github.com/ephemeraHQ/convos-backend/pull/143/files#diff-e2e17828402e48441259e515015cac450bb7966aec49f53e56f2a2b76e531349) that clears matching `pushToken` values on other device registrations and upserts the current device with defaults for `pushTokenType` and `apnsEnv`
- Update `register` handler in [register.ts](https://github.com/ephemeraHQ/convos-backend/pull/143/files#diff-e2e17828402e48441259e515015cac450bb7966aec49f53e56f2a2b76e531349) to use `performDeviceRegistration` and remove explicit Prisma `P2002` conflict handling
- Modify `subscribe` handler in [subscribe.ts](https://github.com/ephemeraHQ/convos-backend/pull/143/files#diff-ceb1529a284486613f3b036bdbc51ee98edad2a540aaf02fca7bfa8bac4715cc) to skip notification installation and subscription when a device has no `pushToken`, logging and returning 200 regardless

#### 📍Where to Start
Start with the `performDeviceRegistration` helper and its usage in the `register` handler in [register.ts](https://github.com/ephemeraHQ/convos-backend/pull/143/files#diff-e2e17828402e48441259e515015cac450bb7966aec49f53e56f2a2b76e531349), then review the conditional subscription flow in [subscribe.ts](https://github.com/ephemeraHQ/convos-backend/pull/143/files#diff-ceb1529a284486613f3b036bdbc51ee98edad2a540aaf02fca7bfa8bac4715cc).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5ba336f. 2 files reviewed, 10 issues evaluated, 9 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>src/api/v2/device/handlers/register.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>

- [line 165](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/device/handlers/register.ts#L165): Error handling regression: previously, unique constraint violations (`Prisma` error code `P2002`) were mapped to a 409 conflict response with a specific message. The new implementation removed that handling and now falls through to the generic 500 response for all errors. This changes the externally visible contract: clients encountering a push-token registration race or constraint violation will now receive a 500 instead of a 409, losing actionable semantics and potentially breaking client error handling logic. <b>[ Low confidence ]</b>
</details>

<details>
<summary>src/api/v2/notifications/handlers/subscribe.ts — 0 comments posted, 8 evaluated, 8 filtered</summary>

- [line 13](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L13): `topic` is only validated as a string and may be empty (`""`) or contain invalid characters for the downstream topic format. Forwarding an empty/invalid topic can cause remote API errors. The schema should enforce non-empty and, if applicable, a topic pattern (e.g., `.min(1)` or a regex). <b>[ Low confidence ]</b>
- [line 14](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L14): `hmacKeys` arrays are allowed to be empty (`z.array(...)` without `.min(1)`). Subscribing with an empty `hmacKeys` array likely violates the downstream API’s requirements for HMAC validation and may cause runtime errors on subscription. Enforce a minimum length (e.g., `.min(1)`) or explicitly handle the empty case with a 400 response. <b>[ Invalidated by documentation search ]</b>
- [line 16](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L16): `thirtyDayPeriodsSinceEpoch` is only validated as a number. Non-integer or negative values are accepted by the schema and forwarded to the notification server. If the downstream expects a non-negative integer period, this can cause remote errors or undefined behavior at runtime. The schema should enforce an integer and range, e.g., `z.number().int().nonnegative()`. <b>[ Low confidence ]</b>
- [line 37](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L37): `req.log` is used multiple times without a visible guarantee that the Express `Request` is augmented with a `log` property at runtime. If middleware adding `req.log` is not applied to this route, `req.log` will be undefined and calls like `req.log.info(...)` will throw a TypeError, resulting in a 500. Either ensure a guard or rely on types/middleware that guarantee its presence at runtime for this handler. <b>[ Low confidence ]</b>
- [line 70](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L70): Potential unbounded input size for `hmacKeys` arrays and `key` length could cause excessive memory usage during conversion to `Uint8Array`, leading to performance degradation or process memory exhaustion (DoS risk). There is no size limit on `hmacKeys` per topic, and no maximum hex length for `key`. Consider adding reasonable `.max(...)` constraints for array length and `key` length. <b>[ Low confidence ]</b>
- [line 72](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L72): Odd-length hex keys are accepted by the schema but may cause `hexToUint8Array` to throw at runtime. The Zod schema (`hmacKeys.*.key`) only checks that the string contains hex characters, not that it has an even number of characters. `hexToUint8Array` typically requires an even-length hex string; an odd-length input can cause a runtime error, resulting in a 500 response instead of a 400 validation error. Add an even-length constraint to the schema or wrap the conversion in a guard and respond with 400 on invalid hex. <b>[ Low confidence ]</b>
- [line 77](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L77): When `device.pushToken` is absent, the handler returns 200 after logging, but does not persist the requested subscriptions anywhere. This silently drops the client’s subscription intent with no mechanism shown to "activate once token is registered." If/when the push token is later registered, the server has no record of which topics/hmac keys to subscribe, resulting in a broken external contract and lost subscriptions. <b>[ Low confidence ]</b>
- [line 89](https://github.com/ephemeraHQ/convos-backend/blob/5ba336f355b30989212a4e182856162bedcb0372/src/api/v2/notifications/handlers/subscribe.ts#L89): If `device.pushToken` is set but `device.pushTokenType` is null/undefined or invalid, the ternary defaults to `firebaseDeviceToken`. This can register an APNS token as Firebase (or vice versa), leading to delivery failures. The code should validate `pushTokenType` when `pushToken` exists and return a clear 500/400 or map only known values with an explicit else-case error. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device subscription now supports devices without push tokens (subscription proceeds without remote registration).

* **Bug Fixes**
  * Device registration resolves conflicts by updating existing device records instead of returning an error.
  * Push token handling improved to clear duplicate tokens from other devices.
  * Improved error handling and logging around subscription and registration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->