### PR TITLE
Update docker compose to connect to XMTP dev, update webhook path to v2

### DIFF
--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -27,7 +27,7 @@ services:
       - mlsdb
       - validation
     healthcheck:
-      test: ["CMD-SHELL", "sleep 5 && exit 0"]
+      test: [ "CMD-SHELL", "sleep 5 && exit 0" ]
       interval: 10s
       timeout: 30s
       retries: 3

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -27,7 +27,7 @@ services:
       - mlsdb
       - validation
     healthcheck:
-      test: [ "CMD-SHELL", "sleep 5 && exit 0" ]
+      test: ["CMD-SHELL", "sleep 5 && exit 0"]
       interval: 10s
       timeout: 30s
       retries: 3

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -55,21 +55,19 @@ services:
     image: xmtp/notifications-server:latest
     platform: linux/amd64
     depends_on:
-      node:
-        condition: service_healthy
       notification_db:
         condition: service_started
     command:
       - --xmtp-listener
       - --db-connection-string=postgres://postgres:notifications@notification_db:5432/postgres?sslmode=disable
-      - --xmtp-address=node:5556 # Local Xmtp Node
+      - --xmtp-address=dev.xmtp.network:5556 # Dev Network
       - --log-level=debug
       - --api
       - --api-port=8080
 
       # HTTP Delivery
       - --http-delivery
-      - --http-delivery-address=${TEST_NOTIFICATION_DELIVERY_URL:-http://host.docker.internal:4000/api/v1/notifications/xmtp/handle-notification}
+      - --http-delivery-address=${TEST_NOTIFICATION_DELIVERY_URL:-http://host.docker.internal:4000/api/v2/notifications/xmtp/handle-notification}
       - --http-auth-header=${XMTP_NOTIFICATION_SECRET}
 
     ports:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update dev docker compose to connect the notifications server to XMTP at dev.xmtp.network:5556 and set the HTTP delivery path to /api/v2/notifications/xmtp/handle-notification
Switch the XMTP address to `dev.xmtp.network:5556` and set the default delivery endpoint to `/api/v2/notifications/xmtp/handle-notification` in [dev/compose.yml](https://github.com/ephemeraHQ/convos-backend/pull/144/files#diff-179aaaa54e90c327e1f24333cdd54163b98fd92fdcdf94a383ae7a2e709748a9). Remove the `depends_on` condition for the `node` service.

#### 📍Where to Start
Start with the service definitions and environment variables in [dev/compose.yml](https://github.com/ephemeraHQ/convos-backend/pull/144/files#diff-179aaaa54e90c327e1f24333cdd54163b98fd92fdcdf94a383ae7a2e709748a9), focusing on the XMTP address and `TEST_NOTIFICATION_DELIVERY_URL` updates.

----
<!-- MACROSCOPE_FOOTER_START -->

<a href="https://app.macroscope.com">Macroscope</a> summarized ae877e3.

<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated notification service configuration for development:
    * Messaging address updated to dev.xmtp.network:5556.
    * HTTP delivery endpoint moved to the v2 API path.
    * Removed health dependency on the node service, altering startup semantics (notification DB still waits for service start).
    * Minor formatting/spacing tweak.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->