### PR TITLE
Switch to asymmetric JWT auth for v2 endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,12 @@ THIRDWEB_SECRET_KEY=
 # XMTP database encryption key
 XMTP_DB_ENCRYPTION_BASE_64_KEY=
 
-# JWT secret
-JWT_SECRET=your-secure-secret-key-here
+# v1 JWT (deprecated)
+# JWT_SECRET=your-secure-secret-key-here
+
+# v2 JWT - Asymmetric ECDSA keys (generate with: bun run dev/scripts/generateEcdsaKeys.ts)
+JWT_PRIVATE_KEY=
+JWT_PUBLIC_KEY=
 
 # Notifications server URL
 NOTIFICATION_SERVER_URL=

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ bun generate:notification-secret
 
 Add the generated value to your `.env` file.
 
+For JWT authentication, generate an ECDSA P-256 key pair:
+
+```bash
+bun run dev/scripts/generateEcdsaKeys.ts
+```
+
+Add the `JWT_PRIVATE_KEY` to your backend `.env` file and share the `JWT_PUBLIC_KEY` with the gateway service.
+
 #### Run the app locally
 
 ```bash
@@ -80,6 +88,7 @@ Adjust the `-p 4000:4000` flag to match the port in the `.env` file. The default
 - `bun format`: Run prettier format and write changes
 - `bun generate:key`: Generate a key for XMTP database encryption
 - `bun generate:notification-secret`: Generate a secure token for XMTP notification authentication
+- `bun run dev/scripts/generateEcdsaKeys.ts`: Generate ECDSA P-256 key pair for JWT authentication
 - `bun install`: Installs all dependencies
 - `bun lint`: Lint with ESLint
 - `bun migrate:dev`: Create a Prisma migration from changes in the Prisma schema, apply to the database, and generate Prisma client code

--- a/dev/scripts/generateEcdsaKeys.ts
+++ b/dev/scripts/generateEcdsaKeys.ts
@@ -1,0 +1,57 @@
+import * as jose from "jose";
+
+/**
+ * Generate ECDSA P-256 key pair for JWT authentication
+ *
+ * Usage:
+ *   bun run dev/scripts/generateEcdsaKeys.ts
+ *
+ * This generates a private key for the backend (JWT_PRIVATE_KEY)
+ * and a public key for the gateway (JWT_PUBLIC_KEY)
+ */
+async function generateKeys() {
+  console.log("Generating ECDSA P-256 key pair...\n");
+
+  const { privateKey, publicKey } = await jose.generateKeyPair("ES256", {
+    extractable: true,
+  });
+
+  // Export keys in PEM format
+  const privateKeyPem = await jose.exportPKCS8(privateKey);
+  const publicKeyPem = await jose.exportSPKI(publicKey);
+
+  console.log("=".repeat(80));
+  console.log("ECDSA P-256 Key Pair Generated Successfully");
+  console.log("=".repeat(80));
+  console.log("\n📝 Private Key (for Backend - JWT_PRIVATE_KEY):");
+  console.log("-".repeat(80));
+  console.log(privateKeyPem);
+
+  console.log("\n📝 Public Key (for Gateway - JWT_PUBLIC_KEY):");
+  console.log("-".repeat(80));
+  console.log(publicKeyPem);
+
+  console.log("\n" + "=".repeat(80));
+  console.log("⚠️  IMPORTANT: Add these to your .env files");
+  console.log("=".repeat(80));
+
+  // Convert to .env format (escaped newlines)
+  const privateKeyEnv = privateKeyPem.replace(/\n/g, "\\n");
+  const publicKeyEnv = publicKeyPem.replace(/\n/g, "\\n");
+
+  console.log("\n📋 Ready to paste into Backend .env:");
+  console.log("-".repeat(80));
+  console.log(`JWT_PRIVATE_KEY="${privateKeyEnv}"`);
+
+  console.log("\n📋 Ready to paste into Gateway .env:");
+  console.log("-".repeat(80));
+  console.log(`JWT_PUBLIC_KEY="${publicKeyEnv}"`);
+
+  console.log("\n" + "=".repeat(80));
+  console.log(
+    "⚠️  Keep the private key SECRET - never commit to version control!",
+  );
+  console.log("=".repeat(80));
+}
+
+generateKeys().catch(console.error);

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,14 +10,6 @@ if (!process.env.XMTP_NOTIFICATION_SECRET) {
   throw new Error("XMTP_NOTIFICATION_SECRET is not configured");
 }
 
-if (!process.env.JWT_PRIVATE_KEY) {
-  throw new Error("JWT_PRIVATE_KEY is not configured");
-}
-
-if (!process.env.JWT_PUBLIC_KEY) {
-  throw new Error("JWT_PUBLIC_KEY is not configured");
-}
-
 if (!process.env.NOTIFICATION_SERVER_URL) {
   throw new Error("NOTIFICATION_SERVER_URL is not configured");
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,32 +25,9 @@ export const JWT_SECRET_BYTES = JWT_SECRET
   : undefined;
 
 // v2 JWT (asymmetric ECDSA ES256)
-const JWT_PRIVATE_KEY_RAW = process.env.JWT_PRIVATE_KEY;
-const JWT_PUBLIC_KEY_RAW = process.env.JWT_PUBLIC_KEY;
-
-// Validate JWT_PRIVATE_KEY is a non-empty string
-if (
-  typeof JWT_PRIVATE_KEY_RAW !== "string" ||
-  JWT_PRIVATE_KEY_RAW.trim().length === 0
-) {
-  throw new Error(
-    "Missing `JWT_PRIVATE_KEY`: set a non-empty PEM-encoded ECDSA private key in environment before starting the app",
-  );
-}
-
-// Validate JWT_PUBLIC_KEY is a non-empty string
-if (
-  typeof JWT_PUBLIC_KEY_RAW !== "string" ||
-  JWT_PUBLIC_KEY_RAW.trim().length === 0
-) {
-  throw new Error(
-    "Missing `JWT_PUBLIC_KEY`: set a non-empty PEM-encoded ECDSA public key in environment before starting the app",
-  );
-}
-
-// Export as non-null strings after validation
-export const JWT_PRIVATE_KEY: string = JWT_PRIVATE_KEY_RAW;
-export const JWT_PUBLIC_KEY: string = JWT_PUBLIC_KEY_RAW;
+// Keys are optional at config load time, but validated at server startup via validateJWTKeys()
+export const JWT_PRIVATE_KEY = process.env.JWT_PRIVATE_KEY || "";
+export const JWT_PUBLIC_KEY = process.env.JWT_PUBLIC_KEY || "";
 
 export const JWT_ISSUER = "convos.org";
 export const NOTIFICATION_SERVER_URL = process.env.NOTIFICATION_SERVER_URL;

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,10 @@ if (!process.env.JWT_PRIVATE_KEY) {
   throw new Error("JWT_PRIVATE_KEY is not configured");
 }
 
+if (!process.env.JWT_PUBLIC_KEY) {
+  throw new Error("JWT_PUBLIC_KEY is not configured");
+}
+
 if (!process.env.NOTIFICATION_SERVER_URL) {
   throw new Error("NOTIFICATION_SERVER_URL is not configured");
 }
@@ -38,17 +42,32 @@ if (typeof JWT_SECRET !== "string" || JWT_SECRET.trim().length === 0) {
 export const JWT_SECRET_BYTES = new TextEncoder().encode(JWT_SECRET);
 
 // V2 JWT (asymmetric ECDSA ES256)
-export const JWT_PRIVATE_KEY = process.env.JWT_PRIVATE_KEY;
+const JWT_PRIVATE_KEY_RAW = process.env.JWT_PRIVATE_KEY;
+const JWT_PUBLIC_KEY_RAW = process.env.JWT_PUBLIC_KEY;
 
 // Validate JWT_PRIVATE_KEY is a non-empty string
 if (
-  typeof JWT_PRIVATE_KEY !== "string" ||
-  JWT_PRIVATE_KEY.trim().length === 0
+  typeof JWT_PRIVATE_KEY_RAW !== "string" ||
+  JWT_PRIVATE_KEY_RAW.trim().length === 0
 ) {
   throw new Error(
     "Missing `JWT_PRIVATE_KEY`: set a non-empty PEM-encoded ECDSA private key in environment before starting the app",
   );
 }
+
+// Validate JWT_PUBLIC_KEY is a non-empty string
+if (
+  typeof JWT_PUBLIC_KEY_RAW !== "string" ||
+  JWT_PUBLIC_KEY_RAW.trim().length === 0
+) {
+  throw new Error(
+    "Missing `JWT_PUBLIC_KEY`: set a non-empty PEM-encoded ECDSA public key in environment before starting the app",
+  );
+}
+
+// Export as non-null strings after validation
+export const JWT_PRIVATE_KEY: string = JWT_PRIVATE_KEY_RAW;
+export const JWT_PUBLIC_KEY: string = JWT_PUBLIC_KEY_RAW;
 
 export const JWT_ISSUER = "convos.org";
 export const NOTIFICATION_SERVER_URL = process.env.NOTIFICATION_SERVER_URL;

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,8 +10,13 @@ if (!process.env.XMTP_NOTIFICATION_SECRET) {
   throw new Error("XMTP_NOTIFICATION_SECRET is not configured");
 }
 
+// v1 JWT (kept for backward compatibility with v1 auth endpoints)
 if (!process.env.JWT_SECRET) {
   throw new Error("JWT_SECRET is not configured");
+}
+
+if (!process.env.JWT_PRIVATE_KEY) {
+  throw new Error("JWT_PRIVATE_KEY is not configured");
 }
 
 if (!process.env.NOTIFICATION_SERVER_URL) {
@@ -20,6 +25,8 @@ if (!process.env.NOTIFICATION_SERVER_URL) {
 
 // Cache environment variables
 export const XMTP_NOTIFICATION_SECRET = process.env.XMTP_NOTIFICATION_SECRET;
+
+// v1 JWT (legacy - symmetric HS256)
 export const JWT_SECRET = process.env.JWT_SECRET;
 
 // Validate JWT_SECRET is a non-empty string before encoding
@@ -29,6 +36,21 @@ if (typeof JWT_SECRET !== "string" || JWT_SECRET.trim().length === 0) {
   );
 }
 export const JWT_SECRET_BYTES = new TextEncoder().encode(JWT_SECRET);
+
+// V2 JWT (asymmetric ECDSA ES256)
+export const JWT_PRIVATE_KEY = process.env.JWT_PRIVATE_KEY;
+
+// Validate JWT_PRIVATE_KEY is a non-empty string
+if (
+  typeof JWT_PRIVATE_KEY !== "string" ||
+  JWT_PRIVATE_KEY.trim().length === 0
+) {
+  throw new Error(
+    "Missing `JWT_PRIVATE_KEY`: set a non-empty PEM-encoded ECDSA private key in environment before starting the app",
+  );
+}
+
+export const JWT_ISSUER = "convos.org";
 export const NOTIFICATION_SERVER_URL = process.env.NOTIFICATION_SERVER_URL;
 export const NODE_ENV = process.env.NODE_ENV || "development";
 export const IS_PRODUCTION = process.env.NODE_ENV === "production";

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,11 +10,6 @@ if (!process.env.XMTP_NOTIFICATION_SECRET) {
   throw new Error("XMTP_NOTIFICATION_SECRET is not configured");
 }
 
-// v1 JWT (kept for backward compatibility with v1 auth endpoints)
-if (!process.env.JWT_SECRET) {
-  throw new Error("JWT_SECRET is not configured");
-}
-
 if (!process.env.JWT_PRIVATE_KEY) {
   throw new Error("JWT_PRIVATE_KEY is not configured");
 }
@@ -30,18 +25,14 @@ if (!process.env.NOTIFICATION_SERVER_URL) {
 // Cache environment variables
 export const XMTP_NOTIFICATION_SECRET = process.env.XMTP_NOTIFICATION_SECRET;
 
-// v1 JWT (legacy - symmetric HS256)
+// v1 JWT (legacy - symmetric HS256, optional for backward compatibility)
+// Only validate and encode if JWT_SECRET is provided
 export const JWT_SECRET = process.env.JWT_SECRET;
+export const JWT_SECRET_BYTES = JWT_SECRET
+  ? new TextEncoder().encode(JWT_SECRET)
+  : undefined;
 
-// Validate JWT_SECRET is a non-empty string before encoding
-if (typeof JWT_SECRET !== "string" || JWT_SECRET.trim().length === 0) {
-  throw new Error(
-    "Missing `JWT_SECRET`: set a non-empty string in environment before starting the app",
-  );
-}
-export const JWT_SECRET_BYTES = new TextEncoder().encode(JWT_SECRET);
-
-// V2 JWT (asymmetric ECDSA ES256)
+// v2 JWT (asymmetric ECDSA ES256)
 const JWT_PRIVATE_KEY_RAW = process.env.JWT_PRIVATE_KEY;
 const JWT_PUBLIC_KEY_RAW = process.env.JWT_PUBLIC_KEY;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,6 @@ validateJWTKeys()
     });
   })
   .catch((error: unknown) => {
-    logger.error("Failed to validate JWT keys at startup", error);
+    logger.error({ error }, "Failed to validate JWT keys at startup");
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { pinoMiddleware } from "./middleware/pino";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
 import healthcheckRouter from "./routes/healthcheck";
 import logger from "./utils/logger";
+import { validateJWTKeys } from "./utils/v2/jwt";
 
 const getLocalIpAddresses = () => {
   const interfaces = os.networkInterfaces();
@@ -54,21 +55,32 @@ app.use(noRouteMiddleware);
 app.use(errorHandlerMiddleware);
 
 const port = process.env.PORT || 4000;
-const server = app.listen(port, () => {
-  logger.info(`Convos API service is running on port ${port}`);
 
-  if (IS_DEVELOPMENT) {
-    const localIps = getLocalIpAddresses();
-    logger.info(`Available at: http://localhost:${port}`);
-    localIps.forEach((ip) => {
-      logger.info(`Available at: http://${ip}:${port}`);
+// Validate JWT keys at startup before starting the server
+validateJWTKeys()
+  .then(() => {
+    logger.info("JWT key validation successful");
+
+    const server = app.listen(port, () => {
+      logger.info(`Convos API service is running on port ${port}`);
+
+      if (IS_DEVELOPMENT) {
+        const localIps = getLocalIpAddresses();
+        logger.info(`Available at: http://localhost:${port}`);
+        localIps.forEach((ip) => {
+          logger.info(`Available at: http://${ip}:${port}`);
+        });
+      }
     });
-  }
-});
 
-process.on("SIGTERM", () => {
-  logger.info("SIGTERM signal received: closing Convos API service");
-  server.close(() => {
-    logger.info("Convos API service closed");
+    process.on("SIGTERM", () => {
+      logger.info("SIGTERM signal received: closing Convos API service");
+      server.close(() => {
+        logger.info("Convos API service closed");
+      });
+    });
+  })
+  .catch((error: unknown) => {
+    logger.error("Failed to validate JWT keys at startup", error);
+    process.exit(1);
   });
-});

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -35,6 +35,11 @@ const loadPrivateKey = async (): Promise<jose.KeyLike> => {
   if (cachedPrivateKey) {
     return cachedPrivateKey;
   }
+  if (!JWT_PRIVATE_KEY || JWT_PRIVATE_KEY.trim().length === 0) {
+    throw new Error(
+      "JWT_PRIVATE_KEY is not configured - set a valid PEM-encoded ECDSA P-256 private key",
+    );
+  }
   const key = await jose.importPKCS8(JWT_PRIVATE_KEY, "ES256");
   cachedPrivateKey = key;
   return key;
@@ -47,6 +52,11 @@ const loadPrivateKey = async (): Promise<jose.KeyLike> => {
 const loadPublicKey = async (): Promise<jose.KeyLike> => {
   if (cachedPublicKey) {
     return cachedPublicKey;
+  }
+  if (!JWT_PUBLIC_KEY || JWT_PUBLIC_KEY.trim().length === 0) {
+    throw new Error(
+      "JWT_PUBLIC_KEY is not configured - set a valid PEM-encoded ECDSA P-256 public key",
+    );
   }
   const key = await jose.importSPKI(JWT_PUBLIC_KEY, "ES256");
   cachedPublicKey = key;

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -113,7 +113,7 @@ export const createV2JwtToken = async (args: {
     await tryCatch(loadPrivateKey());
 
   if (importError) {
-    logger.error("Failed to load JWT private key", importError);
+    logger.error({ error: importError }, "Failed to load JWT private key");
     throw new AppError(500, "Failed to load JWT private key", importError);
   }
 
@@ -129,7 +129,7 @@ export const createV2JwtToken = async (args: {
   );
 
   if (jwtError) {
-    logger.error("Failed to create JWT token", jwtError);
+    logger.error({ error: jwtError }, "Failed to create JWT token");
     throw new AppError(500, "Failed to create JWT token", jwtError);
   }
 
@@ -142,7 +142,10 @@ export const verifyV2JwtToken = async (args: { token: string }) => {
     await tryCatch(loadPublicKey());
 
   if (importError) {
-    logger.error("Failed to load JWT public key for verification", importError);
+    logger.error(
+      { error: importError },
+      "Failed to load JWT public key for verification",
+    );
     throw new AppError(500, "Failed to load JWT public key", importError);
   }
 
@@ -155,13 +158,13 @@ export const verifyV2JwtToken = async (args: { token: string }) => {
   );
 
   if (verifyError) {
-    logger.error("V2 JWT verification failed", verifyError);
+    logger.error({ error: verifyError }, "V2 JWT verification failed");
     throw new AppError(401, "Invalid or expired token", verifyError);
   }
 
   const parseResult = v2JWTPayloadSchema.safeParse(verified.payload);
   if (!parseResult.success) {
-    logger.error("Invalid JWT payload structure", parseResult.error);
+    logger.error({ error: parseResult.error }, "Invalid JWT payload structure");
     throw new AppError(401, "Invalid JWT payload structure");
   }
 

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -24,14 +24,43 @@ const v2JWTPayloadSchema = z.object({
     .optional(),
 });
 
+let cachedPrivateKey: jose.KeyLike | null = null;
+let cachedPublicKey: jose.KeyLike | null = null;
+
 /**
- * Validate JWT keys at application startup
+ * Lazy-load and cache the private key
+ * Safe for concurrent calls - returns the same promise while loading
+ */
+const loadPrivateKey = async (): Promise<jose.KeyLike> => {
+  if (cachedPrivateKey) {
+    return cachedPrivateKey;
+  }
+  const key = await jose.importPKCS8(JWT_PRIVATE_KEY, "ES256");
+  cachedPrivateKey = key;
+  return key;
+};
+
+/**
+ * Lazy-load and cache the public key
+ * Safe for concurrent calls - returns the same promise while loading
+ */
+const loadPublicKey = async (): Promise<jose.KeyLike> => {
+  if (cachedPublicKey) {
+    return cachedPublicKey;
+  }
+  const key = await jose.importSPKI(JWT_PUBLIC_KEY, "ES256");
+  cachedPublicKey = key;
+  return key;
+};
+
+/**
+ * Validate JWT keys at application startup and cache them
  * This should be called during initialization to fail fast on misconfiguration
  */
 export const validateJWTKeys = async () => {
   try {
-    // Validate private key format
-    await jose.importPKCS8(JWT_PRIVATE_KEY, "ES256");
+    // Validate and cache private key
+    await loadPrivateKey();
     logger.info("JWT private key validation successful");
   } catch (error) {
     logger.error({ error }, "Invalid JWT_PRIVATE_KEY format");
@@ -41,8 +70,8 @@ export const validateJWTKeys = async () => {
   }
 
   try {
-    // Validate public key format
-    await jose.importSPKI(JWT_PUBLIC_KEY, "ES256");
+    // Validate and cache public key
+    await loadPublicKey();
     logger.info("JWT public key validation successful");
   } catch (error) {
     logger.error({ error }, "Invalid JWT_PUBLIC_KEY format");
@@ -79,14 +108,13 @@ export const createV2JwtToken = async (args: {
     payload.metadata = args.metadata;
   }
 
-  // Import ECDSA private key
-  const { data: privateKey, error: importError } = await tryCatch(
-    jose.importPKCS8(JWT_PRIVATE_KEY, "ES256"),
-  );
+  // Get cached ECDSA private key
+  const { data: privateKey, error: importError } =
+    await tryCatch(loadPrivateKey());
 
   if (importError) {
-    logger.error("Failed to import JWT private key", importError);
-    throw new AppError(500, "Failed to import JWT private key", importError);
+    logger.error("Failed to load JWT private key", importError);
+    throw new AppError(500, "Failed to load JWT private key", importError);
   }
 
   // Create JWT token with ECDSA ES256
@@ -109,17 +137,13 @@ export const createV2JwtToken = async (args: {
 };
 
 export const verifyV2JwtToken = async (args: { token: string }) => {
-  // Import ECDSA public key for verification
-  const { data: publicKey, error: importError } = await tryCatch(
-    jose.importSPKI(JWT_PUBLIC_KEY, "ES256"),
-  );
+  // Get cached ECDSA public key for verification
+  const { data: publicKey, error: importError } =
+    await tryCatch(loadPublicKey());
 
   if (importError) {
-    logger.error(
-      "Failed to import JWT public key for verification",
-      importError,
-    );
-    throw new AppError(500, "Failed to import JWT public key", importError);
+    logger.error("Failed to load JWT public key for verification", importError);
+    throw new AppError(500, "Failed to load JWT public key", importError);
   }
 
   // Verify JWT token using the public key

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -1,7 +1,7 @@
 import * as jose from "jose";
 import { z } from "zod";
 import { MAX_JWT_METADATA_SIZE } from "@/api/shared/notifications/constants";
-import { JWT_SECRET_BYTES } from "@/config";
+import { JWT_ISSUER, JWT_PRIVATE_KEY } from "@/config";
 import { AppError } from "@/utils/errors";
 import logger from "@/utils/logger";
 import { tryCatch } from "@/utils/try-catch";
@@ -51,17 +51,29 @@ export const createV2JwtToken = async (args: {
     payload.metadata = args.metadata;
   }
 
-  // Create JWT token
+  // Import ECDSA private key
+  const { data: privateKey, error: importError } = await tryCatch(
+    jose.importPKCS8(JWT_PRIVATE_KEY, "ES256"),
+  );
+
+  if (importError) {
+    logger.error("Failed to import JWT private key", importError);
+    throw new AppError(500, "Failed to import JWT private key", importError);
+  }
+
+  // Create JWT token with ECDSA ES256
   const { data: jwt, error: jwtError } = await tryCatch(
     new jose.SignJWT(payload)
-      .setProtectedHeader({ alg: "HS256" })
+      .setProtectedHeader({ alg: "ES256" })
+      .setSubject(args.deviceId) // Standard 'sub' claim for gateway
+      .setIssuer(JWT_ISSUER) // Standard 'iss' claim
       .setIssuedAt()
       .setExpirationTime(args.expirationTime ?? "15m")
-      .sign(JWT_SECRET_BYTES),
+      .sign(privateKey),
   );
 
   if (jwtError) {
-    logger.error(jwtError);
+    logger.error("Failed to create JWT token", jwtError);
     throw new AppError(500, "Failed to create JWT token", jwtError);
   }
 
@@ -69,8 +81,24 @@ export const createV2JwtToken = async (args: {
 };
 
 export const verifyV2JwtToken = async (args: { token: string }) => {
+  // Import ECDSA private key (we need to derive the public key for verification)
+  const { data: privateKey, error: importError } = await tryCatch(
+    jose.importPKCS8(JWT_PRIVATE_KEY, "ES256"),
+  );
+
+  if (importError) {
+    logger.error(
+      "Failed to import JWT private key for verification",
+      importError,
+    );
+    throw new AppError(500, "Failed to import JWT private key", importError);
+  }
+
+  // Verify JWT token
   const { data: verified, error: verifyError } = await tryCatch(
-    jose.jwtVerify(args.token, JWT_SECRET_BYTES),
+    jose.jwtVerify(args.token, privateKey, {
+      issuer: JWT_ISSUER,
+    }),
   );
 
   if (verifyError) {
@@ -80,6 +108,7 @@ export const verifyV2JwtToken = async (args: { token: string }) => {
 
   const parseResult = v2JWTPayloadSchema.safeParse(verified.payload);
   if (!parseResult.success) {
+    logger.error("Invalid JWT payload structure", parseResult.error);
     throw new AppError(401, "Invalid JWT payload structure");
   }
 

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -1,7 +1,7 @@
 import * as jose from "jose";
 import { z } from "zod";
 import { MAX_JWT_METADATA_SIZE } from "@/api/shared/notifications/constants";
-import { JWT_ISSUER, JWT_PRIVATE_KEY } from "@/config";
+import { JWT_ISSUER, JWT_PRIVATE_KEY, JWT_PUBLIC_KEY } from "@/config";
 import { AppError } from "@/utils/errors";
 import logger from "@/utils/logger";
 import { tryCatch } from "@/utils/try-catch";
@@ -81,22 +81,22 @@ export const createV2JwtToken = async (args: {
 };
 
 export const verifyV2JwtToken = async (args: { token: string }) => {
-  // Import ECDSA private key (we need to derive the public key for verification)
-  const { data: privateKey, error: importError } = await tryCatch(
-    jose.importPKCS8(JWT_PRIVATE_KEY, "ES256"),
+  // Import ECDSA public key for verification
+  const { data: publicKey, error: importError } = await tryCatch(
+    jose.importSPKI(JWT_PUBLIC_KEY, "ES256"),
   );
 
   if (importError) {
     logger.error(
-      "Failed to import JWT private key for verification",
+      "Failed to import JWT public key for verification",
       importError,
     );
-    throw new AppError(500, "Failed to import JWT private key", importError);
+    throw new AppError(500, "Failed to import JWT public key", importError);
   }
 
-  // Verify JWT token
+  // Verify JWT token using the public key
   const { data: verified, error: verifyError } = await tryCatch(
-    jose.jwtVerify(args.token, privateKey, {
+    jose.jwtVerify(args.token, publicKey, {
       issuer: JWT_ISSUER,
     }),
   );

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -24,6 +24,34 @@ const v2JWTPayloadSchema = z.object({
     .optional(),
 });
 
+/**
+ * Validate JWT keys at application startup
+ * This should be called during initialization to fail fast on misconfiguration
+ */
+export const validateJWTKeys = async () => {
+  try {
+    // Validate private key format
+    await jose.importPKCS8(JWT_PRIVATE_KEY, "ES256");
+    logger.info("JWT private key validation successful");
+  } catch (error) {
+    logger.error({ error }, "Invalid JWT_PRIVATE_KEY format");
+    throw new Error(
+      "Invalid JWT_PRIVATE_KEY: must be a valid PEM-encoded ECDSA P-256 private key",
+    );
+  }
+
+  try {
+    // Validate public key format
+    await jose.importSPKI(JWT_PUBLIC_KEY, "ES256");
+    logger.info("JWT public key validation successful");
+  } catch (error) {
+    logger.error({ error }, "Invalid JWT_PUBLIC_KEY format");
+    throw new Error(
+      "Invalid JWT_PUBLIC_KEY: must be a valid PEM-encoded ECDSA P-256 public key",
+    );
+  }
+};
+
 export const createV2JwtToken = async (args: {
   deviceId: string;
   metadata?: V2JWTMetadata;
@@ -98,6 +126,7 @@ export const verifyV2JwtToken = async (args: { token: string }) => {
   const { data: verified, error: verifyError } = await tryCatch(
     jose.jwtVerify(args.token, publicKey, {
       issuer: JWT_ISSUER,
+      algorithms: ["ES256"],
     }),
   );
 


### PR DESCRIPTION
This is done to support JWT verification on the payer gateway using a public key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added instructions and a command to generate ECDSA P-256 (ES256) JWT key pairs and updated the .env example, deprecating the old symmetric JWT secret.

* **New Features**
  * Migrated JWT authentication to ES256 with issuer enforcement.
  * Added a key-generation utility that outputs backend and gateway-ready key values.

* **Behavior**
  * Startup now validates JWT keys and fails early with clear errors if keys are missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->