### PR TITLE
Remove auto-disable on push failure on dev

### DIFF
--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -57,11 +57,12 @@ services:
     depends_on:
       notification_db:
         condition: service_started
+      node:
+        condition: service_healthy
     command:
       - --xmtp-listener
-      - --xmtp-listener-tls
       - --db-connection-string=postgres://postgres:notifications@notification_db:5432/postgres?sslmode=disable
-      - --xmtp-address=dev.xmtp.network:5556
+      - --xmtp-address=${XMTP_NODE_ADDRESS:-node:5556}
       - --log-level=debug
       - --api
       - --api-port=8080

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
     "start": "bun run --preload ./src/instrumentation.ts src/index.ts",
-    "test:local": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 dev/restart-notification && bun test",
-    "test:notifications-client": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 dev/restart-notification && bun test tests/notifications.client.test.ts",
+    "test:local": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 XMTP_NOTIFICATION_SECRET=test-notification-secret dev/restart-notification && bun test",
+    "test:notifications-client": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 XMTP_NOTIFICATION_SECRET=test-notification-secret dev/restart-notification && bun test tests/notifications.client.test.ts",
     "test:push": "bun run scripts/test-push-notification.ts",
     "test:push-simple": "bun run scripts/simple-push-test.ts",
     "typecheck": "tsc"

--- a/src/api/shared/notifications/constants.ts
+++ b/src/api/shared/notifications/constants.ts
@@ -1,7 +1,8 @@
 /**
- * Maximum number of consecutive push notification failures before disabling a device
+ * Maximum number of consecutive push notification failures before logging warnings
+ * Note: Does not auto-disable devices; threshold is for monitoring only
  */
-export const MAX_PUSH_FAILURES = 10;
+export const MAX_PUSH_FAILURES = 50;
 
 /**
  * Maximum size in bytes for JWT metadata to prevent token bloat

--- a/src/api/shared/notifications/webhook-handler.ts
+++ b/src/api/shared/notifications/webhook-handler.ts
@@ -324,7 +324,26 @@ async function handleV2Notification(args: {
     );
   } else {
     // Increment failures and conditionally disable in production APNS
-    const shouldAutoDisable =
+    // Increment failures and decide auto-disable based on updated DB state within the transaction
+    let autoDisabled = false;
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const u = await tx.deviceRegistration.update({
+        where: { deviceId: client.deviceId },
+        data: {
+          pushFailures: { increment: 1 },
+          lastFailureAt: new Date(),
+        },
+      });
+
+      // Auto-disable only in production when threshold is reached, based on updated value
+      if (u.apnsEnv === "production" && u.pushFailures >= MAX_PUSH_FAILURES) {
+        await tx.deviceRegistration.updateMany({
+          where: {
+            deviceId: client.deviceId,
+            disabled: false,
+          },
+          data: { disabled: true },
       client.device.apnsEnv === "production" &&
       client.device.pushFailures + 1 >= MAX_PUSH_FAILURES;
 

--- a/src/api/shared/notifications/webhook-handler.ts
+++ b/src/api/shared/notifications/webhook-handler.ts
@@ -323,13 +323,32 @@ async function handleV2Notification(args: {
       `Successfully sent v2 push notification`,
     );
   } else {
-    // Increment failures without auto-disable
-    const updated = await prisma.deviceRegistration.update({
-      where: { deviceId: client.deviceId },
-      data: {
-        pushFailures: { increment: 1 },
-        lastFailureAt: new Date(),
-      },
+    // Increment failures and conditionally disable in production APNS
+    const shouldAutoDisable =
+      client.device.apnsEnv === "production" &&
+      client.device.pushFailures + 1 >= MAX_PUSH_FAILURES;
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const u = await tx.deviceRegistration.update({
+        where: { deviceId: client.deviceId },
+        data: {
+          pushFailures: { increment: 1 },
+          lastFailureAt: new Date(),
+        },
+      });
+
+      // Auto-disable only in production when threshold is reached
+      if (shouldAutoDisable) {
+        await tx.deviceRegistration.updateMany({
+          where: {
+            deviceId: client.deviceId,
+            disabled: false,
+          },
+          data: { disabled: true },
+        });
+      }
+
+      return u;
     });
 
     // Log detailed error information
@@ -340,6 +359,7 @@ async function handleV2Notification(args: {
         failureCount: updated.pushFailures,
         apnsEnv: client.device.apnsEnv,
         lastFailureAt: updated.lastFailureAt,
+        autoDisabled: shouldAutoDisable,
       },
       `Failed to send v2 push notification: ${result.error}`,
     );

--- a/src/api/shared/notifications/webhook-handler.ts
+++ b/src/api/shared/notifications/webhook-handler.ts
@@ -324,7 +324,6 @@ async function handleV2Notification(args: {
     );
   } else {
     // Increment failures and conditionally disable in production APNS
-    // Increment failures and decide auto-disable based on updated DB state within the transaction
     let autoDisabled = false;
 
     const updated = await prisma.$transaction(async (tx) => {
@@ -336,7 +335,7 @@ async function handleV2Notification(args: {
         },
       });
 
-      // Auto-disable only in production when threshold is reached, based on updated value
+      // Auto-disable only in production when threshold is reached
       if (u.apnsEnv === "production" && u.pushFailures >= MAX_PUSH_FAILURES) {
         await tx.deviceRegistration.updateMany({
           where: {
@@ -344,27 +343,8 @@ async function handleV2Notification(args: {
             disabled: false,
           },
           data: { disabled: true },
-      client.device.apnsEnv === "production" &&
-      client.device.pushFailures + 1 >= MAX_PUSH_FAILURES;
-
-    const updated = await prisma.$transaction(async (tx) => {
-      const u = await tx.deviceRegistration.update({
-        where: { deviceId: client.deviceId },
-        data: {
-          pushFailures: { increment: 1 },
-          lastFailureAt: new Date(),
-        },
-      });
-
-      // Auto-disable only in production when threshold is reached
-      if (shouldAutoDisable) {
-        await tx.deviceRegistration.updateMany({
-          where: {
-            deviceId: client.deviceId,
-            disabled: false,
-          },
-          data: { disabled: true },
         });
+        autoDisabled = true;
       }
 
       return u;
@@ -378,7 +358,7 @@ async function handleV2Notification(args: {
         failureCount: updated.pushFailures,
         apnsEnv: client.device.apnsEnv,
         lastFailureAt: updated.lastFailureAt,
-        autoDisabled: shouldAutoDisable,
+        autoDisabled,
       },
       `Failed to send v2 push notification: ${result.error}`,
     );

--- a/src/api/shared/notifications/webhook-handler.ts
+++ b/src/api/shared/notifications/webhook-handler.ts
@@ -323,7 +323,7 @@ async function handleV2Notification(args: {
       `Successfully sent v2 push notification`,
     );
   } else {
-    // Increment failures and conditionally disable in production APNS
+    // Increment failures and conditionally disable in XMTP production environment
     let autoDisabled = false;
 
     const updated = await prisma.$transaction(async (tx) => {
@@ -335,8 +335,11 @@ async function handleV2Notification(args: {
         },
       });
 
-      // Auto-disable only in production when threshold is reached
-      if (u.apnsEnv === "production" && u.pushFailures >= MAX_PUSH_FAILURES) {
+      // Auto-disable only in XMTP production environment when threshold is reached
+      if (
+        process.env.XMTP_ENV === "production" &&
+        u.pushFailures >= MAX_PUSH_FAILURES
+      ) {
         await tx.deviceRegistration.updateMany({
           where: {
             deviceId: client.deviceId,

--- a/src/api/shared/notifications/webhook-handler.ts
+++ b/src/api/shared/notifications/webhook-handler.ts
@@ -221,15 +221,25 @@ async function handleV2Notification(args: {
 }) {
   const { notification, client, req } = args;
 
-  // Check if device is disabled or has too many failures
-  if (
-    client.device.disabled ||
-    client.device.pushFailures >= MAX_PUSH_FAILURES
-  ) {
+  // Only check manual disable flag (not failure count)
+  if (client.device.disabled) {
     req.log.warn(
-      `Device ${client.deviceId} is disabled or has too many failures. Skipping notification.`,
+      { deviceId: client.deviceId },
+      `Device is manually disabled. Skipping notification.`,
     );
     return { success: false };
+  }
+
+  // Log warning if high failure count but don't block
+  if (client.device.pushFailures >= MAX_PUSH_FAILURES) {
+    req.log.warn(
+      {
+        deviceId: client.deviceId,
+        failures: client.device.pushFailures,
+        lastFailureAt: client.device.lastFailureAt,
+      },
+      `Device has high failure count (${client.device.pushFailures}) but continuing`,
+    );
   }
 
   // Generate JWT for NSE to use (24h expiration for security)
@@ -309,34 +319,29 @@ async function handleV2Notification(args: {
       },
     });
     req.log.info(
-      `Successfully sent v2 push notification to ${client.deviceId}`,
+      { deviceId: client.deviceId },
+      `Successfully sent v2 push notification`,
     );
   } else {
-    // Use transaction to atomically increment failures and conditionally disable
-    const updated = await prisma.$transaction(async (tx) => {
-      const u = await tx.deviceRegistration.update({
-        where: { deviceId: client.deviceId },
-        data: {
-          pushFailures: { increment: 1 },
-          lastFailureAt: new Date(),
-        },
-      });
-
-      // Atomic conditional disable - only disables if not already disabled and threshold reached
-      await tx.deviceRegistration.updateMany({
-        where: {
-          deviceId: client.deviceId,
-          disabled: false,
-          pushFailures: { gte: MAX_PUSH_FAILURES },
-        },
-        data: { disabled: true },
-      });
-
-      return u;
+    // Increment failures without auto-disable
+    const updated = await prisma.deviceRegistration.update({
+      where: { deviceId: client.deviceId },
+      data: {
+        pushFailures: { increment: 1 },
+        lastFailureAt: new Date(),
+      },
     });
 
-    req.log.warn(
-      `Failed to send v2 push notification to ${client.deviceId}. Failure count: ${updated.pushFailures}`,
+    // Log detailed error information
+    req.log.error(
+      {
+        deviceId: client.deviceId,
+        error: result.error,
+        failureCount: updated.pushFailures,
+        apnsEnv: client.device.apnsEnv,
+        lastFailureAt: updated.lastFailureAt,
+      },
+      `Failed to send v2 push notification: ${result.error}`,
     );
 
     // Cleanup if unrecoverable error
@@ -345,7 +350,8 @@ async function handleV2Notification(args: {
       result.error === "BadDeviceToken"
     ) {
       req.log.info(
-        `Cleaning up v2 notification client ${client.id} due to unrecoverable error`,
+        { clientId: client.id, error: result.error },
+        `Cleaning up v2 notification client due to unrecoverable error`,
       );
       try {
         // Delete from local DB first to ensure we don't retry on failure

--- a/tests/notifications.client.test.ts
+++ b/tests/notifications.client.test.ts
@@ -57,8 +57,10 @@ describe("Notifications", () => {
       server = app.listen(8081);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       server.close();
+      // Small delay to let any pending notifications drain
+      await new Promise((resolve) => setTimeout(resolve, 100));
       // clean up the test databases
       rimrafSync("tests/**/*.db3*", { glob: true });
     });
@@ -129,7 +131,7 @@ describe("Notifications", () => {
         deliveryMechanism: {
           deliveryMechanismType: {
             case: "apnsDeviceToken",
-            value: "token",
+            value: "test-token",
           },
         },
       });
@@ -163,7 +165,7 @@ describe("Notifications", () => {
           "apns",
         );
         expect(notification.installation.delivery_mechanism.token).toEqual(
-          "token",
+          "test-token",
         );
         expect(notification.message_context.message_type).toEqual("v3-welcome");
       }
@@ -186,7 +188,7 @@ describe("Notifications", () => {
         deliveryMechanism: {
           deliveryMechanismType: {
             case: "apnsDeviceToken",
-            value: "token",
+            value: "test-token",
           },
         },
       });
@@ -230,7 +232,7 @@ describe("Notifications", () => {
           "apns",
         );
         expect(notification.installation.delivery_mechanism.token).toEqual(
-          "token",
+          "test-token",
         );
         expect(notification.message_context.message_type).toEqual(
           "v3-conversation",
@@ -258,7 +260,7 @@ describe("Notifications", () => {
         deliveryMechanism: {
           deliveryMechanismType: {
             case: "apnsDeviceToken",
-            value: "token",
+            value: "test-token",
           },
         },
       });
@@ -315,7 +317,7 @@ describe("Notifications", () => {
           "apns",
         );
         expect(notification.installation.delivery_mechanism.token).toEqual(
-          "token",
+          "test-token",
         );
         expect(notification.message_context.message_type).toEqual(
           "v3-conversation",
@@ -341,7 +343,7 @@ describe("Notifications", () => {
         deliveryMechanism: {
           deliveryMechanismType: {
             case: "apnsDeviceToken",
-            value: "token",
+            value: "test-token",
           },
         },
       });
@@ -396,7 +398,7 @@ describe("Notifications", () => {
           "apns",
         );
         expect(notification.installation.delivery_mechanism.token).toEqual(
-          "token",
+          "test-token",
         );
         expect(notification.message_context.message_type).toEqual(
           "v3-conversation",
@@ -424,7 +426,7 @@ describe("Notifications", () => {
         deliveryMechanism: {
           deliveryMechanismType: {
             case: "apnsDeviceToken",
-            value: "token",
+            value: "test-token",
           },
         },
       });
@@ -496,7 +498,7 @@ describe("Notifications", () => {
           "apns",
         );
         expect(notification.installation.delivery_mechanism.token).toEqual(
-          "token",
+          "test-token",
         );
         expect(notification.message_context.message_type).toEqual(
           "v3-conversation",
@@ -522,7 +524,7 @@ describe("Notifications", () => {
         deliveryMechanism: {
           deliveryMechanismType: {
             case: "apnsDeviceToken",
-            value: "token",
+            value: "test-token",
           },
         },
       });

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -5,6 +5,9 @@ import type { SocialProfile } from "@/utils/thirdweb";
 process.env.PUBLIC_ASSETS_BUCKET = "test-public-assets-bucket";
 process.env.JWT_SECRET = "test-jwt-secret";
 process.env.FIREBASE_SERVICE_ACCOUNT = "{}";
+process.env.XMTP_ENV = "local";
+process.env.NOTIFICATION_SERVER_URL = "http://localhost:8080";
+process.env.XMTP_NOTIFICATION_SECRET = "test-notification-secret";
 
 // mock Firebase functions
 

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -7,7 +7,9 @@ process.env.JWT_SECRET = "test-jwt-secret";
 process.env.FIREBASE_SERVICE_ACCOUNT = "{}";
 process.env.XMTP_ENV = "local";
 process.env.NOTIFICATION_SERVER_URL = "http://localhost:8080";
-process.env.XMTP_NOTIFICATION_SECRET = "test-notification-secret";
+// Only set default if not already set (CI uses GitHub secrets)
+process.env.XMTP_NOTIFICATION_SECRET =
+  process.env.XMTP_NOTIFICATION_SECRET || "test-notification-secret";
 
 // mock Firebase functions
 


### PR DESCRIPTION
### TL;DR

Improved push notification handling by removing auto-disable functionality and enhancing logging.

### What changed?

- Increased `MAX_PUSH_FAILURES` threshold from 10 to 50
- Removed automatic device disabling when failure threshold is reached
- Updated the constant documentation to clarify that the threshold is for monitoring only
- Enhanced logging with structured data and more detailed error information
- Separated handling of manually disabled devices from those with high failure counts
- Improved log messages to include relevant context (deviceId, failure counts, etc.)

### How to test?

1. Verify that devices with high failure counts continue to receive notifications
2. Check logs to confirm enhanced error information is present when push notifications fail
3. Confirm that manually disabled devices still don't receive notifications
4. Verify that unrecoverable errors (like BadDeviceToken) still trigger client cleanup

### Why make this change?

The previous implementation was too aggressive in disabling devices after only 10 failures, which could lead to legitimate devices being unnecessarily disabled. This change takes a more measured approach by continuing to send notifications while providing better monitoring through enhanced logging. This allows us to track problematic devices without interrupting service to users who may be experiencing temporary connectivity issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delivery no longer blocked solely by push-failure counts; only explicitly disabled devices block delivery.
  * Push-failure threshold increased and now logs warnings for monitoring; in production the system may auto-disable when criteria are met.
  * Success, failure, and cleanup logs are more structured and include device/client context.

* **Chores**
  * Startup waits for node health and uses an environment-driven node address; TLS flag removed.
  * Test runner now receives a notification secret env var.

* **Tests**
  * Cleanup hook made async with a short drain delay; test tokens and env vars standardized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->