### PR TITLE
Enable /v2 endpoint asset upload with v2 auth support

### DIFF
--- a/src/api/v2/attachments/attachments.router.ts
+++ b/src/api/v2/attachments/attachments.router.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { getPresignedUrlHandler } from "./handlers/get-presigned-url";
+
+export const attachmentsRouter = Router();
+
+attachmentsRouter.get("/presigned", getPresignedUrlHandler);

--- a/src/api/v2/attachments/handlers/get-presigned-url.ts
+++ b/src/api/v2/attachments/handlers/get-presigned-url.ts
@@ -1,0 +1,73 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import type { Request, Response } from "express";
+import mime from "mime-types";
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { AppError } from "@/utils/errors";
+
+const envSchema = z.object({
+  PUBLIC_ASSETS_BUCKET: z.string().min(1).optional(),
+  AWS_REGION: z.string().optional(),
+});
+
+// Validate environment variables at startup
+const env = envSchema.parse({
+  PUBLIC_ASSETS_BUCKET: process.env.PUBLIC_ASSETS_BUCKET,
+  AWS_REGION: process.env.AWS_REGION,
+});
+
+// Create S3 client only if bucket is configured
+const s3Client = env.PUBLIC_ASSETS_BUCKET ? new S3Client({}) : null;
+
+const getPresignedURL = async (contentType?: string) => {
+  if (!env.PUBLIC_ASSETS_BUCKET || !s3Client) {
+    throw new AppError(503, "File uploads not available - S3 not configured");
+  }
+
+  const objectKey = uuidv4();
+  let extension: string | undefined;
+  if (contentType && mime.extension(contentType)) {
+    extension = mime.extension(contentType) as string;
+  }
+
+  const command = new PutObjectCommand({
+    Bucket: env.PUBLIC_ASSETS_BUCKET,
+    Key: `${objectKey}${extension ? `.${extension}` : ""}`,
+    ContentType: contentType,
+  });
+
+  const url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+  return { objectKey, url };
+};
+
+export async function getPresignedUrlHandler(req: Request, res: Response) {
+  try {
+    const contentType = req.query.contentType as string | undefined;
+    const deviceId = res.locals.deviceId;
+
+    req.log.info(
+      {
+        deviceId,
+        contentType,
+        hasJwtMetadata: !!res.locals.jwtMetadata,
+      },
+      "V2 attachments presigned URL request",
+    );
+
+    const { objectKey, url } = await getPresignedURL(contentType);
+
+    res.json({ objectKey, url });
+    return;
+  } catch (error) {
+    req.log.error({ error }, "Error generating presigned URL");
+
+    if (error instanceof AppError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+
+    res.status(500).json({ error: "Failed to generate presigned URL" });
+    return;
+  }
+}

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { webhookRouter } from "@/api/shared/notifications/webhook.router";
 import { appCheckOnlyMiddleware, authV2Middleware } from "@/middleware/v2/auth";
+import { attachmentsRouter } from "./attachments/attachments.router";
 import { authRouter } from "./auth/auth.router";
 import { deviceRouter } from "./device/device.router";
 import invitesV2Router from "./invites/invites.router";
@@ -11,11 +12,12 @@ const v2Router = Router();
 v2Router.use("/invites", invitesV2Router);
 v2Router.use("/auth", authRouter);
 v2Router.use("/device", appCheckOnlyMiddleware, deviceRouter);
+v2Router.use("/attachments", authV2Middleware, attachmentsRouter);
 
 // XMTP webhook - Must be before /notifications to avoid authV2Middleware
 v2Router.use("/notifications/xmtp", webhookRouter);
 
-// Other notification routes (require auth)
+// Other notification routes
 v2Router.use("/notifications", authV2Middleware, notificationsRouter);
 
 // Auth check endpoint (AppCheck or JWT)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add authenticated `GET /v2/attachments/presigned` to return a 3600-second S3 PUT presigned URL for asset upload with v2 auth
Introduce `attachmentsRouter` with `GET /attachments/presigned` under v2 auth, validate `PUBLIC_ASSETS_BUCKET` and `AWS_REGION` at module load, and implement `getPresignedURL` that returns `{ objectKey, url }` or a 503 when S3 is not configured.

#### 📍Where to Start
Start with the `getPresignedUrlHandler` in [get-presigned-url.ts](https://github.com/ephemeraHQ/convos-backend/pull/149/files#diff-49cc5727fb075e88e19850a97751e76fe65d3508a04d1eb44ce3bfbba97e5eb9) and then review router wiring in [attachments.router.ts](https://github.com/ephemeraHQ/convos-backend/pull/149/files#diff-48231ad37a9665dc0adf099f8777febcd75fe2cba0fe6b594479c9d5d9b093fd).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized db745d8.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced secure attachment upload capability via presigned URL generation. Users can now request temporary upload URLs for files with automatic content type validation and file extension handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->