### PR TITLE
Org name change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*     @ephemeraHQ/engineering
+*     @xmtplabs/engineering

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -102,8 +102,8 @@ jobs:
           terraform-org: xmtp
           terraform-workspace: convos-otr-dev
           variable-name: api_image
-          variable-value: "ghcr.io/ephemerahq/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
-          variable-value-required-prefix: "ghcr.io/ephemerahq/convos-backend@sha256:"
+          variable-value: "ghcr.io/xmtplabs/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
+          variable-value-required-prefix: "ghcr.io/xmtplabs/convos-backend@sha256:"
 
   deploy_otr_prod:
     name: Deploy to OTR Production
@@ -124,5 +124,5 @@ jobs:
           terraform-org: xmtp
           terraform-workspace: convos-otr-prod
           variable-name: api_image
-          variable-value: "ghcr.io/ephemerahq/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
-          variable-value-required-prefix: "ghcr.io/ephemerahq/convos-backend@sha256:"
+          variable-value: "ghcr.io/xmtplabs/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
+          variable-value-required-prefix: "ghcr.io/xmtplabs/convos-backend@sha256:"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ Have a question about how to build with XMTP? Ask your question and learn with t
 
 ## 🐞 Bugs
 
-Report a bug using [GitHub Issues](https://github.com/ephemeraHQ/convos-backend/issues).
+Report a bug using [GitHub Issues](https://github.com/xmtplabs/convos-backend/issues).
 
 ## ✨ Feature Requests
 
-Request a feature using [GitHub Issues](https://github.com/ephemeraHQ/convos-backend/issues).
+Request a feature using [GitHub Issues](https://github.com/xmtplabs/convos-backend/issues).
 
 ## 🔀 Pull Requests
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Ephemera
+Copyright (c) 2025 XMTP Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update org references across deployment workflows, CODEOWNERS, CONTRIBUTING, and LICENSE to reflect the Org name change to XMTP Labs
Switch GitHub Container Registry image paths in deploy jobs to `ghcr.io/xmtplabs/convos-backend@...` with `ghcr.io/xmtplabs/convos-backend@sha256:` validation, reassign CODEOWNERS to `@xmtplabs/engineering`, update issue links, and change the LICENSE holder to XMTP Labs.

#### 📍Where to Start
Start with the Terraform variable assignment steps in the deploy jobs within [deploy-aws.yml](https://github.com/ephemeraHQ/convos-backend/pull/150/files#diff-0d3289eb372cc20ad90cd149a511773611be96818d075262367aee3ec4d77a69).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 563fddd.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ownership and governance structure
  * Updated deployment infrastructure and organizational references across configuration and documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->