### PR TITLE
Fix ClientIdentifier FK error by reordering operations in register.ts

### DIFF
--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -33,8 +33,12 @@ async function performDeviceRegistration(
   logger: Request["log"],
 ) {
   await prisma.$transaction(async (tx) => {
+    // Track old devices and their client identifiers for migration
+    let oldDeviceIds: string[] = [];
+    let clientIdsToMigrate: string[] = [];
+
     // If a push token is provided, handle conflicts with other devices
-    // We check across ALL apnsEnv values because the same physical device
+    // We check across all apnsEnv values because the same physical device
     // can switch between sandbox (Xcode) and production (TestFlight) builds,
     // and Apple may issue the same push token for both environments.
     if (pushToken) {
@@ -53,8 +57,8 @@ async function performDeviceRegistration(
       });
 
       if (existingDevices.length > 0) {
-        const oldDeviceIds = existingDevices.map((d) => d.deviceId);
-        const clientIdsToMigrate = existingDevices.flatMap((d) =>
+        oldDeviceIds = existingDevices.map((d) => d.deviceId);
+        clientIdsToMigrate = existingDevices.flatMap((d) =>
           d.clientIdentifiers.map((c) => c.id),
         );
 
@@ -68,18 +72,7 @@ async function performDeviceRegistration(
           "Push token moving from old device(s) to new device - migrating client identifiers and clearing old registrations",
         );
 
-        // Migrate all ClientIdentifiers from old devices to the new device
-        // This ensures notifications for existing conversations go to the correct device
-        if (clientIdsToMigrate.length > 0) {
-          await tx.clientIdentifier.updateMany({
-            where: {
-              id: { in: clientIdsToMigrate },
-            },
-            data: { deviceId },
-          });
-        }
-
-        // Clear the push token from all old devices (any apnsEnv)
+        // Clear the push token from all old devices FIRST (before upsert to avoid unique constraint)
         await tx.deviceRegistration.updateMany({
           where: {
             deviceId: { in: oldDeviceIds },
@@ -89,7 +82,8 @@ async function performDeviceRegistration(
       }
     }
 
-    // Now upsert the device registration
+    // Upsert the new device registration
+    // This ensures the foreign key target exists
     await tx.deviceRegistration.upsert({
       where: { deviceId },
       create: {
@@ -100,6 +94,17 @@ async function performDeviceRegistration(
       },
       update: updateData,
     });
+
+    // Migrate ClientIdentifiers from old devices to the new device
+    // This must happen after the upsert so the FK target exists
+    if (clientIdsToMigrate.length > 0) {
+      await tx.clientIdentifier.updateMany({
+        where: {
+          id: { in: clientIdsToMigrate },
+        },
+        data: { deviceId },
+      });
+    }
   });
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Reorder device registration flow in `src/api/v2/device/handlers/register.ts` to fix ClientIdentifier foreign key errors by clearing conflicting push tokens before upsert and migrating identifiers after upsert
Refactors `performDeviceRegistration` to collect conflicting device and `ClientIdentifier` IDs, clear push tokens on old devices first, upsert the new device registration next, and migrate `ClientIdentifiers` only after the upsert completes; adds brief comments on the required execution order.

#### 📍Where to Start
Start with the `performDeviceRegistration` helper in [register.ts](https://github.com/ephemeraHQ/convos-backend/pull/152/files#diff-e2e17828402e48441259e515015cac450bb7966aec49f53e56f2a2b76e531349), focusing on the reordered transaction steps and the new accumulators for old device IDs and `ClientIdentifier` IDs.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 0716328.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device registration handling to improve conflict resolution when push tokens overlap across environments and ensure client identifier migration executes with proper data integrity safeguards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->