### PR TITLE
Fix invite proto TS types

### DIFF
--- a/proto/invite/v2/invite.proto
+++ b/proto/invite/v2/invite.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/timestamp.proto";
-
 package invite.v2;
 
 // InvitePayload represents the core invite data

--- a/proto/invite/v2/invite.proto
+++ b/proto/invite/v2/invite.proto
@@ -6,11 +6,12 @@ package invite.v2;
 
 // InvitePayload represents the core invite data
 message InvitePayload {
-    // The encrypted conversation id
-    string conversationToken = 1;
+    // The encrypted conversation id (stored as raw bytes for compactness)
+    bytes conversationToken = 1;
 
-    // The creator's inbox ID
-    string creator_inbox_id = 2;
+    // The creator's inbox ID as raw bytes (hex-decoded for compactness)
+    // Required for: 1) conversation token decryption AAD, 2) joiner to know who to DM
+    bytes creator_inbox_id = 2;
 
     // The tag to mark which conversation this corresponds to, lives in `ConversationCustomMetadata`
     string tag = 3;
@@ -19,10 +20,13 @@ message InvitePayload {
     optional string name = 4;
     optional string description = 5;
     optional string imageURL = 6;
-    optional google.protobuf.Timestamp conversationExpiresAt = 7;
 
-    // optional invite expiration
-    optional google.protobuf.Timestamp expiresAt = 8;
+    // Compact timestamp encoding: Unix timestamp in seconds (8 bytes fixed)
+    // More compact than google.protobuf.Timestamp which uses two varints
+    optional sfixed64 conversationExpiresAtUnix = 7;
+
+    // Compact invite expiration: Unix timestamp in seconds (8 bytes fixed)
+    optional sfixed64 expiresAtUnix = 8;
 
     // Whether the invite should expire after being used once
     bool expiresAfterUse = 9;
@@ -30,8 +34,11 @@ message InvitePayload {
 
 // SignedInvite represents an invite with its cryptographic signature
 message SignedInvite {
-    // The invite payload containing the actual invite data
-    InvitePayload payload = 1;
+    // The invite payload containing the actual invite data, stored as bytes
+    // to preserve the exact serialization that was signed. This ensures signatures
+    // remain valid even if the protobuf schema changes (since protobuf serialization
+    // is not canonical).
+    bytes payload = 1;
 
     // The cryptographic signature (typically 65 bytes for ECDSA with recovery)
     bytes signature = 2;

--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -1,10 +1,13 @@
+import { createHash } from "crypto";
 import { fromBinary } from "@bufbuild/protobuf";
 import type { Request, Response } from "express";
+import * as secp256k1 from "secp256k1";
 import { z } from "zod";
 import {
   InvitePayloadSchema,
   SignedInviteSchema,
   type InvitePayload,
+  type SignedInvite,
 } from "@/gen/invite/v2/invite_pb";
 
 const paramsSchema = z.object({
@@ -61,10 +64,42 @@ function base64URLDecode(slug: string): Uint8Array {
   return new Uint8Array(buffer);
 }
 
+function sha256(data: Uint8Array): Buffer {
+  return createHash("sha256").update(data).digest();
+}
+
+/**
+ * Verifies that the signature is well-formed and recoverable.
+ * This validates the cryptographic integrity of the invite.
+ *
+ * NOTE: This only verifies the signature is valid, not WHO signed it.
+ * Identity verification of the signer happens client-side when joining.
+ */
+function verifySignature(signedInvite: SignedInvite): void {
+  const payloadBytes = signedInvite.payload;
+  if (!payloadBytes || payloadBytes.length === 0) {
+    throw new Error("Missing payload");
+  }
+
+  const signature = signedInvite.signature;
+  if (signature.length !== 65) {
+    throw new Error("Invalid signature length");
+  }
+
+  const signatureData = signature.slice(0, 64);
+  const recoveryId = signature[64];
+
+  const messageHash = sha256(payloadBytes);
+
+  // This will throw if the signature is invalid or unrecoverable
+  secp256k1.ecdsaRecover(signatureData, recoveryId, messageHash, false);
+}
+
 /**
  * Decodes an invite slug into its payload components.
  *
  * NOTE: This endpoint is for UI preview purposes only (showing invite metadata before joining).
+ * Signature validity is verified, but signer identity verification happens client-side.
  */
 function decodeInviteSlug(slug: string): DecodedInvite {
   try {
@@ -77,6 +112,9 @@ function decodeInviteSlug(slug: string): DecodedInvite {
     if (!payloadBytes || payloadBytes.length === 0) {
       throw new Error("Missing payload in signed invite");
     }
+
+    // Verify the signature is valid (well-formed and recoverable)
+    verifySignature(signedInvite);
 
     // Decode the InvitePayload from the payload bytes
     const payload = fromBinary(InvitePayloadSchema, payloadBytes);

--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -1,13 +1,10 @@
-import { createHash } from "crypto";
-import { fromBinary, toBinary } from "@bufbuild/protobuf";
+import { fromBinary } from "@bufbuild/protobuf";
 import type { Request, Response } from "express";
-import * as secp256k1 from "secp256k1";
 import { z } from "zod";
 import {
   InvitePayloadSchema,
   SignedInviteSchema,
   type InvitePayload,
-  type SignedInvite,
 } from "@/gen/invite/v2/invite_pb";
 
 const paramsSchema = z.object({
@@ -34,6 +31,21 @@ type DecodedInvite = Pick<
 // Reserve some space for the rest of the URL path
 const MAX_SLUG_LENGTH = 2048;
 
+// Max valid Date in JS is 8.64e15 ms (±100 million days from epoch)
+const MAX_DATE_MS = 8.64e15;
+
+/**
+ * Safely converts a Unix timestamp (seconds) to an ISO string.
+ * Returns null for undefined, invalid, or out-of-range values.
+ */
+function unixSecondsToISOString(unixSeconds: bigint | undefined): string | null {
+  if (unixSeconds === undefined) return null;
+  const ms = Number(unixSeconds) * 1000;
+  if (!Number.isFinite(ms) || Math.abs(ms) > MAX_DATE_MS) return null;
+  const date = new Date(ms);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
 function base64URLDecode(slug: string): Uint8Array {
   if (slug.length > MAX_SLUG_LENGTH) {
     throw new Error("Slug too large");
@@ -49,42 +61,16 @@ function base64URLDecode(slug: string): Uint8Array {
   return new Uint8Array(buffer);
 }
 
-function sha256(data: Uint8Array): Buffer {
-  return createHash("sha256").update(data).digest();
-}
-
-function recoverPublicKey(signedInvite: SignedInvite) {
-  const payloadBytes = signedInvite.payload;
-  if (!payloadBytes || payloadBytes.length === 0) {
-    throw new Error("Missing payload");
-  }
-
-  const signature = signedInvite.signature;
-  if (signature.length !== 65) {
-    throw new Error("Invalid signature length");
-  }
-
-  const signatureData = signature.slice(0, 64);
-  const recoveryId = signature[64];
-
-  // The payload is already serialized bytes, hash them directly
-  const messageHash = sha256(payloadBytes);
-
-  const publicKey = secp256k1.ecdsaRecover(
-    signatureData,
-    recoveryId,
-    messageHash,
-    false,
-  );
-
-  return Buffer.from(publicKey);
-}
-
+/**
+ * Decodes an invite slug into its payload components.
+ *
+ * NOTE: This endpoint is for UI preview purposes only (showing invite metadata before joining).
+ */
 function decodeInviteSlug(slug: string): DecodedInvite {
   try {
     const data = base64URLDecode(slug);
 
-    // First decode the SignedInvite wrapper
+    // Decode the SignedInvite wrapper
     const signedInvite = fromBinary(SignedInviteSchema, data);
     const payloadBytes = signedInvite.payload;
 
@@ -92,10 +78,7 @@ function decodeInviteSlug(slug: string): DecodedInvite {
       throw new Error("Missing payload in signed invite");
     }
 
-    // Verify signature
-    recoverPublicKey(signedInvite);
-
-    // Now decode the InvitePayload from the payload bytes
+    // Decode the InvitePayload from the payload bytes
     const payload = fromBinary(InvitePayloadSchema, payloadBytes);
 
     return {
@@ -145,12 +128,8 @@ export async function decodeInviteSlugHandler(
         name: decoded.name ?? null,
         description: decoded.description ?? null,
         imageURL: decoded.imageURL ?? null,
-        conversationExpiresAt: decoded.conversationExpiresAtUnix
-          ? new Date(Number(decoded.conversationExpiresAtUnix) * 1000).toISOString()
-          : null,
-        expiresAt: decoded.expiresAtUnix
-          ? new Date(Number(decoded.expiresAtUnix) * 1000).toISOString()
-          : null,
+        conversationExpiresAt: unixSecondsToISOString(decoded.conversationExpiresAtUnix),
+        expiresAt: unixSecondsToISOString(decoded.expiresAtUnix),
         expiresAfterUse: decoded.expiresAfterUse,
       },
     };

--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -1,6 +1,5 @@
 import { createHash } from "crypto";
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
-import { timestampDate } from "@bufbuild/protobuf/wkt";
 import type { Request, Response } from "express";
 import * as secp256k1 from "secp256k1";
 import { z } from "zod";
@@ -26,8 +25,8 @@ type DecodedInvite = Pick<
   | "name"
   | "description"
   | "imageURL"
-  | "conversationExpiresAt"
-  | "expiresAt"
+  | "conversationExpiresAtUnix"
+  | "expiresAtUnix"
   | "expiresAfterUse"
 >;
 
@@ -55,8 +54,8 @@ function sha256(data: Uint8Array): Buffer {
 }
 
 function recoverPublicKey(signedInvite: SignedInvite) {
-  const payload = signedInvite.payload;
-  if (!payload) {
+  const payloadBytes = signedInvite.payload;
+  if (!payloadBytes || payloadBytes.length === 0) {
     throw new Error("Missing payload");
   }
 
@@ -68,7 +67,7 @@ function recoverPublicKey(signedInvite: SignedInvite) {
   const signatureData = signature.slice(0, 64);
   const recoveryId = signature[64];
 
-  const payloadBytes = toBinary(InvitePayloadSchema, payload);
+  // The payload is already serialized bytes, hash them directly
   const messageHash = sha256(payloadBytes);
 
   const publicKey = secp256k1.ecdsaRecover(
@@ -85,14 +84,19 @@ function decodeInviteSlug(slug: string): DecodedInvite {
   try {
     const data = base64URLDecode(slug);
 
+    // First decode the SignedInvite wrapper
     const signedInvite = fromBinary(SignedInviteSchema, data);
-    const payload = signedInvite.payload;
+    const payloadBytes = signedInvite.payload;
 
-    if (!payload) {
+    if (!payloadBytes || payloadBytes.length === 0) {
       throw new Error("Missing payload in signed invite");
     }
 
+    // Verify signature
     recoverPublicKey(signedInvite);
+
+    // Now decode the InvitePayload from the payload bytes
+    const payload = fromBinary(InvitePayloadSchema, payloadBytes);
 
     return {
       conversationToken: payload.conversationToken,
@@ -101,8 +105,8 @@ function decodeInviteSlug(slug: string): DecodedInvite {
       name: payload.name,
       description: payload.description,
       imageURL: payload.imageURL,
-      conversationExpiresAt: payload.conversationExpiresAt,
-      expiresAt: payload.expiresAt,
+      conversationExpiresAtUnix: payload.conversationExpiresAtUnix,
+      expiresAtUnix: payload.expiresAtUnix,
       expiresAfterUse: payload.expiresAfterUse,
     };
   } catch (error) {
@@ -141,11 +145,11 @@ export async function decodeInviteSlugHandler(
         name: decoded.name ?? null,
         description: decoded.description ?? null,
         imageURL: decoded.imageURL ?? null,
-        conversationExpiresAt: decoded.conversationExpiresAt
-          ? timestampDate(decoded.conversationExpiresAt).toISOString()
+        conversationExpiresAt: decoded.conversationExpiresAtUnix
+          ? new Date(Number(decoded.conversationExpiresAtUnix) * 1000).toISOString()
           : null,
-        expiresAt: decoded.expiresAt
-          ? timestampDate(decoded.expiresAt).toISOString()
+        expiresAt: decoded.expiresAtUnix
+          ? new Date(Number(decoded.expiresAtUnix) * 1000).toISOString()
           : null,
         expiresAfterUse: decoded.expiresAfterUse,
       },

--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -41,7 +41,9 @@ const MAX_DATE_MS = 8.64e15;
  * Safely converts a Unix timestamp (seconds) to an ISO string.
  * Returns null for undefined, invalid, or out-of-range values.
  */
-function unixSecondsToISOString(unixSeconds: bigint | undefined): string | null {
+function unixSecondsToISOString(
+  unixSeconds: bigint | undefined,
+): string | null {
   if (unixSeconds === undefined) return null;
   const ms = Number(unixSeconds) * 1000;
   if (!Number.isFinite(ms) || Math.abs(ms) > MAX_DATE_MS) return null;
@@ -166,7 +168,9 @@ export async function decodeInviteSlugHandler(
         name: decoded.name ?? null,
         description: decoded.description ?? null,
         imageURL: decoded.imageURL ?? null,
-        conversationExpiresAt: unixSecondsToISOString(decoded.conversationExpiresAtUnix),
+        conversationExpiresAt: unixSecondsToISOString(
+          decoded.conversationExpiresAtUnix,
+        ),
         expiresAt: unixSecondsToISOString(decoded.expiresAtUnix),
         expiresAfterUse: decoded.expiresAfterUse,
       },


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Change invite.v2 wire types to bytes and sfixed64 Unix seconds to fix invite proto TS types
Update `invite.v2.InvitePayload` to use `bytes` for `conversationToken` and `creator_inbox_id` and `sfixed64` Unix seconds for expiration fields, carry `invite.v2.SignedInvite.payload` as raw `bytes`, and update decoding and signature verification to operate on the payload bytes with ISO timestamp formatting in [decode-invite-slug.ts](https://github.com/ephemeraHQ/convos-backend/pull/153/files#diff-2d0c3ad748e88210424de2d0b48e5626544596ebf6ccc022f69a51d90b5faa43).

#### 📍Where to Start
Start with `decodeInviteSlug` and `verifySignature` in [decode-invite-slug.ts](https://github.com/ephemeraHQ/convos-backend/pull/153/files#diff-2d0c3ad748e88210424de2d0b48e5626544596ebf6ccc022f69a51d90b5faa43), then review `invite.v2` message changes in [proto/invite/v2/invite.proto](https://github.com/ephemeraHQ/convos-backend/pull/153/files#diff-b92c079831e9fecde880360e2625726b6048979b7c3943f8918d7c76d9e6bb6c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 8647ab5.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust invite decoding and validation with clearer errors; responses now consistently convert internal timestamps to ISO strings.

* **Chores**
  * Invite payloads and timestamps moved to a compact binary/Unix representation; signature handling updated to preserve exact serialization for verification.

* **Refactor**
  * Streamlined invite verification and decoding flow to rely on the embedded binary payload for more reliable processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->