### PR TITLE
Remove "*" separators inserted for iMessage compatibility

### DIFF
--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -114,7 +114,7 @@ function decodeInviteSlug(slug: string): DecodedInvite {
     const signedInvite = fromBinary(SignedInviteSchema, data);
     const payloadBytes = signedInvite.payload;
 
-    if (!payloadBytes || payloadBytes.length === 0) {
+    if (payloadBytes.length === 0) {
       throw new Error("Missing payload in signed invite");
     }
 

--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -56,7 +56,10 @@ function base64URLDecode(slug: string): Uint8Array {
     throw new Error("Slug too large");
   }
 
-  let base64 = slug.replace(/-/g, "+").replace(/_/g, "/");
+  // Remove "*" separators inserted for iMessage compatibility
+  // as iMessage breaks URLs with Base64 sections longer than 301 characters
+  // Convert URL-safe base64 back to standard base64 for Buffer.from()
+  let base64 = slug.replace(/\*/g, "").replace(/-/g, "+").replace(/_/g, "/");
 
   while (base64.length % 4 !== 0) {
     base64 += "=";

--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -82,7 +82,7 @@ function sha256(data: Uint8Array): Buffer {
  */
 function verifySignature(signedInvite: SignedInvite): void {
   const payloadBytes = signedInvite.payload;
-  if (!payloadBytes || payloadBytes.length === 0) {
+  if (payloadBytes.length === 0) {
     throw new Error("Missing payload");
   }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Accept invite slugs containing "*" separators and validate `invite.v2.SignedInvite` over raw payload bytes in [decode-invite-slug.ts](https://github.com/ephemeraHQ/convos-backend/pull/154/files#diff-2d0c3ad748e88210424de2d0b48e5626544596ebf6ccc022f69a51d90b5faa43)
Switch `invite.v2.InvitePayload` IDs to `bytes`, replace `Timestamp` fields with optional `sfixed64` Unix seconds, and change `invite.v2.SignedInvite.payload` to raw `bytes`; update slug decoding to strip `*`, verify signatures on the exact payload bytes, and convert Unix seconds to ISO in [decode-invite-slug.ts](https://github.com/ephemeraHQ/convos-backend/pull/154/files#diff-2d0c3ad748e88210424de2d0b48e5626544596ebf6ccc022f69a51d90b5faa43).

#### 📍Where to Start
Start at `decodeInviteSlug` and `verifySignature` in [decode-invite-slug.ts](https://github.com/ephemeraHQ/convos-backend/pull/154/files#diff-2d0c3ad748e88210424de2d0b48e5626544596ebf6ccc022f69a51d90b5faa43), then review the proto changes in [proto/invite/v2/invite.proto](https://github.com/ephemeraHQ/convos-backend/pull/154/files#diff-b92c079831e9fecde880360e2625726b6048979b7c3943f8918d7c76d9e6bb6c).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1529c5e. 2 files reviewed, 7 issues evaluated, 5 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>proto/invite/v2/invite.proto — 0 comments posted, 6 evaluated, 5 filtered</summary>

- [line 8](https://github.com/ephemeraHQ/convos-backend/blob/1529c5e44a5be00c98033481ca215f5d2f7664dd/proto/invite/v2/invite.proto#L8): Type change from `string` to `bytes` for `conversationToken` (field 1). While wire-compatible, existing code that treats this field as a string (e.g., string concatenation, logging, JSON serialization) may produce garbled output or type errors if the bytes contain non-UTF8 data. <b>[ Low confidence ]</b>
- [line 12](https://github.com/ephemeraHQ/convos-backend/blob/1529c5e44a5be00c98033481ca215f5d2f7664dd/proto/invite/v2/invite.proto#L12): Type change from `string` to `bytes` for `creator_inbox_id` (field 2). Existing code expecting a hex string will now receive raw bytes. Any string operations, comparisons with string literals, or JSON serialization will break or produce incorrect results. <b>[ Low confidence ]</b>
- [line 24](https://github.com/ephemeraHQ/convos-backend/blob/1529c5e44a5be00c98033481ca215f5d2f7664dd/proto/invite/v2/invite.proto#L24): Wire format incompatibility at field 7: `conversationExpiresAt` was `google.protobuf.Timestamp` (wire type 2, length-delimited message) but `conversationExpiresAtUnix` is `sfixed64` (wire type 1, 64-bit fixed). Existing serialized messages will fail to deserialize with a wire type mismatch error when the parser encounters old data. <b>[ Low confidence ]</b>
- [line 24](https://github.com/ephemeraHQ/convos-backend/blob/1529c5e44a5be00c98033481ca215f5d2f7664dd/proto/invite/v2/invite.proto#L24): Semantic precision loss: `google.protobuf.Timestamp` provides nanosecond precision while `sfixed64` Unix timestamps only provide second precision. If any existing code relies on sub-second timestamp precision, this will silently truncate that data. <b>[ Low confidence ]</b>
- [line 27](https://github.com/ephemeraHQ/convos-backend/blob/1529c5e44a5be00c98033481ca215f5d2f7664dd/proto/invite/v2/invite.proto#L27): Wire format incompatibility at field 8: `expiresAt` was `google.protobuf.Timestamp` (wire type 2, length-delimited message) but `expiresAtUnix` is `sfixed64` (wire type 1, 64-bit fixed). Existing serialized messages will fail to deserialize with a wire type mismatch error when the parser encounters old data. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invite slugs now tolerate and strip extra "*" separators to improve compatibility with messaging apps (e.g., iMessage).
  * Tightened invite payload validation by relying on an explicit non-empty payload check to prevent malformed invites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->