### PR TITLE
Handle CDN base URL from the backend, return full asset URL to the app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,6 @@ APNS_KEY=
 APNS_KEY_ID=
 APNS_TEAM_ID=
 APNS_BUNDLE_ID=
+
+# Assets CDN Base URL
+CDN_BASE_URL="https://assets.prod.convos.xyz"

--- a/.env.example
+++ b/.env.example
@@ -59,4 +59,4 @@ APNS_TEAM_ID=
 APNS_BUNDLE_ID=
 
 # Assets CDN Base URL
-CDN_BASE_URL="https://assets.prod.convos.xyz"
+CDN_BASE_URL=https://assets.domain.tld

--- a/src/api/v2/attachments/handlers/get-presigned-url.ts
+++ b/src/api/v2/attachments/handlers/get-presigned-url.ts
@@ -60,7 +60,12 @@ export async function getPresignedUrlHandler(req: Request, res: Response) {
     const { objectKey, uploadUrl, assetUrl } =
       await getPresignedURL(contentType);
 
-    res.json({ objectKey, uploadUrl, assetUrl });
+    res.json({
+      objectKey,
+      url: uploadUrl, // @deprecated - use uploadUrl instead
+      uploadUrl,
+      assetUrl,
+    });
     return;
   } catch (error) {
     req.log.error({ error }, "Error generating presigned URL");

--- a/src/api/v2/attachments/handlers/get-presigned-url.ts
+++ b/src/api/v2/attachments/handlers/get-presigned-url.ts
@@ -9,12 +9,14 @@ import { AppError } from "@/utils/errors";
 const envSchema = z.object({
   PUBLIC_ASSETS_BUCKET: z.string().min(1).optional(),
   AWS_REGION: z.string().optional(),
+  CDN_BASE_URL: z.string().url().optional(),
 });
 
 // Validate environment variables at startup
 const env = envSchema.parse({
   PUBLIC_ASSETS_BUCKET: process.env.PUBLIC_ASSETS_BUCKET,
   AWS_REGION: process.env.AWS_REGION,
+  CDN_BASE_URL: process.env.CDN_BASE_URL,
 });
 
 // Create S3 client only if bucket is configured
@@ -26,19 +28,19 @@ const getPresignedURL = async (contentType?: string) => {
   }
 
   const objectKey = uuidv4();
-  let extension: string | undefined;
-  if (contentType && mime.extension(contentType)) {
-    extension = mime.extension(contentType) as string;
-  }
+  const extension = contentType ? mime.extension(contentType) : false;
+  const key = `${objectKey}${extension ? `.${extension}` : ""}`;
 
   const command = new PutObjectCommand({
     Bucket: env.PUBLIC_ASSETS_BUCKET,
-    Key: `${objectKey}${extension ? `.${extension}` : ""}`,
+    Key: key,
     ContentType: contentType,
   });
 
-  const url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
-  return { objectKey, url };
+  const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+  const assetUrl = env.CDN_BASE_URL ? `${env.CDN_BASE_URL}/${key}` : null;
+
+  return { objectKey: key, uploadUrl, assetUrl };
 };
 
 export async function getPresignedUrlHandler(req: Request, res: Response) {
@@ -52,12 +54,13 @@ export async function getPresignedUrlHandler(req: Request, res: Response) {
         contentType,
         hasJwtMetadata: !!res.locals.jwtMetadata,
       },
-      "V2 attachments presigned URL request",
+      "v2 attachments presigned URL request",
     );
 
-    const { objectKey, url } = await getPresignedURL(contentType);
+    const { objectKey, uploadUrl, assetUrl } =
+      await getPresignedURL(contentType);
 
-    res.json({ objectKey, url });
+    res.json({ objectKey, uploadUrl, assetUrl });
     return;
   } catch (error) {
     req.log.error({ error }, "Error generating presigned URL");

--- a/src/api/v2/attachments/handlers/get-presigned-url.ts
+++ b/src/api/v2/attachments/handlers/get-presigned-url.ts
@@ -27,20 +27,22 @@ const getPresignedURL = async (contentType?: string) => {
     throw new AppError(503, "File uploads not available - S3 not configured");
   }
 
-  const objectKey = uuidv4();
+  const baseKey = uuidv4();
   const extension = contentType ? mime.extension(contentType) : false;
-  const key = `${objectKey}${extension ? `.${extension}` : ""}`;
+  const objectKey = `${baseKey}${extension ? `.${extension}` : ""}`;
 
   const command = new PutObjectCommand({
     Bucket: env.PUBLIC_ASSETS_BUCKET,
-    Key: key,
+    Key: objectKey,
     ContentType: contentType,
   });
 
   const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
-  const assetUrl = env.CDN_BASE_URL ? `${env.CDN_BASE_URL}/${key}` : null;
+  const assetUrl = env.CDN_BASE_URL
+    ? `${env.CDN_BASE_URL.replace(/\/+$/, "")}/${objectKey}`
+    : null;
 
-  return { objectKey: key, uploadUrl, assetUrl };
+  return { objectKey, uploadUrl, assetUrl };
 };
 
 export async function getPresignedUrlHandler(req: Request, res: Response) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Return full CDN asset URL from backend and expose `uploadUrl` and `assetUrl` in `getPresignedUrlHandler` response for v2 attachments
Add `CDN_BASE_URL` env support and compute a CDN-facing `assetUrl` alongside the S3 `uploadUrl` in `getPresignedURL`; update the v2 handler to return `objectKey`, a deprecated `url`, new `uploadUrl`, and `assetUrl`.

#### 📍Where to Start
Start with the handler `getPresignedUrlHandler` in [get-presigned-url.ts](https://github.com/ephemeraHQ/convos-backend/pull/155/files#diff-49cc5727fb075e88e19850a97751e76fe65d3508a04d1eb44ce3bfbba97e5eb9), then review `getPresignedURL` and the env schema changes in the same file.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 9e0cf95.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional CDN support for asset delivery via a configurable base URL.
  * Presigned URL endpoint now returns separate upload and asset URLs; previous single URL field is provided as a deprecated alias.

* **Chores**
  * Environment configuration extended with a new optional CDN variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->