### PR TITLE
Distinguish between expired and invalid JWT tokens in verification

### DIFF
--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -168,14 +168,25 @@ export const verifyV2JwtToken = async (args: { token: string }) => {
   );
 
   if (verifyError) {
-    logger.error({ error: verifyError }, "V2 JWT verification failed");
-    throw new AppError(401, "Invalid or expired token", verifyError);
+    if (verifyError instanceof jose.errors.JWTExpired) {
+      logger.info({ error: verifyError }, "JWT token expired");
+      throw new AppError(401, "Token expired", verifyError);
+    }
+
+    logger.warn(
+      { error: verifyError },
+      "JWT verification failed: Invalid token",
+    );
+    throw new AppError(401, "Invalid token", verifyError);
   }
 
   const parseResult = v2JWTPayloadSchema.safeParse(verified.payload);
   if (!parseResult.success) {
-    logger.error({ error: parseResult.error }, "Invalid JWT payload structure");
-    throw new AppError(401, "Invalid JWT payload structure");
+    logger.error(
+      { error: parseResult.error },
+      "JWT verification failed: Invalid payload structure",
+    );
+    throw new AppError(401, "Invalid payload structure");
   }
 
   return parseResult.data;

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -170,14 +170,14 @@ export const verifyV2JwtToken = async (args: { token: string }) => {
   if (verifyError) {
     if (verifyError instanceof jose.errors.JWTExpired) {
       logger.info({ error: verifyError }, "JWT token expired");
-      throw new AppError(401, "Token expired", verifyError);
+      throw new AppError(401, "Token expired");
     }
 
     logger.warn(
       { error: verifyError },
       "JWT verification failed: Invalid token",
     );
-    throw new AppError(401, "Invalid token", verifyError);
+    throw new AppError(401, "Invalid token");
   }
 
   const parseResult = v2JWTPayloadSchema.safeParse(verified.payload);

--- a/src/utils/v2/jwt.ts
+++ b/src/utils/v2/jwt.ts
@@ -195,3 +195,22 @@ export const verifyV2JwtToken = async (args: { token: string }) => {
 export const isNotificationExtensionOnlyToken = (payload: V2JWTPayload) => {
   return payload.metadata?.notificationExtensionOnly === true;
 };
+
+/**
+ * Create a JWT with a custom payload - This is for testing only
+ * Allows testing invalid payload structures
+ */
+export const createTestJwtWithPayload = async (args: {
+  payload: Record<string, unknown>;
+  expirationTime?: string;
+}) => {
+  const privateKey = await loadPrivateKey();
+
+  return new jose.SignJWT(args.payload)
+    .setProtectedHeader({ alg: "ES256" })
+    .setSubject("test")
+    .setIssuer(JWT_ISSUER)
+    .setIssuedAt()
+    .setExpirationTime(args.expirationTime ?? "15m")
+    .sign(privateKey);
+};

--- a/tests/jwt.test.ts
+++ b/tests/jwt.test.ts
@@ -1,0 +1,189 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import * as jose from "jose";
+import { JWT_ISSUER } from "@/config";
+import { AppError } from "@/utils/errors";
+import {
+  createTestJwtWithPayload,
+  createV2JwtToken,
+  validateJWTKeys,
+  verifyV2JwtToken,
+} from "@/utils/v2/jwt";
+
+// Pre-generated ECDSA P-256 test keys (for testing only)
+const TEST_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgN0N6LqJKwJpVvbxV
+ZV0cA6xBdPQvEh+p0YYLjGkf8sKhRANCAAQvqC/R6n8cLwzNsVTQgQ1c8JCYQe/j
+LQs0E8yKdZ9DflF8zS7VPeZCmZvJxzPVB8xDH0+L/lh8vLhvIKJz8kFx
+-----END PRIVATE KEY-----`;
+
+const TEST_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL6gv0ep/HC8MzbFU0IENXPCQmEHv
+4y0LNBPMinWfQ35RfM0u1T3mQpmbyccz1QfMQx9Pi/5YfLy4byCic/JBcQ==
+-----END PUBLIC KEY-----`;
+
+beforeAll(async () => {
+  process.env.JWT_PRIVATE_KEY = TEST_PRIVATE_KEY;
+  process.env.JWT_PUBLIC_KEY = TEST_PUBLIC_KEY;
+
+  // Validate and cache the keys
+  await validateJWTKeys();
+});
+
+describe("verifyV2JwtToken", () => {
+  test("should verify a valid token and return payload", async () => {
+    const deviceId = "test-device-123";
+    const token = await createV2JwtToken({ deviceId });
+
+    const payload = await verifyV2JwtToken({ token });
+
+    expect(payload.deviceId).toBe(deviceId);
+  });
+
+  test("should verify token with metadata", async () => {
+    const deviceId = "test-device-456";
+    const metadata = { notificationExtensionOnly: true };
+    const token = await createV2JwtToken({ deviceId, metadata });
+
+    const payload = await verifyV2JwtToken({ token });
+
+    expect(payload.deviceId).toBe(deviceId);
+    expect(payload.metadata?.notificationExtensionOnly).toBe(true);
+  });
+
+  test("should throw 'Token expired' for expired tokens", async () => {
+    const deviceId = "test-device-expired";
+    // Create token that expires immediately
+    const token = await createV2JwtToken({
+      deviceId,
+      expirationTime: "0s",
+    });
+
+    // Small delay to ensure token is expired
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    try {
+      await verifyV2JwtToken({ token });
+      expect.unreachable("Should have thrown an error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.statusCode).toBe(401);
+      expect(appError.message).toBe("Token expired");
+      // Verify no implementation details are leaked
+      expect(appError.details).toBeUndefined();
+    }
+  });
+
+  test("should throw 'Invalid token' for tampered signature", async () => {
+    const deviceId = "test-device-tampered";
+    const token = await createV2JwtToken({ deviceId });
+
+    // Tamper with the signature (last part of JWT)
+    const parts = token.split(".");
+    parts[2] = parts[2].slice(0, -5) + "XXXXX";
+    const tamperedToken = parts.join(".");
+
+    try {
+      await verifyV2JwtToken({ token: tamperedToken });
+      expect.unreachable("Should have thrown an error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.statusCode).toBe(401);
+      expect(appError.message).toBe("Invalid token");
+      expect(appError.details).toBeUndefined();
+    }
+  });
+
+  test("should throw 'Invalid token' for wrong signing key", async () => {
+    // Create a token signed with a different key
+    const differentKeyPair = await jose.generateKeyPair("ES256");
+    const token = await new jose.SignJWT({ deviceId: "test-device" })
+      .setProtectedHeader({ alg: "ES256" })
+      .setSubject("test-device")
+      .setIssuer(JWT_ISSUER)
+      .setIssuedAt()
+      .setExpirationTime("15m")
+      .sign(differentKeyPair.privateKey);
+
+    try {
+      await verifyV2JwtToken({ token });
+      expect.unreachable("Should have thrown an error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.statusCode).toBe(401);
+      expect(appError.message).toBe("Invalid token");
+      expect(appError.details).toBeUndefined();
+    }
+  });
+
+  test("should throw 'Invalid payload structure' for missing deviceId", async () => {
+    // Create a valid JWT but with wrong payload structure (missing deviceId)
+    const token = await createTestJwtWithPayload({
+      payload: { wrongField: "value" },
+    });
+
+    try {
+      await verifyV2JwtToken({ token });
+      expect.unreachable("Should have thrown an error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.statusCode).toBe(401);
+      expect(appError.message).toBe("Invalid payload structure");
+      expect(appError.details).toBeUndefined();
+    }
+  });
+
+  test("should throw 'Invalid token' for malformed JWT", async () => {
+    try {
+      await verifyV2JwtToken({ token: "not-a-valid-jwt" });
+      expect.unreachable("Should have thrown an error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.statusCode).toBe(401);
+      expect(appError.message).toBe("Invalid token");
+      expect(appError.details).toBeUndefined();
+    }
+  });
+});
+
+describe("createV2JwtToken", () => {
+  test("should create a valid token", async () => {
+    const deviceId = "test-device-create";
+    const token = await createV2JwtToken({ deviceId });
+
+    expect(token).toBeDefined();
+    expect(typeof token).toBe("string");
+    expect(token.split(".")).toHaveLength(3);
+  });
+
+  test("should include metadata in token", async () => {
+    const deviceId = "test-device-metadata";
+    const metadata = { notificationExtensionOnly: true };
+    const token = await createV2JwtToken({ deviceId, metadata });
+
+    // Decode and verify payload contains metadata
+    const payload = await verifyV2JwtToken({ token });
+    expect(payload.metadata).toEqual(metadata);
+  });
+
+  test("should respect custom expiration time", async () => {
+    const deviceId = "test-device-expiry";
+    const token = await createV2JwtToken({
+      deviceId,
+      expirationTime: "1h",
+    });
+
+    // Decode token to check expiration
+    const decoded = jose.decodeJwt(token);
+    const now = Math.floor(Date.now() / 1000);
+    const expectedExp = now + 3600; // 1 hour
+
+    // Allow 5 second tolerance
+    expect(decoded.exp).toBeGreaterThan(expectedExp - 5);
+    expect(decoded.exp).toBeLessThan(expectedExp + 5);
+  });
+});

--- a/tests/jwt.test.ts
+++ b/tests/jwt.test.ts
@@ -9,23 +9,9 @@ import {
   verifyV2JwtToken,
 } from "@/utils/v2/jwt";
 
-// Pre-generated ECDSA P-256 test keys (for testing only)
-const TEST_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
-MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgN0N6LqJKwJpVvbxV
-ZV0cA6xBdPQvEh+p0YYLjGkf8sKhRANCAAQvqC/R6n8cLwzNsVTQgQ1c8JCYQe/j
-LQs0E8yKdZ9DflF8zS7VPeZCmZvJxzPVB8xDH0+L/lh8vLhvIKJz8kFx
------END PRIVATE KEY-----`;
-
-const TEST_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL6gv0ep/HC8MzbFU0IENXPCQmEHv
-4y0LNBPMinWfQ35RfM0u1T3mQpmbyccz1QfMQx9Pi/5YfLy4byCic/JBcQ==
------END PUBLIC KEY-----`;
+// JWT tests keys are set in tests/preload.ts before config.ts loads
 
 beforeAll(async () => {
-  process.env.JWT_PRIVATE_KEY = TEST_PRIVATE_KEY;
-  process.env.JWT_PUBLIC_KEY = TEST_PUBLIC_KEY;
-
-  // Validate and cache the keys
   await validateJWTKeys();
 });
 

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -11,6 +11,18 @@ process.env.NOTIFICATION_SERVER_URL = "http://localhost:8080";
 process.env.XMTP_NOTIFICATION_SECRET =
   process.env.XMTP_NOTIFICATION_SECRET || "test-notification-secret";
 
+// v2 JWT test keys (ECDSA P-256) - must be set before config.ts loads
+process.env.JWT_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgGis9E4WiE4Ou51Ho
+2tH6goYKt2nxLsKgadVvCYaklRyhRANCAARIw/oKiY4bkkW8iOcgiyUb1XPOtBQ4
+/7NXGEExhSwpySP8P8tpOUlKoI2DryaYFx4EJhqtnV3Dhp1wLcxDKZYG
+-----END PRIVATE KEY-----`;
+
+process.env.JWT_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESMP6ComOG5JFvIjnIIslG9VzzrQU
+OP+zVxhBMYUsKckj/D/LaTlJSqCNg68mmBceBCYarZ1dw4adcC3MQymWBg==
+-----END PUBLIC KEY-----`;
+
 // mock Firebase functions
 
 void mock.module("firebase-admin/app-check", () => ({


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Distinguish expired from invalid JWTs in `src/utils/v2/jwt.verifyV2JwtToken` and return 401 with 'Token expired' or 'Invalid token'
Update `verifyV2JwtToken` to map `JWTExpired` to 401 'Token expired' and other verification failures to 401 'Invalid token', adjust payload schema failure messaging, and add `createTestJwtWithPayload` for constructing arbitrary-payload tokens; add tests covering these cases in [tests/jwt.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/156/files#diff-4ef80bc97a02d54084f3af9cf278077f5e6ddda11fb266f76ba16b8d4104e8a7) and set test keys in [tests/preload.ts](https://github.com/ephemeraHQ/convos-backend/pull/156/files#diff-18a45496d94f5e8e63a98b459daedad20117c38f6331f9c92841c3182fc8b9e9).

#### 📍Where to Start
Start with the error handling in `verifyV2JwtToken` in [src/utils/v2/jwt.ts](https://github.com/ephemeraHQ/convos-backend/pull/156/files#diff-995f6340d0a8bbea41f06a750751e1d0e1b6778460aef5cf32a438d6853510fb).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6c53b6b.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper to generate test JWTs with customizable payloads and expiration for testing.

* **Bug Fixes**
  * Improved JWT validation feedback: distinguishes expired tokens from invalid tokens with clearer messages and consistent 401 responses.
  * Clarified payload validation failure message to indicate an invalid payload structure.

* **Tests**
  * Added comprehensive tests covering JWT creation, verification, expiration, tampering, wrong keys, malformed tokens, and payload validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->