### PR TITLE
Support compressed invite slugs from iOS app

### DIFF
--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -1,4 +1,5 @@
 import { createHash } from "crypto";
+import { inflateRawSync } from "zlib";
 import { fromBinary } from "@bufbuild/protobuf";
 import type { Request, Response } from "express";
 import * as secp256k1 from "secp256k1";
@@ -34,6 +35,11 @@ type DecodedInvite = Pick<
 // Reserve some space for the rest of the URL path
 const MAX_SLUG_LENGTH = 2048;
 
+// iOS compression format: [0x1F marker][4-byte BE size][raw DEFLATE data]
+const COMPRESSION_MARKER = 0x1f;
+const COMPRESSION_HEADER_SIZE = 5; // 1 byte marker + 4 bytes size
+const MAX_DECOMPRESSED_SIZE = 64 * 1024; // 64KB - prevent decompression bombs
+
 // Max valid Date in JS is 8.64e15 ms (±100 million days from epoch)
 const MAX_DATE_MS = 8.64e15;
 
@@ -49,6 +55,42 @@ function unixSecondsToISOString(
   if (!Number.isFinite(ms) || Math.abs(ms) > MAX_DATE_MS) return null;
   const date = new Date(ms);
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+/**
+ * Decompresses data if it has the iOS compression marker.
+ * iOS format: [0x1F marker][4-byte BE original size][raw DEFLATE data]
+ * Returns original data if not compressed.
+ */
+function maybeDecompress(data: Uint8Array): Uint8Array {
+  if (data.length < COMPRESSION_HEADER_SIZE || data[0] !== COMPRESSION_MARKER) {
+    return data;
+  }
+
+  // Read 4-byte big-endian original size (for validation)
+  // Use >>> 0 to coerce to unsigned 32-bit (bitwise ops are signed in JS)
+  const originalSize =
+    ((data[1] << 24) | (data[2] << 16) | (data[3] << 8) | data[4]) >>> 0;
+
+  // Validate size BEFORE decompression to prevent decompression bombs
+  if (originalSize > MAX_DECOMPRESSED_SIZE) {
+    throw new Error(
+      `Decompressed size ${originalSize} exceeds maximum allowed ${MAX_DECOMPRESSED_SIZE}`,
+    );
+  }
+
+  // Decompress the raw DEFLATE data (after 5-byte header)
+  const compressedData = data.slice(COMPRESSION_HEADER_SIZE);
+  const decompressed = inflateRawSync(Buffer.from(compressedData));
+
+  // Validate decompressed size matches header
+  if (decompressed.length !== originalSize) {
+    throw new Error(
+      `Decompressed size mismatch: expected ${originalSize}, got ${decompressed.length}`,
+    );
+  }
+
+  return new Uint8Array(decompressed);
 }
 
 function base64URLDecode(slug: string): Uint8Array {
@@ -109,9 +151,10 @@ function verifySignature(signedInvite: SignedInvite): void {
 function decodeInviteSlug(slug: string): DecodedInvite {
   try {
     const data = base64URLDecode(slug);
+    const decompressed = maybeDecompress(data);
 
     // Decode the SignedInvite wrapper
-    const signedInvite = fromBinary(SignedInviteSchema, data);
+    const signedInvite = fromBinary(SignedInviteSchema, decompressed);
     const payloadBytes = signedInvite.payload;
 
     if (payloadBytes.length === 0) {

--- a/tests/invites.test.ts
+++ b/tests/invites.test.ts
@@ -122,6 +122,52 @@ describe("Invites API Tests", () => {
       expect(data.data.expiresAt).toBeNull();
       expect(data.data.expiresAfterUse).toBe(false);
     });
+
+    test("should decode compressed invite slug from iOS", async () => {
+      // iOS app compresses invites using raw DEFLATE with a 5-byte header:
+      // [0x1F marker][4-byte BE original size][compressed data]
+      const compressedSlug =
+        "HwAAAb4lj09IVFEUxplJ0GZhZK2m0Q5GECkjuNEYRJxJZEiISInJ1Z13D3bk3Xuf7947DGqrWoiJBTqDSbRw4ywCN7Xq36KFDLYRJYSgP0QFLhQJI3DjnWZ3Duc7v-_7Yv-isf5I_Nyr1p-5_KW95pdH0YuRjStr60MNnztyc21vl-JdD6eL2cTdppWxaHT5y7vHZ3ZkqXzt68LZbOOj131_5ystUK2O_Dm1mHt_79NBZb9ns-Pj7evF84dvvMaJrfRaYW82HqOsSN8IM5l0sb01o2RBaRhBbSCjRBCi1sgh*Kwtk8OrvyLAKUQAF2grgylchaDLABJpO8JTU6Bk0NgTGKSDtkRwH9MkdaxSuAMlqoTgYFIF7JukRJ26lAWvAZ3mHBzR1NIJg45IB82nSsiSMGkBJwrFBUG0ouJWJTpi0pEEqbULLAYsYemSYISXB-j4TnqqTayLSVHP6j6TAiQGZCy5cJlUv4KxMsmVg9XR19cLcrxLHXUhsv3iQenq_3y7dHPwGz55M5S-33-re-t5bGUssHt-Z_bGb-tB14KdWSs-DzaTqLrOZcuQE";
+
+      const response = await fetch(
+        `${baseURL}/api/v2/invites/${compressedSlug}`,
+        {
+          method: "GET",
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as {
+        success: boolean;
+        data: {
+          name: string | null;
+          description: string | null;
+          imageURL: string | null;
+          conversationExpiresAt: string | null;
+          expiresAt: string | null;
+          expiresAfterUse: boolean;
+        };
+      };
+      expect(data.success).toBe(true);
+      expect(data.data).toBeDefined();
+    });
+
+    test("should reject decompression bombs (oversized originalSize)", async () => {
+      // Create payload with 0x1F marker + huge size (1GB) + minimal data
+      const marker = Buffer.from([0x1f]);
+      const hugeSize = Buffer.from([0x40, 0x00, 0x00, 0x00]); // 1GB in big-endian
+      const minimalData = Buffer.from([0x00]);
+      const maliciousPayload = Buffer.concat([marker, hugeSize, minimalData]);
+      const slug = maliciousPayload.toString("base64url");
+
+      const response = await fetch(`${baseURL}/api/v2/invites/${slug}`, {
+        method: "GET",
+      });
+
+      expect(response.status).toBe(400);
+      const data = (await response.json()) as { success: boolean };
+      expect(data.success).toBe(false);
+    });
   });
 
   describe("Response format validation", () => {


### PR DESCRIPTION
Convos iOS app compresses invite slugs using raw DEFLATE when it produces a smaller result. The format is:

```
[0x1F marker][4-byte BE original size][raw DEFLATE data]
```

This adds a maybeDecompress() function that detects the compression marker and decompresses before protobuf parsing, while maintaining compatibility with uncompressed invites.

Fixes IOS-232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invite slug decoding now automatically detects and decompresses compressed invite data from iOS devices, including comprehensive validation of the decompressed payload to ensure data integrity across platforms.

* **Tests**
  * Added test coverage for iOS compressed invite slug decoding, including validation of HTTP response status, response structure, and successful decompressed payload handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->