### PR TITLE
fix: lifecycle test paths

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -160,10 +160,10 @@ jobs:
       - name: Test lifecycle renewal endpoint
         run: |
           response=$(curl -s -w "\n%{http_code}" \
-            --max-time 30 \
+            --max-time 60 \
             --retry 3 \
             --retry-connrefused \
-            -X POST "${{ vars.DEV_API_URL }}/v2/assets/test/lifecycle" \
+            -X POST "${{ vars.DEV_API_URL }}/api/v2/assets/test/lifecycle" \
             -H "Authorization: Bearer ${{ secrets.LIFECYCLE_TEST_TOKEN }}")
           http_code=$(echo "$response" | tail -1)
           body=$(echo "$response" | head -n -1)
@@ -196,10 +196,10 @@ jobs:
       - name: Test lifecycle renewal endpoint
         run: |
           response=$(curl -s -w "\n%{http_code}" \
-            --max-time 30 \
+            --max-time 60 \
             --retry 3 \
             --retry-connrefused \
-            -X POST "${{ vars.PROD_API_URL }}/v2/assets/test/lifecycle" \
+            -X POST "${{ vars.PROD_API_URL }}/api/v2/assets/test/lifecycle" \
             -H "Authorization: Bearer ${{ secrets.LIFECYCLE_TEST_TOKEN }}")
           http_code=$(echo "$response" | tail -1)
           body=$(echo "$response" | head -n -1)

--- a/.github/workflows/s3-lifecycle-verify.yml
+++ b/.github/workflows/s3-lifecycle-verify.yml
@@ -17,7 +17,7 @@ jobs:
             --max-time 60 \
             --retry 3 \
             --retry-connrefused \
-            -X POST "${{ vars.DEV_API_URL }}/v2/assets/test/lifecycle-status" \
+            -X POST "${{ vars.DEV_API_URL }}/api/v2/assets/test/lifecycle-status" \
             -H "Authorization: Bearer ${{ secrets.LIFECYCLE_TEST_TOKEN }}")
           http_code=$(echo "$response" | tail -1)
           body=$(echo "$response" | head -n -1)
@@ -88,7 +88,7 @@ jobs:
             --max-time 60 \
             --retry 3 \
             --retry-connrefused \
-            -X POST "${{ vars.PROD_API_URL }}/v2/assets/test/lifecycle-status" \
+            -X POST "${{ vars.PROD_API_URL }}/api/v2/assets/test/lifecycle-status" \
             -H "Authorization: Bearer ${{ secrets.LIFECYCLE_TEST_TOKEN }}")
           http_code=$(echo "$response" | tail -1)
           body=$(echo "$response" | head -n -1)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix lifecycle test paths by updating GitHub Actions to call `/api/v2/assets/test/lifecycle` and `/api/v2/assets/test/lifecycle-status` and increase curl `--max-time` to 60s in deploy workflow
Update workflow curl targets to `/api/v2/...` and raise request timeout to 60s in deploy AWS jobs; align lifecycle-status verification to `/api/v2/...` in S3 canary checks.

#### 📍Where to Start
Start with the `jobs.push_to_registry` steps in [deploy-aws.yml](https://github.com/ephemeraHQ/convos-backend/pull/165/files#diff-0d3289eb372cc20ad90cd149a511773611be96818d075262367aee3ec4d77a69), then review the `jobs.verify-dev` and `jobs.verify-prod` steps in [s3-lifecycle-verify.yml](https://github.com/ephemeraHQ/convos-backend/pull/165/files#diff-5a55b5efc7bf5c1edc0d674b3fb108a05b7cea55a3a858cd696128853d64c9d9).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 45767d2.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased deployment timeout threshold from 30 to 60 seconds to improve stability during testing and verification processes.
  * Updated internal API endpoint paths for lifecycle status verification across deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->