### PR TITLE
fix: increase S3 lifecycle canary grace period

### DIFF
--- a/src/api/v2/assets/handlers/lifecycle-status.ts
+++ b/src/api/v2/assets/handlers/lifecycle-status.ts
@@ -20,7 +20,7 @@ const env = envSchema.parse({
 const s3Client = env.LIFECYCLE_TEST_BUCKET ? new S3Client({}) : null;
 
 // Verification window constants
-const MIN_VERIFICATION_DAYS = 2; // S3 lifecycle grace period (files need 24h+ to expire)
+const MIN_VERIFICATION_DAYS = 3; // S3 lifecycle needs 2+ full days: creation + Days rounds to next midnight, then batch-processes
 const MAX_VERIFICATION_DAYS = 7; // Window for historical verification
 
 /**

--- a/src/api/v2/assets/handlers/lifecycle-status.ts
+++ b/src/api/v2/assets/handlers/lifecycle-status.ts
@@ -20,7 +20,7 @@ const env = envSchema.parse({
 const s3Client = env.LIFECYCLE_TEST_BUCKET ? new S3Client({}) : null;
 
 // Verification window constants
-const MIN_VERIFICATION_DAYS = 3; // S3 lifecycle needs 2+ full days: creation + Days rounds to next midnight, then batch-processes
+const MIN_VERIFICATION_DAYS = 3; // S3 lifecycle: file created Day X → expires at midnight Day X+1 → batch-deleted during Day X+2. Verify on Day X+3.
 const MAX_VERIFICATION_DAYS = 7; // Window for historical verification
 
 /**


### PR DESCRIPTION
## Summary
- S3 lifecycle verification has been failing since Jan 31 on both dev and prod
- Root cause: `MIN_VERIFICATION_DAYS=2` is too short given how S3 lifecycle expiration actually works
- With `Days: 1`, S3 computes `creation + 1 day`, rounds to next midnight UTC, then batch-deletes sometime during that day — meaning a file created on Day X isn't actually removed until sometime during Day X+2
- The 6 AM UTC verification check was racing against S3's batch processing
- Fix: bump `MIN_VERIFICATION_DAYS` from 2 to 3, giving 30+ hours of margin after the calculated expiration

## Test plan
- [x] Existing tests pass (1 pre-existing unrelated failure in invites.test.ts due to missing protobuf module)
- [ ] After deploy, manually trigger the S3 Lifecycle Verification workflow or wait for next daily run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the asset lifecycle verification interval by one day (verification now occurs one day later than before), aligning comments and behavior with the updated lifecycle timing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->