### PR TITLE
feat: add FCM push notification support for Android

### DIFF
--- a/docs/architecture/push-notification-architecture.md
+++ b/docs/architecture/push-notification-architecture.md
@@ -1,0 +1,42 @@
+# Push Notification System
+
+## Overview
+
+```mermaid
+flowchart LR
+    XMTP["XMTP Network"] -->|"1. New message"| Go["Go Notification Server"]
+    Go -->|"2. HTTP Webhook"| Convos["Convos Backend"]
+    Convos -->|"3. Push"| APNs["APNs / FCM"]
+    APNs -->|"4. Deliver"| Device["Mobile Device"]
+```
+
+## Webhook Sequence
+
+```mermaid
+sequenceDiagram
+    participant XMTP as XMTP Network
+    participant Go as Go Notification Server
+    participant Convos as Convos Backend
+    participant Push as APNs / FCM
+    participant Device as Mobile Device
+
+    XMTP->>Go: New message on topic
+    Go->>Go: Validate HMAC key
+    Go->>Convos: POST /api/v2/notifications/xmtp/handle-notification
+    Convos->>Convos: Lookup device by clientId
+    Convos->>Convos: Generate JWT for NSE
+    Convos->>Push: Send push notification
+    Push->>Device: Deliver notification
+    Device->>Device: Wake up, fetch full message
+```
+
+## Why Use the Go Notification Server?
+
+The Go server (`xmtp/notifications-server`) is part of XMTP infrastructure. It listens directly to the XMTP network for new messages - something our TypeScript backend cannot do.
+
+| Go Server | Convos Backend |
+|-----------|----------------|
+| Listens to XMTP network (gRPC) | Receives HTTP webhooks |
+| Validates HMAC keys | Sends push notifications |
+| Detects new messages on subscribed topics | Manages device registrations |
+| Part of XMTP infrastructure | Our custom code |

--- a/docs/architecture/push-notification-architecture.md
+++ b/docs/architecture/push-notification-architecture.md
@@ -34,9 +34,9 @@ sequenceDiagram
 
 The Go server (`xmtp/notifications-server`) is part of XMTP infrastructure. It listens directly to the XMTP network for new messages - something our TypeScript backend cannot do.
 
-| Go Server | Convos Backend |
-|-----------|----------------|
-| Listens to XMTP network (gRPC) | Receives HTTP webhooks |
-| Validates HMAC keys | Sends push notifications |
+| Go Server                                 | Convos Backend               |
+| ----------------------------------------- | ---------------------------- |
+| Listens to XMTP network (gRPC)            | Receives HTTP webhooks       |
+| Validates HMAC keys                       | Sends push notifications     |
 | Detects new messages on subscribed topics | Manages device registrations |
-| Part of XMTP infrastructure | Our custom code |
+| Part of XMTP infrastructure               | Our custom code              |

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,10 +17,9 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// NOTE: Only APNS is supported. FCM is not supported.
 enum PushTokenType {
   apns
-  fcm // Not supported - kept for database compatibility only
+  fcm
 }
 
 enum ApnsEnvironment {

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -115,19 +115,6 @@ export async function register(
   try {
     const body = registerRequestSchema.parse(req.body);
 
-    // Reject FCM as it is not supported
-    if (body.pushTokenType === "fcm") {
-      req.log.warn(
-        { deviceId: body.deviceId },
-        "FCM push token type is not supported",
-      );
-      res.status(400).json({
-        error:
-          "FCM push notifications are not supported. Only APNS is supported.",
-      });
-      return;
-    }
-
     req.log.info(
       {
         deviceId: body.deviceId,

--- a/src/api/v2/notifications/apns-push.service.ts
+++ b/src/api/v2/notifications/apns-push.service.ts
@@ -295,7 +295,9 @@ export function createApnsService(): ApnsPushService | null {
   const bundleId = process.env.APNS_BUNDLE_ID;
 
   if (!teamId || !keyId || !privateKey || !bundleId) {
-    logger.warn("APNS configuration incomplete, APNS push notifications disabled");
+    logger.warn(
+      "APNS configuration incomplete, APNS push notifications disabled",
+    );
     return null;
   }
 

--- a/src/api/v2/notifications/apns-push.service.ts
+++ b/src/api/v2/notifications/apns-push.service.ts
@@ -277,27 +277,37 @@ export class ApnsPushService {
   }
 }
 
-// Factory function to create APNS service from environment variables
+// Cached APNS service instance
+let cachedApnsService: ApnsPushService | null = null;
+let apnsServiceInitialized = false;
+
+// Factory function to create or return cached APNS service
 export function createApnsService(): ApnsPushService | null {
+  if (apnsServiceInitialized) {
+    return cachedApnsService;
+  }
+
+  apnsServiceInitialized = true;
+
   const teamId = process.env.APNS_TEAM_ID;
   const keyId = process.env.APNS_KEY_ID;
   const privateKey = process.env.APNS_PRIVATE_KEY;
   const bundleId = process.env.APNS_BUNDLE_ID;
 
   if (!teamId || !keyId || !privateKey || !bundleId) {
-    console.warn(
-      "APNS configuration incomplete, APNS push notifications disabled",
-    );
+    logger.warn("APNS configuration incomplete, APNS push notifications disabled");
     return null;
   }
 
   // Convert \n escape sequences to actual newlines
   const formattedPrivateKey = privateKey.replace(/\\n/g, "\n");
 
-  return new ApnsPushService({
+  cachedApnsService = new ApnsPushService({
     teamId,
     keyId,
     privateKey: formattedPrivateKey,
     bundleId,
   });
+
+  return cachedApnsService;
 }

--- a/src/api/v2/notifications/fcm-push.service.ts
+++ b/src/api/v2/notifications/fcm-push.service.ts
@@ -33,13 +33,28 @@ export class FcmPushService {
       return { success: false, error: "Device is not configured for FCM" };
     }
 
+    let notificationData: string;
+    try {
+      notificationData = JSON.stringify(notification.notificationData);
+    } catch (error) {
+      logger.error(
+        {
+          deviceId: device.id,
+          error,
+          verbose: true,
+        },
+        "[VERBOSE] Failed to serialize notification data",
+      );
+      return { success: false, error: "Invalid notification data" };
+    }
+
     // FCM data messages - all values must be strings
     // Data-only messages are always delivered to onMessageReceived() on Android
     // even when the app is in background, allowing proper handling
     const data: Record<string, string> = {
       apiJWT: notification.apiJWT,
       notificationType: notification.notificationType,
-      notificationData: JSON.stringify(notification.notificationData),
+      notificationData,
     };
 
     // Add clientId or inboxId depending on which is present

--- a/src/api/v2/notifications/fcm-push.service.ts
+++ b/src/api/v2/notifications/fcm-push.service.ts
@@ -1,0 +1,122 @@
+import type { PushTokenType } from "@prisma/client";
+import { getMessaging, type Messaging } from "firebase-admin/messaging";
+import { getFirebaseApp } from "@/utils/firebase";
+import logger from "@/utils/logger";
+import type { AnyNotificationPayloadWithJWT } from "./types";
+
+export interface FcmDevice {
+  id: string;
+  pushToken: string | null;
+  pushTokenType: PushTokenType;
+}
+
+export class FcmPushService {
+  private messaging: Messaging;
+
+  constructor() {
+    const app = getFirebaseApp();
+    this.messaging = getMessaging(app);
+  }
+
+  async sendPushNotification(args: {
+    device: FcmDevice;
+    notification: AnyNotificationPayloadWithJWT;
+    isSilent?: boolean;
+  }): Promise<{ success: boolean; error?: string }> {
+    const { device, notification, isSilent } = args;
+
+    if (!device.pushToken) {
+      return { success: false, error: "No FCM push token available" };
+    }
+
+    if (device.pushTokenType !== "fcm") {
+      return { success: false, error: "Device is not configured for FCM" };
+    }
+
+    // FCM data messages - all values must be strings
+    // Data-only messages are always delivered to onMessageReceived() on Android
+    // even when the app is in background, allowing proper handling
+    const data: Record<string, string> = {
+      apiJWT: notification.apiJWT,
+      notificationType: notification.notificationType,
+      notificationData: JSON.stringify(notification.notificationData),
+    };
+
+    // Add clientId or inboxId depending on which is present
+    if ("clientId" in notification && notification.clientId) {
+      data.clientId = notification.clientId;
+    } else if ("inboxId" in notification && notification.inboxId) {
+      data.inboxId = notification.inboxId;
+    }
+
+    try {
+      logger.info(
+        {
+          deviceId: device.id,
+          isSilent,
+          verbose: true,
+        },
+        "[VERBOSE] Sending FCM push notification",
+      );
+
+      const messageId = await this.messaging.send({
+        token: device.pushToken,
+        data,
+        android: {
+          // High priority ensures immediate delivery
+          priority: isSilent ? "normal" : "high",
+        },
+      });
+
+      logger.info(
+        {
+          deviceId: device.id,
+          messageId,
+          verbose: true,
+        },
+        "[VERBOSE] FCM push notification sent successfully",
+      );
+
+      return { success: true };
+    } catch (error) {
+      const fcmError = error as Error & { code?: string };
+
+      logger.error(
+        {
+          deviceId: device.id,
+          error: fcmError.message,
+          code: fcmError.code,
+          verbose: true,
+        },
+        "[VERBOSE] FCM push notification failed",
+      );
+
+      // Map FCM error codes to consistent error responses
+      if (
+        fcmError.code === "messaging/registration-token-not-registered" ||
+        fcmError.code === "messaging/invalid-registration-token"
+      ) {
+        return { success: false, error: "BadDeviceToken" };
+      }
+
+      return { success: false, error: fcmError.message || "Unknown FCM error" };
+    }
+  }
+}
+
+// Factory function to create FCM service
+export function createFcmService(): FcmPushService | null {
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+    console.warn(
+      "FIREBASE_SERVICE_ACCOUNT not set, FCM push notifications disabled",
+    );
+    return null;
+  }
+
+  try {
+    return new FcmPushService();
+  } catch (error) {
+    console.warn("Failed to initialize FCM service:", error);
+    return null;
+  }
+}

--- a/src/api/v2/notifications/fcm-push.service.ts
+++ b/src/api/v2/notifications/fcm-push.service.ts
@@ -104,19 +104,28 @@ export class FcmPushService {
   }
 }
 
-// Factory function to create FCM service
+// Cached FCM service instance
+let cachedFcmService: FcmPushService | null = null;
+let fcmServiceInitialized = false;
+
+// Factory function to create or return cached FCM service
 export function createFcmService(): FcmPushService | null {
+  if (fcmServiceInitialized) {
+    return cachedFcmService;
+  }
+
+  fcmServiceInitialized = true;
+
   if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
-    console.warn(
-      "FIREBASE_SERVICE_ACCOUNT not set, FCM push notifications disabled",
-    );
+    logger.warn("FIREBASE_SERVICE_ACCOUNT not set, FCM push notifications disabled");
     return null;
   }
 
   try {
-    return new FcmPushService();
+    cachedFcmService = new FcmPushService();
+    return cachedFcmService;
   } catch (error) {
-    console.warn("Failed to initialize FCM service:", error);
+    logger.warn({ error }, "Failed to initialize FCM service");
     return null;
   }
 }

--- a/src/api/v2/notifications/fcm-push.service.ts
+++ b/src/api/v2/notifications/fcm-push.service.ts
@@ -117,7 +117,9 @@ export function createFcmService(): FcmPushService | null {
   fcmServiceInitialized = true;
 
   if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
-    logger.warn("FIREBASE_SERVICE_ACCOUNT not set, FCM push notifications disabled");
+    logger.warn(
+      "FIREBASE_SERVICE_ACCOUNT not set, FCM push notifications disabled",
+    );
     return null;
   }
 

--- a/src/api/v2/notifications/handlers/webhook.ts
+++ b/src/api/v2/notifications/handlers/webhook.ts
@@ -1,6 +1,7 @@
 import type { ClientIdentifier, DeviceRegistration } from "@prisma/client";
 import type { Request, Response } from "express";
 import { createApnsService } from "@/api/v2/notifications/apns-push.service";
+import { createFcmService } from "@/api/v2/notifications/fcm-push.service";
 import type { V2NotificationPayload } from "@/api/v2/notifications/types";
 import {
   createNotificationClient,
@@ -128,16 +129,8 @@ async function handleV2Notification(args: {
     },
   });
 
-  // NOTE: v2 only supports APNS/iOS push notifications
-  // We do not support FCM/Android
-  const apnsService = createApnsService();
-
-  if (!apnsService) {
-    req.log.error("APNS service not configured");
-    return { success: false };
-  }
-
-  // Check if this is a welcome message (too large for APNS)
+  // Check if this is a welcome message (too large for push payload limit)
+  // Both APNS and FCM have a 4KB limit
   const isWelcome = isWelcomeMessage({
     contentTopic: notification.message.content_topic,
     messageType: notification.message_context.message_type,
@@ -146,11 +139,11 @@ async function handleV2Notification(args: {
   if (isWelcome) {
     req.log.info(
       { contentTopic: notification.message.content_topic },
-      "Detected welcome message - omitting encrypted content to avoid APNS payload limit",
+      "Detected welcome message - omitting encrypted content to avoid payload limit",
     );
   }
 
-  // Send push notification with v2 types
+  // Build notification payload (same for both APNS and FCM)
   const v2Notification: V2NotificationPayload = {
     clientId: notification.installation.id,
     apiJWT,
@@ -158,33 +151,49 @@ async function handleV2Notification(args: {
     notificationData: {
       contentTopic: notification.message.content_topic,
       messageType: notification.message_context.message_type,
-      // Omit encryptedMessage for welcome messages (too large for APNS 4KB limit)
+      // Omit encryptedMessage for welcome messages (too large for 4KB limit)
       ...(isWelcome ? {} : { encryptedMessage: notification.message.message }),
       timestamp: notification.message.timestamp_ns,
     },
   };
 
-  // Create a device-like object for APNS service
-  // NOTE: os is hardcoded to "ios" since v2 only supports APNS (no FCM/Android support)
-  const deviceForApns = {
-    id: client.deviceId,
-    pushToken: client.device.pushToken,
-    pushTokenType: client.device.pushTokenType,
-    apnsEnv: client.device.apnsEnv,
-    pushFailures: client.device.pushFailures,
-    name: null,
-    os: "ios" as const,
-    appVersion: null,
-    appBuildNumber: null,
-    createdAt: client.device.addedAt,
-    updatedAt: client.device.updatedAt,
-    lastPushSuccessAt: client.device.lastSentAt,
-  };
+  // Route to appropriate push service based on token type
+  let result: { success: boolean; error?: string };
 
-  const result = await apnsService.sendPushNotification({
-    device: deviceForApns,
-    notification: v2Notification,
-  });
+  if (client.device.pushTokenType === "fcm") {
+    // Android/FCM push notification
+    const fcmService = createFcmService();
+    if (!fcmService) {
+      req.log.error("FCM service not configured");
+      return { success: false };
+    }
+
+    result = await fcmService.sendPushNotification({
+      device: {
+        id: client.deviceId,
+        pushToken: client.device.pushToken,
+        pushTokenType: client.device.pushTokenType,
+      },
+      notification: v2Notification,
+    });
+  } else {
+    // iOS/APNS push notification
+    const apnsService = createApnsService();
+    if (!apnsService) {
+      req.log.error("APNS service not configured");
+      return { success: false };
+    }
+
+    result = await apnsService.sendPushNotification({
+      device: {
+        id: client.deviceId,
+        pushToken: client.device.pushToken,
+        pushTokenType: client.device.pushTokenType,
+        apnsEnv: client.device.apnsEnv,
+      },
+      notification: v2Notification,
+    });
+  }
 
   // Track success/failure using atomic operations to prevent race conditions
   if (result.success) {
@@ -236,6 +245,7 @@ async function handleV2Notification(args: {
         deviceId: client.deviceId,
         error: result.error,
         failureCount: updated.pushFailures,
+        pushTokenType: client.device.pushTokenType,
         apnsEnv: client.device.apnsEnv,
         lastFailureAt: updated.lastFailureAt,
         autoDisabled,

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -10,7 +10,7 @@ import logger from "./logger";
 
 let cachedFirebaseApp: App | undefined;
 
-const getFirebaseApp = () => {
+export const getFirebaseApp = () => {
   if (cachedFirebaseApp) {
     return cachedFirebaseApp;
   }

--- a/tests/fcm-push.test.ts
+++ b/tests/fcm-push.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createFcmService,
+  FcmPushService,
+} from "@/api/v2/notifications/fcm-push.service";
+import type { V2NotificationPayload } from "@/api/v2/notifications/types";
+
+const mockNotification: V2NotificationPayload = {
+  clientId: "test-client-123",
+  apiJWT: "test-jwt-token",
+  notificationType: "Protocol",
+  notificationData: {
+    contentTopic: "/xmtp/test",
+    messageType: "v3-message",
+    encryptedMessage: "encrypted-content",
+    timestamp: "1234567890",
+  },
+};
+
+describe("FcmPushService", () => {
+  describe("createFcmService", () => {
+    test("should create a service instance when FIREBASE_SERVICE_ACCOUNT is set", () => {
+      const service = createFcmService();
+      expect(service).toBeInstanceOf(FcmPushService);
+    });
+
+    test("should return cached instance on subsequent calls", () => {
+      const service1 = createFcmService();
+      const service2 = createFcmService();
+      expect(service1).toBe(service2);
+    });
+  });
+
+  describe("sendPushNotification", () => {
+    test("should return error when push token is null", async () => {
+      const service = createFcmService();
+      expect(service).not.toBeNull();
+
+      const result = await service!.sendPushNotification({
+        device: {
+          id: "device-123",
+          pushToken: null,
+          pushTokenType: "fcm",
+        },
+        notification: mockNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No FCM push token available");
+    });
+
+    test("should return error when device is not configured for FCM", async () => {
+      const service = createFcmService();
+      expect(service).not.toBeNull();
+
+      const result = await service!.sendPushNotification({
+        device: {
+          id: "device-123",
+          pushToken: "some-token",
+          pushTokenType: "apns",
+        },
+        notification: mockNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Device is not configured for FCM");
+    });
+
+    test("should send push notification successfully with valid FCM token", async () => {
+      const service = createFcmService();
+      expect(service).not.toBeNull();
+
+      const result = await service!.sendPushNotification({
+        device: {
+          id: "device-123",
+          pushToken: "valid-fcm-token",
+          pushTokenType: "fcm",
+        },
+        notification: mockNotification,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    test("should return BadDeviceToken error for invalid FCM token", async () => {
+      const service = createFcmService();
+      expect(service).not.toBeNull();
+
+      const result = await service!.sendPushNotification({
+        device: {
+          id: "device-123",
+          pushToken: "invalid-fcm-token",
+          pushTokenType: "fcm",
+        },
+        notification: mockNotification,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("BadDeviceToken");
+    });
+
+    test("should handle silent notifications", async () => {
+      const service = createFcmService();
+      expect(service).not.toBeNull();
+
+      const result = await service!.sendPushNotification({
+        device: {
+          id: "device-123",
+          pushToken: "valid-fcm-token",
+          pushTokenType: "fcm",
+        },
+        notification: mockNotification,
+        isSilent: true,
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/tests/fcm-push.test.ts
+++ b/tests/fcm-push.test.ts
@@ -116,5 +116,25 @@ describe("FcmPushService", () => {
 
       expect(result.success).toBe(true);
     });
+
+    test("should return error when notification data cannot be serialized", async () => {
+      const service = createFcmService();
+      expect(service).not.toBeNull();
+
+      const result = await service!.sendPushNotification({
+        device: {
+          id: "device-123",
+          pushToken: "valid-fcm-token",
+          pushTokenType: "fcm",
+        },
+        notification: {
+          ...mockNotification,
+          notificationData: { bad: BigInt(1) } as never,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid notification data");
+    });
   });
 });

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -47,3 +47,17 @@ void mock.module("firebase-admin/app", () => ({
   initializeApp: () => {},
   cert: () => {},
 }));
+
+void mock.module("firebase-admin/messaging", () => ({
+  getMessaging: () => ({
+    send: (message: { token?: string }) => {
+      if (message.token === "valid-fcm-token") {
+        return Promise.resolve("mock-message-id");
+      }
+      const error = new Error("Invalid registration token");
+      (error as Error & { code: string }).code =
+        "messaging/invalid-registration-token";
+      return Promise.reject(error);
+    },
+  }),
+}));


### PR DESCRIPTION
## Summary
- Add FCM push notification support for Android devices via Firebase Cloud Messaging
- Route webhook notifications based on `pushTokenType` (fcm vs apns)
- Remove FCM rejection in device registration, allowing Android devices to register
- No new environment variables needed - reuses existing `FIREBASE_SERVICE_ACCOUNT`
- AppCheck already supports Android via Play Integrity (no backend changes needed)

## Changes
- **New file**: `src/api/v2/notifications/fcm-push.service.ts` - FCM push service using Firebase Admin SDK
- **Modified**: `src/api/v2/notifications/handlers/webhook.ts` - Route to FCM or APNS based on token type
- **Modified**: `src/api/v2/device/handlers/register.ts` - Remove FCM rejection block
- **Modified**: `src/utils/firebase.ts` - Export `getFirebaseApp()` for FCM service
- **Modified**: `prisma/schema.prisma` - Update comments to reflect FCM support
- **Modified**: `tests/preload.ts` - Add FCM messaging mock

## Test plan
- [x] All 48 existing tests pass
- [x] TypeScript compiles without errors
- [ ] Manual test: Register Android device with FCM token
- [ ] Manual test: Verify webhook routes to FCM for Android devices
- [ ] Manual test: Verify push notification received on Android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class Firebase Cloud Messaging (FCM) support for push notifications alongside APNS.
  * Device registration now accepts FCM push tokens and routes pushes to FCM or APNS.

* **Improvements**
  * Push services use cached singleton instances for reuse.
  * Unified logging and consistent 4KB payload messaging across providers.
  * Public Firebase initialization utility exposed.

* **Tests**
  * Added unit tests and mocks covering FCM behavior and error cases.

* **Documentation**
  * New push notification architecture overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->