### PR TITLE
feat: runtime App Attest toggle for dev

### DIFF
--- a/prisma/migrations/20260213000000_add_runtime_config/migration.sql
+++ b/prisma/migrations/20260213000000_add_runtime_config/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "RuntimeConfig" (
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RuntimeConfig_pkey" PRIMARY KEY ("key")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,3 +55,9 @@ model ClientIdentifier {
 
   @@index([deviceId])
 }
+
+model RuntimeConfig {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt
+}

--- a/src/api/v2/dev/dev.router.ts
+++ b/src/api/v2/dev/dev.router.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import {
+  getRuntimeConfig,
+  setRuntimeConfig,
+} from "@/utils/runtimeConfig";
+
+const devRouter = Router();
+
+devRouter.get("/app-attest", async (req, res) => {
+  const value = await getRuntimeConfig("app_attest_enabled", "true");
+  res.json({ enabled: value === "true" });
+});
+
+devRouter.post("/app-attest", async (req, res) => {
+  const { enabled } = req.body;
+
+  if (typeof enabled !== "boolean") {
+    res.status(400).json({ error: "Request body must include 'enabled' (boolean)" });
+    return;
+  }
+
+  await setRuntimeConfig("app_attest_enabled", String(enabled));
+  req.log.info({ enabled }, "App Attest toggled via dev endpoint");
+  res.json({ enabled });
+});
+
+export { devRouter };

--- a/src/api/v2/dev/dev.router.ts
+++ b/src/api/v2/dev/dev.router.ts
@@ -1,5 +1,10 @@
 import { Router } from "express";
+import { z } from "zod";
 import { getRuntimeConfig, setRuntimeConfig } from "@/utils/runtimeConfig";
+
+const appAttestToggleSchema = z.object({
+  enabled: z.boolean(),
+});
 
 const devRouter = Router();
 
@@ -9,15 +14,16 @@ devRouter.get("/app-attest", async (req, res) => {
 });
 
 devRouter.post("/app-attest", async (req, res) => {
-  const { enabled } = req.body;
+  const result = appAttestToggleSchema.safeParse(req.body);
 
-  if (typeof enabled !== "boolean") {
+  if (!result.success) {
     res
       .status(400)
       .json({ error: "Request body must include 'enabled' (boolean)" });
     return;
   }
 
+  const { enabled } = result.data;
   await setRuntimeConfig("app_attest_enabled", String(enabled));
   req.log.info({ enabled }, "App Attest toggled via dev endpoint");
   res.json({ enabled });

--- a/src/api/v2/dev/dev.router.ts
+++ b/src/api/v2/dev/dev.router.ts
@@ -1,8 +1,5 @@
 import { Router } from "express";
-import {
-  getRuntimeConfig,
-  setRuntimeConfig,
-} from "@/utils/runtimeConfig";
+import { getRuntimeConfig, setRuntimeConfig } from "@/utils/runtimeConfig";
 
 const devRouter = Router();
 
@@ -15,7 +12,9 @@ devRouter.post("/app-attest", async (req, res) => {
   const { enabled } = req.body;
 
   if (typeof enabled !== "boolean") {
-    res.status(400).json({ error: "Request body must include 'enabled' (boolean)" });
+    res
+      .status(400)
+      .json({ error: "Request body must include 'enabled' (boolean)" });
     return;
   }
 

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -4,6 +4,7 @@ import {
   authMiddleware,
   authMiddlewareAllowNSE,
 } from "@/middleware/auth";
+import { devAuthMiddleware } from "@/middleware/devAuth";
 import { lifecycleTestAuthMiddleware } from "@/middleware/lifecycleTestAuth";
 import { assetRenewalLimiter } from "@/middleware/rateLimit";
 import { assetsRouter } from "./assets/assets.router";
@@ -11,12 +12,17 @@ import { lifecycleStatusHandler } from "./assets/handlers/lifecycle-status";
 import { testLifecycleHandler } from "./assets/handlers/test-lifecycle";
 import { attachmentsRouter } from "./attachments/attachments.router";
 import { authRouter } from "./auth/auth.router";
+import { devRouter } from "./dev/dev.router";
 import { deviceRouter } from "./device/device.router";
 import invitesV2Router from "./invites/invites.router";
 import { notificationsRouter } from "./notifications/notifications.router";
 import { webhookRouter } from "./notifications/webhook.router";
 
 const v2Router = Router();
+
+if (process.env.XMTP_ENV !== "production") {
+  v2Router.use("/dev", devAuthMiddleware, devRouter);
+}
 
 v2Router.use("/invites", invitesV2Router);
 v2Router.use("/auth", authRouter);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, Response } from "express";
 import { AppError } from "@/utils/errors";
 import { verifyAppCheckToken } from "@/utils/firebase";
 import { isNotificationExtensionOnlyToken, verifyJwtToken } from "@/utils/jwt";
+import { getRuntimeConfig } from "@/utils/runtimeConfig";
 
 export const AUTH_HEADER = "X-Convos-AuthToken";
 export const APPCHECK_HEADER = "X-Firebase-AppCheck";
@@ -11,6 +12,15 @@ export const appCheckOnlyMiddleware = async (
   res: Response,
   next: NextFunction,
 ) => {
+  const appAttestEnabled =
+    (await getRuntimeConfig("app_attest_enabled", "true")) === "true";
+
+  if (!appAttestEnabled) {
+    req.log.warn("AppCheck bypassed - disabled via runtime config");
+    next();
+    return;
+  }
+
   const appCheckToken = req.header(APPCHECK_HEADER);
 
   req.log.info(

--- a/src/middleware/devAuth.ts
+++ b/src/middleware/devAuth.ts
@@ -1,0 +1,60 @@
+import { timingSafeEqual } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+
+/**
+ * Validates that the request has a valid DEV_API_TOKEN.
+ * Used to protect dev-only endpoints from unauthorized access.
+ */
+export const devAuthMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const expectedToken = process.env.DEV_API_TOKEN?.trim();
+  if (!expectedToken || expectedToken.length < 32) {
+    req.log.error(
+      "DEV_API_TOKEN not configured or too short (min 32 chars) - rejecting request",
+    );
+    res.status(500).json({
+      error: "Server configuration error",
+    });
+    return;
+  }
+
+  const authHeader = req.headers.authorization?.trim() ?? "";
+
+  if (authHeader.length === 0) {
+    req.log.error("Missing dev auth authorization header");
+    res.status(401).json({
+      error: "Unauthorized: Missing authentication token",
+    });
+    return;
+  }
+
+  const providedToken = authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7).trim()
+    : authHeader.trim();
+
+  if (providedToken.length === 0) {
+    req.log.error("Empty dev auth token");
+    res.status(401).json({
+      error: "Unauthorized: Invalid authentication token",
+    });
+    return;
+  }
+
+  const provided = Buffer.from(providedToken, "utf8");
+  const expected = Buffer.from(expectedToken, "utf8");
+  const valid =
+    provided.length === expected.length && timingSafeEqual(provided, expected);
+
+  if (!valid) {
+    req.log.error("Invalid dev auth authorization token");
+    res.status(401).json({
+      error: "Unauthorized: Invalid authentication token",
+    });
+    return;
+  }
+
+  next();
+};

--- a/src/utils/runtimeConfig.ts
+++ b/src/utils/runtimeConfig.ts
@@ -1,0 +1,38 @@
+import { prisma } from "./prisma";
+import logger from "./logger";
+
+const CACHE_TTL_MS = 30_000;
+
+const cache = new Map<string, { value: string; expiresAt: number }>();
+
+export async function getRuntimeConfig(
+  key: string,
+  defaultValue: string,
+): Promise<string> {
+  const cached = cache.get(key);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.value;
+  }
+
+  try {
+    const config = await prisma.runtimeConfig.findUnique({ where: { key } });
+    const value = config?.value ?? defaultValue;
+    cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+    return value;
+  } catch (error) {
+    logger.error({ error, key }, "Failed to read runtime config");
+    return defaultValue;
+  }
+}
+
+export async function setRuntimeConfig(
+  key: string,
+  value: string,
+): Promise<void> {
+  await prisma.runtimeConfig.upsert({
+    where: { key },
+    create: { key, value },
+    update: { value },
+  });
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+}

--- a/src/utils/runtimeConfig.ts
+++ b/src/utils/runtimeConfig.ts
@@ -34,5 +34,5 @@ export async function setRuntimeConfig(
     create: { key, value },
     update: { value },
   });
-  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  cache.delete(key);
 }

--- a/src/utils/runtimeConfig.ts
+++ b/src/utils/runtimeConfig.ts
@@ -1,5 +1,5 @@
-import { prisma } from "./prisma";
 import logger from "./logger";
+import { prisma } from "./prisma";
 
 const CACHE_TTL_MS = 30_000;
 


### PR DESCRIPTION
## Summary
- Adds a database-backed runtime toggle to disable App Attest (Firebase App Check) verification without redeploying
- New `RuntimeConfig` table with 30s in-memory cache ensures consistent state across both servers behind the load balancer
- Dev-only endpoint (`/api/v2/dev/app-attest`) gated on `XMTP_ENV !== "production"` — routes don't exist in prod
- Protected by a separate `DEV_API_TOKEN` bearer token (not the lifecycle test token)

## Usage
```bash
# Check status
curl -H "Authorization: Bearer $DEV_API_TOKEN" https://dev-api/api/v2/dev/app-attest

# Disable App Attest
curl -X POST -H "Authorization: Bearer $DEV_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"enabled": false}' https://dev-api/api/v2/dev/app-attest

# Re-enable
curl -X POST -H "Authorization: Bearer $DEV_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"enabled": true}' https://dev-api/api/v2/dev/app-attest
```

## Test plan
- [x] Set `DEV_API_TOKEN` env var in dev environment (min 32 chars)
- [x] Deploy to otr-dev
- [x] Verify App Attest is enabled by default (no App Check token → 401)
- [x] Disable via endpoint, verify requests pass through without App Check
- [x] Re-enable, verify enforcement returns
- [ ] Confirm `/api/v2/dev/app-attest` returns 404 when `XMTP_ENV=production`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add development-only /dev endpoints to view and toggle App Attest at runtime (mounted only in non-production).
  * Persist runtime configuration to the database with a cached runtime-config layer for faster reads and writes.
  * Require dev-only authentication to access the development endpoints.

* **Bug Fixes / Behavior**
  * App Attest verification can be enabled/disabled at runtime, with clear logging when bypassed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->