### PR TITLE
Relax deviceId validation for Android registration (FID-compatible)

### DIFF
--- a/docs/plans/android-device-registration-device-id-validation-plan.md
+++ b/docs/plans/android-device-registration-device-id-validation-plan.md
@@ -5,6 +5,7 @@
 Current backend request schemas validate `deviceId` as a UUID. This works for iOS (`identifierForVendor`) but fails for Android values such as `ANDROID_ID` (64-bit hex string) and would also reject Firebase Installation ID (FID) values.
 
 Engineering discussion aligned on:
+
 - Backend should become more permissive for `deviceId`.
 - Android should move from `ANDROID_ID` to Firebase Installation ID (FID) for better privacy properties.
 - App Check remains the primary app authenticity control.
@@ -18,10 +19,13 @@ Engineering discussion aligned on:
 ## Backend Changes
 
 ### Validation
+
 Use a shared schema for `deviceId`:
+
 - `z.string().trim().min(1).max(128)`
 
 Apply it in:
+
 - `src/api/v2/device/handlers/register.ts`
 - `src/api/v2/auth/handlers/generate-token.ts`
 - `src/api/v2/notifications/handlers/subscribe.ts`
@@ -30,10 +34,13 @@ Apply it in:
 `clientId` remains UUID-validated.
 
 ### Data Layer
+
 No DB migration required now:
+
 - Prisma stores `deviceId` as `String`/`TEXT`.
 
 Optional hardening follow-up:
+
 - Add DB check constraint for max length (e.g. `char_length(deviceId) <= 128`).
 
 ## Android Changes
@@ -62,6 +69,7 @@ Optional hardening follow-up:
 ## Observability
 
 Track:
+
 - 400 rate for device-related endpoints.
 - Device register success rate.
 - Token generation success rate.
@@ -70,5 +78,6 @@ Track:
 ## Follow-up
 
 After Android migration stabilizes, decide whether to:
+
 - support legacy Android IDs indefinitely, or
 - tighten accepted patterns/charset once all active clients use FID.

--- a/docs/plans/android-device-registration-device-id-validation-plan.md
+++ b/docs/plans/android-device-registration-device-id-validation-plan.md
@@ -1,0 +1,74 @@
+# Android Device Registration: Device ID Validation Plan
+
+## Context
+
+Current backend request schemas validate `deviceId` as a UUID. This works for iOS (`identifierForVendor`) but fails for Android values such as `ANDROID_ID` (64-bit hex string) and would also reject Firebase Installation ID (FID) values.
+
+Engineering discussion aligned on:
+- Backend should become more permissive for `deviceId`.
+- Android should move from `ANDROID_ID` to Firebase Installation ID (FID) for better privacy properties.
+- App Check remains the primary app authenticity control.
+
+## Decision
+
+1. Replace strict UUID validation for `deviceId` with bounded string validation.
+2. Keep iOS behavior unchanged (IDFV still accepted).
+3. Android app migrates to FID as the `deviceId` source.
+
+## Backend Changes
+
+### Validation
+Use a shared schema for `deviceId`:
+- `z.string().trim().min(1).max(128)`
+
+Apply it in:
+- `src/api/v2/device/handlers/register.ts`
+- `src/api/v2/auth/handlers/generate-token.ts`
+- `src/api/v2/notifications/handlers/subscribe.ts`
+- `src/utils/jwt.ts` payload validation (`deviceId`)
+
+`clientId` remains UUID-validated.
+
+### Data Layer
+No DB migration required now:
+- Prisma stores `deviceId` as `String`/`TEXT`.
+
+Optional hardening follow-up:
+- Add DB check constraint for max length (e.g. `char_length(deviceId) <= 128`).
+
+## Android Changes
+
+- Replace `deviceId` source from `ANDROID_ID` to Firebase Installation ID.
+- Ensure the same value is used consistently for:
+  - `/v2/device/register`
+  - `/v2/auth/generate-token`
+  - `/v2/notifications/subscribe`
+
+## Rollout Plan
+
+1. Deploy backend validation change first (backward-compatible).
+2. Release Android app update using FID.
+3. Monitor request failures and success rates.
+
+## Test & Verification
+
+- iOS UUID `deviceId` accepted end-to-end.
+- Android legacy hex `ANDROID_ID` accepted during migration.
+- Android FID accepted.
+- Overlong `deviceId` (>128) rejected with 400.
+- JWT ownership checks still valid (`deviceId` string equality).
+- Register -> generate-token -> subscribe flow succeeds on both platforms.
+
+## Observability
+
+Track:
+- 400 rate for device-related endpoints.
+- Device register success rate.
+- Token generation success rate.
+- Topic subscribe success rate.
+
+## Follow-up
+
+After Android migration stabilizes, decide whether to:
+- support legacy Android IDs indefinitely, or
+- tighten accepted patterns/charset once all active clients use FID.

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { deviceIdSchema } from "@/utils/device-id";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
 
@@ -19,7 +20,7 @@ import { prisma } from "@/utils/prisma";
  */
 
 const generateTokenRequestSchema = z.object({
-  deviceId: z.string().uuid(),
+  deviceId: deviceIdSchema,
 });
 
 export type IGenerateTokenRequestBody = z.infer<

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -2,10 +2,11 @@ import { ApnsEnvironmentSchema, PushTokenTypeSchema } from "@prisma-zod/index";
 import type { ApnsEnvironment, PushTokenType } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { deviceIdSchema } from "@/utils/device-id";
 import { prisma } from "@/utils/prisma";
 
 const registerRequestSchema = z.object({
-  deviceId: z.string().uuid(),
+  deviceId: deviceIdSchema,
   pushToken: z
     .string()
     .optional()

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -3,10 +3,11 @@ import { hexToUint8Array } from "uint8array-extras";
 import { z } from "zod";
 import { createNotificationClient } from "@/notifications/client";
 import { verifyDeviceOwnership } from "@/utils/auth-guards";
+import { deviceIdSchema } from "@/utils/device-id";
 import { prisma } from "@/utils/prisma";
 
 const subscribeRequestSchema = z.object({
-  deviceId: z.string().uuid(),
+  deviceId: deviceIdSchema,
   clientId: z.string().uuid(),
   topics: z
     .array(

--- a/src/utils/device-id.ts
+++ b/src/utils/device-id.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const DEVICE_ID_MAX_LENGTH = 128;
+
+/**
+ * Device IDs are platform-defined opaque identifiers.
+ *
+ * iOS: identifierForVendor (UUID-like)
+ * Android: ANDROID_ID (hex) or Firebase Installation ID (base64url-like)
+ */
+export const deviceIdSchema = z.string().trim().min(1).max(DEVICE_ID_MAX_LENGTH);

--- a/src/utils/device-id.ts
+++ b/src/utils/device-id.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+/** Maximum allowed length for device identifiers (iOS UUID, Android FID, etc.). */
 export const DEVICE_ID_MAX_LENGTH = 128;
 
 /**

--- a/src/utils/device-id.ts
+++ b/src/utils/device-id.ts
@@ -8,4 +8,8 @@ export const DEVICE_ID_MAX_LENGTH = 128;
  * iOS: identifierForVendor (UUID-like)
  * Android: ANDROID_ID (hex) or Firebase Installation ID (base64url-like)
  */
-export const deviceIdSchema = z.string().trim().min(1).max(DEVICE_ID_MAX_LENGTH);
+export const deviceIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(DEVICE_ID_MAX_LENGTH);

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -126,6 +126,13 @@ export const createJwtToken = async (args: {
   metadata?: V2JWTMetadata;
   expirationTime?: string;
 }) => {
+  // Validate and normalize deviceId to match verification semantics.
+  const deviceIdParseResult = deviceIdSchema.safeParse(args.deviceId);
+  if (!deviceIdParseResult.success) {
+    throw new AppError(400, "Invalid deviceId");
+  }
+  const deviceId = deviceIdParseResult.data;
+
   // Validate metadata size to prevent JWT bloat
   if (args.metadata) {
     const metadataSize = new TextEncoder().encode(
@@ -140,7 +147,7 @@ export const createJwtToken = async (args: {
   }
 
   const payload: V2JWTPayload = {
-    deviceId: args.deviceId,
+    deviceId,
   };
 
   // Add metadata if provided
@@ -161,7 +168,7 @@ export const createJwtToken = async (args: {
   const { data: jwt, error: jwtError } = await tryCatch(
     new jose.SignJWT(payload)
       .setProtectedHeader({ alg: "ES256" })
-      .setSubject(args.deviceId) // Standard 'sub' claim for gateway
+      .setSubject(deviceId) // Standard 'sub' claim for gateway
       .setIssuer(JWT_ISSUER) // Standard 'iss' claim
       .setIssuedAt()
       .setExpirationTime(args.expirationTime ?? "15m")

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,6 +1,7 @@
 import * as jose from "jose";
 import { z } from "zod";
 import { JWT_ISSUER, JWT_PRIVATE_KEY, JWT_PUBLIC_KEY } from "@/config";
+import { deviceIdSchema } from "@/utils/device-id";
 import { AppError } from "@/utils/errors";
 import logger from "@/utils/logger";
 import { tryCatch } from "@/utils/try-catch";
@@ -20,7 +21,7 @@ export type V2JWTPayload = {
 };
 
 const v2JWTPayloadSchema = z.object({
-  deviceId: z.string(),
+  deviceId: deviceIdSchema,
   metadata: z
     .object({
       notificationExtensionOnly: z.boolean().optional(),

--- a/tests/device-id.test.ts
+++ b/tests/device-id.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { DEVICE_ID_MAX_LENGTH, deviceIdSchema } from "@/utils/device-id";
+
+describe("deviceIdSchema", () => {
+  test("accepts iOS UUID", () => {
+    const value = "123e4567-e89b-12d3-a456-426614174000";
+    expect(deviceIdSchema.parse(value)).toBe(value);
+  });
+
+  test("accepts Android ANDROID_ID-like hex", () => {
+    const value = "9774d56d682e549c";
+    expect(deviceIdSchema.parse(value)).toBe(value);
+  });
+
+  test("accepts Firebase Installation ID-like format", () => {
+    const value = "cJNt-u7vTxKXEoJi1b9sMz";
+    expect(deviceIdSchema.parse(value)).toBe(value);
+  });
+
+  test("trims leading/trailing whitespace", () => {
+    expect(deviceIdSchema.parse("  test-id  ")).toBe("test-id");
+  });
+
+  test("rejects empty string after trim", () => {
+    expect(() => deviceIdSchema.parse("   ")).toThrow();
+  });
+
+  test("rejects over max length", () => {
+    expect(() => deviceIdSchema.parse("a".repeat(DEVICE_ID_MAX_LENGTH + 1))).toThrow();
+  });
+});

--- a/tests/device-id.test.ts
+++ b/tests/device-id.test.ts
@@ -17,6 +17,15 @@ describe("deviceIdSchema", () => {
     expect(deviceIdSchema.parse(value)).toBe(value);
   });
 
+  test("accepts single character (min length)", () => {
+    expect(deviceIdSchema.parse("x")).toBe("x");
+  });
+
+  test("accepts exactly max length", () => {
+    const value = "a".repeat(DEVICE_ID_MAX_LENGTH);
+    expect(deviceIdSchema.parse(value)).toBe(value);
+  });
+
   test("trims leading/trailing whitespace", () => {
     expect(deviceIdSchema.parse("  test-id  ")).toBe("test-id");
   });

--- a/tests/device-id.test.ts
+++ b/tests/device-id.test.ts
@@ -26,6 +26,8 @@ describe("deviceIdSchema", () => {
   });
 
   test("rejects over max length", () => {
-    expect(() => deviceIdSchema.parse("a".repeat(DEVICE_ID_MAX_LENGTH + 1))).toThrow();
+    expect(() =>
+      deviceIdSchema.parse("a".repeat(DEVICE_ID_MAX_LENGTH + 1)),
+    ).toThrow();
   });
 });

--- a/tests/jwt.test.ts
+++ b/tests/jwt.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import * as jose from "jose";
 import { JWT_ISSUER } from "@/config";
+import { DEVICE_ID_MAX_LENGTH } from "@/utils/device-id";
 import { AppError } from "@/utils/errors";
 import {
   createJwtToken,
@@ -156,8 +157,8 @@ describe("createJwtToken", () => {
     expect(payload.metadata).toEqual(metadata);
   });
 
-  test("JWT with max length deviceId stays under size limits", async () => {
-    const maxDeviceId = "a".repeat(128);
+  test("should stay under size limits with max-length deviceId", async () => {
+    const maxDeviceId = "a".repeat(DEVICE_ID_MAX_LENGTH);
     const token = await createJwtToken({ deviceId: maxDeviceId });
 
     // Conservative upper bound to keep healthy margin against header limits.

--- a/tests/jwt.test.ts
+++ b/tests/jwt.test.ts
@@ -164,6 +164,15 @@ describe("createJwtToken", () => {
     expect(token.length).toBeLessThan(2000);
   });
 
+  test("should normalize deviceId by trimming whitespace", async () => {
+    const token = await createJwtToken({ deviceId: "  test-device-trim  " });
+    const payload = await verifyJwtToken({ token });
+    const decoded = jose.decodeJwt(token);
+
+    expect(payload.deviceId).toBe("test-device-trim");
+    expect(decoded.sub).toBe("test-device-trim");
+  });
+
   test("should respect custom expiration time", async () => {
     const deviceId = "test-device-expiry";
     const token = await createJwtToken({
@@ -179,5 +188,17 @@ describe("createJwtToken", () => {
     // Allow 5 second tolerance
     expect(decoded.exp).toBeGreaterThan(expectedExp - 5);
     expect(decoded.exp).toBeLessThan(expectedExp + 5);
+  });
+
+  test("should throw for invalid deviceId", async () => {
+    try {
+      await createJwtToken({ deviceId: "   " });
+      expect.unreachable("Should have thrown an error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.statusCode).toBe(400);
+      expect(appError.message).toBe("Invalid deviceId");
+    }
   });
 });

--- a/tests/jwt.test.ts
+++ b/tests/jwt.test.ts
@@ -156,6 +156,14 @@ describe("createJwtToken", () => {
     expect(payload.metadata).toEqual(metadata);
   });
 
+  test("JWT with max length deviceId stays under size limits", async () => {
+    const maxDeviceId = "a".repeat(128);
+    const token = await createJwtToken({ deviceId: maxDeviceId });
+
+    // Conservative upper bound to keep healthy margin against header limits.
+    expect(token.length).toBeLessThan(2000);
+  });
+
   test("should respect custom expiration time", async () => {
     const deviceId = "test-device-expiry";
     const token = await createJwtToken({


### PR DESCRIPTION
## Summary
- add a plan doc for Android device registration deviceId migration
- replace UUID-only `deviceId` validation with shared bounded string validation (`min(1)`, `max(128)`)
- apply shared schema across v2 register, generate-token, subscribe, and JWT payload validation
- keep `clientId` UUID validation unchanged

## Why
Android `deviceId` values are not always UUIDs (`ANDROID_ID` is hex and Firebase Installation ID is base64url-like). This change keeps iOS compatibility while allowing Android migration to FID.

## Changes
- `docs/plans/android-device-registration-device-id-validation-plan.md`
- `src/utils/device-id.ts` (new shared schema)
- `src/api/v2/device/handlers/register.ts`
- `src/api/v2/auth/handlers/generate-token.ts`
- `src/api/v2/notifications/handlers/subscribe.ts`
- `src/utils/jwt.ts`

## Validation
- lint/typecheck follow-ups addressed in a separate commit

## Rollout
1. Deploy backend permissive validation
2. Roll Android update to use FID
3. Monitor 400s and registration/token/subscribe success rates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized device ID validation across registration, auth, and notification flows: accepts trimmed strings 1–128 characters; supports iOS UUIDs, Firebase Installation IDs, and legacy Android IDs during migration.

* **Documentation**
  * Added device registration and device ID validation plan with rollout, verification, and observability guidance.

* **Tests**
  * Added tests covering device ID validation, trimming/normalization, max-length behavior, and JWT handling of long device IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->