### PR TITLE
feat: make timestamp migration resumable to avoid gateway timeouts

### DIFF
--- a/docs/plans/backend-asset-renewal.md
+++ b/docs/plans/backend-asset-renewal.md
@@ -502,6 +502,9 @@ Copy-to-self all existing objects in `PUBLIC_ASSETS_BUCKET` to reset `LastModifi
 //   ?dryRun=true   — list objects and report counts without copying (default: true)
 //   ?olderThanDays=25 — only touch objects with LastModified older than N days (default: 25)
 //   ?concurrency=50   — parallel copy operations (default: 50, max: 200)
+//   ?maxPages=5       — maximum ListObjects pages to process in this request (default: 5, max: 50)
+//   ?continuationToken=... — resume from previous response token
+//   ?verbose=true     — log each successfully renewed key
 
 // 1. Validate S3 access: HeadBucket on PUBLIC_ASSETS_BUCKET
 // 2. List all objects with paginated ListObjectsV2 (handle ContinuationToken)
@@ -509,18 +512,22 @@ Copy-to-self all existing objects in `PUBLIC_ASSETS_BUCKET` to reset `LastModifi
 // 4. If dryRun: return { total, eligible, skipped } without copying
 // 5. If !dryRun:
 //    - process keys page-by-page (no full in-memory key list)
-//    - HeadObject + CopyObject(copy-to-self, MetadataDirective=REPLACE) for each eligible key
+//    - HeadObject + CopyObject(copy-to-self, MetadataDirective=COPY) for each eligible key
 //    - preserve metadata/content headers on copy
 //    - retry transient throttling errors with exponential backoff
 //    - track failed keys with error detail
 // 6. After completion: sample renewed keys (min 5, max 100), HeadObject verify LastModified updated
-// 7. Return detailed report:
+// 7. Return detailed report and continuation state for next request:
 
 interface MigrateResponse {
   dryRun: boolean;
   bucket: string;
   olderThanDays: number;
   concurrency: number;
+  maxPages: number;
+  processedPages: number; // pages processed in this request
+  nextContinuationToken: string | null; // pass back in next call
+  done: boolean; // true when full bucket scan is complete
   total: number; // all objects in bucket
   eligible: number; // objects older than threshold
   skipped: number; // objects newer than threshold
@@ -565,10 +572,10 @@ v2Router.post(
 - [ ] Deploy endpoint to dev and prod
 - [ ] Dry-run on dev: `curl -X POST -H "Authorization: Bearer $TOKEN" "$DEV_URL/api/v2/assets/test/migrate-timestamps?dryRun=true"`
 - [ ] Review report (total, eligible, skipped counts)
-- [ ] Execute on dev: `curl -X POST -H "Authorization: Bearer $TOKEN" "$DEV_URL/api/v2/assets/test/migrate-timestamps?dryRun=false"`
-- [ ] Verify report (renewed, failed, verified counts)
+- [ ] Execute on dev in chunks (set `maxPages`, loop using `nextContinuationToken` until `done=true`)
+- [ ] Verify per-chunk report (renewed, failed, verified counts)
 - [ ] Dry-run on prod, review report
-- [ ] Execute on prod, verify report
+- [ ] Execute on prod in chunks, verify report
 
 #### Step 2: Enable 30-Day Lifecycle Rule on Dev
 

--- a/src/api/v2/assets/handlers/migrate-timestamps.ts
+++ b/src/api/v2/assets/handlers/migrate-timestamps.ts
@@ -22,6 +22,8 @@ const s3Client = env.PUBLIC_ASSETS_BUCKET ? new S3Client({}) : null;
 const MAX_CONCURRENCY = 200;
 const DEFAULT_CONCURRENCY = 50;
 const DEFAULT_OLDER_THAN_DAYS = 25;
+const MAX_PAGES_PER_REQUEST = 50;
+const DEFAULT_MAX_PAGES = 5;
 const MIN_VERIFICATION_SAMPLE = 5;
 const MAX_VERIFICATION_SAMPLE = 100;
 const MAX_RETRY_ATTEMPTS = 4;
@@ -55,6 +57,23 @@ const querySchema = z.object({
     .min(1)
     .max(MAX_CONCURRENCY)
     .default(DEFAULT_CONCURRENCY),
+  maxPages: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_PAGES_PER_REQUEST)
+    .default(DEFAULT_MAX_PAGES),
+  continuationToken: z.preprocess((value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? undefined : trimmed;
+  }, z.string().max(2048).optional()),
+  verbose: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((v) => v === "true"),
 });
 
 interface MigrateResponse {
@@ -62,6 +81,10 @@ interface MigrateResponse {
   bucket: string;
   olderThanDays: number;
   concurrency: number;
+  maxPages: number;
+  processedPages: number;
+  nextContinuationToken: string | null;
+  done: boolean;
   total: number;
   eligible: number;
   skipped: number;
@@ -186,7 +209,7 @@ async function sendWithRetry<T>(
 }
 
 /**
- * Preserve object metadata when using copy-to-self with MetadataDirective=REPLACE.
+ * Preserve selected object headers/metadata during copy-to-self operations.
  */
 function copyMetadataFromHead(head: HeadObjectCommandOutput) {
   return {
@@ -250,7 +273,10 @@ function pickRandomSamples<T>(items: T[], sampleSize: number): T[] {
  * Query params:
  *   dryRun=true|false   (default: true) — report counts without copying
  *   olderThanDays=N     (default: 25) — only touch objects older than N days
- *   concurrency=N       (default: 50, max: 200) — parallel copy operations
+ *   concurrency=N         (default: 50, max: 200) — parallel copy operations
+ *   maxPages=N            (default: 5, max: 50) — pages to process per request
+ *   continuationToken=T   (optional) — resume listing from prior chunk token
+ *   verbose=true|false    (default: false) — log every successfully renewed key
  *
  * Protected by lifecycleTestAuthMiddleware. Remove after migration is complete.
  */
@@ -279,11 +305,20 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
     throw error;
   }
 
-  const { dryRun, olderThanDays, concurrency } = params;
+  const { dryRun, olderThanDays, concurrency, maxPages, verbose } = params;
   const startTime = Date.now();
+  const startContinuationToken = params.continuationToken;
 
   req.log.info(
-    { bucket, dryRun, olderThanDays, concurrency },
+    {
+      bucket,
+      dryRun,
+      olderThanDays,
+      concurrency,
+      maxPages,
+      continuationTokenProvided: Boolean(startContinuationToken),
+      verbose,
+    },
     "Starting timestamp migration",
   );
 
@@ -302,12 +337,11 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
     let renewed = 0;
     let renewedSeenCount = 0;
     const verificationCandidates: string[] = [];
-    let continuationToken: string | undefined;
+    let continuationToken: string | undefined = startContinuationToken;
     const failedKeys: { key: string; error: string }[] = [];
-    let page = 0;
+    let processedPages = 0;
 
-    do {
-      page++;
+    while (processedPages < maxPages) {
       const listResponse = await client.send(
         new ListObjectsV2Command({
           Bucket: bucket,
@@ -359,6 +393,9 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
               );
 
               renewed++;
+              if (verbose) {
+                req.log.info({ key }, "Renewed object");
+              }
               renewedSeenCount++;
               addReservoirSample(
                 verificationCandidates,
@@ -380,10 +417,11 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
       continuationToken = listResponse.IsTruncated
         ? listResponse.NextContinuationToken
         : undefined;
+      processedPages++;
 
       req.log.info(
         {
-          page,
+          page: processedPages,
           pageObjects: listResponse.Contents?.length ?? 0,
           total,
           eligible,
@@ -391,16 +429,27 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
           renewed,
           failed: failedKeys.length,
           hasMorePages: Boolean(continuationToken),
+          processedPages,
+          maxPages,
         },
         "Processed migration listing page",
       );
-    } while (continuationToken);
+      if (!continuationToken) {
+        break;
+      }
+    }
+    const nextContinuationToken = continuationToken ?? null;
+    const done = nextContinuationToken === null;
 
     req.log.info(
       {
         total,
         eligible,
         skipped,
+        processedPages,
+        maxPages,
+        done,
+        hasNextContinuationToken: Boolean(nextContinuationToken),
         cutoff: cutoff.toISOString(),
       },
       "Object listing complete",
@@ -413,6 +462,10 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
         bucket,
         olderThanDays,
         concurrency,
+        maxPages,
+        processedPages,
+        nextContinuationToken,
+        done,
         total,
         eligible,
         skipped,
@@ -463,6 +516,10 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
       bucket,
       olderThanDays,
       concurrency,
+      maxPages,
+      processedPages,
+      nextContinuationToken,
+      done,
       total,
       eligible,
       skipped,

--- a/src/api/v2/assets/handlers/migrate-timestamps.ts
+++ b/src/api/v2/assets/handlers/migrate-timestamps.ts
@@ -263,6 +263,15 @@ function pickRandomSamples<T>(items: T[], sampleSize: number): T[] {
 }
 
 /**
+ * S3 requires URL-encoded source key in CopySource header.
+ * Preserve "/" so object keys with path-like prefixes remain readable.
+ */
+function buildCopySource(bucket: string, key: string): string {
+  const encodedKey = encodeURIComponent(key).replace(/%2F/g, "/");
+  return `${bucket}/${encodedKey}`;
+}
+
+/**
  * POST /v2/assets/test/migrate-timestamps
  *
  * One-time migration endpoint that copies all objects in PUBLIC_ASSETS_BUCKET
@@ -384,7 +393,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
                 client.send(
                   new CopyObjectCommand({
                     Bucket: bucket,
-                    CopySource: `${bucket}/${encodeURIComponent(key)}`,
+                    CopySource: buildCopySource(bucket, key),
                     Key: key,
                     MetadataDirective: "COPY",
                     ...copyMetadataFromHead(sourceHead),

--- a/src/api/v2/assets/handlers/migrate-timestamps.ts
+++ b/src/api/v2/assets/handlers/migrate-timestamps.ts
@@ -263,15 +263,6 @@ function pickRandomSamples<T>(items: T[], sampleSize: number): T[] {
 }
 
 /**
- * S3 requires URL-encoded source key in CopySource header.
- * Preserve "/" so object keys with path-like prefixes remain readable.
- */
-function buildCopySource(bucket: string, key: string): string {
-  const encodedKey = encodeURIComponent(key).replace(/%2F/g, "/");
-  return `${bucket}/${encodedKey}`;
-}
-
-/**
  * POST /v2/assets/test/migrate-timestamps
  *
  * One-time migration endpoint that copies all objects in PUBLIC_ASSETS_BUCKET
@@ -393,7 +384,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
                 client.send(
                   new CopyObjectCommand({
                     Bucket: bucket,
-                    CopySource: buildCopySource(bucket, key),
+                    CopySource: `${bucket}/${key}`,
                     Key: key,
                     MetadataDirective: "COPY",
                     ...copyMetadataFromHead(sourceHead),

--- a/tests/migrate-timestamps.test.ts
+++ b/tests/migrate-timestamps.test.ts
@@ -170,6 +170,9 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect(res.status).toBe(200);
     const data = (await res.json()) as {
       dryRun: boolean;
+      processedPages: number;
+      nextContinuationToken: string | null;
+      done: boolean;
       total: number;
       eligible: number;
       skipped: number;
@@ -184,6 +187,9 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect(data.renewed).toBe(0);
     expect(data.failed).toBe(0);
     expect(data.verified).toEqual([]);
+    expect(data.processedPages).toBe(1);
+    expect(data.nextContinuationToken).toBeNull();
+    expect(data.done).toBe(true);
 
     const commands = mockS3Send.mock.calls.map((call) => commandName(call[0]));
     expect(commands).not.toContain("CopyObjectCommand");
@@ -238,6 +244,9 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect(res.status).toBe(200);
     const data = (await res.json()) as {
       dryRun: boolean;
+      processedPages: number;
+      nextContinuationToken: string | null;
+      done: boolean;
       total: number;
       eligible: number;
       skipped: number;
@@ -252,6 +261,9 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect(data.renewed).toBe(1);
     expect(data.failed).toBe(0);
     expect(data.verified.length).toBe(1);
+    expect(data.processedPages).toBe(1);
+    expect(data.nextContinuationToken).toBeNull();
+    expect(data.done).toBe(true);
 
     const copyCall = mockS3Send.mock.calls.find(
       (call) => commandName(call[0]) === "CopyObjectCommand",
@@ -318,6 +330,9 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
 
     expect(res.status).toBe(200);
     const data = (await res.json()) as {
+      processedPages: number;
+      nextContinuationToken: string | null;
+      done: boolean;
       total: number;
       eligible: number;
       skipped: number;
@@ -330,6 +345,9 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect(data.skipped).toBe(1);
     expect(data.renewed).toBe(1);
     expect(data.failed).toBe(1);
+    expect(data.processedPages).toBe(2);
+    expect(data.nextContinuationToken).toBeNull();
+    expect(data.done).toBe(true);
     expect(data.failedKeys[0]?.key).toBe("fails.bin");
     expect(data.failedKeys[0]?.error).toContain("AccessDenied");
 
@@ -340,6 +358,82 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect((listCalls[1][0] as MockCommand).input.ContinuationToken).toBe(
       "page-2-token",
     );
+  });
+
+  test("returns nextContinuationToken when maxPages limit is reached", async () => {
+    mockS3Send = mock((command: MockCommand) => {
+      if (commandName(command) === "HeadBucketCommand") {
+        return Promise.resolve({});
+      }
+      if (commandName(command) === "ListObjectsV2Command") {
+        if (!command.input.ContinuationToken) {
+          return Promise.resolve({
+            IsTruncated: true,
+            NextContinuationToken: "next-page",
+            Contents: [{ Key: "old-1.bin", LastModified: daysAgo(40) }],
+          });
+        }
+        throw new Error("should only read one page when maxPages=1");
+      }
+      throw new Error(`unexpected command: ${commandName(command)}`);
+    });
+
+    const res = await post(
+      "?dryRun=true&maxPages=1",
+      "test-secret-token-for-lifecycle-testing-minimum-32-chars",
+    );
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      processedPages: number;
+      nextContinuationToken: string | null;
+      done: boolean;
+      total: number;
+      eligible: number;
+    };
+    expect(data.processedPages).toBe(1);
+    expect(data.nextContinuationToken).toBe("next-page");
+    expect(data.done).toBe(false);
+    expect(data.total).toBe(1);
+    expect(data.eligible).toBe(1);
+
+    const listCalls = mockS3Send.mock.calls.filter(
+      (call) => commandName(call[0]) === "ListObjectsV2Command",
+    );
+    expect(listCalls.length).toBe(1);
+  });
+
+  test("starts listing from provided continuationToken", async () => {
+    mockS3Send = mock((command: MockCommand) => {
+      if (commandName(command) === "HeadBucketCommand") {
+        return Promise.resolve({});
+      }
+      if (commandName(command) === "ListObjectsV2Command") {
+        expect(command.input.ContinuationToken).toBe("resume-token");
+        return Promise.resolve({
+          IsTruncated: false,
+          Contents: [{ Key: "old-2.bin", LastModified: daysAgo(40) }],
+        });
+      }
+      throw new Error(`unexpected command: ${commandName(command)}`);
+    });
+
+    const res = await post(
+      "?dryRun=true&continuationToken=resume-token",
+      "test-secret-token-for-lifecycle-testing-minimum-32-chars",
+    );
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      processedPages: number;
+      nextContinuationToken: string | null;
+      done: boolean;
+      total: number;
+    };
+    expect(data.processedPages).toBe(1);
+    expect(data.nextContinuationToken).toBeNull();
+    expect(data.done).toBe(true);
+    expect(data.total).toBe(1);
   });
 
   test("returns 500 when bucket access check fails", async () => {

--- a/tests/migrate-timestamps.test.ts
+++ b/tests/migrate-timestamps.test.ts
@@ -279,7 +279,7 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect(copyCommand.input.ContentType).toBe("application/octet-stream");
     expect(copyCommand.input.Key).toBe("folder with space/file+name.bin");
     expect(copyCommand.input.CopySource).toBe(
-      "test-public-assets-bucket/folder%20with%20space/file%2Bname.bin",
+      "test-public-assets-bucket/folder with space/file+name.bin",
     );
   });
 

--- a/tests/migrate-timestamps.test.ts
+++ b/tests/migrate-timestamps.test.ts
@@ -215,7 +215,10 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
         return Promise.resolve({
           IsTruncated: false,
           Contents: [
-            { Key: "needs-refresh.bin", LastModified: daysAgo(60) },
+            {
+              Key: "folder with space/file+name.bin",
+              LastModified: daysAgo(60),
+            },
             { Key: "new.bin", LastModified: daysAgo(1) },
           ],
         });
@@ -274,6 +277,10 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     expect(copyCommand.input.MetadataDirective).toBe("COPY");
     expect(copyCommand.input.Metadata).toEqual({ source: "test" });
     expect(copyCommand.input.ContentType).toBe("application/octet-stream");
+    expect(copyCommand.input.Key).toBe("folder with space/file+name.bin");
+    expect(copyCommand.input.CopySource).toBe(
+      "test-public-assets-bucket/folder%20with%20space/file%2Bname.bin",
+    );
   });
 
   test("handles paginated listing and continues after individual copy failures", async () => {


### PR DESCRIPTION
## Summary
- add chunked execution controls to `POST /api/v2/assets/test/migrate-timestamps`
- support resume tokens via `continuationToken` + `nextContinuationToken`
- add `maxPages` cap per request and `done` flag for loop orchestration
- add optional `verbose=true` per-key success logs
- update docs and tests for resumable flow

## Why
Gateway timeouts (504) can interrupt full-bucket scans. This makes the one-time migration safe to run in bounded chunks through the public endpoint.

## Test
- `bun test tests/migrate-timestamps.test.ts`
- `bunx eslint src/api/v2/assets/handlers/migrate-timestamps.ts tests/migrate-timestamps.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add resumable pagination to `migrateTimestampsHandler` to avoid gateway timeouts by processing up to 50 pages per request with `maxPages` and `continuationToken`
> Add `maxPages`, `continuationToken`, and `verbose` query params; bound per-request processing with defaults; return `processedPages`, `nextContinuationToken`, `done`, and echo `maxPages`; update CopySource to avoid URL-encoding; update docs and tests.
>
> #### 📍Where to Start
> Start with the handler flow in `migrateTimestampsHandler` in [migrate-timestamps.ts](https://github.com/ephemeraHQ/convos-backend/pull/172/files#diff-5e708dfe1b68ce38e5a50bea951addfee74af871f8a659ab7b121d45ecefa8bf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5cf8d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset timestamp migration supports pagination (maxPages) and continuation tokens to process large buckets in chunks.
  * Responses now include pagination progress (processed pages, next continuation token, done) so clients can resume and track progress.
  * Optional verbose mode for more detailed migration logs.

* **Configuration**
  * Configurable rate limiting for asset renewals (per-device per-hour cap).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->