### PR TITLE
feat: add maxKeys control to timestamp migration endpoint

### DIFF
--- a/docs/plans/backend-asset-renewal.md
+++ b/docs/plans/backend-asset-renewal.md
@@ -503,6 +503,7 @@ Copy-to-self all existing objects in `PUBLIC_ASSETS_BUCKET` to reset `LastModifi
 //   ?olderThanDays=25 — only touch objects with LastModified older than N days (default: 25)
 //   ?concurrency=50   — parallel copy operations (default: 50, max: 200)
 //   ?maxPages=5       — maximum ListObjects pages to process in this request (default: 5, max: 50)
+//   ?maxKeys=1000     — max keys returned per ListObjectsV2 page (default: 1000, max: 1000)
 //   ?continuationToken=... — resume from previous response token
 //   ?verbose=true     — log each successfully renewed key
 
@@ -525,6 +526,7 @@ interface MigrateResponse {
   olderThanDays: number;
   concurrency: number;
   maxPages: number;
+  maxKeys: number;
   processedPages: number; // pages processed in this request
   nextContinuationToken: string | null; // pass back in next call
   done: boolean; // true when full bucket scan is complete
@@ -572,7 +574,7 @@ v2Router.post(
 - [ ] Deploy endpoint to dev and prod
 - [ ] Dry-run on dev: `curl -X POST -H "Authorization: Bearer $TOKEN" "$DEV_URL/api/v2/assets/test/migrate-timestamps?dryRun=true"`
 - [ ] Review report (total, eligible, skipped counts)
-- [ ] Execute on dev in chunks (set `maxPages`, loop using `nextContinuationToken` until `done=true`)
+- [ ] Execute on dev in chunks (set `maxPages` and `maxKeys`, loop using `nextContinuationToken` until `done=true`)
 - [ ] Verify per-chunk report (renewed, failed, verified counts)
 - [ ] Dry-run on prod, review report
 - [ ] Execute on prod in chunks, verify report

--- a/src/api/v2/assets/handlers/migrate-timestamps.ts
+++ b/src/api/v2/assets/handlers/migrate-timestamps.ts
@@ -24,6 +24,8 @@ const DEFAULT_CONCURRENCY = 50;
 const DEFAULT_OLDER_THAN_DAYS = 25;
 const MAX_PAGES_PER_REQUEST = 50;
 const DEFAULT_MAX_PAGES = 5;
+const MAX_S3_LIST_KEYS = 1000;
+const DEFAULT_MAX_KEYS = 1000;
 const MIN_VERIFICATION_SAMPLE = 5;
 const MAX_VERIFICATION_SAMPLE = 100;
 const MAX_RETRY_ATTEMPTS = 4;
@@ -63,6 +65,12 @@ const querySchema = z.object({
     .min(1)
     .max(MAX_PAGES_PER_REQUEST)
     .default(DEFAULT_MAX_PAGES),
+  maxKeys: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_S3_LIST_KEYS)
+    .default(DEFAULT_MAX_KEYS),
   continuationToken: z.preprocess((value) => {
     if (typeof value !== "string") {
       return value;
@@ -82,6 +90,7 @@ interface MigrateResponse {
   olderThanDays: number;
   concurrency: number;
   maxPages: number;
+  maxKeys: number;
   processedPages: number;
   nextContinuationToken: string | null;
   done: boolean;
@@ -275,6 +284,7 @@ function pickRandomSamples<T>(items: T[], sampleSize: number): T[] {
  *   olderThanDays=N     (default: 25) — only touch objects older than N days
  *   concurrency=N         (default: 50, max: 200) — parallel copy operations
  *   maxPages=N            (default: 5, max: 50) — pages to process per request
+ *   maxKeys=N             (default: 1000, max: 1000) — keys per listed page
  *   continuationToken=T   (optional) — resume listing from prior chunk token
  *   verbose=true|false    (default: false) — log every successfully renewed key
  *
@@ -305,7 +315,8 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
     throw error;
   }
 
-  const { dryRun, olderThanDays, concurrency, maxPages, verbose } = params;
+  const { dryRun, olderThanDays, concurrency, maxPages, maxKeys, verbose } =
+    params;
   const startTime = Date.now();
   const startContinuationToken = params.continuationToken;
 
@@ -316,6 +327,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
       olderThanDays,
       concurrency,
       maxPages,
+      maxKeys,
       continuationTokenProvided: Boolean(startContinuationToken),
       verbose,
     },
@@ -345,6 +357,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
       const listResponse = await client.send(
         new ListObjectsV2Command({
           Bucket: bucket,
+          MaxKeys: maxKeys,
           ContinuationToken: continuationToken,
         }),
       );
@@ -431,6 +444,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
           hasMorePages: Boolean(continuationToken),
           processedPages,
           maxPages,
+          maxKeys,
         },
         "Processed migration listing page",
       );
@@ -448,6 +462,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
         skipped,
         processedPages,
         maxPages,
+        maxKeys,
         done,
         hasNextContinuationToken: Boolean(nextContinuationToken),
         cutoff: cutoff.toISOString(),
@@ -463,6 +478,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
         olderThanDays,
         concurrency,
         maxPages,
+        maxKeys,
         processedPages,
         nextContinuationToken,
         done,
@@ -517,6 +533,7 @@ export async function migrateTimestampsHandler(req: Request, res: Response) {
       olderThanDays,
       concurrency,
       maxPages,
+      maxKeys,
       processedPages,
       nextContinuationToken,
       done,

--- a/tests/migrate-timestamps.test.ts
+++ b/tests/migrate-timestamps.test.ts
@@ -15,6 +15,7 @@ import { pinoMiddleware } from "@/middleware/pino";
 
 interface MockCommandInput {
   Bucket?: string;
+  MaxKeys?: number;
   ContinuationToken?: string;
   CopySource?: string;
   Key?: string;
@@ -197,7 +198,7 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
 
   test("rejects invalid query parameters", async () => {
     const res = await post(
-      "?concurrency=999&olderThanDays=366",
+      "?concurrency=999&olderThanDays=366&maxKeys=1001",
       "test-secret-token-for-lifecycle-testing-minimum-32-chars",
     );
 
@@ -386,18 +387,20 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
     });
 
     const res = await post(
-      "?dryRun=true&maxPages=1",
+      "?dryRun=true&maxPages=1&maxKeys=42",
       "test-secret-token-for-lifecycle-testing-minimum-32-chars",
     );
 
     expect(res.status).toBe(200);
     const data = (await res.json()) as {
+      maxKeys: number;
       processedPages: number;
       nextContinuationToken: string | null;
       done: boolean;
       total: number;
       eligible: number;
     };
+    expect(data.maxKeys).toBe(42);
     expect(data.processedPages).toBe(1);
     expect(data.nextContinuationToken).toBe("next-page");
     expect(data.done).toBe(false);
@@ -408,6 +411,7 @@ describe("POST /api/v2/assets/test/migrate-timestamps", () => {
       (call) => commandName(call[0]) === "ListObjectsV2Command",
     );
     expect(listCalls.length).toBe(1);
+    expect((listCalls[0][0] as MockCommand).input.MaxKeys).toBe(42);
   });
 
   test("starts listing from provided continuationToken", async () => {


### PR DESCRIPTION
## Summary
- add `maxKeys` query param to `POST /api/v2/assets/test/migrate-timestamps`
- pass `maxKeys` into `ListObjectsV2Command.MaxKeys` to reduce per-request work and avoid gateway timeouts
- include `maxKeys` in response/log payloads
- update tests and migration plan docs

## Testing
- `bun test tests/migrate-timestamps.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `maxKeys` query control to `migrate-timestamps` endpoint to set S3 page size between 1 and 1000
> Add `maxKeys` to request validation and response, pass `MaxKeys` to `ListObjectsV2Command`, and update tests and docs; default and max are 1000.
>
> #### 📍Where to Start
> Start with the `migrateTimestampsHandler` in [migrate-timestamps.ts](https://github.com/ephemeraHQ/convos-backend/pull/174/files#diff-5e708dfe1b68ce38e5a50bea951addfee74af871f8a659ab7b121d45ecefa8bf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e263dc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->