### PR TITLE
Rename convos-agent to Assistant

### DIFF
--- a/docs/plans/agent-invite-endpoint-plan.md
+++ b/docs/plans/agent-invite-endpoint-plan.md
@@ -54,7 +54,7 @@ POST /api/v2/agents/join
 - Constructs the full invite URL from the slug (using the correct domain based on `XMTP_ENV`)
 - Calls `POST <AGENT_POOL_URL>/api/pool/claim` with:
   - `joinUrl` — the full invite URL
-  - `agentName` — `"convos-agent"`
+  - `agentName` — `"Assistant"`
   - `instructions` — from client if provided, otherwise defaults to `"You are a helpful assistant."`
 - Returns result to iOS client
 

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -49,7 +49,7 @@ export async function joinHandler(req: Request, res: Response) {
       },
       signal: AbortSignal.timeout(30_000),
       body: JSON.stringify({
-        agentName: "convos-agent",
+        agentName: "Assistant",
         instructions: instructions || "You are a helpful assistant.",
         joinUrl,
       }),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Rename agent name from `convos-agent` to `Assistant` in agent pool claim requests
Updates the `agentName` field sent in the JSON body of the agent pool claim request in [join.ts](https://github.com/ephemeraHQ/convos-backend/pull/175/files#diff-56b3806a78b9509421cf23cd82891715d11c219bad27f45a5a9ff9665a18cd7c) and the corresponding plan document.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29cea32.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated agent service naming conventions for improved clarity in service integrations.

* **Documentation**
  * Updated technical documentation reflecting agent naming changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->