### PR TITLE
feat: add X-Force-Error header to simulate agent join failures

### DIFF
--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -13,7 +13,49 @@ function buildInviteUrl(slug: string): string {
   return `https://${domain}/v2?i=${encodeURIComponent(slug)}`;
 }
 
+/**
+ * Handler for POST /api/v2/agents/join
+ *
+ * Requests an AI agent to join a conversation by claiming an idle instance
+ * from the agent pool and directing it to the conversation's invite URL.
+ *
+ * ## Testing with forced errors
+ *
+ * Send the `X-Force-Error` header to simulate error responses without
+ * hitting the real agent pool. The response is delayed by 5 seconds to
+ * mimic real-world latency. Works in all environments (dev & production).
+ *
+ * | Header value       | Simulated response                  |
+ * |--------------------|-------------------------------------|
+ * | `X-Force-Error: 502` | 502 AGENT_PROVISION_FAILED        |
+ * | `X-Force-Error: 503` | 503 NO_AGENTS_AVAILABLE           |
+ * | `X-Force-Error: 504` | 504 AGENT_POOL_TIMEOUT            |
+ *
+ * Example:
+ * ```
+ * curl -X POST https://api.convos.org/api/v2/agents/join \
+ *   -H "Authorization: Bearer <jwt>" \
+ *   -H "Content-Type: application/json" \
+ *   -H "X-Force-Error: 502" \
+ *   -d '{"slug": "test-slug"}'
+ * ```
+ */
 export async function joinHandler(req: Request, res: Response) {
+  // Force error responses for testing — see JSDoc above for usage
+  const forceError = req.headers["x-force-error"];
+  if (forceError === "502" || forceError === "503" || forceError === "504") {
+    const status = Number(forceError);
+    const errorMap: Record<number, { error: string; message: string }> = {
+      502: { error: "AGENT_PROVISION_FAILED", message: "Failed to provision agent" },
+      503: { error: "NO_AGENTS_AVAILABLE", message: "No agents are currently available" },
+      504: { error: "AGENT_POOL_TIMEOUT", message: "Agent pool request timed out" },
+    };
+    req.log.warn(`Forcing ${status} ${errorMap[status].error} for testing (5s delay)`);
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    res.status(status).json({ success: false, ...errorMap[status] });
+    return;
+  }
+
   if (!AGENT_POOL_URL || !AGENT_POOL_API_KEY) {
     req.log.error("Agent pool not configured");
     res.status(503).json({

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -7,6 +7,14 @@ const bodySchema = z.object({
   instructions: z.string().max(4096, "Instructions too long").optional(),
 });
 
+const FORCE_ERROR_DELAY_MS = 5_000;
+
+const ERRORS = {
+  AGENT_PROVISION_FAILED: { status: 502, error: "AGENT_PROVISION_FAILED", message: "Failed to provision agent" },
+  NO_AGENTS_AVAILABLE: { status: 503, error: "NO_AGENTS_AVAILABLE", message: "No agents are currently available" },
+  AGENT_POOL_TIMEOUT: { status: 504, error: "AGENT_POOL_TIMEOUT", message: "Agent pool request timed out" },
+} as const;
+
 function buildInviteUrl(slug: string): string {
   const domain =
     XMTP_ENV === "production" ? "popup.convos.org" : "dev.convos.org";
@@ -43,16 +51,12 @@ function buildInviteUrl(slug: string): string {
 export async function joinHandler(req: Request, res: Response) {
   // Force error responses for testing — see JSDoc above for usage
   const forceError = req.headers["x-force-error"];
-  if (forceError === "502" || forceError === "503" || forceError === "504") {
-    const status = Number(forceError);
-    const errorMap: Record<number, { error: string; message: string }> = {
-      502: { error: "AGENT_PROVISION_FAILED", message: "Failed to provision agent" },
-      503: { error: "NO_AGENTS_AVAILABLE", message: "No agents are currently available" },
-      504: { error: "AGENT_POOL_TIMEOUT", message: "Agent pool request timed out" },
-    };
-    req.log.warn(`Forcing ${status} ${errorMap[status].error} for testing (5s delay)`);
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-    res.status(status).json({ success: false, ...errorMap[status] });
+  const forcedError = Object.values(ERRORS).find((e) => String(e.status) === forceError);
+  if (forcedError) {
+    req.log.warn(`Forcing ${forcedError.status} ${forcedError.error} for testing (${FORCE_ERROR_DELAY_MS}ms delay)`);
+    await new Promise((resolve) => setTimeout(resolve, FORCE_ERROR_DELAY_MS));
+    const { status, ...body } = forcedError;
+    res.status(status).json({ success: false, ...body });
     return;
   }
 
@@ -105,19 +109,13 @@ export async function joinHandler(req: Request, res: Response) {
       );
 
       if (poolRes.status === 503 || poolRes.status === 404) {
-        res.status(503).json({
-          success: false,
-          error: "NO_AGENTS_AVAILABLE",
-          message: "No agents are currently available",
-        });
+        const { status, ...body } = ERRORS.NO_AGENTS_AVAILABLE;
+        res.status(status).json({ success: false, ...body });
         return;
       }
 
-      res.status(502).json({
-        success: false,
-        error: "AGENT_PROVISION_FAILED",
-        message: "Failed to provision agent",
-      });
+      const { status, ...body } = ERRORS.AGENT_PROVISION_FAILED;
+      res.status(status).json({ success: false, ...body });
       return;
     }
 
@@ -131,11 +129,8 @@ export async function joinHandler(req: Request, res: Response) {
   } catch (error) {
     if (error instanceof DOMException && error.name === "TimeoutError") {
       req.log.error("Agent pool request timed out");
-      res.status(504).json({
-        success: false,
-        error: "AGENT_POOL_TIMEOUT",
-        message: "Agent pool request timed out",
-      });
+      const { status, ...body } = ERRORS.AGENT_POOL_TIMEOUT;
+      res.status(status).json({ success: false, ...body });
       return;
     }
 
@@ -143,11 +138,8 @@ export async function joinHandler(req: Request, res: Response) {
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Agent pool request failed",
     );
-    res.status(502).json({
-      success: false,
-      error: "AGENT_PROVISION_FAILED",
-      message: "Failed to provision agent",
-    });
+    const { status, ...body } = ERRORS.AGENT_PROVISION_FAILED;
+    res.status(status).json({ success: false, ...body });
     return;
   }
 }

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -10,9 +10,21 @@ const bodySchema = z.object({
 const FORCE_ERROR_DELAY_MS = 5_000;
 
 const ERRORS = {
-  AGENT_PROVISION_FAILED: { status: 502, error: "AGENT_PROVISION_FAILED", message: "Failed to provision agent" },
-  NO_AGENTS_AVAILABLE: { status: 503, error: "NO_AGENTS_AVAILABLE", message: "No agents are currently available" },
-  AGENT_POOL_TIMEOUT: { status: 504, error: "AGENT_POOL_TIMEOUT", message: "Agent pool request timed out" },
+  AGENT_PROVISION_FAILED: {
+    status: 502,
+    error: "AGENT_PROVISION_FAILED",
+    message: "Failed to provision agent",
+  },
+  NO_AGENTS_AVAILABLE: {
+    status: 503,
+    error: "NO_AGENTS_AVAILABLE",
+    message: "No agents are currently available",
+  },
+  AGENT_POOL_TIMEOUT: {
+    status: 504,
+    error: "AGENT_POOL_TIMEOUT",
+    message: "Agent pool request timed out",
+  },
 } as const;
 
 function buildInviteUrl(slug: string): string {
@@ -52,10 +64,15 @@ function buildInviteUrl(slug: string): string {
  */
 export async function joinHandler(req: Request, res: Response) {
   // Force error responses for testing (non-production XMTP env only) — see JSDoc above for usage
-  const forceError = XMTP_ENV !== "production" ? req.headers["x-force-error"] : undefined;
-  const forcedError = Object.values(ERRORS).find((e) => String(e.status) === forceError);
+  const forceError =
+    XMTP_ENV !== "production" ? req.headers["x-force-error"] : undefined;
+  const forcedError = Object.values(ERRORS).find(
+    (e) => String(e.status) === forceError,
+  );
   if (forcedError) {
-    req.log.warn(`Forcing ${forcedError.status} ${forcedError.error} for testing (${FORCE_ERROR_DELAY_MS}ms delay)`);
+    req.log.warn(
+      `Forcing ${forcedError.status} ${forcedError.error} for testing (${FORCE_ERROR_DELAY_MS}ms delay)`,
+    );
     await new Promise((resolve) => setTimeout(resolve, FORCE_ERROR_DELAY_MS));
     const { status, ...body } = forcedError;
     res.status(status).json({ success: false, ...body });

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
-import { AGENT_POOL_API_KEY, AGENT_POOL_URL, IS_DEVELOPMENT, XMTP_ENV } from "@/config";
+import { AGENT_POOL_API_KEY, AGENT_POOL_URL, XMTP_ENV } from "@/config";
 
 const bodySchema = z.object({
   slug: z.string().min(1, "Slug is required").max(2048),
@@ -31,7 +31,7 @@ function buildInviteUrl(slug: string): string {
  *
  * Send the `X-Force-Error` header to simulate error responses without
  * hitting the real agent pool. The response is delayed by 5 seconds to
- * mimic real-world latency. Only available in development (`IS_DEVELOPMENT`).
+ * mimic real-world latency. Only available when `XMTP_ENV` is not `"production"`.
  * In production, the `X-Force-Error` header is silently ignored and normal
  * logic proceeds.
  *
@@ -51,8 +51,8 @@ function buildInviteUrl(slug: string): string {
  * ```
  */
 export async function joinHandler(req: Request, res: Response) {
-  // Force error responses for testing (development only) — see JSDoc above for usage
-  const forceError = IS_DEVELOPMENT ? req.headers["x-force-error"] : undefined;
+  // Force error responses for testing (non-production XMTP env only) — see JSDoc above for usage
+  const forceError = XMTP_ENV !== "production" ? req.headers["x-force-error"] : undefined;
   const forcedError = Object.values(ERRORS).find((e) => String(e.status) === forceError);
   if (forcedError) {
     req.log.warn(`Forcing ${forcedError.status} ${forcedError.error} for testing (${FORCE_ERROR_DELAY_MS}ms delay)`);

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
-import { AGENT_POOL_API_KEY, AGENT_POOL_URL, XMTP_ENV } from "@/config";
+import { AGENT_POOL_API_KEY, AGENT_POOL_URL, IS_DEVELOPMENT, XMTP_ENV } from "@/config";
 
 const bodySchema = z.object({
   slug: z.string().min(1, "Slug is required").max(2048),
@@ -31,7 +31,9 @@ function buildInviteUrl(slug: string): string {
  *
  * Send the `X-Force-Error` header to simulate error responses without
  * hitting the real agent pool. The response is delayed by 5 seconds to
- * mimic real-world latency. Works in all environments (dev & production).
+ * mimic real-world latency. Only available in development (`IS_DEVELOPMENT`).
+ * In production, the `X-Force-Error` header is silently ignored and normal
+ * logic proceeds.
  *
  * | Header value       | Simulated response                  |
  * |--------------------|-------------------------------------|
@@ -49,8 +51,8 @@ function buildInviteUrl(slug: string): string {
  * ```
  */
 export async function joinHandler(req: Request, res: Response) {
-  // Force error responses for testing — see JSDoc above for usage
-  const forceError = req.headers["x-force-error"];
+  // Force error responses for testing (development only) — see JSDoc above for usage
+  const forceError = IS_DEVELOPMENT ? req.headers["x-force-error"] : undefined;
   const forcedError = Object.values(ERRORS).find((e) => String(e.status) === forceError);
   if (forcedError) {
     req.log.warn(`Forcing ${forcedError.status} ${forcedError.error} for testing (${FORCE_ERROR_DELAY_MS}ms delay)`);


### PR DESCRIPTION
## What

Adds an `X-Force-Error` header to `POST /api/v2/agents/join` that lets clients simulate error responses for testing.

## Why

The iOS app is implementing in-chat error UX for the assistant join flow (pending → error → retry). This lets QA and developers trigger all three error states without needing to actually break the agent pool.

## How

Send the `X-Force-Error` header with a status code:

| Header value | Simulated response |
|---|---|
| `X-Force-Error: 502` | 502 `AGENT_PROVISION_FAILED` |
| `X-Force-Error: 503` | 503 `NO_AGENTS_AVAILABLE` |
| `X-Force-Error: 504` | 504 `AGENT_POOL_TIMEOUT` |

- Responds after a **5-second delay** to simulate real latency
- Returns **identical payloads** to real errors
- No header = normal behavior (zero impact on existing flow)
- Works in all environments (dev & production)

## Testing

```bash
curl -X POST https://api.convos.org/api/v2/agents/join \
  -H "Authorization: Bearer <jwt>" \
  -H "Content-Type: application/json" \
  -H "X-Force-Error: 502" \
  -d '{"slug": "test-slug"}'
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `X-Force-Error` header support to simulate agent join failures
> - Adds early-exit logic in [join.ts](https://github.com/ephemeraHQ/convos-backend/pull/176/files#diff-56b3806a78b9509421cf23cd82891715d11c219bad27f45a5a9ff9665a18cd7c) that checks for an `X-Force-Error` header matching 502, 503, or 504, waits 5 seconds, then returns the corresponding structured error response.
> - Centralizes all error response construction into a new `ERRORS` constant mapping status codes to structured descriptors (`AGENT_PROVISION_FAILED`, `NO_AGENTS_AVAILABLE`, `AGENT_POOL_TIMEOUT`), replacing inline literals throughout the handler.
> - Behavioral Change: existing error response payloads are now sourced from `ERRORS` rather than inline — status codes and payload fields are unchanged.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #176 opened
>
> - Restricted `X-Force-Error` header processing in `joinHandler` to development environments only [c8e232c]
> - Changed forced error simulation gating in `joinHandler` from `IS_DEVELOPMENT` flag to `XMTP_ENV !== 'production'` check [ad2bb17]
> - Reformatted code in agent join handler for readability [4a8414b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66e4a05.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error responses so failures return consistent status codes and messages.

* **Documentation**
  * Expanded docs describing error scenarios and how to exercise error responses for testing.

* **Tests**
  * Added a configurable testing path to simulate delayed error responses (502/503/504) in non-production environments to validate client handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->