### PR TITLE
docs: agent asset upload plan (AGNT-41)

### DIFF
--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -103,13 +103,12 @@ v2Router.use("/agents/assets", agentApiKeyAuth, agentAssetsRouter);
 
 Agent-uploaded assets follow the same 30-day lifecycle. However, **iOS currently only renews its own PFP and the group image** — it does not renew other members' PFPs or images sent in chat. This means agent profile pictures and any files agents share in messages would expire after 30 days with no one renewing them.
 
-**❓ Team decision needed: who is responsible for renewing agent assets?**
+**Decision:** Agents renew their own assets. Two strategies:
 
-Options:
-- **A) Extend iOS renewal to include agent PFPs** — iOS already calls `POST /api/v2/assets/renew-batch`; expand the scan to include other members' profile images
-- **B) Agent pool renews its own assets** — pool manager periodically renews assets for active agents
-- **C) Backend renews agent assets** — a scheduled job renews all assets under `agents/` prefix
-- **D) Accept expiry** — agent PFPs expire after 30 days, agent would need to re-upload if still active
+1. **On activity** — when an agent becomes active (sends/receives a message), it renews its assets
+2. **Scheduled** — agent pool runs a cron job around the 30-day mark, renews assets for agents that have had recent group activity
+
+Agents need access to `POST /api/v2/assets/renew-batch` using the same `AGENT_ASSETS_API_KEY` auth. This endpoint currently uses JWT auth — needs to also accept agent API key auth.
 
 ---
 
@@ -152,6 +151,7 @@ The encryption materials (key) are already stored in `appData` and implemented o
 | `src/api/v2/agents/assets/agent-assets.router.ts` | **New** — router with presigned URL endpoint |
 | `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, adds `agents/` prefix) |
 | `src/api/v2/index.ts` | Mount agent assets router |
+| `src/api/v2/agents/assets/agent-assets.router.ts` | Also mount `POST /renew-batch` for agents |
 
 ---
 
@@ -196,6 +196,6 @@ export const agentAssetLimiter = rateLimit({
 |---|----------|--------|
 | 1 | ~~Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`?~~ | ✅ New separate `AGENT_ASSETS_API_KEY` |
 | 2 | ~~Rate limit for agent uploads?~~ | ✅ 50/min |
-| 3 | Content type restrictions? | ❓ Open — images only? Or any file type? |
-| 4 | ~~CLI encryption work tracked?~~ | ✅ TODO in convos-cli |
-| 5 | Who renews agent PFPs to prevent 30-day expiry? | ❓ Open — iOS currently only renews own PFP + group image |
+| 3 | ~~Content type restrictions?~~ | ✅ Any file type — needed in near-term |
+| 4 | ~~CLI encryption work tracked?~~ | ✅ In progress — [convos-cli#15](https://github.com/xmtplabs/convos-cli/pull/15) |
+| 5 | ~~Who renews agent PFPs?~~ | ✅ Agents renew their own assets (see below) |

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -16,7 +16,7 @@ PR [convos-cli#11](https://github.com/xmtplabs/convos-cli/pull/11) migrated conv
 
 | Decision           | Outcome                                                                                                              |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| **Bucket**         | Same `PUBLIC_ASSETS_BUCKET`, dedicated route/directory: assistant/\*                                                 |
+| **Bucket**         | Same `PUBLIC_ASSETS_BUCKET`, dedicated route/directory: `a/*`                                                        |
 | **Retention**      | Same 30-day rolling policy (same as user PFPs and group images)                                                      |
 | **Auth**           | Dedicated auth mechanism — shared API key between agent pool and backend (like existing `AGENT_POOL_API_KEY`)        |
 | **Endpoint**       | New dedicated upload route for agents                                                                                |
@@ -32,7 +32,6 @@ Agent (convos-cli)          convos-backend                    S3
   │                              │                             │
   │  GET /api/v2/agents/assets/presigned-url                   │
   │  (X-Agent-API-Key)           │                             │
-  │  ?contentType=image/png      │                             │
   │ ───────────────────────────> │                             │
   │                              │  Generate presigned PUT URL │
   │      { uploadUrl, assetUrl,  │                             │
@@ -92,13 +91,19 @@ export const agentApiKeyAuth = (
 Mirrors the existing `GET /api/v2/attachments/presigned-url` but:
 
 - Uses `agentApiKeyAuth` middleware instead of JWT auth
-- Stores files under `agents/` prefix in the same bucket
+- Stores files under `a/` prefix in the same bucket
+- Content-type is hardcoded to `application/octet-stream` — uploads are always encrypted binary blobs, no `?contentType` param needed, no file extension in the key
 - Same CDN base URL
 - Same presigned URL expiry (1 hour)
 
 ```typescript
-// Key generation with agents/ prefix
-const objectKey = `agents/${uuidv4()}${extension ? `.${extension}` : ""}`;
+const objectKey = `a/${uuidv4()}`;
+
+const command = new PutObjectCommand({
+  Bucket: env.PUBLIC_ASSETS_BUCKET,
+  Key: objectKey,
+  ContentType: "application/octet-stream",
+});
 ```
 
 ### 4. Wire up in router
@@ -131,12 +136,11 @@ Agents need access to `POST /api/v2/assets/renew-batch` using the same `AGENT_AS
 PUBLIC_ASSETS_BUCKET/
 ├── <uuid>.png              ← user uploads (existing)
 ├── <uuid>.jpg              ← user uploads (existing)
-└── agents/
-    ├── <uuid>.png          ← agent uploads (new)
-    └── <uuid>.jpg          ← agent uploads (new)
+└── a/
+    └── <uuid>              ← agent uploads (new, no extension — always octet-stream)
 ```
 
-The `agents/` prefix is purely organizational — same lifecycle rules apply (S3 lifecycle is bucket-wide based on `LastModified`).
+The `a/` prefix is purely organizational — same lifecycle rules apply (S3 lifecycle is bucket-wide based on `LastModified`).
 
 ---
 
@@ -162,7 +166,7 @@ The encryption materials (key) are already stored in `appData` and implemented o
 | `src/config.ts`                                          | Add `AGENT_ASSETS_API_KEY` export                                         |
 | `src/middleware/agentAuth.ts`                            | **New** — API key auth middleware (503 on missing config, 401 on bad key) |
 | `src/api/v2/agents/assets/agent-assets.router.ts`        | **New** — router with presigned URL endpoint                              |
-| `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, adds `agents/` prefix)               |
+| `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, `a/` prefix, hardcoded octet-stream) |
 | `src/api/v2/assets/handlers/renew-batch.ts`              | Also accept `agentApiKeyAuth` (currently JWT-only)                        |
 | `src/api/v2/index.ts`                                    | Mount agent assets router **before** `/agents` (order matters)            |
 
@@ -189,7 +193,7 @@ export const agentAssetLimiter = rateLimit({
 - **API key auth is simpler than JWT** — acceptable because agents are trusted server-side processes, not end-user clients
 - **Key rotation** — if compromised, rotate the env var and redeploy. No device re-registration needed
 - **No AppCheck** — agents can't do device attestation. The API key is the trust boundary
-- **S3 prefix isolation** — `agents/` prefix lets us audit/delete agent files independently if needed
+- **S3 prefix isolation** — `a/` prefix lets us audit/delete agent files independently if needed
 
 ---
 
@@ -209,6 +213,6 @@ export const agentAssetLimiter = rateLimit({
 | --- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | 1   | ~~Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`?~~ | ✅ New separate `AGENT_ASSETS_API_KEY`                                           |
 | 2   | ~~Rate limit for agent uploads?~~                             | ✅ 50/min                                                                        |
-| 3   | ~~Content type restrictions?~~                                | ✅ Any file type — needed in near-term                                           |
+| 3   | ~~Content type restrictions?~~                                | ✅ Always `application/octet-stream` — uploads are encrypted binary              |
 | 4   | ~~CLI encryption work tracked?~~                              | ✅ In progress — [convos-cli#15](https://github.com/xmtplabs/convos-cli/pull/15) |
 | 5   | ~~Who renews agent PFPs?~~                                    | ✅ Agents renew their own assets (see below)                                     |

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -74,8 +74,12 @@ export const agentApiKeyAuth = (
   res: Response,
   next: NextFunction,
 ) => {
+  if (!AGENT_ASSETS_API_KEY) {
+    res.status(503).json({ error: "Agent assets API key not configured" });
+    return;
+  }
   const apiKey = req.header("X-Agent-API-Key");
-  if (!AGENT_ASSETS_API_KEY || apiKey !== AGENT_ASSETS_API_KEY) {
+  if (apiKey !== AGENT_ASSETS_API_KEY) {
     res.status(401).json({ error: "Invalid or missing agent API key" });
     return;
   }
@@ -101,7 +105,11 @@ const objectKey = `agents/${uuidv4()}${extension ? `.${extension}` : ""}`;
 
 ```typescript
 // src/api/v2/index.ts
+// ⚠️ Must be mounted BEFORE /agents — Express matches routes in order,
+// so /agents/assets/* would otherwise be caught by the broader /agents route
+// and routed through JWT authMiddleware instead of agentApiKeyAuth.
 v2Router.use("/agents/assets", agentApiKeyAuth, agentAssetsRouter);
+v2Router.use("/agents", agentJoinLimiter, authMiddleware, agentsRouter);
 ```
 
 ### 5. Renewal — who renews agent assets?
@@ -114,6 +122,25 @@ Agent-uploaded assets follow the same 30-day lifecycle. However, **iOS currently
 2. **Scheduled** — agent pool runs a cron job around the 30-day mark, renews assets for agents that have had recent group activity
 
 Agents need access to `POST /api/v2/assets/renew-batch` using the same `AGENT_ASSETS_API_KEY` auth. This endpoint currently uses JWT auth — needs to also accept agent API key auth.
+
+#### 5a. Durable asset inventory
+
+`POST /api/v2/assets/renew-batch` requires explicit `assetKeys`. The cron job has no way to discover which keys to pass after a restart unless asset metadata is persisted somewhere.
+
+**Solution:** Add an `agent_assets` table:
+
+```sql
+CREATE TABLE agent_assets (
+  object_key  TEXT        NOT NULL PRIMARY KEY,
+  uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+- The `get-presigned-url` handler writes a row after generating the key (before returning the response).
+- A new `GET /api/v2/agents/assets/keys-due-for-renewal` endpoint (protected by `agentApiKeyAuth`) returns keys where `uploaded_at` is between 27–30 days ago, paginated to ≤ 100 per page (matching `MAX_BATCH_SIZE`).
+- The renewal cron calls that endpoint to build its batch, then calls `POST /api/v2/assets/renew-batch`. On success, the handler bumps `uploaded_at` to `now()` so the 30-day clock resets.
+
+This keeps the backend authoritative about which keys exist and when they expire, with no per-agent identity tracking required.
 
 ---
 
@@ -149,14 +176,16 @@ The encryption materials (key) are already stored in `appData` and implemented o
 
 ## Files to Create/Modify
 
-| File                                                     | Change                                                      |
-| -------------------------------------------------------- | ----------------------------------------------------------- |
-| `src/config.ts`                                          | Add `AGENT_ASSETS_API_KEY` export                           |
-| `src/middleware/agentAuth.ts`                            | **New** — API key auth middleware                           |
-| `src/api/v2/agents/assets/agent-assets.router.ts`        | **New** — router with presigned URL endpoint                |
-| `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, adds `agents/` prefix) |
-| `src/api/v2/index.ts`                                    | Mount agent assets router                                   |
-| `src/api/v2/agents/assets/agent-assets.router.ts`        | Also mount `POST /renew-batch` for agents                   |
+| File                                                               | Change                                                                           |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `src/config.ts`                                                    | Add `AGENT_ASSETS_API_KEY` export                                                |
+| `src/middleware/agentAuth.ts`                                      | **New** — API key auth middleware (503 on missing config, 401 on bad key)        |
+| `src/api/v2/agents/assets/agent-assets.router.ts`                  | **New** — router with presigned URL + renewal-keys endpoints                     |
+| `src/api/v2/agents/assets/handlers/get-presigned-url.ts`           | **New** — handler (mirrors existing, adds `agents/` prefix, inserts to DB)       |
+| `src/api/v2/agents/assets/handlers/get-keys-due-for-renewal.ts`    | **New** — returns agent asset keys 27–30 days old                                |
+| `src/api/v2/assets/handlers/renew-batch.ts`                        | Bump `uploaded_at` in `agent_assets` after successful copy                       |
+| `src/api/v2/index.ts`                                              | Mount agent assets router **before** `/agents` (order matters)                   |
+| migrations                                                         | **New** — `agent_assets` table (`object_key PK`, `uploaded_at`)                  |
 
 ---
 

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -101,11 +101,17 @@ const objectKey = `agents/${uuidv4()}${extension ? `.${extension}` : ""}`;
 v2Router.use("/agents/assets", agentApiKeyAuth, agentAssetsRouter);
 ```
 
-### 5. Renewal — iOS client handles it
+### 5. Renewal — who renews agent assets?
 
-Agent-uploaded assets follow the same 30-day lifecycle. The iOS client already scans conversation messages for asset URLs to renew via `POST /api/v2/assets/renew-batch`. Agent message attachments (including profile pics) will be included in that scan — no backend changes needed for renewal.
+Agent-uploaded assets follow the same 30-day lifecycle. However, **iOS currently only renews its own PFP and the group image** — it does not renew other members' PFPs or images sent in chat. This means agent profile pictures and any files agents share in messages would expire after 30 days with no one renewing them.
 
-If no client renews them, they expire after 30 days. This is the same behavior as user-uploaded assets.
+**❓ Team decision needed: who is responsible for renewing agent assets?**
+
+Options:
+- **A) Extend iOS renewal to include agent PFPs** — iOS already calls `POST /api/v2/assets/renew-batch`; expand the scan to include other members' profile images
+- **B) Agent pool renews its own assets** — pool manager periodically renews assets for active agents
+- **C) Backend renews agent assets** — a scheduled job renews all assets under `agents/` prefix
+- **D) Accept expiry** — agent PFPs expire after 30 days, agent would need to re-upload if still active
 
 ---
 
@@ -194,3 +200,4 @@ export const agentAssetLimiter = rateLimit({
 | 2 | Rate limit for agent uploads? | 30/min? More? Less? |
 | 3 | Content type restrictions? | Images only? Or any file type? |
 | 4 | Is CLI encryption work tracked separately? | @Jarod needs to implement `EncryptedProfileImage` in convos-cli |
+| 5 | Who renews agent PFPs to prevent 30-day expiry? | iOS currently only renews own PFP + group image, not other members' PFPs or chat images |

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -1,0 +1,196 @@
+# Agent Asset Upload — Auth & S3 Endpoint
+
+**Status:** Draft
+**Linear:** [AGNT-41](https://linear.app/convos/issue/AGNT-41/add-agent-asset-upload-auth-and-s3-endpoint)
+**Assignee:** @louis
+
+## Context
+
+Agents (AI assistants via convos-cli) need to upload files to S3 — starting with profile pictures, but also for general image handling in conversations. The current upload flow (`GET /api/v2/attachments/presigned-url`) requires iOS device auth (AppCheck → JWT), which agents can't use.
+
+### What broke
+
+PR [convos-cli#11](https://github.com/xmtplabs/convos-cli/pull/11) migrated conversation profiles from `appData` (shared protobuf blob) to dedicated `ProfileUpdate` XMTP messages. The old proto had a plain `image` string field (field 3) that accepted raw URLs. The new proto only has `encrypted_image` (field 2, `EncryptedProfileImage`). The CLI's `update-profile --image <url>` command silently discards the image — it reports success but the image is never included in the `ProfileUpdate` message. See [convos-cli#14](https://github.com/xmtplabs/convos-cli/issues/14).
+
+### Decisions from team discussion (2026-03-10)
+
+| Decision | Outcome |
+|----------|---------|
+| **Bucket** | Same `PUBLIC_ASSETS_BUCKET`, dedicated route |
+| **Retention** | Same 30-day rolling policy (same as user PFPs) |
+| **Auth** | Dedicated auth mechanism — shared API key between agent pool and backend (like existing `AGENT_POOL_API_KEY`) |
+| **Endpoint** | New dedicated upload route for agents |
+| **Encryption** | Agents should encrypt profile photos same as users (encryption materials are in `appData`, can be replicated in CLI) |
+| **Infrastructure** | Keep everything in one AWS account, Terraform-managed (xmtp-infra repo) |
+
+---
+
+## Architecture
+
+```
+Agent (convos-cli)          convos-backend                    S3
+  │                              │                             │
+  │  GET /api/v2/agents/assets/presigned-url                   │
+  │  (X-Agent-API-Key)           │                             │
+  │  ?contentType=image/png      │                             │
+  │ ───────────────────────────> │                             │
+  │                              │  Generate presigned PUT URL │
+  │      { uploadUrl, assetUrl,  │                             │
+  │        objectKey }           │                             │
+  │ <─────────────────────────── │                             │
+  │                                                            │
+  │  PUT <uploadUrl>                                           │
+  │  (file data)                                               │
+  │ ─────────────────────────────────────────────────────────> │
+  │        200 OK                                              │
+  │ <───────────────────────────────────────────────────────── │
+  │                                                            │
+  │  [encrypt image, send ProfileUpdate via XMTP               │
+  │   or send as message attachment]                           │
+```
+
+---
+
+## Implementation
+
+### 1. New env var
+
+```
+AGENT_ASSETS_API_KEY=<shared secret>
+```
+
+Shared between convos-backend and the agent pool/CLI. Added to `src/config.ts` as optional (endpoint returns 503 if not configured). Managed via Terraform in xmtp-infra.
+
+Can reuse `AGENT_POOL_API_KEY` if the team prefers a single shared secret, but a separate key gives independent rotation.
+
+**❓ Team decision: reuse `AGENT_POOL_API_KEY` or separate `AGENT_ASSETS_API_KEY`?**
+
+### 2. New middleware: `agentApiKeyAuth`
+
+Simple API key check — no AppCheck, no JWT, no device registration.
+
+```typescript
+// src/middleware/agentAuth.ts
+export const agentApiKeyAuth = (req: Request, res: Response, next: NextFunction) => {
+  const apiKey = req.header("X-Agent-API-Key");
+  if (!AGENT_ASSETS_API_KEY || apiKey !== AGENT_ASSETS_API_KEY) {
+    res.status(401).json({ error: "Invalid or missing agent API key" });
+    return;
+  }
+  next();
+};
+```
+
+### 3. New route: `GET /api/v2/agents/assets/presigned-url`
+
+Mirrors the existing `GET /api/v2/attachments/presigned-url` but:
+- Uses `agentApiKeyAuth` middleware instead of JWT auth
+- Stores files under `agents/` prefix in the same bucket
+- Same CDN base URL
+- Same presigned URL expiry (1 hour)
+
+```typescript
+// Key generation with agents/ prefix
+const objectKey = `agents/${uuidv4()}${extension ? `.${extension}` : ""}`;
+```
+
+### 4. Wire up in router
+
+```typescript
+// src/api/v2/index.ts
+v2Router.use("/agents/assets", agentApiKeyAuth, agentAssetsRouter);
+```
+
+### 5. Renewal — iOS client handles it
+
+Agent-uploaded assets follow the same 30-day lifecycle. The iOS client already scans conversation messages for asset URLs to renew via `POST /api/v2/assets/renew-batch`. Agent message attachments (including profile pics) will be included in that scan — no backend changes needed for renewal.
+
+If no client renews them, they expire after 30 days. This is the same behavior as user-uploaded assets.
+
+---
+
+## S3 Key Structure
+
+```
+PUBLIC_ASSETS_BUCKET/
+├── <uuid>.png              ← user uploads (existing)
+├── <uuid>.jpg              ← user uploads (existing)
+└── agents/
+    ├── <uuid>.png          ← agent uploads (new)
+    └── <uuid>.jpg          ← agent uploads (new)
+```
+
+The `agents/` prefix is purely organizational — same lifecycle rules apply (S3 lifecycle is bucket-wide based on `LastModified`).
+
+---
+
+## Profile Picture Encryption
+
+For agent profile pictures to work with the new `ProfileUpdate` proto, agents need to:
+
+1. Upload the image to S3 (via this new endpoint)
+2. Read the encryption key from conversation `appData`
+3. Encrypt the image URL using the same scheme as iOS
+4. Send a `ProfileUpdate` XMTP message with `encrypted_image`
+
+The encryption materials (key) are already stored in `appData` and implemented on iOS. The convos-cli needs to replicate this encryption. This is a **convos-cli change**, not a backend change.
+
+**❓ @Jarod — convos-cli needs to implement the encryption path. Is this tracked separately?**
+
+---
+
+## Files to Create/Modify
+
+| File | Change |
+|------|--------|
+| `src/config.ts` | Add `AGENT_ASSETS_API_KEY` export |
+| `src/middleware/agentAuth.ts` | **New** — API key auth middleware |
+| `src/api/v2/agents/assets/agent-assets.router.ts` | **New** — router with presigned URL endpoint |
+| `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, adds `agents/` prefix) |
+| `src/api/v2/index.ts` | Mount agent assets router |
+
+---
+
+## Rate Limiting
+
+Use a dedicated rate limiter for agent uploads, separate from user uploads:
+
+```typescript
+export const agentAssetLimiter = rateLimit({
+  windowMs: 60 * 1000,    // 1 minute
+  max: 30,                // 30 requests per minute
+  keyGenerator: () => "agent-global", // single pool, not per-IP
+});
+```
+
+**❓ Team input: what's a reasonable rate limit? 30/min seems generous for profile pics but may be needed for general image handling.**
+
+---
+
+## Security Considerations
+
+- **API key auth is simpler than JWT** — acceptable because agents are trusted server-side processes, not end-user clients
+- **Key rotation** — if compromised, rotate the env var and redeploy. No device re-registration needed
+- **No AppCheck** — agents can't do device attestation. The API key is the trust boundary
+- **S3 prefix isolation** — `agents/` prefix lets us audit/delete agent files independently if needed
+
+---
+
+## Out of Scope
+
+- Image encryption in convos-cli (separate task for @Jarod)
+- Virus/malware scanning
+- Image resizing/optimization
+- Per-agent identity tracking (all agents share one API key)
+- Railway storage buckets (decided to keep on AWS/Terraform)
+
+---
+
+## Open Questions Summary
+
+| # | Question | Context |
+|---|----------|---------|
+| 1 | Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`? | Single shared secret vs. independent rotation |
+| 2 | Rate limit for agent uploads? | 30/min? More? Less? |
+| 3 | Content type restrictions? | Images only? Or any file type? |
+| 4 | Is CLI encryption work tracked separately? | @Jarod needs to implement `EncryptedProfileImage` in convos-cli |

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -61,9 +61,7 @@ AGENT_ASSETS_API_KEY=<shared secret>
 
 Shared between convos-backend and the agent pool/CLI. Added to `src/config.ts` as optional (endpoint returns 503 if not configured). Managed via Terraform in xmtp-infra.
 
-Can reuse `AGENT_POOL_API_KEY` if the team prefers a single shared secret, but a separate key gives independent rotation.
-
-**❓ Team decision: reuse `AGENT_POOL_API_KEY` or separate `AGENT_ASSETS_API_KEY`?**
+Separate from `AGENT_POOL_API_KEY` to allow independent rotation.
 
 ### 2. New middleware: `agentApiKeyAuth`
 
@@ -141,7 +139,7 @@ For agent profile pictures to work with the new `ProfileUpdate` proto, agents ne
 
 The encryption materials (key) are already stored in `appData` and implemented on iOS. The convos-cli needs to replicate this encryption. This is a **convos-cli change**, not a backend change.
 
-**❓ @Jarod — convos-cli needs to implement the encryption path. Is this tracked separately?**
+**TODO (convos-cli):** Implement the `EncryptedProfileImage` encryption path in convos-cli.
 
 ---
 
@@ -164,12 +162,12 @@ Use a dedicated rate limiter for agent uploads, separate from user uploads:
 ```typescript
 export const agentAssetLimiter = rateLimit({
   windowMs: 60 * 1000,    // 1 minute
-  max: 30,                // 30 requests per minute
+  max: 50,                // 50 requests per minute
   keyGenerator: () => "agent-global", // single pool, not per-IP
 });
 ```
 
-**❓ Team input: what's a reasonable rate limit? 30/min seems generous for profile pics but may be needed for general image handling.**
+50/min to accommodate general image handling beyond just profile pics.
 
 ---
 
@@ -184,7 +182,7 @@ export const agentAssetLimiter = rateLimit({
 
 ## Out of Scope
 
-- Image encryption in convos-cli (separate task for @Jarod)
+- Image encryption in convos-cli (tracked as TODO in convos-cli)
 - Virus/malware scanning
 - Image resizing/optimization
 - Per-agent identity tracking (all agents share one API key)
@@ -194,10 +192,10 @@ export const agentAssetLimiter = rateLimit({
 
 ## Open Questions Summary
 
-| # | Question | Context |
-|---|----------|---------|
-| 1 | Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`? | Single shared secret vs. independent rotation |
-| 2 | Rate limit for agent uploads? | 30/min? More? Less? |
-| 3 | Content type restrictions? | Images only? Or any file type? |
-| 4 | Is CLI encryption work tracked separately? | @Jarod needs to implement `EncryptedProfileImage` in convos-cli |
-| 5 | Who renews agent PFPs to prevent 30-day expiry? | iOS currently only renews own PFP + group image, not other members' PFPs or chat images |
+| # | Question | Status |
+|---|----------|--------|
+| 1 | ~~Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`?~~ | ✅ New separate `AGENT_ASSETS_API_KEY` |
+| 2 | ~~Rate limit for agent uploads?~~ | ✅ 50/min |
+| 3 | Content type restrictions? | ❓ Open — images only? Or any file type? |
+| 4 | ~~CLI encryption work tracked?~~ | ✅ TODO in convos-cli |
+| 5 | Who renews agent PFPs to prevent 30-day expiry? | ❓ Open — iOS currently only renews own PFP + group image |

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Agents (AI assistants via convos-cli) need to upload files to S3 — starting with profile pictures, but also for general image handling in conversations. The current upload flow (`GET /api/v2/attachments/presigned-url`) requires iOS device auth (AppCheck → JWT), which agents can't use.
+Agents (AI assistants via convos-cli) need to upload files to S3 — starting with profile pictures, but also for general image handling in conversations. The current upload flow (`GET /api/v2/attachments/presigned`) requires iOS device auth (AppCheck → JWT), which agents can't use.
 
 ### What broke
 
@@ -30,7 +30,7 @@ PR [convos-cli#11](https://github.com/xmtplabs/convos-cli/pull/11) migrated conv
 ```
 Agent (convos-cli)          convos-backend                    S3
   │                              │                             │
-  │  GET /api/v2/agents/assets/presigned-url                   │
+  │  GET /api/v2/agents/assets/presigned                       │
   │  (X-Agent-API-Key)           │                             │
   │ ───────────────────────────> │                             │
   │                              │  Generate presigned PUT URL │
@@ -65,30 +65,46 @@ Separate from `AGENT_POOL_API_KEY` to allow independent rotation.
 ### 2. New middleware: `agentApiKeyAuth`
 
 Simple API key check — no AppCheck, no JWT, no device registration.
+Use constant-time comparison (`timingSafeEqual`) to avoid timing leaks.
 
 ```typescript
 // src/middleware/agentAuth.ts
+import { timingSafeEqual } from "crypto";
+
 export const agentApiKeyAuth = (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
-  if (!AGENT_ASSETS_API_KEY) {
+  const expectedKey = AGENT_ASSETS_API_KEY?.trim();
+  if (!expectedKey) {
     res.status(503).json({ error: "Agent assets API key not configured" });
     return;
   }
-  const apiKey = req.header("X-Agent-API-Key");
-  if (apiKey !== AGENT_ASSETS_API_KEY) {
+
+  const providedKey = req.header("X-Agent-API-Key")?.trim() ?? "";
+  if (providedKey.length === 0) {
     res.status(401).json({ error: "Invalid or missing agent API key" });
     return;
   }
+
+  const provided = Buffer.from(providedKey, "utf8");
+  const expected = Buffer.from(expectedKey, "utf8");
+  const valid =
+    provided.length === expected.length && timingSafeEqual(provided, expected);
+
+  if (!valid) {
+    res.status(401).json({ error: "Invalid or missing agent API key" });
+    return;
+  }
+
   next();
 };
 ```
 
-### 3. New route: `GET /api/v2/agents/assets/presigned-url`
+### 3. New route: `GET /api/v2/agents/assets/presigned`
 
-Mirrors the existing `GET /api/v2/attachments/presigned-url` but:
+Mirrors the existing `GET /api/v2/attachments/presigned` but:
 
 - Uses `agentApiKeyAuth` middleware instead of JWT auth
 - Stores files under `a/` prefix in the same bucket
@@ -103,11 +119,14 @@ const command = new PutObjectCommand({
   Bucket: env.PUBLIC_ASSETS_BUCKET,
   Key: objectKey,
   ContentType: "application/octet-stream",
-  ContentLengthRange: [1, 20 * 1024 * 1024], // 1 byte – 20 MB
 });
 ```
 
-The 20 MB cap is enforced by S3 via the presigned URL conditions — the PUT will be rejected by S3 if the uploaded payload exceeds it, no backend validation needed.
+⚠️ `content-length-range` is not supported for presigned **PUT** URLs.
+So this endpoint does **not** get strict max-size enforcement from S3 policy conditions.
+
+For now, agents must enforce the 20 MB client-side before upload.
+If we need hard S3-enforced size limits later, switch this endpoint to presigned **POST** (policy-based upload).
 
 ### 4. Wire up in router
 
@@ -122,7 +141,38 @@ v2Router.use("/agents", agentJoinLimiter, authMiddleware, agentsRouter);
 
 ### 5. Renewal
 
-Agents renew their own assets. They have access to `POST /api/v2/assets/renew-batch` using `AGENT_ASSETS_API_KEY` auth. This endpoint currently uses JWT auth — needs to also accept agent API key auth.
+Agents renew their own assets via `POST /api/v2/assets/renew-batch` using `AGENT_ASSETS_API_KEY`.
+
+Important: this cannot be solved in `renew-batch` handler alone, because `/assets` is currently mounted behind `authMiddleware` at router level.
+
+Implement a combined auth middleware and apply it at route wiring level:
+
+```typescript
+// src/middleware/agentAuth.ts
+export const authOrAgentApiKeyAuth = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  // If agent key is present, validate via agentApiKeyAuth.
+  // Otherwise, fall back to JWT authMiddleware.
+};
+```
+
+```typescript
+// src/api/v2/index.ts
+v2Router.post(
+  "/assets/renew-batch",
+  assetRenewalLimiter,
+  authOrAgentApiKeyAuth,
+  renewBatchHandler,
+);
+
+// Keep the rest of /assets JWT-protected as-is
+v2Router.use("/assets", authMiddleware, assetsRouter);
+```
+
+This ensures renew-batch accepts either JWT (existing iOS flow) or `X-Agent-API-Key` (agent flow), without unintentionally opening other `/assets/*` routes.
 
 ---
 
@@ -157,14 +207,14 @@ The encryption materials (key) are already stored in `appData` and implemented o
 
 ## Files to Create/Modify
 
-| File                                                     | Change                                                                    |
-| -------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `src/config.ts`                                          | Add `AGENT_ASSETS_API_KEY` export                                         |
-| `src/middleware/agentAuth.ts`                            | **New** — API key auth middleware (503 on missing config, 401 on bad key) |
-| `src/api/v2/agents/assets/agent-assets.router.ts`        | **New** — router with presigned URL endpoint                              |
-| `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, `a/` prefix, hardcoded octet-stream) |
-| `src/api/v2/assets/handlers/renew-batch.ts`              | Also accept `agentApiKeyAuth` (currently JWT-only)                        |
-| `src/api/v2/index.ts`                                    | Mount agent assets router **before** `/agents` (order matters)            |
+| File                                                     | Change                                                                                               |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `src/config.ts`                                          | Add `AGENT_ASSETS_API_KEY` export                                                                    |
+| `src/middleware/agentAuth.ts`                            | **New** — `agentApiKeyAuth` + `authOrAgentApiKeyAuth` (constant-time key comparison)               |
+| `src/api/v2/agents/assets/agent-assets.router.ts`        | **New** — router with presigned URL endpoint                                                         |
+| `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, `a/` prefix, hardcoded octet-stream)                           |
+| `src/api/v2/index.ts`                                    | Mount agent assets router **before** `/agents`; wire `/assets/renew-batch` with `authOr...` auth   |
+| `src/api/v2/assets/assets.router.ts`                     | Remove `/renew-batch` from JWT-only assets router if renew-batch is mounted explicitly in `index.ts` |
 
 ---
 
@@ -190,7 +240,7 @@ export const agentAssetLimiter = rateLimit({
 - **Key rotation** — if compromised, rotate the env var and redeploy. No device re-registration needed
 - **No AppCheck** — agents can't do device attestation. The API key is the trust boundary
 - **S3 prefix isolation** — `a/` prefix lets us audit/delete agent files independently if needed
-- **20 MB size cap** — enforced via presigned URL conditions (`ContentLengthRange`); S3 rejects oversized PUTs without the backend ever seeing the payload
+- **20 MB size cap** — for presigned PUT, this is client-enforced (not S3-policy-enforced). Hard S3 size enforcement would require presigned POST
 
 ---
 

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -16,12 +16,12 @@ PR [convos-cli#11](https://github.com/xmtplabs/convos-cli/pull/11) migrated conv
 
 | Decision | Outcome |
 |----------|---------|
-| **Bucket** | Same `PUBLIC_ASSETS_BUCKET`, dedicated route |
-| **Retention** | Same 30-day rolling policy (same as user PFPs) |
+| **Bucket** | Same `PUBLIC_ASSETS_BUCKET`, dedicated route/directory: assistant/* |
+| **Retention** | Same 30-day rolling policy (same as user PFPs and group images) |
 | **Auth** | Dedicated auth mechanism — shared API key between agent pool and backend (like existing `AGENT_POOL_API_KEY`) |
 | **Endpoint** | New dedicated upload route for agents |
 | **Encryption** | Agents should encrypt profile photos same as users (encryption materials are in `appData`, can be replicated in CLI) |
-| **Infrastructure** | Keep everything in one AWS account, Terraform-managed (xmtp-infra repo) |
+| **Infrastructure** | Keep everything in one AWS account, Terraform-managed |
 
 ---
 

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -123,25 +123,6 @@ Agent-uploaded assets follow the same 30-day lifecycle. However, **iOS currently
 
 Agents need access to `POST /api/v2/assets/renew-batch` using the same `AGENT_ASSETS_API_KEY` auth. This endpoint currently uses JWT auth — needs to also accept agent API key auth.
 
-#### 5a. Durable asset inventory
-
-`POST /api/v2/assets/renew-batch` requires explicit `assetKeys`. The cron job has no way to discover which keys to pass after a restart unless asset metadata is persisted somewhere.
-
-**Solution:** Add an `agent_assets` table:
-
-```sql
-CREATE TABLE agent_assets (
-  object_key  TEXT        NOT NULL PRIMARY KEY,
-  uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-```
-
-- The `get-presigned-url` handler writes a row after generating the key (before returning the response).
-- A new `GET /api/v2/agents/assets/keys-due-for-renewal` endpoint (protected by `agentApiKeyAuth`) returns keys where `uploaded_at` is between 27–30 days ago, paginated to ≤ 100 per page (matching `MAX_BATCH_SIZE`).
-- The renewal cron calls that endpoint to build its batch, then calls `POST /api/v2/assets/renew-batch`. On success, the handler bumps `uploaded_at` to `now()` so the 30-day clock resets.
-
-This keeps the backend authoritative about which keys exist and when they expire, with no per-agent identity tracking required.
-
 ---
 
 ## S3 Key Structure
@@ -176,16 +157,14 @@ The encryption materials (key) are already stored in `appData` and implemented o
 
 ## Files to Create/Modify
 
-| File                                                               | Change                                                                           |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
-| `src/config.ts`                                                    | Add `AGENT_ASSETS_API_KEY` export                                                |
-| `src/middleware/agentAuth.ts`                                      | **New** — API key auth middleware (503 on missing config, 401 on bad key)        |
-| `src/api/v2/agents/assets/agent-assets.router.ts`                  | **New** — router with presigned URL + renewal-keys endpoints                     |
-| `src/api/v2/agents/assets/handlers/get-presigned-url.ts`           | **New** — handler (mirrors existing, adds `agents/` prefix, inserts to DB)       |
-| `src/api/v2/agents/assets/handlers/get-keys-due-for-renewal.ts`    | **New** — returns agent asset keys 27–30 days old                                |
-| `src/api/v2/assets/handlers/renew-batch.ts`                        | Bump `uploaded_at` in `agent_assets` after successful copy                       |
-| `src/api/v2/index.ts`                                              | Mount agent assets router **before** `/agents` (order matters)                   |
-| migrations                                                         | **New** — `agent_assets` table (`object_key PK`, `uploaded_at`)                  |
+| File                                                     | Change                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `src/config.ts`                                          | Add `AGENT_ASSETS_API_KEY` export                                         |
+| `src/middleware/agentAuth.ts`                            | **New** — API key auth middleware (503 on missing config, 401 on bad key) |
+| `src/api/v2/agents/assets/agent-assets.router.ts`        | **New** — router with presigned URL endpoint                              |
+| `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, adds `agents/` prefix)               |
+| `src/api/v2/assets/handlers/renew-batch.ts`              | Also accept `agentApiKeyAuth` (currently JWT-only)                        |
+| `src/api/v2/index.ts`                                    | Mount agent assets router **before** `/agents` (order matters)            |
 
 ---
 

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -14,14 +14,14 @@ PR [convos-cli#11](https://github.com/xmtplabs/convos-cli/pull/11) migrated conv
 
 ### Decisions from team discussion (2026-03-10)
 
-| Decision | Outcome |
-|----------|---------|
-| **Bucket** | Same `PUBLIC_ASSETS_BUCKET`, dedicated route/directory: assistant/* |
-| **Retention** | Same 30-day rolling policy (same as user PFPs and group images) |
-| **Auth** | Dedicated auth mechanism — shared API key between agent pool and backend (like existing `AGENT_POOL_API_KEY`) |
-| **Endpoint** | New dedicated upload route for agents |
-| **Encryption** | Agents should encrypt profile photos same as users (encryption materials are in `appData`, can be replicated in CLI) |
-| **Infrastructure** | Keep everything in one AWS account, Terraform-managed |
+| Decision           | Outcome                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| **Bucket**         | Same `PUBLIC_ASSETS_BUCKET`, dedicated route/directory: assistant/\*                                                 |
+| **Retention**      | Same 30-day rolling policy (same as user PFPs and group images)                                                      |
+| **Auth**           | Dedicated auth mechanism — shared API key between agent pool and backend (like existing `AGENT_POOL_API_KEY`)        |
+| **Endpoint**       | New dedicated upload route for agents                                                                                |
+| **Encryption**     | Agents should encrypt profile photos same as users (encryption materials are in `appData`, can be replicated in CLI) |
+| **Infrastructure** | Keep everything in one AWS account, Terraform-managed                                                                |
 
 ---
 
@@ -69,7 +69,11 @@ Simple API key check — no AppCheck, no JWT, no device registration.
 
 ```typescript
 // src/middleware/agentAuth.ts
-export const agentApiKeyAuth = (req: Request, res: Response, next: NextFunction) => {
+export const agentApiKeyAuth = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
   const apiKey = req.header("X-Agent-API-Key");
   if (!AGENT_ASSETS_API_KEY || apiKey !== AGENT_ASSETS_API_KEY) {
     res.status(401).json({ error: "Invalid or missing agent API key" });
@@ -82,6 +86,7 @@ export const agentApiKeyAuth = (req: Request, res: Response, next: NextFunction)
 ### 3. New route: `GET /api/v2/agents/assets/presigned-url`
 
 Mirrors the existing `GET /api/v2/attachments/presigned-url` but:
+
 - Uses `agentApiKeyAuth` middleware instead of JWT auth
 - Stores files under `agents/` prefix in the same bucket
 - Same CDN base URL
@@ -144,14 +149,14 @@ The encryption materials (key) are already stored in `appData` and implemented o
 
 ## Files to Create/Modify
 
-| File | Change |
-|------|--------|
-| `src/config.ts` | Add `AGENT_ASSETS_API_KEY` export |
-| `src/middleware/agentAuth.ts` | **New** — API key auth middleware |
-| `src/api/v2/agents/assets/agent-assets.router.ts` | **New** — router with presigned URL endpoint |
+| File                                                     | Change                                                      |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| `src/config.ts`                                          | Add `AGENT_ASSETS_API_KEY` export                           |
+| `src/middleware/agentAuth.ts`                            | **New** — API key auth middleware                           |
+| `src/api/v2/agents/assets/agent-assets.router.ts`        | **New** — router with presigned URL endpoint                |
 | `src/api/v2/agents/assets/handlers/get-presigned-url.ts` | **New** — handler (mirrors existing, adds `agents/` prefix) |
-| `src/api/v2/index.ts` | Mount agent assets router |
-| `src/api/v2/agents/assets/agent-assets.router.ts` | Also mount `POST /renew-batch` for agents |
+| `src/api/v2/index.ts`                                    | Mount agent assets router                                   |
+| `src/api/v2/agents/assets/agent-assets.router.ts`        | Also mount `POST /renew-batch` for agents                   |
 
 ---
 
@@ -161,8 +166,8 @@ Use a dedicated rate limiter for agent uploads, separate from user uploads:
 
 ```typescript
 export const agentAssetLimiter = rateLimit({
-  windowMs: 60 * 1000,    // 1 minute
-  max: 50,                // 50 requests per minute
+  windowMs: 60 * 1000, // 1 minute
+  max: 50, // 50 requests per minute
   keyGenerator: () => "agent-global", // single pool, not per-IP
 });
 ```
@@ -192,10 +197,10 @@ export const agentAssetLimiter = rateLimit({
 
 ## Open Questions Summary
 
-| # | Question | Status |
-|---|----------|--------|
-| 1 | ~~Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`?~~ | ✅ New separate `AGENT_ASSETS_API_KEY` |
-| 2 | ~~Rate limit for agent uploads?~~ | ✅ 50/min |
-| 3 | ~~Content type restrictions?~~ | ✅ Any file type — needed in near-term |
-| 4 | ~~CLI encryption work tracked?~~ | ✅ In progress — [convos-cli#15](https://github.com/xmtplabs/convos-cli/pull/15) |
-| 5 | ~~Who renews agent PFPs?~~ | ✅ Agents renew their own assets (see below) |
+| #   | Question                                                      | Status                                                                           |
+| --- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| 1   | ~~Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`?~~ | ✅ New separate `AGENT_ASSETS_API_KEY`                                           |
+| 2   | ~~Rate limit for agent uploads?~~                             | ✅ 50/min                                                                        |
+| 3   | ~~Content type restrictions?~~                                | ✅ Any file type — needed in near-term                                           |
+| 4   | ~~CLI encryption work tracked?~~                              | ✅ In progress — [convos-cli#15](https://github.com/xmtplabs/convos-cli/pull/15) |
+| 5   | ~~Who renews agent PFPs?~~                                    | ✅ Agents renew their own assets (see below)                                     |

--- a/docs/plans/agent-file-uploads.md
+++ b/docs/plans/agent-file-uploads.md
@@ -103,8 +103,11 @@ const command = new PutObjectCommand({
   Bucket: env.PUBLIC_ASSETS_BUCKET,
   Key: objectKey,
   ContentType: "application/octet-stream",
+  ContentLengthRange: [1, 20 * 1024 * 1024], // 1 byte – 20 MB
 });
 ```
+
+The 20 MB cap is enforced by S3 via the presigned URL conditions — the PUT will be rejected by S3 if the uploaded payload exceeds it, no backend validation needed.
 
 ### 4. Wire up in router
 
@@ -117,16 +120,9 @@ v2Router.use("/agents/assets", agentApiKeyAuth, agentAssetsRouter);
 v2Router.use("/agents", agentJoinLimiter, authMiddleware, agentsRouter);
 ```
 
-### 5. Renewal — who renews agent assets?
+### 5. Renewal
 
-Agent-uploaded assets follow the same 30-day lifecycle. However, **iOS currently only renews its own PFP and the group image** — it does not renew other members' PFPs or images sent in chat. This means agent profile pictures and any files agents share in messages would expire after 30 days with no one renewing them.
-
-**Decision:** Agents renew their own assets. Two strategies:
-
-1. **On activity** — when an agent becomes active (sends/receives a message), it renews its assets
-2. **Scheduled** — agent pool runs a cron job around the 30-day mark, renews assets for agents that have had recent group activity
-
-Agents need access to `POST /api/v2/assets/renew-batch` using the same `AGENT_ASSETS_API_KEY` auth. This endpoint currently uses JWT auth — needs to also accept agent API key auth.
+Agents renew their own assets. They have access to `POST /api/v2/assets/renew-batch` using `AGENT_ASSETS_API_KEY` auth. This endpoint currently uses JWT auth — needs to also accept agent API key auth.
 
 ---
 
@@ -194,6 +190,7 @@ export const agentAssetLimiter = rateLimit({
 - **Key rotation** — if compromised, rotate the env var and redeploy. No device re-registration needed
 - **No AppCheck** — agents can't do device attestation. The API key is the trust boundary
 - **S3 prefix isolation** — `a/` prefix lets us audit/delete agent files independently if needed
+- **20 MB size cap** — enforced via presigned URL conditions (`ContentLengthRange`); S3 rejects oversized PUTs without the backend ever seeing the payload
 
 ---
 


### PR DESCRIPTION
## Plan for agent file uploads to S3

Captures team decisions from Slack discussion (2026-03-10) and lays out the implementation plan with open questions for team review.

### Decisions made
- Same `PUBLIC_ASSETS_BUCKET` with `agents/` prefix
- Same 30-day retention — iOS client renews agent assets
- Dedicated API key auth (agents can't do AppCheck)
- Dedicated upload route: `GET /api/v2/agents/assets/presigned-url`
- Agents encrypt profile photos same as users (CLI change needed)
- Keep on AWS/Terraform (no Railway)

### Open questions
1. Reuse `AGENT_POOL_API_KEY` or new `AGENT_ASSETS_API_KEY`?
2. Rate limit for agent uploads?
3. Content type restrictions?
4. Is CLI encryption work tracked separately? (@Jarod)

**Linear:** [AGNT-41](https://linear.app/convos/issue/AGNT-41/add-agent-asset-upload-auth-and-s3-endpoint)

Plan doc: `docs/plans/agent-file-uploads.md`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add planning document for agent asset upload flow
> Adds [agent-file-uploads.md](https://github.com/ephemeraHQ/convos-backend/pull/177/files#diff-00f4fec3bc72334929f7848eec90f23f735054fbc5ea7b77a23467ee9ed1d83e) specifying the design for an agent asset upload API.
>
> - Introduces a dedicated `AGENT_ASSETS_API_KEY` with an `agentApiKeyAuth` middleware using constant-time comparison
> - Defines a new presigned S3 PUT URL endpoint at `POST /api/v2/agents/assets/presigned`, storing objects under an `a/` prefix with `application/octet-stream`
> - Adds a combined `authOrAgentApiKeyAuth` guard for `POST /api/v2/assets/renew-batch`
> - Specifies rate limiting at 50 requests/min globally and documents router ordering considerations
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a41528.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent asset upload: obtain presigned PUT URLs to upload assets under an agents/ namespace; uploads use a dedicated agent API key for authentication.

* **Documentation**
  * Added design and implementation plan covering auth flow, presigned-upload endpoint, 30-day lifecycle with renewal and batch-renewal support, storage key structure, encryption guidance for agent profile pictures, rate-limiting guidance, and security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->