### PR TITLE
feat(assets): add assistant asset upload auth and S3 presigned endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ APNS_BUNDLE_ID=
 # Assets CDN Base URL
 CDN_BASE_URL=https://assets.domain.tld
 
+# Agent integration (optional)
+AGENT_POOL_URL=
+AGENT_POOL_API_KEY=
+AGENT_ASSETS_API_KEY=
+
 # S3 Lifecycle Test Configuration
 # Bucket for lifecycle testing (24h expiry policy)
 LIFECYCLE_TEST_BUCKET=

--- a/src/api/v2/agents/assets/agent-assets.router.ts
+++ b/src/api/v2/agents/assets/agent-assets.router.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { getAgentPresignedUrlHandler } from "./handlers/get-presigned-url";
+
+export const agentAssetsRouter = Router();
+
+agentAssetsRouter.get("/presigned", getAgentPresignedUrlHandler);

--- a/src/api/v2/agents/assets/handlers/get-presigned-url.ts
+++ b/src/api/v2/agents/assets/handlers/get-presigned-url.ts
@@ -1,0 +1,67 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import type { Request, Response } from "express";
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { AppError } from "@/utils/errors";
+
+const envSchema = z.object({
+  PUBLIC_ASSETS_BUCKET: z.string().min(1).optional(),
+  AWS_REGION: z.string().optional(),
+  CDN_BASE_URL: z.string().url().optional(),
+});
+
+const env = envSchema.parse({
+  PUBLIC_ASSETS_BUCKET: process.env.PUBLIC_ASSETS_BUCKET,
+  AWS_REGION: process.env.AWS_REGION,
+  CDN_BASE_URL: process.env.CDN_BASE_URL,
+});
+
+const s3Client = env.PUBLIC_ASSETS_BUCKET ? new S3Client({}) : null;
+
+const getAgentPresignedURL = async () => {
+  if (!env.PUBLIC_ASSETS_BUCKET || !s3Client) {
+    throw new AppError(503, "File uploads not available - S3 not configured");
+  }
+
+  const objectKey = `a/${uuidv4()}`;
+
+  const command = new PutObjectCommand({
+    Bucket: env.PUBLIC_ASSETS_BUCKET,
+    Key: objectKey,
+    ContentType: "application/octet-stream",
+  });
+
+  const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+  const assetUrl = env.CDN_BASE_URL
+    ? `${env.CDN_BASE_URL.replace(/\/+$/, "")}/${objectKey}`
+    : null;
+
+  return { objectKey, uploadUrl, assetUrl };
+};
+
+export async function getAgentPresignedUrlHandler(req: Request, res: Response) {
+  try {
+    req.log.info("v2 agent assets presigned URL request");
+
+    const { objectKey, uploadUrl, assetUrl } = await getAgentPresignedURL();
+
+    res.json({
+      objectKey,
+      url: uploadUrl, // @deprecated - use uploadUrl instead
+      uploadUrl,
+      assetUrl,
+    });
+    return;
+  } catch (error) {
+    req.log.error({ error }, "Error generating agent assets presigned URL");
+
+    if (error instanceof AppError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+
+    res.status(500).json({ error: "Failed to generate presigned URL" });
+    return;
+  }
+}

--- a/src/api/v2/agents/assets/handlers/get-presigned-url.ts
+++ b/src/api/v2/agents/assets/handlers/get-presigned-url.ts
@@ -46,6 +46,12 @@ export async function getAgentPresignedUrlHandler(req: Request, res: Response) {
 
     const { objectKey, uploadUrl, assetUrl } = await getAgentPresignedURL();
 
+    res.set({
+      "Cache-Control": "no-store",
+      Pragma: "no-cache",
+      Expires: "0",
+    });
+
     res.json({
       objectKey,
       url: uploadUrl, // @deprecated - use uploadUrl instead

--- a/src/api/v2/assets/assets.router.ts
+++ b/src/api/v2/assets/assets.router.ts
@@ -1,6 +1,3 @@
 import { Router } from "express";
-import { renewBatchHandler } from "./handlers/renew-batch";
 
 export const assetsRouter = Router();
-
-assetsRouter.post("/renew-batch", renewBatchHandler);

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -9,6 +9,7 @@ import { devAuthMiddleware } from "@/middleware/devAuth";
 import { lifecycleTestAuthMiddleware } from "@/middleware/lifecycleTestAuth";
 import {
   agentAssetLimiter,
+  agentAssetPreAuthLimiter,
   agentJoinLimiter,
   assetRenewalLimiter,
 } from "@/middleware/rateLimit";
@@ -70,6 +71,7 @@ v2Router.use("/assets", authMiddleware, assetsRouter);
 // Must be mounted before /agents to avoid being caught by /agents auth middleware
 v2Router.use(
   "/agents/assets",
+  agentAssetPreAuthLimiter,
   agentApiKeyAuth,
   agentAssetLimiter,
   agentAssetsRouter,

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { agentApiKeyAuth, authOrAgentApiKeyAuth } from "@/middleware/agentAuth";
 import {
   appCheckOnlyMiddleware,
   authMiddleware,
@@ -6,11 +7,17 @@ import {
 } from "@/middleware/auth";
 import { devAuthMiddleware } from "@/middleware/devAuth";
 import { lifecycleTestAuthMiddleware } from "@/middleware/lifecycleTestAuth";
-import { agentJoinLimiter, assetRenewalLimiter } from "@/middleware/rateLimit";
+import {
+  agentAssetLimiter,
+  agentJoinLimiter,
+  assetRenewalLimiter,
+} from "@/middleware/rateLimit";
 import { agentsRouter } from "./agents/agents.router";
+import { agentAssetsRouter } from "./agents/assets/agent-assets.router";
 import { assetsRouter } from "./assets/assets.router";
 import { lifecycleStatusHandler } from "./assets/handlers/lifecycle-status";
 import { migrateTimestampsHandler } from "./assets/handlers/migrate-timestamps";
+import { renewBatchHandler } from "./assets/handlers/renew-batch";
 import { testLifecycleHandler } from "./assets/handlers/test-lifecycle";
 import { attachmentsRouter } from "./attachments/attachments.router";
 import { authRouter } from "./auth/auth.router";
@@ -50,7 +57,23 @@ v2Router.post(
   migrateTimestampsHandler,
 );
 
-v2Router.use("/assets", authMiddleware, assetRenewalLimiter, assetsRouter);
+// Renew assets with either JWT auth (iOS clients) or agent API key auth
+v2Router.post(
+  "/assets/renew-batch",
+  assetRenewalLimiter,
+  authOrAgentApiKeyAuth,
+  renewBatchHandler,
+);
+
+v2Router.use("/assets", authMiddleware, assetsRouter);
+
+// Must be mounted before /agents to avoid being caught by /agents auth middleware
+v2Router.use(
+  "/agents/assets",
+  agentApiKeyAuth,
+  agentAssetLimiter,
+  agentAssetsRouter,
+);
 v2Router.use("/agents", agentJoinLimiter, authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
 v2Router.use("/notifications/xmtp", webhookRouter);

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -60,8 +60,8 @@ v2Router.post(
 // Renew assets with either JWT auth (iOS clients) or agent API key auth
 v2Router.post(
   "/assets/renew-batch",
-  assetRenewalLimiter,
   authOrAgentApiKeyAuth,
+  assetRenewalLimiter,
   renewBatchHandler,
 );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,4 +31,8 @@ export const IS_DEVELOPMENT = process.env.NODE_ENV === "development";
 // Agent pool (optional — endpoint returns 503 if not configured)
 export const AGENT_POOL_URL = process.env.AGENT_POOL_URL || "";
 export const AGENT_POOL_API_KEY = process.env.AGENT_POOL_API_KEY || "";
+
+// Agent asset upload auth (optional — endpoint returns 503 if not configured)
+export const AGENT_ASSETS_API_KEY = process.env.AGENT_ASSETS_API_KEY || "";
+
 export const XMTP_ENV = process.env.XMTP_ENV || "dev";

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -1,9 +1,20 @@
-import { timingSafeEqual } from "crypto";
+import { createHash, timingSafeEqual } from "crypto";
 import type { NextFunction, Request, Response } from "express";
 import { AGENT_ASSETS_API_KEY } from "@/config";
 import { authMiddleware } from "./auth";
 
 export const AGENT_API_KEY_HEADER = "X-Agent-API-Key";
+const MIN_AGENT_API_KEY_LENGTH = 32;
+
+function constantTimeSecretCompare(
+  provided: string,
+  expected: string,
+): boolean {
+  // Compare fixed-length SHA-256 digests to avoid leaking secret length.
+  const providedDigest = createHash("sha256").update(provided, "utf8").digest();
+  const expectedDigest = createHash("sha256").update(expected, "utf8").digest();
+  return timingSafeEqual(providedDigest, expectedDigest);
+}
 
 export const agentApiKeyAuth = (
   req: Request,
@@ -11,7 +22,20 @@ export const agentApiKeyAuth = (
   next: NextFunction,
 ) => {
   const expectedKey = AGENT_ASSETS_API_KEY.trim();
+
   if (!expectedKey) {
+    res.status(503).json({ error: "Agent assets API key not configured" });
+    return;
+  }
+
+  if (expectedKey.length < MIN_AGENT_API_KEY_LENGTH) {
+    req.log.error(
+      {
+        minLength: MIN_AGENT_API_KEY_LENGTH,
+        actualLength: expectedKey.length,
+      },
+      "AGENT_ASSETS_API_KEY too short - rejecting request",
+    );
     res.status(503).json({ error: "Agent assets API key not configured" });
     return;
   }
@@ -22,11 +46,7 @@ export const agentApiKeyAuth = (
     return;
   }
 
-  const provided = Buffer.from(providedKey, "utf8");
-  const expected = Buffer.from(expectedKey, "utf8");
-  const valid =
-    provided.length === expected.length && timingSafeEqual(provided, expected);
-
+  const valid = constantTimeSecretCompare(providedKey, expectedKey);
   if (!valid) {
     res.status(401).json({ error: "Invalid or missing agent API key" });
     return;
@@ -43,9 +63,11 @@ export const authOrAgentApiKeyAuth = async (
   const providedAgentApiKey = req.header(AGENT_API_KEY_HEADER)?.trim();
 
   if (providedAgentApiKey) {
+    req.log.debug("Attempting agent API key authentication");
     agentApiKeyAuth(req, res, next);
     return;
   }
 
+  req.log.debug("Attempting JWT authentication");
   await authMiddleware(req, res, next);
 };

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -1,0 +1,51 @@
+import { timingSafeEqual } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+import { AGENT_ASSETS_API_KEY } from "@/config";
+import { authMiddleware } from "./auth";
+
+export const AGENT_API_KEY_HEADER = "X-Agent-API-Key";
+
+export const agentApiKeyAuth = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const expectedKey = AGENT_ASSETS_API_KEY.trim();
+  if (!expectedKey) {
+    res.status(503).json({ error: "Agent assets API key not configured" });
+    return;
+  }
+
+  const providedKey = req.header(AGENT_API_KEY_HEADER)?.trim() ?? "";
+  if (!providedKey) {
+    res.status(401).json({ error: "Invalid or missing agent API key" });
+    return;
+  }
+
+  const provided = Buffer.from(providedKey, "utf8");
+  const expected = Buffer.from(expectedKey, "utf8");
+  const valid =
+    provided.length === expected.length && timingSafeEqual(provided, expected);
+
+  if (!valid) {
+    res.status(401).json({ error: "Invalid or missing agent API key" });
+    return;
+  }
+
+  next();
+};
+
+export const authOrAgentApiKeyAuth = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const providedAgentApiKey = req.header(AGENT_API_KEY_HEADER)?.trim();
+
+  if (providedAgentApiKey) {
+    agentApiKeyAuth(req, res, next);
+    return;
+  }
+
+  await authMiddleware(req, res, next);
+};

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -38,3 +38,13 @@ export const assetRenewalLimiter = rateLimit({
   standardHeaders: "draft-8",
   message: { error: "Too many renewal requests, please try again later" },
 });
+
+// Rate limiting for agent asset uploads (50 requests per minute, shared global key)
+export const agentAssetLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  limit: 50,
+  keyGenerator: () => "agent-global",
+  legacyHeaders: false,
+  standardHeaders: "draft-8",
+  message: { error: "Too many agent upload requests, please try again later" },
+});

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -39,7 +39,17 @@ export const assetRenewalLimiter = rateLimit({
   message: { error: "Too many renewal requests, please try again later" },
 });
 
-// Rate limiting for agent asset uploads (50 requests per minute, shared global key)
+// Pre-auth rate limiting for agent asset uploads (protects API key auth surface)
+export const agentAssetPreAuthLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  limit: 20,
+  keyGenerator: (req) => req.ip || "unknown",
+  legacyHeaders: false,
+  standardHeaders: "draft-8",
+  message: { error: "Too many agent auth attempts, please try again later" },
+});
+
+// Post-auth rate limiting for agent asset uploads (shared global throughput cap)
 export const agentAssetLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   limit: 50,


### PR DESCRIPTION
Implements AGNT-41 backend support for assistant asset uploads.

 ### Changes

 - Added AGENT_ASSETS_API_KEY config.
 - Added agentApiKeyAuth (constant-time comparison) and authOrAgentApiKeyAuth.
 - Added GET /api/v2/agents/assets/presigned:
     - uploads to a/<uuid>
     - Content-Type: application/octet-stream
     - 1h presigned PUT URL
 - Wired POST /api/v2/assets/renew-batch to accept JWT or assistant API key.
 - Mounted /agents/assets before /agents.
 - Added dedicated agentAssetLimiter (50 req/min, global key).
 - Removed renew-batch route from JWT-only assetsRouter (now mounted explicitly in v2/index.ts).

 ### Validation

 - bun run typecheck
 - bun run lint
 - bun test tests/renew-batch.test.ts

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent asset upload auth and S3 presigned URL endpoint at `GET /v2/agents/assets/presigned`
> - Adds `GET /v2/agents/assets/presigned` ([agent-assets.router.ts](https://github.com/ephemeraHQ/convos-backend/pull/178/files#diff-1ec46fb176e97934ef1ac18bb7e672ae5ec42d15e41e16cf82e637758dfa8f2c)) that generates an S3 presigned upload URL and optional CDN asset URL, expiring in 3600s.
> - Introduces `agentApiKeyAuth` middleware ([agentAuth.ts](https://github.com/ephemeraHQ/convos-backend/pull/178/files#diff-c07ee7992441b9b727b00d4e310f981c93de6f22be1f3b1f34efdeca3b319c39)) that validates the `X-Agent-API-Key` header against `AGENT_ASSETS_API_KEY` using constant-time comparison; returns 503 if unconfigured, 401 if missing or invalid.
> - Adds `authOrAgentApiKeyAuth` middleware so `POST /v2/assets/renew-batch` accepts either a valid agent API key or a JWT, while other `/v2/assets` routes continue to require JWT auth.
> - Applies two-layer rate limiting to the new endpoint: 20 req/min per IP (pre-auth) and 50 req/min globally (post-auth).
> - Risk: `AGENT_ASSETS_API_KEY` defaults to an empty string if not set, causing the endpoint to return 503 until explicitly configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18736a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->