### PR TITLE
feat: improve push notification logging for APNS and FCM

### DIFF
--- a/src/api/v2/notifications/apns-push.service.ts
+++ b/src/api/v2/notifications/apns-push.service.ts
@@ -35,6 +35,12 @@ export type ApnsNotificationPayload = NotificationPayload & {
   };
 };
 
+/** Mask a token for safe logging: show first 8 and last 4 chars */
+function maskToken(token: string): string {
+  if (token.length <= 16) return `${token.slice(0, 4)}...${token.slice(-4)}`;
+  return `${token.slice(0, 8)}...${token.slice(-4)} (len=${token.length})`;
+}
+
 export class ApnsPushService {
   private config: ApnsConfig;
   private jwtToken?: string;
@@ -89,10 +95,18 @@ export class ApnsPushService {
     const { device, notification, isSilent } = args;
 
     if (!device.pushToken) {
+      logger.warn(
+        { deviceId: device.id },
+        "[APNS] No push token available – skipping send",
+      );
       return { success: false, error: "No APNS push token available" };
     }
 
     if (device.pushTokenType !== "apns") {
+      logger.warn(
+        { deviceId: device.id, pushTokenType: device.pushTokenType },
+        "[APNS] Device push token type mismatch – expected 'apns'",
+      );
       return { success: false, error: "Device is not configured for APNS" };
     }
 
@@ -129,7 +143,7 @@ export class ApnsPushService {
       client.on("error", (error: Error) => {
         logger.error(
           { error: error.message, stack: error.stack, deviceId: device.id },
-          "HTTP/2 connection error",
+          "[APNS] HTTP/2 connection error",
         );
         client.close();
         resolve({ success: false, error: error.message });
@@ -145,16 +159,29 @@ export class ApnsPushService {
         "content-type": "application/json",
       };
 
+      // Extract content topic for logging (if Protocol notification)
+      const contentTopic =
+        "contentTopic" in notification.notificationData
+          ? (notification.notificationData as { contentTopic?: string })
+              .contentTopic
+          : undefined;
+
       const safeHeaders = { ...headers, authorization: "[REDACTED]" };
       logger.info(
         {
-          url: `https://${hostname}/3/device/${device.pushToken}`,
+          url: `https://${hostname}/3/device/${maskToken(device.pushToken!)}`,
+          pushTokenMasked: maskToken(device.pushToken!),
           headers: safeHeaders,
-          payload,
           deviceId: device.id,
+          apnsEnv: device.apnsEnv,
+          isSilent,
+          notificationType: notification.notificationType,
+          contentTopic,
+          bundleId: this.config.bundleId,
+          payloadSize: JSON.stringify(payload).length,
           verbose: true,
         },
-        "[VERBOSE] Sending APNS HTTP/2 request",
+        "[APNS] Sending HTTP/2 push request",
       );
 
       const request = client.request(headers);
@@ -173,7 +200,7 @@ export class ApnsPushService {
             deviceId: device.id,
             verbose: true,
           },
-          "[VERBOSE] APNS HTTP/2 response received",
+          "[APNS] HTTP/2 response received",
         );
       });
 
@@ -182,7 +209,7 @@ export class ApnsPushService {
         responseData += chunkStr;
         logger.info(
           { chunk: chunkStr, deviceId: device.id, verbose: true },
-          "[VERBOSE] APNS response data chunk",
+          "[APNS] Response data chunk",
         );
       });
 
@@ -194,10 +221,11 @@ export class ApnsPushService {
             {
               deviceId: device.id,
               apnsEnv: device.apnsEnv,
+              pushTokenMasked: maskToken(device.pushToken!),
               apnsId: responseHeaders["apns-id"] as string,
-              verbose: true,
+              bundleId: this.config.bundleId,
             },
-            "[VERBOSE] APNS push notification sent successfully",
+            "[APNS] Push notification sent successfully",
           );
           resolve({ success: true });
           return;
@@ -220,9 +248,10 @@ export class ApnsPushService {
             responseData,
             deviceId: device.id,
             apnsEnv: device.apnsEnv,
-            verbose: true,
+            pushTokenMasked: maskToken(device.pushToken!),
+            bundleId: this.config.bundleId,
           },
-          "[VERBOSE] APNS push notification failed",
+          "[APNS] Push notification failed",
         );
 
         // Handle specific APNS errors
@@ -247,9 +276,9 @@ export class ApnsPushService {
             error: error.message,
             stack: error.stack,
             deviceId: device.id,
-            verbose: true,
+            pushTokenMasked: maskToken(device.pushToken!),
           },
-          "[VERBOSE] APNS HTTP/2 request error",
+          "[APNS] HTTP/2 request error",
         );
         client.close();
         resolve({ success: false, error: error.message });
@@ -263,16 +292,11 @@ export class ApnsPushService {
           deviceId: device.id,
           verbose: true,
         },
-        "[VERBOSE] Writing APNS payload to HTTP/2 stream",
+        "[APNS] Writing payload to HTTP/2 stream",
       );
 
       request.write(payloadStr);
       request.end();
-
-      logger.info(
-        { deviceId: device.id, verbose: true },
-        "[VERBOSE] APNS HTTP/2 request stream ended",
-      );
     });
   }
 }
@@ -296,13 +320,18 @@ export function createApnsService(): ApnsPushService | null {
 
   if (!teamId || !keyId || !privateKey || !bundleId) {
     logger.warn(
-      "APNS configuration incomplete, APNS push notifications disabled",
+      "[APNS] Configuration incomplete, APNS push notifications disabled",
     );
     return null;
   }
 
   // Convert \n escape sequences to actual newlines
   const formattedPrivateKey = privateKey.replace(/\\n/g, "\n");
+
+  logger.info(
+    { teamId, keyId, bundleId },
+    "[APNS] Initialising APNS service",
+  );
 
   cachedApnsService = new ApnsPushService({
     teamId,

--- a/src/api/v2/notifications/fcm-push.service.ts
+++ b/src/api/v2/notifications/fcm-push.service.ts
@@ -1,4 +1,5 @@
 import type { PushTokenType } from "@prisma/client";
+import type { ServiceAccount } from "firebase-admin/app";
 import { getMessaging, type Messaging } from "firebase-admin/messaging";
 import { getFirebaseApp } from "@/utils/firebase";
 import logger from "@/utils/logger";
@@ -10,12 +11,33 @@ export interface FcmDevice {
   pushTokenType: PushTokenType;
 }
 
+/** Mask a token for safe logging: show first 8 and last 4 chars */
+function maskToken(token: string): string {
+  if (token.length <= 16) return `${token.slice(0, 4)}...${token.slice(-4)}`;
+  return `${token.slice(0, 8)}...${token.slice(-4)} (len=${token.length})`;
+}
+
 export class FcmPushService {
   private messaging: Messaging;
+  /** Firebase project ID extracted from the service account (for diagnostics) */
+  private projectId: string | undefined;
+  /** Service account email (for diagnostics) */
+  private serviceAccountEmail: string | undefined;
 
   constructor() {
     const app = getFirebaseApp();
     this.messaging = getMessaging(app);
+
+    // Extract project metadata from service account for diagnostic logging
+    try {
+      const sa = JSON.parse(
+        process.env.FIREBASE_SERVICE_ACCOUNT ?? "{}",
+      ) as ServiceAccount;
+      this.projectId = sa.projectId as string | undefined;
+      this.serviceAccountEmail = sa.clientEmail as string | undefined;
+    } catch {
+      // Non-critical – just for logging
+    }
   }
 
   async sendPushNotification(args: {
@@ -26,10 +48,18 @@ export class FcmPushService {
     const { device, notification, isSilent } = args;
 
     if (!device.pushToken) {
+      logger.warn(
+        { deviceId: device.id },
+        "[FCM] No push token available – skipping send",
+      );
       return { success: false, error: "No FCM push token available" };
     }
 
     if (device.pushTokenType !== "fcm") {
+      logger.warn(
+        { deviceId: device.id, pushTokenType: device.pushTokenType },
+        "[FCM] Device push token type mismatch – expected 'fcm'",
+      );
       return { success: false, error: "Device is not configured for FCM" };
     }
 
@@ -41,9 +71,8 @@ export class FcmPushService {
         {
           deviceId: device.id,
           error,
-          verbose: true,
         },
-        "[VERBOSE] Failed to serialize notification data",
+        "[FCM] Failed to serialize notification data",
       );
       return { success: false, error: "Invalid notification data" };
     }
@@ -58,20 +87,38 @@ export class FcmPushService {
     };
 
     // Add clientId or inboxId depending on which is present
-    if ("clientId" in notification && notification.clientId) {
-      data.clientId = notification.clientId;
-    } else if ("inboxId" in notification && notification.inboxId) {
-      data.inboxId = notification.inboxId;
+    const identifierType =
+      "clientId" in notification && notification.clientId
+        ? "clientId"
+        : "inboxId" in notification && notification.inboxId
+          ? "inboxId"
+          : undefined;
+    if (identifierType === "clientId" && "clientId" in notification) {
+      data.clientId = notification.clientId!;
+    } else if (identifierType === "inboxId" && "inboxId" in notification) {
+      data.inboxId = notification.inboxId!;
     }
+
+    // Extract content topic for logging (if Protocol notification)
+    const contentTopic =
+      "contentTopic" in notification.notificationData
+        ? (notification.notificationData as { contentTopic?: string })
+            .contentTopic
+        : undefined;
 
     try {
       logger.info(
         {
           deviceId: device.id,
+          pushTokenMasked: maskToken(device.pushToken),
           isSilent,
-          verbose: true,
+          notificationType: notification.notificationType,
+          identifierType,
+          contentTopic,
+          firebaseProject: this.projectId,
+          payloadSize: notificationData.length,
         },
-        "[VERBOSE] Sending FCM push notification",
+        "[FCM] Sending push notification",
       );
 
       const messageId = await this.messaging.send({
@@ -87,24 +134,52 @@ export class FcmPushService {
         {
           deviceId: device.id,
           messageId,
-          verbose: true,
+          pushTokenMasked: maskToken(device.pushToken),
+          firebaseProject: this.projectId,
         },
-        "[VERBOSE] FCM push notification sent successfully",
+        "[FCM] Push notification sent successfully",
       );
 
       return { success: true };
     } catch (error) {
-      const fcmError = error as Error & { code?: string };
+      const fcmError = error as Error & {
+        code?: string;
+        details?: unknown;
+        errorInfo?: Record<string, unknown>;
+      };
 
       logger.error(
         {
           deviceId: device.id,
+          pushTokenMasked: maskToken(device.pushToken),
           error: fcmError.message,
           code: fcmError.code,
-          verbose: true,
+          errorInfo: fcmError.errorInfo,
+          firebaseProject: this.projectId,
+          serviceAccountEmail: this.serviceAccountEmail,
+          notificationType: notification.notificationType,
+          contentTopic,
         },
-        "[VERBOSE] FCM push notification failed",
+        "[FCM] Push notification failed",
       );
+
+      // Emit a targeted diagnostic for IAM permission errors so the fix is obvious in logs
+      const isIamError =
+        fcmError.message?.includes("cloudmessaging.messages.create") ||
+        fcmError.message?.includes("PERMISSION_DENIED") ||
+        (fcmError.message?.includes("Permission") &&
+          fcmError.message?.includes("denied"));
+      if (isIamError) {
+        logger.error(
+          {
+            serviceAccountEmail: this.serviceAccountEmail,
+            firebaseProject: this.projectId,
+            requiredRole: "roles/cloudmessaging.admin",
+            gcloudFix: `gcloud projects add-iam-policy-binding ${this.projectId} --member="serviceAccount:${this.serviceAccountEmail}" --role="roles/cloudmessaging.admin"`,
+          },
+          "[FCM] IAM PERMISSION DENIED – service account is missing cloudmessaging.messages.create. Grant roles/cloudmessaging.admin (see gcloudFix field)",
+        );
+      }
 
       // Map FCM error codes to consistent error responses
       if (
@@ -133,16 +208,28 @@ export function createFcmService(): FcmPushService | null {
 
   if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
     logger.warn(
-      "FIREBASE_SERVICE_ACCOUNT not set, FCM push notifications disabled",
+      "[FCM] FIREBASE_SERVICE_ACCOUNT not set, FCM push notifications disabled",
     );
     return null;
   }
 
   try {
+    // Log which Firebase project we're initialising against
+    const sa = JSON.parse(
+      process.env.FIREBASE_SERVICE_ACCOUNT,
+    ) as ServiceAccount;
+    logger.info(
+      {
+        firebaseProject: sa.projectId,
+        serviceAccountEmail: sa.clientEmail,
+      },
+      "[FCM] Initialising FCM service",
+    );
+
     cachedFcmService = new FcmPushService();
     return cachedFcmService;
   } catch (error) {
-    logger.warn({ error }, "Failed to initialize FCM service");
+    logger.warn({ error }, "[FCM] Failed to initialize FCM service");
     return null;
   }
 }

--- a/src/api/v2/notifications/handlers/webhook.ts
+++ b/src/api/v2/notifications/handlers/webhook.ts
@@ -53,13 +53,15 @@ export async function handleXmtpNotification(req: Request, res: Response) {
 
     const notification = parseResult.data;
 
-    // Log the notification for debugging
+    // Log the incoming webhook for debugging
     req.log.info(
       {
         contentTopic: notification.message.content_topic,
+        messageType: notification.message_context.message_type,
         installationId: notification.installation.id,
+        timestampNs: notification.message.timestamp_ns,
       },
-      "received notification",
+      "Received XMTP notification webhook",
     );
 
     // Process v2 notifications (clientId lookup)
@@ -69,9 +71,19 @@ export async function handleXmtpNotification(req: Request, res: Response) {
     });
 
     if (v2Client) {
+      const pushType = v2Client.device.pushTokenType; // 'fcm' | 'apns'
+      const tag = pushType === "fcm" ? "[FCM]" : "[APNS]";
       req.log.info(
-        { clientId: notification.installation.id },
-        "Processing v2 notification",
+        {
+          clientId: notification.installation.id,
+          deviceId: v2Client.deviceId,
+          pushTokenType: pushType,
+          hasPushToken: !!v2Client.device.pushToken,
+          apnsEnv: v2Client.device.apnsEnv,
+          disabled: v2Client.device.disabled,
+          pushFailures: v2Client.device.pushFailures,
+        },
+        `${tag} Processing v2 notification`,
       );
       await handleV2Notification({
         notification,
@@ -97,11 +109,14 @@ async function handleV2Notification(args: {
 }) {
   const { notification, client, req } = args;
 
+  const pushType = client.device.pushTokenType; // 'fcm' | 'apns'
+  const tag = pushType === "fcm" ? "[FCM]" : "[APNS]";
+
   // Only check manual disable flag (not failure count)
   if (client.device.disabled) {
     req.log.warn(
-      { deviceId: client.deviceId },
-      `Device is manually disabled. Skipping notification.`,
+      { deviceId: client.deviceId, pushTokenType: pushType },
+      `${tag} Device is manually disabled. Skipping notification.`,
     );
     return { success: false };
   }
@@ -111,10 +126,11 @@ async function handleV2Notification(args: {
     req.log.warn(
       {
         deviceId: client.deviceId,
+        pushTokenType: pushType,
         failures: client.device.pushFailures,
         lastFailureAt: client.device.lastFailureAt,
       },
-      `Device has high failure count (${client.device.pushFailures}) but continuing`,
+      `${tag} Device has high failure count (${client.device.pushFailures}) but continuing`,
     );
   }
 
@@ -138,8 +154,8 @@ async function handleV2Notification(args: {
 
   if (isWelcome) {
     req.log.info(
-      { contentTopic: notification.message.content_topic },
-      "Detected welcome message - omitting encrypted content to avoid payload limit",
+      { contentTopic: notification.message.content_topic, pushTokenType: pushType },
+      `${tag} Detected welcome message – omitting encrypted content to avoid payload limit`,
     );
   }
 
@@ -160,11 +176,26 @@ async function handleV2Notification(args: {
   // Route to appropriate push service based on token type
   let result: { success: boolean; error?: string };
 
-  if (client.device.pushTokenType === "fcm") {
+  req.log.info(
+    {
+      deviceId: client.deviceId,
+      pushTokenType: pushType,
+      contentTopic: notification.message.content_topic,
+      messageType: notification.message_context.message_type,
+      isWelcome,
+      payloadSize: JSON.stringify(v2Notification.notificationData).length,
+    },
+    `${tag} Routing push notification to ${pushType} service`,
+  );
+
+  if (pushType === "fcm") {
     // Android/FCM push notification
     const fcmService = createFcmService();
     if (!fcmService) {
-      req.log.error("FCM service not configured");
+      req.log.error(
+        { deviceId: client.deviceId },
+        "[FCM] Service not configured – cannot send push",
+      );
       return { success: false };
     }
 
@@ -180,7 +211,10 @@ async function handleV2Notification(args: {
     // iOS/APNS push notification
     const apnsService = createApnsService();
     if (!apnsService) {
-      req.log.error("APNS service not configured");
+      req.log.error(
+        { deviceId: client.deviceId },
+        "[APNS] Service not configured – cannot send push",
+      );
       return { success: false };
     }
 
@@ -205,8 +239,12 @@ async function handleV2Notification(args: {
       },
     });
     req.log.info(
-      { deviceId: client.deviceId },
-      `Successfully sent v2 push notification`,
+      {
+        deviceId: client.deviceId,
+        pushTokenType: pushType,
+        contentTopic: notification.message.content_topic,
+      },
+      `${tag} Successfully sent v2 push notification`,
     );
   } else {
     // Increment failures and conditionally disable in XMTP production environment
@@ -240,17 +278,26 @@ async function handleV2Notification(args: {
     });
 
     // Log detailed error information
+    const rawToken = client.device.pushToken ?? "";
+    const maskedToken = rawToken.length > 16
+      ? `${rawToken.slice(0, 8)}...${rawToken.slice(-4)} (len=${rawToken.length})`
+      : rawToken.length > 0
+        ? `${rawToken.slice(0, 4)}...${rawToken.slice(-4)}`
+        : "(none)";
     req.log.error(
       {
         deviceId: client.deviceId,
         error: result.error,
         failureCount: updated.pushFailures,
-        pushTokenType: client.device.pushTokenType,
+        pushTokenType: pushType,
+        pushTokenMasked: maskedToken,
         apnsEnv: client.device.apnsEnv,
         lastFailureAt: updated.lastFailureAt,
         autoDisabled,
+        contentTopic: notification.message.content_topic,
+        messageType: notification.message_context.message_type,
       },
-      `Failed to send v2 push notification: ${result.error}`,
+      `${tag} Failed to send v2 push notification: ${result.error}`,
     );
 
     // Cleanup if unrecoverable error
@@ -259,8 +306,8 @@ async function handleV2Notification(args: {
       result.error === "BadDeviceToken"
     ) {
       req.log.info(
-        { clientId: client.id, error: result.error },
-        `Cleaning up v2 notification client due to unrecoverable error`,
+        { clientId: client.id, error: result.error, pushTokenType: pushType },
+        `${tag} Cleaning up v2 notification client due to unrecoverable error`,
       );
       try {
         // Delete from local DB first to ensure we don't retry on failure
@@ -277,18 +324,18 @@ async function handleV2Notification(args: {
           // Log but don't fail - DB is authoritative, orphaned XMTP installation is harmless
           req.log.warn(
             { error: xmtpError, clientId: client.id },
-            "Failed to delete XMTP installation, but local DB is clean",
+            `${tag} Failed to delete XMTP installation, but local DB is clean`,
           );
         }
 
         req.log.info(
-          { clientId: client.id },
-          "Successfully cleaned up v2 notifications",
+          { clientId: client.id, pushTokenType: pushType },
+          `${tag} Successfully cleaned up v2 notifications`,
         );
       } catch (cleanupError) {
         req.log.error(
           { error: cleanupError, clientId: client.id },
-          "Failed to cleanup v2 notification subscriptions after push failure",
+          `${tag} Failed to cleanup v2 notification subscriptions after push failure`,
         );
         // Don't throw here - this is already in error handling path
       }

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -5,7 +5,6 @@ process.env.LOG_FORMAT = "json";
 
 // Set required environment variables for tests
 process.env.PUBLIC_ASSETS_BUCKET = "test-public-assets-bucket";
-process.env.JWT_SECRET = "test-jwt-secret";
 process.env.FIREBASE_SERVICE_ACCOUNT = "{}";
 process.env.XMTP_ENV = "local";
 process.env.NOTIFICATION_SERVER_URL = "http://localhost:8080";


### PR DESCRIPTION
## Summary

 Improve push notification logging to make debugging APNS/FCM issues much easier in production.

 ## Changes

 ### Logging improvements (\`apns-push.service.ts\`, \`fcm-push.service.ts\`, \`webhook.ts\`)

 - **\`[APNS]\` / \`[FCM]\` prefixes** on all log messages for easy grep/filtering
 - **Masked push tokens** in logs (first 8 + last 4 chars) — safe for production
 - **Firebase project ID & service account email** logged for FCM diagnostics
 - **Content topic, notification type, payload size, push token type** included in log context
 - **Targeted IAM permission error diagnostic** with a \`gcloudFix\` field showing the exact command to grant the missing role
 - **Device state** (disabled, pushFailures, apnsEnv) logged in webhook handler
 - **Init logging** for both APNS and FCM services on startup
 - Removed \`verbose\`-only flags from important diagnostic logs

 ### Cleanup (\`tests/preload.ts\`)

 - Removed unused \`JWT_SECRET\` env var from test preload (leftover from deleted v1 HMAC auth — replaced by \`JWT_PRIVATE_KEY\` / \`JWT_PUBLIC_KEY\`)

## Verification

All 99 passing tests continue to pass after this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve push notification logging for APNS and FCM with masked tokens and richer context
> - Adds a `maskToken` helper in both [apns-push.service.ts](https://github.com/ephemeraHQ/convos-backend/pull/180/files#diff-fe0e5d0fa93539414a2a3e4aa999cabebec32ff49e88ba83daced03a400150d0) and [fcm-push.service.ts](https://github.com/ephemeraHQ/convos-backend/pull/180/files#diff-768a546e104c8e78d9eb2173d125305ba16e04faa2b4713aff83e6defd1aec9c) that exposes only the first 8 and last 4 characters of device tokens in logs.
> - Standardizes all APNS and FCM log messages under `[APNS]` and `[FCM]` tags, adding context such as environment, bundle ID, notification type, payload size, and content topic.
> - Enriches webhook handler logs in [webhook.ts](https://github.com/ephemeraHQ/convos-backend/pull/180/files#diff-2c3cc6a8c68731e072d96d296d1318af672d2c799e8c7ff791fd047ffea30e87) with per-device details (token type, failure counts, routing decisions) tagged by push type.
> - Adds targeted IAM permission-denied diagnostics for FCM errors, including a suggested `gcloud` command.
> - Removes `JWT_SECRET` from test preload in [tests/preload.ts](https://github.com/ephemeraHQ/convos-backend/pull/180/files#diff-18a45496d94f5e8e63a98b459daedad20117c38f6331f9c92841c3182fc8b9e9); tests relying on this env var will now see it unset unless provided elsewhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4710ba5. 62 files reviewed, 12 issues evaluated, 7 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/api/v2/attachments/handlers/get-presigned-url.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 50](https://github.com/ephemeraHQ/convos-backend/blob/4710ba5aefb7dcc6d60ae7275256de4d70797c54/src/api/v2/attachments/handlers/get-presigned-url.ts#L50): The type assertion `req.query.contentType as string | undefined` on line 50 is unsafe. In Express 5, if a query parameter is provided multiple times (e.g., `?contentType=image/png&contentType=image/jpeg`), `req.query.contentType` will be an array (`string[]`), not a string. When this array is passed to `mime.extension()`, it will be coerced to a comma-separated string that won't match any known MIME type, resulting in no file extension being added when one was intended. Consider validating the type or using `Array.isArray()` to handle this case. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/api/v2/notifications/handlers/subscribe.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 19](https://github.com/ephemeraHQ/convos-backend/blob/4710ba5aefb7dcc6d60ae7275256de4d70797c54/src/api/v2/notifications/handlers/subscribe.ts#L19): The regex `/^[0-9a-fA-F]+$/` for validating HMAC `key` values allows odd-length hex strings (e.g., `"a"`, `"abc"`). The `hexToUint8Array` function from `uint8array-extras` may throw or produce incorrect results for odd-length hex strings since each byte requires exactly 2 hex characters. This would cause a 500 error at line 86 instead of a proper 400 validation error. Consider adding `.regex(/^([0-9a-fA-F]{2})+$/)` to ensure valid even-length hex strings. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/api/v2/notifications/handlers/unsubscribe.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 14](https://github.com/ephemeraHQ/convos-backend/blob/4710ba5aefb7dcc6d60ae7275256de4d70797c54/src/api/v2/notifications/handlers/unsubscribe.ts#L14): The `notificationClient` is instantiated at module load time using `NOTIFICATION_SERVER_URL`, which may be `undefined` if the environment variable is not set. The diff shows that the validation check (`throw new Error("NOTIFICATION_SERVER_URL is not set")`) was removed from `createNotificationClient()`. Now `createConnectTransport` receives an undefined `baseUrl`, which will cause runtime failures when any request is made through this client. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>src/api/v2/notifications/handlers/webhook.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 15](https://github.com/ephemeraHQ/convos-backend/blob/4710ba5aefb7dcc6d60ae7275256de4d70797c54/src/api/v2/notifications/handlers/webhook.ts#L15): The `notificationClient` is initialized at module load time by calling `createNotificationClient()`, but the diff shows that the validation `throw new Error("NOTIFICATION_SERVER_URL is not set")` was removed from `createNotificationClient()`. If `NOTIFICATION_SERVER_URL` is not set in the environment, `createConnectTransport` will receive `baseUrl: undefined`, creating a client that will fail with a cryptic error when `deleteInstallation()` is called at line 273. The cleanup path (lines 272-282) catches this, but the error message won't indicate the root cause is missing configuration. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>src/config.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 29](https://github.com/ephemeraHQ/convos-backend/blob/4710ba5aefb7dcc6d60ae7275256de4d70797c54/src/config.ts#L29): `IS_PRODUCTION` and `IS_DEVELOPMENT` read directly from `process.env.NODE_ENV` instead of using the cached `NODE_ENV` constant (line 27) which has a default fallback of `"development"`. When `process.env.NODE_ENV` is undefined (common in local development), `IS_DEVELOPMENT` will be `false` even though `NODE_ENV` is `"development"`. This causes inconsistent behavior - for example, the error handler won't include error details in responses even when running in a development environment with no NODE_ENV set. Should use `NODE_ENV === "development"` instead of `process.env.NODE_ENV === "development"`. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/routes/healthcheck.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 38](https://github.com/ephemeraHQ/convos-backend/blob/4710ba5aefb7dcc6d60ae7275256de4d70797c54/src/routes/healthcheck.ts#L38): The notification service healthcheck at line 38 will falsely report `healthy` status even when `NOTIFICATION_SERVER_URL` is undefined. The diff shows the validation (`throw new Error("NOTIFICATION_SERVER_URL is not set")`) was removed from `createNotificationClient()`. Since `createConnectTransport` accepts `baseUrl: undefined` without throwing, this healthcheck will always succeed, masking a misconfigured notification service. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>src/utils/firebase.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 22](https://github.com/ephemeraHQ/convos-backend/blob/4710ba5aefb7dcc6d60ae7275256de4d70797c54/src/utils/firebase.ts#L22): `JSON.parse` at line 22 can throw a `SyntaxError` if `FIREBASE_SERVICE_ACCOUNT` contains malformed JSON. The function checks if the variable is set (line 18) but does not handle invalid JSON, causing an uncaught exception to propagate with a confusing error message instead of a clear `AppError`. This is reachable via `verifyAppCheckToken` which calls `getFirebaseApp()` without a try-catch. <b>[ Posting failed ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced push notification logging with secure token masking for improved security
  * Improved diagnostic information and error messages for APNS and FCM services
  * Added actionable guidance for push notification configuration issues
  * Upgraded webhook logging with push type context and routing diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->