### PR TITLE
feat: proxy .well-known/agents.json from agent pool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { noRouteMiddleware } from "./middleware/noRoute";
 import { pinoMiddleware } from "./middleware/pino";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
 import healthcheckRouter from "./routes/healthcheck";
+import { wellKnownRouter } from "./routes/well-known";
 import { validateJWTKeys } from "./utils/jwt";
 import logger from "./utils/logger";
 
@@ -44,6 +45,9 @@ app.use(rateLimitMiddleware);
 
 // add healthcheck routes
 app.use("/healthcheck", healthcheckRouter);
+
+// .well-known proxied from agent pool (RFC 8615 – must be at domain root)
+app.use("/.well-known", wellKnownRouter);
 
 // add api routes
 app.use("/api", apiRouter);

--- a/src/routes/well-known.ts
+++ b/src/routes/well-known.ts
@@ -1,0 +1,71 @@
+import { Router } from "express";
+import { AGENT_POOL_URL } from "@/config";
+import logger from "@/utils/logger";
+
+const wellKnownRouter = Router();
+
+/**
+ * GET /.well-known/agents.json
+ *
+ * Proxies the agents.json from the agent pool manager so it is discoverable
+ * at the root of the Convos Backend API domain (RFC 8615).
+ *
+ * The upstream URL is derived from AGENT_POOL_URL which is already set
+ * per-environment (dev/staging vs production).
+ */
+wellKnownRouter.get("/agents.json", async (req, res) => {
+  const poolBaseUrl = AGENT_POOL_URL.replace(/\/+$/, "");
+
+  if (!poolBaseUrl) {
+    req.log.warn(
+      "AGENT_POOL_URL not configured – cannot proxy .well-known/agents.json",
+    );
+    res.status(503).json({ error: "Agent pool not configured" });
+    return;
+  }
+
+  const upstreamUrl = `${poolBaseUrl}/.well-known/agents.json`;
+
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!upstream.ok) {
+      const text = await upstream.text();
+      logger.error(
+        { status: upstream.status, body: text, upstreamUrl },
+        "Upstream .well-known/agents.json returned non-200",
+      );
+      res.status(upstream.status).end();
+      return;
+    }
+
+    const body = await upstream.text();
+
+    // Forward relevant headers
+    const contentType = upstream.headers.get("content-type");
+    const cacheControl = upstream.headers.get("cache-control");
+
+    if (contentType) res.setHeader("Content-Type", contentType);
+    // Default to a short cache if upstream doesn't specify one
+    res.setHeader("Cache-Control", cacheControl ?? "public, max-age=300");
+
+    res.status(200).send(body);
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      logger.error({ upstreamUrl }, "Upstream .well-known/agents.json timed out");
+      res.status(504).json({ error: "Upstream timeout" });
+      return;
+    }
+
+    logger.error(
+      { error, upstreamUrl },
+      "Failed to proxy .well-known/agents.json",
+    );
+    res.status(502).json({ error: "Failed to fetch upstream agents.json" });
+  }
+});
+
+export { wellKnownRouter };


### PR DESCRIPTION
## Summary

Exposes `/.well-known/agents.json` at the API domain root by proxying the response from the agent pool (`AGENT_POOL_URL`).

This makes the agents manifest discoverable at the standard RFC 8615 well-known path (e.g. `https://api.convos.org/.well-known/agents.json`).

## Details

- **Mounted at root** (`/.well-known/agents.json`), not under `/api` — RFC 8615 requires well-known URIs at the domain root
- **Uses existing `AGENT_POOL_URL`** — each environment already has its own pool URL, so no staging/production branching needed
- No auth required (public endpoint)
- 10s upstream timeout
- Forwards `Content-Type` and `Cache-Control` from upstream (defaults to `public, max-age=300`)
- Returns `503` if pool not configured, `504` on timeout, `502` on fetch failures

## New files
- `src/routes/well-known.ts` — proxy route

## Modified files
- `src/index.ts` — mounts well-known router at `/.well-known`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Proxy `/.well-known/agents.json` from the configured agent pool
> Adds a new Express router in [well-known.ts](https://github.com/ephemeraHQ/convos-backend/pull/181/files#diff-8565349bff5c16d3d4b40e5626e1ed8f56fcd61b2c5cfa49817a14f192a81df1) that proxies `GET /.well-known/agents.json` to `AGENT_POOL_URL/.well-known/agents.json`, forwarding `content-type` and `cache-control` headers (defaulting cache-control to `public, max-age=300`). Returns 503 if `AGENT_POOL_URL` is not set, 504 on timeout (10s limit), 502 on other fetch errors, and the upstream status code on non-2xx responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 270cc60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/.well-known/agents.json` endpoint for retrieving agent configuration from upstream services. Features include intelligent caching (default 5-minute TTL), 10-second request timeout protection, and proper error handling (504 for timeouts, 502 for upstream failures).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->