### PR TITLE
feat: Invite code gating for Instant Assistant

### DIFF
--- a/docs/plans/invite-code-gating.md
+++ b/docs/plans/invite-code-gating.md
@@ -1,0 +1,197 @@
+# Invite Code Gating for Instant Assistant
+
+> **Status**: Draft
+> **Linear**: IOS-393
+> **Created**: 2026-03-24
+
+## Overview
+
+The "Instant assistant" toggle in the Assistants settings screen is currently available to all users. This feature gates that toggle behind a one-time invite code. The first time a user tries to enable "Instant assistant", they are prompted to enter a code. Once a valid code is redeemed, the feature is permanently unlocked app-wide for that installation — not per-conversation.
+
+Codes are generated in bulk on the Convos backend and distributed manually. Codes can be managed via Retool.
+
+## Problem Statement
+
+Instant assistant is a high-value, supply-constrained feature. Without access controls, any user can enable it, which could overwhelm agent capacity and make it impossible to manage rollout. A lightweight invite code system allows the team to control distribution without requiring a full gating infrastructure.
+
+## Goals
+
+- [ ] Gate the "Instant assistant" toggle behind a one-time invite code on first activation
+- [ ] Provide a clear, low-friction code entry experience that matches the Figma design
+- [ ] Permanently unlock the feature for a user once their code is successfully redeemed
+- [ ] Allow code generation and monitoring via the existing Retool setup
+- [ ] Surface clear error feedback for invalid, already-used, or malformed codes
+
+## Non-Goals
+
+- No "invites remaining" counter or quota concept per user
+- No ability for users to share or transfer codes to others
+- No expiry date on codes — codes are valid until redeemed
+- No self-serve code request flow in the app
+- No referral or social graph features
+- Not gating any other feature — this is specifically for "Instant assistant"
+
+---
+
+## iOS Feature
+
+### User Stories
+
+**As a new user trying to enable Instant assistant for the first time**, I want to be prompted for an invite code so that I can unlock the feature and get started.
+
+Acceptance criteria:
+- [ ] The "Instant assistant" toggle is visible in the Assistants settings screen for all users
+- [ ] Tapping the toggle ON for the first time (when not yet unlocked) opens the code entry modal instead of immediately toggling on
+- [ ] Tapping outside the modal dismisses it without enabling the toggle
+- [ ] Submitting a valid code dismisses the modal and enables the toggle
+- [ ] The toggle remains ON and the unlock persists across app restarts (stored locally — no server-side identity record)
+
+**As a user whose code has already been redeemed**, I want the toggle to work without any prompts so that I am not asked for a code again.
+
+Acceptance criteria:
+- [ ] On subsequent app launches, if the local unlock state is set, the toggle reflects the current state with no code prompt
+- [ ] On a fresh install, the unlock state is gone — a new code is required (no server-side lookup)
+
+**As a user who enters an incorrect or already-used code**, I want clear feedback so that I understand what went wrong.
+
+Acceptance criteria:
+- [ ] Invalid code shows an inline error message below the text field
+- [ ] Already-used code shows a distinct inline error message
+- [ ] The text field remains editable after an error so the user can correct their input
+- [ ] The "Continue" button is disabled while a redemption request is in flight
+
+### UX Flow
+
+**Trigger**: The code entry modal appears when a user taps the "Instant assistant" toggle ON and the feature is not yet unlocked for their account.
+
+**Modal content** (per Figma):
+- Title: "Additional assistants"
+- Body: "To invite Assistants into more convos, please enter your code below."
+- Text field with placeholder: "Invite code"
+- Primary button: "Continue" (blue, pill-shaped)
+- No explicit dismiss button — tapping the scrim behind the modal dismisses it
+
+**Success path**: Modal dismisses, toggle switches ON. The feature is unlocked app-wide — not tied to any specific conversation.
+
+**Error path**: Inline error message appears beneath the text field. Modal stays open. User can correct and retry.
+
+**Dismiss without redeeming**: Modal dismisses, toggle stays OFF.
+
+### States
+
+| State | Toggle | Modal |
+|-------|--------|-------|
+| Not yet unlocked | OFF, tappable | Hidden |
+| Toggle tapped (not unlocked) | Stays OFF | Opens |
+| Submitting code | Stays OFF | Continue button disabled, loading indicator |
+| Code accepted | ON | Dismisses |
+| Code rejected | Stays OFF | Error message shown inline |
+| Already unlocked | ON/OFF, fully functional | Never shown again |
+
+### Persistence
+
+The unlock state is stored **locally only** (e.g., in UserDefaults or GRDB). The backend does not record who redeemed a code — it only validates the code and marks it as used (or deletes it). No server-side identity is stored.
+
+This means:
+- On a fresh install, the unlock state is gone and a new code is required
+- No cross-device sync of unlock state
+- The backend cannot answer "is this user unlocked?" — the local store is the only record
+
+### Architecture Notes
+
+- The unlock state check belongs in a service in ConvosCore
+- The modal is a new SwiftUI view in the main app target
+- The code redemption API call goes through `ConvosAPIClient`
+- The local unlock state is the source of truth — no backend query needed after a successful redemption
+- Privacy: the backend never stores who redeemed a code
+
+---
+
+## Backend Feature
+
+### Code Storage
+
+A new database table holds invite codes. Suggested schema:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID | Primary key |
+| `code` | string | Unique, 8 uppercase letters (e.g. `XKQBWFMR`) |
+| `created_at` | timestamp | When the code was generated |
+| `redeemed_at` | timestamp | Null until used; set on redemption |
+| `batch_label` | string | Optional label grouping codes from the same generation run |
+
+No `redeemed_by` column — the backend does not record who redeemed a code. On redemption, the row is either deleted or its `redeemed_at` is set. Either approach is fine; marking as redeemed (rather than deleting) is preferable for auditability in Retool.
+
+### Code Generation
+
+Codes are generated in bulk via Retool. The generation interface should support:
+
+- Specifying a count (e.g., generate 50 codes at once)
+- Optionally tagging codes with a batch label for tracking distribution campaigns
+- Viewing all existing codes with their redemption status (pending / redeemed) and timestamp — no identity shown
+
+Code format: 8 uppercase random letters, e.g. `XKQBWFMR`. Exclude visually ambiguous characters (`O`, `I`). No hyphens or segments.
+
+### Redemption API
+
+**Endpoint**: `POST /api/v2/invite-codes/redeem`
+
+**Authentication**: Requires a valid JWT (`X-Convos-AuthToken` header), same as other authenticated endpoints.
+
+**Request body**:
+```json
+{ "code": "XKQBWFMR" }
+```
+
+**Success response** (`200`):
+```json
+{ "success": true }
+```
+
+**Error responses**:
+
+| HTTP status | Error code | Meaning |
+|-------------|------------|---------|
+| 404 | `CODE_NOT_FOUND` | No code exists with that value |
+| 409 | `CODE_ALREADY_REDEEMED` | Code exists but has already been used |
+| 422 | `CODE_INVALID_FORMAT` | Malformed code string (before DB lookup) |
+| 401 | — | Invalid or missing JWT |
+
+No idempotency guarantee — since the backend does not store who redeemed a code, it cannot detect a duplicate redemption by the same client. The client must not retry on a `200` response; it should only retry on network errors before a response is received.
+
+### Unlock State
+
+The backend has no record of which clients are unlocked. There is no session/profile flag to return. The local app store is the sole source of truth.
+
+### Retool Integration
+
+The Retool setup already exists for other admin operations. What's needed:
+
+1. **Generate codes** — form with a count input and optional batch label, calls an internal API to bulk-insert codes
+2. **View codes** — table showing all codes, their status (pending / redeemed), redeemed-at timestamp, and batch label — no identity shown
+3. **Filter / search** — filter by batch label or redemption status
+
+No delete or invalidation UI is needed in the initial version (codes that are not yet redeemed are valid indefinitely, unless the team decides to add expiry later).
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| User loses network mid-redemption | Medium | Show a clear retry state; do not mark code as used until the server confirms |
+| Client fails to persist unlock after a successful redemption | Low | Write local unlock state synchronously before dismissing the modal |
+| Duplicate codes generated | Low | Enforce uniqueness constraint in the database |
+| User installs the app on a new device | Low | Unlock state is local-only; a new code is required per install — this is intentional and privacy-preserving |
+
+## Open Questions
+
+- [ ] Is there a need to revoke or invalidate a code after distribution (e.g., if a code leaks publicly)?
+
+## References
+
+- Linear: IOS-393
+- Figma: Assistants screen and code entry modal designs
+- Existing agent join endpoint: `docs/plans/agent-join-endpoint.md`
+- Assistant status PRD: `docs/plans/assistant-status.md`

--- a/docs/plans/invite-code-gating.md
+++ b/docs/plans/invite-code-gating.md
@@ -40,6 +40,7 @@ Instant assistant is a high-value, supply-constrained feature. Without access co
 **As a new user trying to enable Instant assistant for the first time**, I want to be prompted for an invite code so that I can unlock the feature and get started.
 
 Acceptance criteria:
+
 - [ ] The "Instant assistant" toggle is visible in the Assistants settings screen for all users
 - [ ] Tapping the toggle ON for the first time (when not yet unlocked) opens the code entry modal instead of immediately toggling on
 - [ ] Tapping outside the modal dismisses it without enabling the toggle
@@ -49,12 +50,14 @@ Acceptance criteria:
 **As a user whose code has already been redeemed**, I want the toggle to work without any prompts so that I am not asked for a code again.
 
 Acceptance criteria:
+
 - [ ] On subsequent app launches, if the local unlock state is set, the toggle reflects the current state with no code prompt
 - [ ] On a fresh install, the unlock state is gone — a new code is required (no server-side lookup)
 
 **As a user who enters an incorrect or already-used code**, I want clear feedback so that I understand what went wrong.
 
 Acceptance criteria:
+
 - [ ] Invalid code shows an inline error message below the text field
 - [ ] Already-used code shows a distinct inline error message
 - [ ] The text field remains editable after an error so the user can correct their input
@@ -65,6 +68,7 @@ Acceptance criteria:
 **Trigger**: The code entry modal appears when a user taps the "Instant assistant" toggle ON and the feature is not yet unlocked for their account.
 
 **Modal content** (per Figma):
+
 - Title: "Additional assistants"
 - Body: "To invite Assistants into more convos, please enter your code below."
 - Text field with placeholder: "Invite code"
@@ -79,20 +83,21 @@ Acceptance criteria:
 
 ### States
 
-| State | Toggle | Modal |
-|-------|--------|-------|
-| Not yet unlocked | OFF, tappable | Hidden |
-| Toggle tapped (not unlocked) | Stays OFF | Opens |
-| Submitting code | Stays OFF | Continue button disabled, loading indicator |
-| Code accepted | ON | Dismisses |
-| Code rejected | Stays OFF | Error message shown inline |
-| Already unlocked | ON/OFF, fully functional | Never shown again |
+| State                        | Toggle                   | Modal                                       |
+| ---------------------------- | ------------------------ | ------------------------------------------- |
+| Not yet unlocked             | OFF, tappable            | Hidden                                      |
+| Toggle tapped (not unlocked) | Stays OFF                | Opens                                       |
+| Submitting code              | Stays OFF                | Continue button disabled, loading indicator |
+| Code accepted                | ON                       | Dismisses                                   |
+| Code rejected                | Stays OFF                | Error message shown inline                  |
+| Already unlocked             | ON/OFF, fully functional | Never shown again                           |
 
 ### Persistence
 
 The unlock state is stored **locally only** (e.g., in UserDefaults or GRDB). The backend does not record who redeemed a code — it only validates the code and marks it as used (or deletes it). No server-side identity is stored.
 
 This means:
+
 - On a fresh install, the unlock state is gone and a new code is required
 - No cross-device sync of unlock state
 - The backend cannot answer "is this user unlocked?" — the local store is the only record
@@ -113,13 +118,13 @@ This means:
 
 A new database table holds invite codes. Suggested schema:
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | UUID | Primary key |
-| `code` | string | Unique, 8 uppercase letters (e.g. `XKQBWFMR`) |
-| `created_at` | timestamp | When the code was generated |
-| `redeemed_at` | timestamp | Null until used; set on redemption |
-| `batch_label` | string | Optional label grouping codes from the same generation run |
+| Column        | Type      | Notes                                                      |
+| ------------- | --------- | ---------------------------------------------------------- |
+| `id`          | UUID      | Primary key                                                |
+| `code`        | string    | Unique, 8 uppercase letters (e.g. `XKQBWFMR`)              |
+| `created_at`  | timestamp | When the code was generated                                |
+| `redeemed_at` | timestamp | Null until used; set on redemption                         |
+| `batch_label` | string    | Optional label grouping codes from the same generation run |
 
 No `redeemed_by` column — the backend does not record who redeemed a code. On redemption, the row is either deleted or its `redeemed_at` is set. Either approach is fine; marking as redeemed (rather than deleting) is preferable for auditability in Retool.
 
@@ -140,23 +145,25 @@ Code format: 8 uppercase random letters, e.g. `XKQBWFMR`. Exclude visually ambig
 **Authentication**: Requires a valid JWT (`X-Convos-AuthToken` header), same as other authenticated endpoints.
 
 **Request body**:
+
 ```json
 { "code": "XKQBWFMR" }
 ```
 
 **Success response** (`200`):
+
 ```json
 { "success": true }
 ```
 
 **Error responses**:
 
-| HTTP status | Error code | Meaning |
-|-------------|------------|---------|
-| 404 | `CODE_NOT_FOUND` | No code exists with that value |
-| 409 | `CODE_ALREADY_REDEEMED` | Code exists but has already been used |
-| 422 | `CODE_INVALID_FORMAT` | Malformed code string (before DB lookup) |
-| 401 | — | Invalid or missing JWT |
+| HTTP status | Error code              | Meaning                                  |
+| ----------- | ----------------------- | ---------------------------------------- |
+| 404         | `CODE_NOT_FOUND`        | No code exists with that value           |
+| 409         | `CODE_ALREADY_REDEEMED` | Code exists but has already been used    |
+| 422         | `CODE_INVALID_FORMAT`   | Malformed code string (before DB lookup) |
+| 401         | —                       | Invalid or missing JWT                   |
 
 No idempotency guarantee — since the backend does not store who redeemed a code, it cannot detect a duplicate redemption by the same client. The client must not retry on a `200` response; it should only retry on network errors before a response is received.
 
@@ -178,12 +185,12 @@ No delete or invalidation UI is needed in the initial version (codes that are no
 
 ## Risks & Mitigations
 
-| Risk | Impact | Mitigation |
-|------|--------|------------|
-| User loses network mid-redemption | Medium | Show a clear retry state; do not mark code as used until the server confirms |
-| Client fails to persist unlock after a successful redemption | Low | Write local unlock state synchronously before dismissing the modal |
-| Duplicate codes generated | Low | Enforce uniqueness constraint in the database |
-| User installs the app on a new device | Low | Unlock state is local-only; a new code is required per install — this is intentional and privacy-preserving |
+| Risk                                                         | Impact | Mitigation                                                                                                  |
+| ------------------------------------------------------------ | ------ | ----------------------------------------------------------------------------------------------------------- |
+| User loses network mid-redemption                            | Medium | Show a clear retry state; do not mark code as used until the server confirms                                |
+| Client fails to persist unlock after a successful redemption | Low    | Write local unlock state synchronously before dismissing the modal                                          |
+| Duplicate codes generated                                    | Low    | Enforce uniqueness constraint in the database                                                               |
+| User installs the app on a new device                        | Low    | Unlock state is local-only; a new code is required per install — this is intentional and privacy-preserving |
 
 ## Open Questions
 

--- a/prisma/migrations/20260325000000_add_invite_codes/migration.sql
+++ b/prisma/migrations/20260325000000_add_invite_codes/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "InviteCode" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "code" VARCHAR(8) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "redeemedAt" TIMESTAMP(3),
+    "batchLabel" VARCHAR(255),
+
+    CONSTRAINT "InviteCode_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InviteCode_code_key" ON "InviteCode"("code");
+
+-- CreateIndex
+CREATE INDEX "InviteCode_batchLabel_idx" ON "InviteCode"("batchLabel");
+
+-- CreateIndex
+CREATE INDEX "InviteCode_redeemedAt_idx" ON "InviteCode"("redeemedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,3 +61,14 @@ model RuntimeConfig {
   value     String
   updatedAt DateTime @updatedAt
 }
+
+model InviteCode {
+  id         String    @id @default(uuid()) @db.Uuid
+  code       String    @unique @db.VarChar(8)
+  createdAt  DateTime  @default(now())
+  redeemedAt DateTime?
+  batchLabel String?   @db.VarChar(255)
+
+  @@index([batchLabel])
+  @@index([redeemedAt])
+}

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -29,7 +29,6 @@ import { authRouter } from "./auth/auth.router";
 import { devRouter } from "./dev/dev.router";
 import { deviceRouter } from "./device/device.router";
 import {
-  inviteCodesAdminPageRouter,
   inviteCodesAdminRouter,
   inviteCodesRouter,
 } from "./invite-codes/invite-codes.router";
@@ -45,10 +44,8 @@ if (process.env.XMTP_ENV !== "production") {
 
 v2Router.use("/invites", invitesV2Router);
 
-// Invite codes: admin page (HTML, no auth — page handles auth client-side)
-v2Router.use("/invite-codes/admin/page", inviteCodesAdminPageRouter);
-// Invite codes: admin API (devAuth-protected, called by the admin page)
-v2Router.use("/invite-codes/admin", devAuthMiddleware, inviteCodesAdminRouter);
+// Invite codes: admin page + API (auth applied per-route inside the router)
+v2Router.use("/invite-codes/admin", inviteCodesAdminRouter);
 // Invite codes: client redemption (JWT-authenticated)
 v2Router.use(
   "/invite-codes",

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -13,6 +13,7 @@ import {
   agentAssetPreAuthLimiter,
   agentJoinLimiter,
   assetRenewalLimiter,
+  inviteCodeRedeemLimiter,
   serviceProvisionLimiter,
 } from "@/middleware/rateLimit";
 import { agentsRouter } from "./agents/agents.router";
@@ -27,6 +28,10 @@ import { attachmentsRouter } from "./attachments/attachments.router";
 import { authRouter } from "./auth/auth.router";
 import { devRouter } from "./dev/dev.router";
 import { deviceRouter } from "./device/device.router";
+import {
+  inviteCodesAdminRouter,
+  inviteCodesRouter,
+} from "./invite-codes/invite-codes.router";
 import invitesV2Router from "./invites/invites.router";
 import { notificationsRouter } from "./notifications/notifications.router";
 import { webhookRouter } from "./notifications/webhook.router";
@@ -38,6 +43,13 @@ if (process.env.XMTP_ENV !== "production") {
 }
 
 v2Router.use("/invites", invitesV2Router);
+v2Router.use("/invite-codes/admin", devAuthMiddleware, inviteCodesAdminRouter);
+v2Router.use(
+  "/invite-codes",
+  inviteCodeRedeemLimiter,
+  authMiddleware,
+  inviteCodesRouter,
+);
 v2Router.use("/auth", authRouter);
 v2Router.use("/device", appCheckOnlyMiddleware, deviceRouter);
 

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -29,6 +29,7 @@ import { authRouter } from "./auth/auth.router";
 import { devRouter } from "./dev/dev.router";
 import { deviceRouter } from "./device/device.router";
 import {
+  inviteCodesAdminPageRouter,
   inviteCodesAdminRouter,
   inviteCodesRouter,
 } from "./invite-codes/invite-codes.router";
@@ -43,7 +44,12 @@ if (process.env.XMTP_ENV !== "production") {
 }
 
 v2Router.use("/invites", invitesV2Router);
+
+// Invite codes: admin page (HTML, no auth — page handles auth client-side)
+v2Router.use("/invite-codes/admin/page", inviteCodesAdminPageRouter);
+// Invite codes: admin API (devAuth-protected, called by the admin page)
 v2Router.use("/invite-codes/admin", devAuthMiddleware, inviteCodesAdminRouter);
+// Invite codes: client redemption (JWT-authenticated)
 v2Router.use(
   "/invite-codes",
   inviteCodeRedeemLimiter,

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { Request, Response } from "express";
 
 /**
@@ -7,14 +8,26 @@ import type { Request, Response } from "express";
  * The page prompts for the admin password (DEV_API_TOKEN) and stores it
  * in sessionStorage. All API calls are made client-side with the token
  * as a Bearer header against the existing admin endpoints.
+ *
+ * A per-request nonce is generated for CSP so inline scripts are allowed
+ * without resorting to 'unsafe-inline'.
  */
 export function adminPageHandler(_req: Request, res: Response) {
+  const nonce = crypto.randomBytes(16).toString("base64");
+
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-store");
-  res.send(ADMIN_HTML);
+  // Override helmet's CSP — only our nonced script and inline styles are allowed
+  res.removeHeader("Content-Security-Policy");
+  res.setHeader(
+    "Content-Security-Policy",
+    `default-src 'self'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'`,
+  );
+  res.send(buildHTML(nonce));
 }
 
-const ADMIN_HTML = `<!DOCTYPE html>
+function buildHTML(nonce: string): string {
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -26,31 +39,20 @@ const ADMIN_HTML = `<!DOCTYPE html>
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f7; color: #1d1d1f; padding: 2rem; max-width: 960px; margin: 0 auto; }
   h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; }
   h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 0.75rem; }
-
-  /* Login */
   #login { max-width: 360px; margin: 4rem auto; }
   #login h1 { text-align: center; }
-
-  /* Cards */
   .card { background: #fff; border-radius: 12px; padding: 1.25rem; margin-bottom: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
-
-  /* Forms */
   label { display: block; font-size: 0.85rem; font-weight: 500; margin-bottom: 0.25rem; color: #6e6e73; }
   input, select { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #d2d2d7; border-radius: 8px; font-size: 0.95rem; margin-bottom: 0.75rem; outline: none; }
   input:focus, select:focus { border-color: #0071e3; box-shadow: 0 0 0 3px rgba(0,113,227,0.15); }
   .row { display: flex; gap: 0.75rem; }
   .row > * { flex: 1; }
-
-  /* Buttons */
   button { padding: 0.5rem 1.25rem; border: none; border-radius: 8px; font-size: 0.9rem; font-weight: 500; cursor: pointer; transition: background 0.15s; }
   .btn-primary { background: #0071e3; color: #fff; }
   .btn-primary:hover { background: #0077ed; }
   .btn-primary:disabled { background: #a1c4e8; cursor: not-allowed; }
   .btn-secondary { background: #e8e8ed; color: #1d1d1f; }
   .btn-secondary:hover { background: #dddde1; }
-  .btn-danger { background: #ff3b30; color: #fff; font-size: 0.8rem; padding: 0.35rem 0.75rem; }
-
-  /* Table */
   .table-wrap { overflow-x: auto; margin-top: 0.5rem; }
   table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
   th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e8e8ed; }
@@ -58,40 +60,30 @@ const ADMIN_HTML = `<!DOCTYPE html>
   .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; }
   .badge-pending { background: #e8f5e9; color: #2e7d32; }
   .badge-redeemed { background: #fce4ec; color: #c62828; }
-
-  /* Pagination */
   .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 0.75rem; font-size: 0.85rem; color: #6e6e73; }
-
-  /* Toast */
   .toast { position: fixed; bottom: 1.5rem; right: 1.5rem; padding: 0.75rem 1.25rem; border-radius: 10px; color: #fff; font-size: 0.9rem; font-weight: 500; opacity: 0; transition: opacity 0.2s; pointer-events: none; z-index: 100; }
   .toast.show { opacity: 1; }
   .toast-success { background: #34c759; }
   .toast-error { background: #ff3b30; }
-
-  /* Generated codes output */
   .generated-codes { background: #f5f5f7; border-radius: 8px; padding: 0.75rem; margin-top: 0.5rem; font-family: "SF Mono", Monaco, monospace; font-size: 0.85rem; word-break: break-all; line-height: 1.8; }
   .generated-codes span { display: inline-block; background: #fff; padding: 0.15rem 0.5rem; border-radius: 4px; margin: 0.15rem; border: 1px solid #e8e8ed; }
-
   .logout { float: right; font-size: 0.8rem; }
 </style>
 </head>
 <body>
 
-<!-- Login -->
 <div id="login">
   <h1>🔑 Invite Codes</h1>
   <div class="card">
     <label for="pw">Admin password</label>
     <input type="password" id="pw" placeholder="Enter password" autofocus>
-    <button class="btn-primary" style="width:100%" onclick="doLogin()">Sign in</button>
+    <button class="btn-primary" style="width:100%" id="login-btn">Sign in</button>
   </div>
 </div>
 
-<!-- Main app (hidden until authed) -->
 <div id="app" style="display:none">
-  <h1>🔑 Invite Codes <button class="btn-secondary logout" onclick="doLogout()">Sign out</button></h1>
+  <h1>🔑 Invite Codes <button class="btn-secondary logout" id="logout-btn">Sign out</button></h1>
 
-  <!-- Generate -->
   <div class="card">
     <h2>Generate codes</h2>
     <div class="row">
@@ -104,17 +96,16 @@ const ADMIN_HTML = `<!DOCTYPE html>
         <input type="text" id="gen-label" placeholder="e.g. beta-wave-1">
       </div>
     </div>
-    <button class="btn-primary" id="gen-btn" onclick="doGenerate()">Generate</button>
+    <button class="btn-primary" id="gen-btn">Generate</button>
     <div id="gen-output"></div>
   </div>
 
-  <!-- List -->
   <div class="card">
     <h2>Browse codes</h2>
     <div class="row">
       <div>
         <label for="filter-status">Status</label>
-        <select id="filter-status" onchange="loadCodes()">
+        <select id="filter-status">
           <option value="all">All</option>
           <option value="pending">Pending</option>
           <option value="redeemed">Redeemed</option>
@@ -122,7 +113,7 @@ const ADMIN_HTML = `<!DOCTYPE html>
       </div>
       <div>
         <label for="filter-batch">Batch label</label>
-        <input type="text" id="filter-batch" placeholder="Filter…" oninput="debounceLoad()">
+        <input type="text" id="filter-batch" placeholder="Filter…">
       </div>
     </div>
     <div class="table-wrap">
@@ -134,8 +125,8 @@ const ADMIN_HTML = `<!DOCTYPE html>
     <div class="pagination">
       <span id="page-info"></span>
       <div>
-        <button class="btn-secondary" id="prev-btn" onclick="prevPage()" disabled>← Prev</button>
-        <button class="btn-secondary" id="next-btn" onclick="nextPage()">Next →</button>
+        <button class="btn-secondary" id="prev-btn" disabled>← Prev</button>
+        <button class="btn-secondary" id="next-btn">Next →</button>
       </div>
     </div>
   </div>
@@ -143,158 +134,142 @@ const ADMIN_HTML = `<!DOCTYPE html>
 
 <div class="toast" id="toast"></div>
 
-<script>
-const PAGE_SIZE = 50;
-let currentOffset = 0;
-let totalCodes = 0;
-let debounceTimer = null;
+<script nonce="${nonce}">
+(function () {
+  var PAGE_SIZE = 50;
+  var currentOffset = 0;
+  var debounceTimer = null;
 
-function token() { return sessionStorage.getItem("invite_admin_token") || ""; }
+  function token() { return sessionStorage.getItem("invite_admin_token") || ""; }
+  function apiBase() { return window.location.origin + "/api/v2/invite-codes/admin"; }
 
-function apiBase() {
-  // The admin API endpoints live under the same origin
-  return window.location.origin + "/api/v2/invite-codes/admin";
-}
+  function apiFetch(path, opts) {
+    opts = opts || {};
+    return fetch(apiBase() + path, Object.assign({}, opts, {
+      headers: Object.assign({
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + token()
+      }, opts.headers || {})
+    }));
+  }
 
-async function apiFetch(path, opts = {}) {
-  const res = await fetch(apiBase() + path, {
-    ...opts,
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": "Bearer " + token(),
-      ...(opts.headers || {}),
-    },
-  });
-  return res;
-}
+  function toast(msg, type) {
+    var el = document.getElementById("toast");
+    el.textContent = msg;
+    el.className = "toast toast-" + (type || "success") + " show";
+    setTimeout(function () { el.className = "toast"; }, 3000);
+  }
 
-function toast(msg, type = "success") {
-  const el = document.getElementById("toast");
-  el.textContent = msg;
-  el.className = "toast toast-" + type + " show";
-  setTimeout(() => { el.className = "toast"; }, 3000);
-}
+  function fmtDate(iso) {
+    if (!iso) return "—";
+    var d = new Date(iso);
+    return d.toLocaleDateString() + " " + d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
 
-function fmtDate(iso) {
-  if (!iso) return "—";
-  const d = new Date(iso);
-  return d.toLocaleDateString() + " " + d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
+  // --- Auth ---
+  function doLogin() {
+    var pw = document.getElementById("pw").value.trim();
+    if (!pw) return;
+    sessionStorage.setItem("invite_admin_token", pw);
+    apiFetch("/codes?limit=1").then(function (res) {
+      if (res.ok) { showApp(); }
+      else { sessionStorage.removeItem("invite_admin_token"); toast("Invalid password", "error"); }
+    }).catch(function () { sessionStorage.removeItem("invite_admin_token"); toast("Network error", "error"); });
+  }
 
-// Auth
-async function doLogin() {
-  const pw = document.getElementById("pw").value.trim();
-  if (!pw) return;
-  sessionStorage.setItem("invite_admin_token", pw);
-  // Test the token by listing codes
-  const res = await apiFetch("/codes?limit=1");
-  if (res.ok) {
-    showApp();
-  } else {
+  function doLogout() {
     sessionStorage.removeItem("invite_admin_token");
-    toast("Invalid password", "error");
+    document.getElementById("app").style.display = "none";
+    document.getElementById("login").style.display = "block";
+    document.getElementById("pw").value = "";
   }
-}
 
-document.getElementById("pw").addEventListener("keydown", (e) => {
-  if (e.key === "Enter") doLogin();
-});
+  function showApp() {
+    document.getElementById("login").style.display = "none";
+    document.getElementById("app").style.display = "block";
+    loadCodes();
+  }
 
-function doLogout() {
-  sessionStorage.removeItem("invite_admin_token");
-  document.getElementById("app").style.display = "none";
-  document.getElementById("login").style.display = "block";
-  document.getElementById("pw").value = "";
-}
-
-function showApp() {
-  document.getElementById("login").style.display = "none";
-  document.getElementById("app").style.display = "block";
-  loadCodes();
-}
-
-// On load, check if already authed
-if (token()) {
-  apiFetch("/codes?limit=1").then(r => { if (r.ok) showApp(); });
-}
-
-// Generate
-async function doGenerate() {
-  const btn = document.getElementById("gen-btn");
-  const count = parseInt(document.getElementById("gen-count").value, 10) || 10;
-  const label = document.getElementById("gen-label").value.trim() || undefined;
-  btn.disabled = true;
-  btn.textContent = "Generating…";
-  try {
-    const res = await apiFetch("/generate", {
+  // --- Generate ---
+  function doGenerate() {
+    var btn = document.getElementById("gen-btn");
+    var count = parseInt(document.getElementById("gen-count").value, 10) || 10;
+    var label = document.getElementById("gen-label").value.trim() || undefined;
+    btn.disabled = true;
+    btn.textContent = "Generating…";
+    apiFetch("/generate", {
       method: "POST",
-      body: JSON.stringify({ count, batchLabel: label }),
-    });
-    const json = await res.json();
-    if (res.ok && json.success) {
-      const out = document.getElementById("gen-output");
-      out.innerHTML = '<div class="generated-codes">' +
-        json.data.codes.map(c => "<span>" + c + "</span>").join("") +
-        "</div>";
-      toast("Generated " + json.data.count + " codes");
-      loadCodes();
-    } else {
-      toast(json.message || "Generation failed", "error");
-    }
-  } catch (e) {
-    toast("Network error", "error");
+      body: JSON.stringify({ count: count, batchLabel: label })
+    }).then(function (res) { return res.json().then(function (json) { return { ok: res.ok, json: json }; }); })
+      .then(function (r) {
+        if (r.ok && r.json.success) {
+          var out = document.getElementById("gen-output");
+          out.innerHTML = '<div class="generated-codes">' +
+            r.json.data.codes.map(function (c) { return "<span>" + c + "</span>"; }).join("") +
+            "</div>";
+          toast("Generated " + r.json.data.count + " codes");
+          loadCodes();
+        } else {
+          toast(r.json.message || "Generation failed", "error");
+        }
+      }).catch(function () { toast("Network error", "error"); })
+      .finally(function () { btn.disabled = false; btn.textContent = "Generate"; });
   }
-  btn.disabled = false;
-  btn.textContent = "Generate";
-}
 
-// List
-function debounceLoad() {
-  clearTimeout(debounceTimer);
-  debounceTimer = setTimeout(() => { currentOffset = 0; loadCodes(); }, 300);
-}
+  // --- List ---
+  function loadCodes() {
+    var status = document.getElementById("filter-status").value;
+    var batch = document.getElementById("filter-batch").value.trim();
+    var params = new URLSearchParams({ status: status, limit: PAGE_SIZE, offset: currentOffset });
+    if (batch) params.set("batchLabel", batch);
 
-async function loadCodes() {
-  const status = document.getElementById("filter-status").value;
-  const batch = document.getElementById("filter-batch").value.trim();
-  const params = new URLSearchParams({ status, limit: PAGE_SIZE, offset: currentOffset });
-  if (batch) params.set("batchLabel", batch);
-
-  try {
-    const res = await apiFetch("/codes?" + params.toString());
-    const json = await res.json();
-    if (!res.ok) { toast(json.message || "Failed to load", "error"); return; }
-
-    const { codes, total } = json.data;
-    totalCodes = total;
-
-    const tbody = document.getElementById("codes-body");
-    if (codes.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:#6e6e73;padding:1.5rem">No codes found</td></tr>';
-    } else {
-      tbody.innerHTML = codes.map(c =>
-        "<tr>" +
-        "<td><code>" + c.code + "</code></td>" +
-        '<td><span class="badge badge-' + c.status + '">' + c.status + "</span></td>" +
-        "<td>" + (c.batchLabel || "—") + "</td>" +
-        "<td>" + fmtDate(c.createdAt) + "</td>" +
-        "<td>" + fmtDate(c.redeemedAt) + "</td>" +
-        "</tr>"
-      ).join("");
-    }
-
-    const start = total === 0 ? 0 : currentOffset + 1;
-    const end = Math.min(currentOffset + PAGE_SIZE, total);
-    document.getElementById("page-info").textContent = start + "–" + end + " of " + total;
-    document.getElementById("prev-btn").disabled = currentOffset === 0;
-    document.getElementById("next-btn").disabled = currentOffset + PAGE_SIZE >= total;
-  } catch (e) {
-    toast("Network error", "error");
+    apiFetch("/codes?" + params.toString())
+      .then(function (res) { return res.json().then(function (json) { return { ok: res.ok, json: json }; }); })
+      .then(function (r) {
+        if (!r.ok) { toast(r.json.message || "Failed to load", "error"); return; }
+        var codes = r.json.data.codes;
+        var total = r.json.data.total;
+        var tbody = document.getElementById("codes-body");
+        if (codes.length === 0) {
+          tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:#6e6e73;padding:1.5rem">No codes found</td></tr>';
+        } else {
+          tbody.innerHTML = codes.map(function (c) {
+            return "<tr>" +
+              "<td><code>" + c.code + "</code></td>" +
+              '<td><span class="badge badge-' + c.status + '">' + c.status + "</span></td>" +
+              "<td>" + (c.batchLabel || "—") + "</td>" +
+              "<td>" + fmtDate(c.createdAt) + "</td>" +
+              "<td>" + fmtDate(c.redeemedAt) + "</td>" +
+              "</tr>";
+          }).join("");
+        }
+        var start = total === 0 ? 0 : currentOffset + 1;
+        var end = Math.min(currentOffset + PAGE_SIZE, total);
+        document.getElementById("page-info").textContent = start + "–" + end + " of " + total;
+        document.getElementById("prev-btn").disabled = currentOffset === 0;
+        document.getElementById("next-btn").disabled = currentOffset + PAGE_SIZE >= total;
+      }).catch(function () { toast("Network error", "error"); });
   }
-}
 
-function prevPage() { currentOffset = Math.max(0, currentOffset - PAGE_SIZE); loadCodes(); }
-function nextPage() { currentOffset += PAGE_SIZE; loadCodes(); }
+  // --- Event listeners ---
+  document.getElementById("login-btn").addEventListener("click", doLogin);
+  document.getElementById("pw").addEventListener("keydown", function (e) { if (e.key === "Enter") doLogin(); });
+  document.getElementById("logout-btn").addEventListener("click", doLogout);
+  document.getElementById("gen-btn").addEventListener("click", doGenerate);
+  document.getElementById("filter-status").addEventListener("change", function () { currentOffset = 0; loadCodes(); });
+  document.getElementById("filter-batch").addEventListener("input", function () {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function () { currentOffset = 0; loadCodes(); }, 300);
+  });
+  document.getElementById("prev-btn").addEventListener("click", function () { currentOffset = Math.max(0, currentOffset - PAGE_SIZE); loadCodes(); });
+  document.getElementById("next-btn").addEventListener("click", function () { currentOffset += PAGE_SIZE; loadCodes(); });
+
+  // Auto-login if session still valid
+  if (token()) {
+    apiFetch("/codes?limit=1").then(function (r) { if (r.ok) showApp(); });
+  }
+})();
 </script>
 </body>
 </html>`;
+}

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -209,9 +209,15 @@ function buildHTML(nonce: string): string {
       .then(function (r) {
         if (r.ok && r.json.success) {
           var out = document.getElementById("gen-output");
-          out.innerHTML = '<div class="generated-codes">' +
-            r.json.data.codes.map(function (c) { return "<span>" + esc(c) + "</span>"; }).join("") +
-            "</div>";
+          out.textContent = "";
+          var wrap = document.createElement("div");
+          wrap.className = "generated-codes";
+          r.json.data.codes.forEach(function (c) {
+            var span = document.createElement("span");
+            span.textContent = c;
+            wrap.appendChild(span);
+          });
+          out.appendChild(wrap);
           toast("Generated " + r.json.data.count + " codes");
           loadCodes();
         } else {
@@ -235,18 +241,46 @@ function buildHTML(nonce: string): string {
         var codes = r.json.data.codes;
         var total = r.json.data.total;
         var tbody = document.getElementById("codes-body");
+        tbody.textContent = "";
         if (codes.length === 0) {
-          tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:#6e6e73;padding:1.5rem">No codes found</td></tr>';
+          var emptyRow = document.createElement("tr");
+          var emptyCell = document.createElement("td");
+          emptyCell.colSpan = 5;
+          emptyCell.style.cssText = "text-align:center;color:#6e6e73;padding:1.5rem";
+          emptyCell.textContent = "No codes found";
+          emptyRow.appendChild(emptyCell);
+          tbody.appendChild(emptyRow);
         } else {
-          tbody.innerHTML = codes.map(function (c) {
-            return "<tr>" +
-              "<td><code>" + esc(c.code) + "</code></td>" +
-              '<td><span class="badge badge-' + esc(c.status) + '">' + esc(c.status) + "</span></td>" +
-              "<td>" + (c.batchLabel ? esc(c.batchLabel) : "—") + "</td>" +
-              "<td>" + fmtDate(c.createdAt) + "</td>" +
-              "<td>" + fmtDate(c.redeemedAt) + "</td>" +
-              "</tr>";
-          }).join("");
+          codes.forEach(function (c) {
+            var tr = document.createElement("tr");
+
+            var tdCode = document.createElement("td");
+            var codeEl = document.createElement("code");
+            codeEl.textContent = c.code;
+            tdCode.appendChild(codeEl);
+            tr.appendChild(tdCode);
+
+            var tdStatus = document.createElement("td");
+            var badge = document.createElement("span");
+            badge.classList.add("badge", "badge-" + c.status);
+            badge.textContent = c.status;
+            tdStatus.appendChild(badge);
+            tr.appendChild(tdStatus);
+
+            var tdBatch = document.createElement("td");
+            tdBatch.textContent = c.batchLabel || "\u2014";
+            tr.appendChild(tdBatch);
+
+            var tdCreated = document.createElement("td");
+            tdCreated.textContent = fmtDate(c.createdAt);
+            tr.appendChild(tdCreated);
+
+            var tdRedeemed = document.createElement("td");
+            tdRedeemed.textContent = fmtDate(c.redeemedAt);
+            tr.appendChild(tdRedeemed);
+
+            tbody.appendChild(tr);
+          });
         }
         var start = total === 0 ? 0 : currentOffset + 1;
         var end = Math.min(currentOffset + PAGE_SIZE, total);

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -187,7 +187,7 @@ async function doLogin() {
   if (!pw) return;
   sessionStorage.setItem("invite_admin_token", pw);
   // Test the token by listing codes
-  const res = await apiFetch("/?limit=1");
+  const res = await apiFetch("/codes?limit=1");
   if (res.ok) {
     showApp();
   } else {
@@ -215,7 +215,7 @@ function showApp() {
 
 // On load, check if already authed
 if (token()) {
-  apiFetch("/?limit=1").then(r => { if (r.ok) showApp(); });
+  apiFetch("/codes?limit=1").then(r => { if (r.ok) showApp(); });
 }
 
 // Generate
@@ -261,7 +261,7 @@ async function loadCodes() {
   if (batch) params.set("batchLabel", batch);
 
   try {
-    const res = await apiFetch("/?" + params.toString());
+    const res = await apiFetch("/codes?" + params.toString());
     const json = await res.json();
     if (!res.ok) { toast(json.message || "Failed to load", "error"); return; }
 

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -160,6 +160,11 @@ function buildHTML(nonce: string): string {
     setTimeout(function () { el.className = "toast"; }, 3000);
   }
 
+  function esc(s) {
+    if (!s) return "";
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
   function fmtDate(iso) {
     if (!iso) return "—";
     var d = new Date(iso);
@@ -205,7 +210,7 @@ function buildHTML(nonce: string): string {
         if (r.ok && r.json.success) {
           var out = document.getElementById("gen-output");
           out.innerHTML = '<div class="generated-codes">' +
-            r.json.data.codes.map(function (c) { return "<span>" + c + "</span>"; }).join("") +
+            r.json.data.codes.map(function (c) { return "<span>" + esc(c) + "</span>"; }).join("") +
             "</div>";
           toast("Generated " + r.json.data.count + " codes");
           loadCodes();
@@ -235,9 +240,9 @@ function buildHTML(nonce: string): string {
         } else {
           tbody.innerHTML = codes.map(function (c) {
             return "<tr>" +
-              "<td><code>" + c.code + "</code></td>" +
-              '<td><span class="badge badge-' + c.status + '">' + c.status + "</span></td>" +
-              "<td>" + (c.batchLabel || "—") + "</td>" +
+              "<td><code>" + esc(c.code) + "</code></td>" +
+              '<td><span class="badge badge-' + esc(c.status) + '">' + esc(c.status) + "</span></td>" +
+              "<td>" + (c.batchLabel ? esc(c.batchLabel) : "—") + "</td>" +
               "<td>" + fmtDate(c.createdAt) + "</td>" +
               "<td>" + fmtDate(c.redeemedAt) + "</td>" +
               "</tr>";

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -1,0 +1,300 @@
+import type { Request, Response } from "express";
+
+/**
+ * Handler for GET /api/v2/invite-codes/admin
+ *
+ * Serves a self-contained admin page for managing invite codes.
+ * The page prompts for the admin password (DEV_API_TOKEN) and stores it
+ * in sessionStorage. All API calls are made client-side with the token
+ * as a Bearer header against the existing admin endpoints.
+ */
+export function adminPageHandler(_req: Request, res: Response) {
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.send(ADMIN_HTML);
+}
+
+const ADMIN_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Invite Codes — Convos Admin</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f7; color: #1d1d1f; padding: 2rem; max-width: 960px; margin: 0 auto; }
+  h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; }
+  h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 0.75rem; }
+
+  /* Login */
+  #login { max-width: 360px; margin: 4rem auto; }
+  #login h1 { text-align: center; }
+
+  /* Cards */
+  .card { background: #fff; border-radius: 12px; padding: 1.25rem; margin-bottom: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+
+  /* Forms */
+  label { display: block; font-size: 0.85rem; font-weight: 500; margin-bottom: 0.25rem; color: #6e6e73; }
+  input, select { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #d2d2d7; border-radius: 8px; font-size: 0.95rem; margin-bottom: 0.75rem; outline: none; }
+  input:focus, select:focus { border-color: #0071e3; box-shadow: 0 0 0 3px rgba(0,113,227,0.15); }
+  .row { display: flex; gap: 0.75rem; }
+  .row > * { flex: 1; }
+
+  /* Buttons */
+  button { padding: 0.5rem 1.25rem; border: none; border-radius: 8px; font-size: 0.9rem; font-weight: 500; cursor: pointer; transition: background 0.15s; }
+  .btn-primary { background: #0071e3; color: #fff; }
+  .btn-primary:hover { background: #0077ed; }
+  .btn-primary:disabled { background: #a1c4e8; cursor: not-allowed; }
+  .btn-secondary { background: #e8e8ed; color: #1d1d1f; }
+  .btn-secondary:hover { background: #dddde1; }
+  .btn-danger { background: #ff3b30; color: #fff; font-size: 0.8rem; padding: 0.35rem 0.75rem; }
+
+  /* Table */
+  .table-wrap { overflow-x: auto; margin-top: 0.5rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+  th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e8e8ed; }
+  th { font-weight: 600; color: #6e6e73; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; }
+  .badge-pending { background: #e8f5e9; color: #2e7d32; }
+  .badge-redeemed { background: #fce4ec; color: #c62828; }
+
+  /* Pagination */
+  .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 0.75rem; font-size: 0.85rem; color: #6e6e73; }
+
+  /* Toast */
+  .toast { position: fixed; bottom: 1.5rem; right: 1.5rem; padding: 0.75rem 1.25rem; border-radius: 10px; color: #fff; font-size: 0.9rem; font-weight: 500; opacity: 0; transition: opacity 0.2s; pointer-events: none; z-index: 100; }
+  .toast.show { opacity: 1; }
+  .toast-success { background: #34c759; }
+  .toast-error { background: #ff3b30; }
+
+  /* Generated codes output */
+  .generated-codes { background: #f5f5f7; border-radius: 8px; padding: 0.75rem; margin-top: 0.5rem; font-family: "SF Mono", Monaco, monospace; font-size: 0.85rem; word-break: break-all; line-height: 1.8; }
+  .generated-codes span { display: inline-block; background: #fff; padding: 0.15rem 0.5rem; border-radius: 4px; margin: 0.15rem; border: 1px solid #e8e8ed; }
+
+  .logout { float: right; font-size: 0.8rem; }
+</style>
+</head>
+<body>
+
+<!-- Login -->
+<div id="login">
+  <h1>🔑 Invite Codes</h1>
+  <div class="card">
+    <label for="pw">Admin password</label>
+    <input type="password" id="pw" placeholder="Enter password" autofocus>
+    <button class="btn-primary" style="width:100%" onclick="doLogin()">Sign in</button>
+  </div>
+</div>
+
+<!-- Main app (hidden until authed) -->
+<div id="app" style="display:none">
+  <h1>🔑 Invite Codes <button class="btn-secondary logout" onclick="doLogout()">Sign out</button></h1>
+
+  <!-- Generate -->
+  <div class="card">
+    <h2>Generate codes</h2>
+    <div class="row">
+      <div>
+        <label for="gen-count">Count</label>
+        <input type="number" id="gen-count" value="10" min="1" max="500">
+      </div>
+      <div>
+        <label for="gen-label">Batch label (optional)</label>
+        <input type="text" id="gen-label" placeholder="e.g. beta-wave-1">
+      </div>
+    </div>
+    <button class="btn-primary" id="gen-btn" onclick="doGenerate()">Generate</button>
+    <div id="gen-output"></div>
+  </div>
+
+  <!-- List -->
+  <div class="card">
+    <h2>Browse codes</h2>
+    <div class="row">
+      <div>
+        <label for="filter-status">Status</label>
+        <select id="filter-status" onchange="loadCodes()">
+          <option value="all">All</option>
+          <option value="pending">Pending</option>
+          <option value="redeemed">Redeemed</option>
+        </select>
+      </div>
+      <div>
+        <label for="filter-batch">Batch label</label>
+        <input type="text" id="filter-batch" placeholder="Filter…" oninput="debounceLoad()">
+      </div>
+    </div>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Code</th><th>Status</th><th>Batch</th><th>Created</th><th>Redeemed</th></tr></thead>
+        <tbody id="codes-body"></tbody>
+      </table>
+    </div>
+    <div class="pagination">
+      <span id="page-info"></span>
+      <div>
+        <button class="btn-secondary" id="prev-btn" onclick="prevPage()" disabled>← Prev</button>
+        <button class="btn-secondary" id="next-btn" onclick="nextPage()">Next →</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+const PAGE_SIZE = 50;
+let currentOffset = 0;
+let totalCodes = 0;
+let debounceTimer = null;
+
+function token() { return sessionStorage.getItem("invite_admin_token") || ""; }
+
+function apiBase() {
+  // The admin API endpoints live under the same origin
+  return window.location.origin + "/api/v2/invite-codes/admin";
+}
+
+async function apiFetch(path, opts = {}) {
+  const res = await fetch(apiBase() + path, {
+    ...opts,
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer " + token(),
+      ...(opts.headers || {}),
+    },
+  });
+  return res;
+}
+
+function toast(msg, type = "success") {
+  const el = document.getElementById("toast");
+  el.textContent = msg;
+  el.className = "toast toast-" + type + " show";
+  setTimeout(() => { el.className = "toast"; }, 3000);
+}
+
+function fmtDate(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleDateString() + " " + d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+// Auth
+async function doLogin() {
+  const pw = document.getElementById("pw").value.trim();
+  if (!pw) return;
+  sessionStorage.setItem("invite_admin_token", pw);
+  // Test the token by listing codes
+  const res = await apiFetch("/?limit=1");
+  if (res.ok) {
+    showApp();
+  } else {
+    sessionStorage.removeItem("invite_admin_token");
+    toast("Invalid password", "error");
+  }
+}
+
+document.getElementById("pw").addEventListener("keydown", (e) => {
+  if (e.key === "Enter") doLogin();
+});
+
+function doLogout() {
+  sessionStorage.removeItem("invite_admin_token");
+  document.getElementById("app").style.display = "none";
+  document.getElementById("login").style.display = "block";
+  document.getElementById("pw").value = "";
+}
+
+function showApp() {
+  document.getElementById("login").style.display = "none";
+  document.getElementById("app").style.display = "block";
+  loadCodes();
+}
+
+// On load, check if already authed
+if (token()) {
+  apiFetch("/?limit=1").then(r => { if (r.ok) showApp(); });
+}
+
+// Generate
+async function doGenerate() {
+  const btn = document.getElementById("gen-btn");
+  const count = parseInt(document.getElementById("gen-count").value, 10) || 10;
+  const label = document.getElementById("gen-label").value.trim() || undefined;
+  btn.disabled = true;
+  btn.textContent = "Generating…";
+  try {
+    const res = await apiFetch("/generate", {
+      method: "POST",
+      body: JSON.stringify({ count, batchLabel: label }),
+    });
+    const json = await res.json();
+    if (res.ok && json.success) {
+      const out = document.getElementById("gen-output");
+      out.innerHTML = '<div class="generated-codes">' +
+        json.data.codes.map(c => "<span>" + c + "</span>").join("") +
+        "</div>";
+      toast("Generated " + json.data.count + " codes");
+      loadCodes();
+    } else {
+      toast(json.message || "Generation failed", "error");
+    }
+  } catch (e) {
+    toast("Network error", "error");
+  }
+  btn.disabled = false;
+  btn.textContent = "Generate";
+}
+
+// List
+function debounceLoad() {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => { currentOffset = 0; loadCodes(); }, 300);
+}
+
+async function loadCodes() {
+  const status = document.getElementById("filter-status").value;
+  const batch = document.getElementById("filter-batch").value.trim();
+  const params = new URLSearchParams({ status, limit: PAGE_SIZE, offset: currentOffset });
+  if (batch) params.set("batchLabel", batch);
+
+  try {
+    const res = await apiFetch("/?" + params.toString());
+    const json = await res.json();
+    if (!res.ok) { toast(json.message || "Failed to load", "error"); return; }
+
+    const { codes, total } = json.data;
+    totalCodes = total;
+
+    const tbody = document.getElementById("codes-body");
+    if (codes.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:#6e6e73;padding:1.5rem">No codes found</td></tr>';
+    } else {
+      tbody.innerHTML = codes.map(c =>
+        "<tr>" +
+        "<td><code>" + c.code + "</code></td>" +
+        '<td><span class="badge badge-' + c.status + '">' + c.status + "</span></td>" +
+        "<td>" + (c.batchLabel || "—") + "</td>" +
+        "<td>" + fmtDate(c.createdAt) + "</td>" +
+        "<td>" + fmtDate(c.redeemedAt) + "</td>" +
+        "</tr>"
+      ).join("");
+    }
+
+    const start = total === 0 ? 0 : currentOffset + 1;
+    const end = Math.min(currentOffset + PAGE_SIZE, total);
+    document.getElementById("page-info").textContent = start + "–" + end + " of " + total;
+    document.getElementById("prev-btn").disabled = currentOffset === 0;
+    document.getElementById("next-btn").disabled = currentOffset + PAGE_SIZE >= total;
+  } catch (e) {
+    toast("Network error", "error");
+  }
+}
+
+function prevPage() { currentOffset = Math.max(0, currentOffset - PAGE_SIZE); loadCodes(); }
+function nextPage() { currentOffset += PAGE_SIZE; loadCodes(); }
+</script>
+</body>
+</html>`;

--- a/src/api/v2/invite-codes/handlers/generate.ts
+++ b/src/api/v2/invite-codes/handlers/generate.ts
@@ -68,12 +68,14 @@ export async function generateHandler(req: Request, res: Response) {
     let codes: string[] = [];
     let retries = 0;
 
-    // Retry loop to handle (extremely unlikely) collisions with existing codes
+    // Retry loop to handle (extremely unlikely) collisions with existing codes.
+    // We can't trust candidates ordering after skipDuplicates, so we query
+    // back the codes that were actually inserted in each batch.
     while (codes.length < count && retries < MAX_GENERATION_RETRIES) {
       const remaining = count - codes.length;
       const candidates = generateUniqueCodes(remaining);
 
-      const created = await prisma.inviteCode.createMany({
+      await prisma.inviteCode.createMany({
         data: candidates.map((code) => ({
           code,
           batchLabel: batchLabel ?? null,
@@ -81,7 +83,14 @@ export async function generateHandler(req: Request, res: Response) {
         skipDuplicates: true,
       });
 
-      codes = codes.concat(candidates.slice(0, created.count));
+      // Query back which candidates were actually inserted (skipped
+      // duplicates won't be found with this batch label + code combo)
+      const inserted = await prisma.inviteCode.findMany({
+        where: { code: { in: candidates }, batchLabel: batchLabel ?? null },
+        select: { code: true },
+      });
+
+      codes = codes.concat(inserted.map((r) => r.code));
       retries++;
     }
 

--- a/src/api/v2/invite-codes/handlers/generate.ts
+++ b/src/api/v2/invite-codes/handlers/generate.ts
@@ -75,6 +75,13 @@ export async function generateHandler(req: Request, res: Response) {
       const remaining = count - codes.length;
       const candidates = generateUniqueCodes(remaining);
 
+      // Find which candidates already exist before inserting
+      const existing = await prisma.inviteCode.findMany({
+        where: { code: { in: candidates } },
+        select: { code: true },
+      });
+      const existingSet = new Set(existing.map((r) => r.code));
+
       await prisma.inviteCode.createMany({
         data: candidates.map((code) => ({
           code,
@@ -83,14 +90,9 @@ export async function generateHandler(req: Request, res: Response) {
         skipDuplicates: true,
       });
 
-      // Query back which candidates were actually inserted (skipped
-      // duplicates won't be found with this batch label + code combo)
-      const inserted = await prisma.inviteCode.findMany({
-        where: { code: { in: candidates }, batchLabel: batchLabel ?? null },
-        select: { code: true },
-      });
-
-      codes = codes.concat(inserted.map((r) => r.code));
+      // Only include candidates that didn't exist before the insert
+      const newCodes = candidates.filter((c) => !existingSet.has(c));
+      codes = codes.concat(newCodes);
       retries++;
     }
 

--- a/src/api/v2/invite-codes/handlers/generate.ts
+++ b/src/api/v2/invite-codes/handlers/generate.ts
@@ -1,0 +1,118 @@
+import crypto from "node:crypto";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+// Uppercase letters excluding visually ambiguous O and I
+const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+const CODE_LENGTH = 8;
+const MAX_BATCH_SIZE = 500;
+const MAX_GENERATION_RETRIES = 3;
+
+const bodySchema = z.object({
+  count: z
+    .number()
+    .int()
+    .min(1, "Count must be at least 1")
+    .max(MAX_BATCH_SIZE, `Count must be at most ${MAX_BATCH_SIZE}`),
+  batchLabel: z.string().max(255, "Batch label too long").optional().nullable(),
+});
+
+function generateCode(): string {
+  const bytes = crypto.randomBytes(CODE_LENGTH);
+  let code = "";
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    code += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return code;
+}
+
+function generateUniqueCodes(count: number): string[] {
+  const codes = new Set<string>();
+  // Guard against infinite loops with a generous iteration cap
+  const maxIterations = count * 10;
+  let iterations = 0;
+  while (codes.size < count && iterations < maxIterations) {
+    codes.add(generateCode());
+    iterations++;
+  }
+  return Array.from(codes);
+}
+
+/**
+ * Handler for POST /api/v2/invite-codes/generate
+ *
+ * Bulk-generates invite codes. This endpoint is intended for internal use
+ * (Retool admin panel) and is protected by the dev auth middleware.
+ *
+ * Request body:
+ *   - count: number of codes to generate (1–500)
+ *   - batchLabel: optional label for tracking distribution campaigns
+ *
+ * Response: array of generated codes
+ */
+export async function generateHandler(req: Request, res: Response) {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      success: false,
+      error: "INVALID_REQUEST",
+      message: parsed.error.issues[0]?.message ?? "Invalid request",
+    });
+    return;
+  }
+
+  const { count, batchLabel } = parsed.data;
+
+  try {
+    let codes: string[] = [];
+    let retries = 0;
+
+    // Retry loop to handle (extremely unlikely) collisions with existing codes
+    while (codes.length < count && retries < MAX_GENERATION_RETRIES) {
+      const remaining = count - codes.length;
+      const candidates = generateUniqueCodes(remaining);
+
+      const created = await prisma.inviteCode.createMany({
+        data: candidates.map((code) => ({
+          code,
+          batchLabel: batchLabel ?? null,
+        })),
+        skipDuplicates: true,
+      });
+
+      codes = codes.concat(candidates.slice(0, created.count));
+      retries++;
+    }
+
+    if (codes.length < count) {
+      req.log.warn(
+        { requested: count, generated: codes.length },
+        "Could not generate all requested codes after retries",
+      );
+    }
+
+    req.log.info({ count: codes.length, batchLabel }, "Invite codes generated");
+
+    res.status(201).json({
+      success: true,
+      data: {
+        codes,
+        count: codes.length,
+        batchLabel: batchLabel ?? null,
+      },
+    });
+    return;
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to generate invite codes",
+    );
+    res.status(500).json({
+      success: false,
+      error: "INTERNAL_ERROR",
+      message: "Failed to generate invite codes",
+    });
+    return;
+  }
+}

--- a/src/api/v2/invite-codes/handlers/list.ts
+++ b/src/api/v2/invite-codes/handlers/list.ts
@@ -1,0 +1,92 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const querySchema = z.object({
+  batchLabel: z.string().optional(),
+  status: z.enum(["pending", "redeemed", "all"]).optional().default("all"),
+  limit: z.coerce.number().int().min(1).max(500).optional().default(100),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+/**
+ * Handler for GET /api/v2/invite-codes
+ *
+ * Lists invite codes with filtering. This endpoint is intended for
+ * internal use (Retool admin panel) and is protected by the dev auth middleware.
+ *
+ * Query parameters:
+ *   - batchLabel: filter by batch label
+ *   - status: "pending" | "redeemed" | "all" (default: "all")
+ *   - limit: max results (1–500, default: 100)
+ *   - offset: pagination offset (default: 0)
+ */
+export async function listHandler(req: Request, res: Response) {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({
+      success: false,
+      error: "INVALID_REQUEST",
+      message: parsed.error.issues[0]?.message ?? "Invalid query parameters",
+    });
+    return;
+  }
+
+  const { batchLabel, status, limit, offset } = parsed.data;
+
+  try {
+    const where: Record<string, unknown> = {};
+
+    if (batchLabel !== undefined) {
+      where.batchLabel = batchLabel;
+    }
+
+    if (status === "pending") {
+      where.redeemedAt = null;
+    } else if (status === "redeemed") {
+      where.redeemedAt = { not: null };
+    }
+
+    const [codes, total] = await Promise.all([
+      prisma.inviteCode.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        skip: offset,
+        select: {
+          id: true,
+          code: true,
+          createdAt: true,
+          redeemedAt: true,
+          batchLabel: true,
+        },
+      }),
+      prisma.inviteCode.count({ where }),
+    ]);
+
+    res.status(200).json({
+      success: true,
+      data: {
+        codes: codes.map((c) => ({
+          ...c,
+          status: c.redeemedAt ? "redeemed" : "pending",
+        })),
+        total,
+        limit,
+        offset,
+      },
+    });
+    return;
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to list invite codes",
+    );
+    res.status(500).json({
+      success: false,
+      error: "INTERNAL_ERROR",
+      message: "Failed to list invite codes",
+    });
+    return;
+  }
+}

--- a/src/api/v2/invite-codes/handlers/redeem.ts
+++ b/src/api/v2/invite-codes/handlers/redeem.ts
@@ -1,0 +1,88 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+// 8 uppercase letters excluding visually ambiguous O and I
+const CODE_PATTERN = /^[A-HJ-NP-Z]{8}$/;
+
+const bodySchema = z.object({
+  code: z.string().min(1, "Code is required").max(8),
+});
+
+/**
+ * Handler for POST /api/v2/invite-codes/redeem
+ *
+ * Redeems an invite code for the "Instant assistant" feature.
+ * The backend does not record who redeemed the code — it only validates
+ * the code and marks it as used. The client stores the unlock state locally.
+ */
+export async function redeemHandler(req: Request, res: Response) {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(422).json({
+      success: false,
+      error: "CODE_INVALID_FORMAT",
+      message: parsed.error.issues[0]?.message ?? "Invalid code format",
+    });
+    return;
+  }
+
+  const { code } = parsed.data;
+  const normalised = code.toUpperCase().trim();
+
+  // Validate format before hitting the database
+  if (!CODE_PATTERN.test(normalised)) {
+    res.status(422).json({
+      success: false,
+      error: "CODE_INVALID_FORMAT",
+      message: "Code must be 8 uppercase letters (excluding O and I)",
+    });
+    return;
+  }
+
+  try {
+    const inviteCode = await prisma.inviteCode.findUnique({
+      where: { code: normalised },
+    });
+
+    if (!inviteCode) {
+      res.status(404).json({
+        success: false,
+        error: "CODE_NOT_FOUND",
+        message: "No invite code found with that value",
+      });
+      return;
+    }
+
+    if (inviteCode.redeemedAt !== null) {
+      res.status(409).json({
+        success: false,
+        error: "CODE_ALREADY_REDEEMED",
+        message: "This invite code has already been used",
+      });
+      return;
+    }
+
+    // Mark the code as redeemed (keep the row for auditability in Retool)
+    await prisma.inviteCode.update({
+      where: { code: normalised },
+      data: { redeemedAt: new Date() },
+    });
+
+    req.log.info({ code: normalised }, "Invite code redeemed");
+
+    res.status(200).json({ success: true });
+    return;
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to redeem invite code",
+    );
+    res.status(500).json({
+      success: false,
+      error: "INTERNAL_ERROR",
+      message: "Failed to redeem invite code",
+    });
+    return;
+  }
+}

--- a/src/api/v2/invite-codes/handlers/redeem.ts
+++ b/src/api/v2/invite-codes/handlers/redeem.ts
@@ -41,11 +41,28 @@ export async function redeemHandler(req: Request, res: Response) {
   }
 
   try {
-    const inviteCode = await prisma.inviteCode.findUnique({
-      where: { code: normalised },
+    // Atomic update: only redeem if the code exists AND hasn't been redeemed yet.
+    // This avoids the TOCTOU race where two concurrent requests both read
+    // redeemedAt as null and both succeed.
+    const result = await prisma.inviteCode.updateMany({
+      where: { code: normalised, redeemedAt: null },
+      data: { redeemedAt: new Date() },
     });
 
-    if (!inviteCode) {
+    if (result.count === 1) {
+      req.log.info({ code: normalised }, "Invite code redeemed");
+      res.status(200).json({ success: true });
+      return;
+    }
+
+    // count === 0: either the code doesn't exist or it was already redeemed.
+    // One more read to distinguish the two cases for the error response.
+    const existing = await prisma.inviteCode.findUnique({
+      where: { code: normalised },
+      select: { redeemedAt: true },
+    });
+
+    if (!existing) {
       res.status(404).json({
         success: false,
         error: "CODE_NOT_FOUND",
@@ -54,24 +71,11 @@ export async function redeemHandler(req: Request, res: Response) {
       return;
     }
 
-    if (inviteCode.redeemedAt !== null) {
-      res.status(409).json({
-        success: false,
-        error: "CODE_ALREADY_REDEEMED",
-        message: "This invite code has already been used",
-      });
-      return;
-    }
-
-    // Mark the code as redeemed (keep the row for auditability in Retool)
-    await prisma.inviteCode.update({
-      where: { code: normalised },
-      data: { redeemedAt: new Date() },
+    res.status(409).json({
+      success: false,
+      error: "CODE_ALREADY_REDEEMED",
+      message: "This invite code has already been used",
     });
-
-    req.log.info({ code: normalised }, "Invite code redeemed");
-
-    res.status(200).json({ success: true });
     return;
   } catch (error) {
     req.log.error(

--- a/src/api/v2/invite-codes/invite-codes.router.ts
+++ b/src/api/v2/invite-codes/invite-codes.router.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { devAuthMiddleware } from "@/middleware/devAuth";
 import { adminPageHandler } from "./handlers/admin-page";
 import { generateHandler } from "./handlers/generate";
 import { listHandler } from "./handlers/list";
@@ -9,15 +10,12 @@ export const inviteCodesRouter = Router();
 // Public (authenticated) endpoint — clients redeem codes here
 inviteCodesRouter.post("/redeem", redeemHandler);
 
-// Admin endpoints — protected by dev auth at the mount level
+// Admin router — single mount point, auth applied per-route
 export const inviteCodesAdminRouter = Router();
 
-// Serve the admin UI (HTML page) — no additional auth needed, the page
-// authenticates client-side by sending the token on every API call
-inviteCodesAdminRouter.get("/", listHandler);
-inviteCodesAdminRouter.post("/generate", generateHandler);
+// HTML page (no server auth — page authenticates client-side via Bearer token)
+inviteCodesAdminRouter.get("/", adminPageHandler);
 
-// The admin HTML page is served without devAuth so the browser can load it,
-// but every API call from the page includes the Bearer token.
-export const inviteCodesAdminPageRouter = Router();
-inviteCodesAdminPageRouter.get("/", adminPageHandler);
+// API endpoints (devAuth-protected, called by the admin page)
+inviteCodesAdminRouter.get("/codes", devAuthMiddleware, listHandler);
+inviteCodesAdminRouter.post("/generate", devAuthMiddleware, generateHandler);

--- a/src/api/v2/invite-codes/invite-codes.router.ts
+++ b/src/api/v2/invite-codes/invite-codes.router.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { generateHandler } from "./handlers/generate";
+import { listHandler } from "./handlers/list";
+import { redeemHandler } from "./handlers/redeem";
+
+export const inviteCodesRouter = Router();
+
+// Public (authenticated) endpoint — clients redeem codes here
+inviteCodesRouter.post("/redeem", redeemHandler);
+
+// Admin endpoints — protected by dev auth at the mount level
+export const inviteCodesAdminRouter = Router();
+inviteCodesAdminRouter.post("/generate", generateHandler);
+inviteCodesAdminRouter.get("/", listHandler);

--- a/src/api/v2/invite-codes/invite-codes.router.ts
+++ b/src/api/v2/invite-codes/invite-codes.router.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { adminPageHandler } from "./handlers/admin-page";
 import { generateHandler } from "./handlers/generate";
 import { listHandler } from "./handlers/list";
 import { redeemHandler } from "./handlers/redeem";
@@ -10,5 +11,13 @@ inviteCodesRouter.post("/redeem", redeemHandler);
 
 // Admin endpoints — protected by dev auth at the mount level
 export const inviteCodesAdminRouter = Router();
-inviteCodesAdminRouter.post("/generate", generateHandler);
+
+// Serve the admin UI (HTML page) — no additional auth needed, the page
+// authenticates client-side by sending the token on every API call
 inviteCodesAdminRouter.get("/", listHandler);
+inviteCodesAdminRouter.post("/generate", generateHandler);
+
+// The admin HTML page is served without devAuth so the browser can load it,
+// but every API call from the page includes the Bearer token.
+export const inviteCodesAdminPageRouter = Router();
+inviteCodesAdminPageRouter.get("/", adminPageHandler);

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -60,6 +60,17 @@ export const serviceProvisionLimiter = rateLimit({
   },
 });
 
+// Rate limiting for invite code redemption (5 attempts per 15 minutes per IP)
+export const inviteCodeRedeemLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 5,
+  legacyHeaders: false,
+  standardHeaders: "draft-8",
+  message: {
+    error: "Too many code redemption attempts, please try again later",
+  },
+});
+
 // Post-auth rate limiting for agent asset uploads (shared global throughput cap)
 export const agentAssetLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -67,7 +67,9 @@ export const inviteCodeRedeemLimiter = rateLimit({
   legacyHeaders: false,
   standardHeaders: "draft-8",
   message: {
-    error: "Too many code redemption attempts, please try again later",
+    success: false,
+    error: "RATE_LIMITED",
+    message: "Too many code redemption attempts, please try again later",
   },
 });
 

--- a/tests/invite-codes.test.ts
+++ b/tests/invite-codes.test.ts
@@ -1,0 +1,232 @@
+import type { Server } from "node:http";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { inviteCodesRouter } from "@/api/v2/invite-codes/invite-codes.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+
+// Minimal test app — skip full JWT auth for unit testing the handler logic.
+// Auth is tested separately in jwt.test.ts; here we focus on the code
+// redemption business logic.
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/invite-codes", inviteCodesRouter);
+
+describe("Invite Codes API Tests", () => {
+  let server: Server;
+  const baseURL = "http://localhost:4002";
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4002, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+    await prisma.$disconnect();
+  });
+
+  afterEach(async () => {
+    // Clean up test codes between tests
+    await prisma.inviteCode.deleteMany({
+      where: { batchLabel: "test" },
+    });
+  });
+
+  describe("POST /api/v2/invite-codes/redeem", () => {
+    test("should return 422 for missing code in body", async () => {
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(422);
+      const data = (await response.json()) as {
+        success: boolean;
+        error: string;
+      };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("CODE_INVALID_FORMAT");
+    });
+
+    test("should return 422 for malformed code (too short)", async () => {
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "ABC" }),
+      });
+
+      expect(response.status).toBe(422);
+      const data = (await response.json()) as {
+        success: boolean;
+        error: string;
+      };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("CODE_INVALID_FORMAT");
+    });
+
+    test("should return 422 for code with ambiguous characters (O, I)", async () => {
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "ABCDEFOI" }),
+      });
+
+      expect(response.status).toBe(422);
+      const data = (await response.json()) as {
+        success: boolean;
+        error: string;
+      };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("CODE_INVALID_FORMAT");
+    });
+
+    test("should return 422 for code with numbers", async () => {
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "ABCD1234" }),
+      });
+
+      expect(response.status).toBe(422);
+      const data = (await response.json()) as {
+        success: boolean;
+        error: string;
+      };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("CODE_INVALID_FORMAT");
+    });
+
+    test("should return 404 for code that does not exist", async () => {
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "XKQBWFMR" }),
+      });
+
+      expect(response.status).toBe(404);
+      const data = (await response.json()) as {
+        success: boolean;
+        error: string;
+      };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("CODE_NOT_FOUND");
+    });
+
+    test("should return 200 for valid unredeemed code", async () => {
+      // Seed a code
+      await prisma.inviteCode.create({
+        data: { code: "XKQBWFMR", batchLabel: "test" },
+      });
+
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "XKQBWFMR" }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as { success: boolean };
+      expect(data.success).toBe(true);
+
+      // Verify the code was marked as redeemed
+      const updated = await prisma.inviteCode.findUnique({
+        where: { code: "XKQBWFMR" },
+      });
+      expect(updated?.redeemedAt).not.toBeNull();
+    });
+
+    test("should return 409 for already redeemed code", async () => {
+      // Seed a redeemed code
+      await prisma.inviteCode.create({
+        data: {
+          code: "ALRDYUSD",
+          batchLabel: "test",
+          redeemedAt: new Date(),
+        },
+      });
+
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "ALRDYUSD" }),
+      });
+
+      expect(response.status).toBe(409);
+      const data = (await response.json()) as {
+        success: boolean;
+        error: string;
+      };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("CODE_ALREADY_REDEEMED");
+    });
+
+    test("should normalise lowercase input to uppercase", async () => {
+      await prisma.inviteCode.create({
+        data: { code: "LWRCSETX", batchLabel: "test" },
+      });
+
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "lwrcsetx" }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as { success: boolean };
+      expect(data.success).toBe(true);
+    });
+
+    test("should return consistent error format", async () => {
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "NOTFOUND" }),
+      });
+
+      const data = (await response.json()) as {
+        success: boolean;
+        error: string;
+        message: string;
+      };
+      expect(data).toHaveProperty("success");
+      expect(data).toHaveProperty("error");
+      expect(data).toHaveProperty("message");
+      expect(data.success).toBe(false);
+      expect(typeof data.error).toBe("string");
+      expect(typeof data.message).toBe("string");
+    });
+  });
+
+  describe("Security tests", () => {
+    test("should not expose internal error details", async () => {
+      const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "NOTFOUND" }),
+      });
+
+      const data = (await response.json()) as { message: string };
+      expect(data.message).not.toContain("stack");
+      expect(data.message).not.toContain("Error:");
+      expect(JSON.stringify(data)).not.toContain("prisma");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the backend for invite code gating (IOS-393). Users must redeem a one-time invite code to unlock the Instant Assistant feature. The backend validates codes and marks them as redeemed but **never records who redeemed them** (privacy-preserving design). The unlock state lives entirely on the client.

PRD: `docs/plans/invite-code-gating.md`

---

## iOS Integration — what you need

### Redeem a code

```
POST /api/v2/invite-codes/redeem
```

**Auth:** JWT via `X-Convos-AuthToken` header (same as other authenticated endpoints).

**Request:**
```json
{ "code": "XKQBWFMR" }
```

Input is case-insensitive — lowercase is normalised to uppercase on the server.

**Success (`200`):**
```json
{ "success": true }
```

On success, persist the unlock state locally (UserDefaults / GRDB). The backend cannot answer "is this user unlocked?" — your local store is the only record.

**Errors:**

| HTTP | `error` field | When |
|------|--------------|------|
| 422 | `CODE_INVALID_FORMAT` | Code is not 8 uppercase letters, or contains O/I |
| 404 | `CODE_NOT_FOUND` | No such code exists |
| 409 | `CODE_ALREADY_REDEEMED` | Code exists but was already used |
| 401 | — | Missing or invalid JWT |
| 429 | — | Rate limited (5 attempts per 15 min per IP) |

All error responses have this shape:
```json
{ "success": false, "error": "CODE_NOT_FOUND", "message": "Human-readable message" }
```

**Code format:** 8 uppercase letters from `ABCDEFGHJKLMNPQRSTUVWXYZ` (no `O` or `I`). Example: `XKQBWFMR`.

**Rate limiting:** 5 redemption attempts per 15 minutes per IP. On `429`, show a generic "try again later" message.

**No idempotency:** The backend does not store who redeemed a code, so it cannot detect duplicate redemptions by the same client. Do not retry after a `200`. Only retry on network errors before a response is received.

---

## Admin Endpoints

### Admin page (browser)

```
GET /api/v2/invite-codes/admin
```

Self-contained HTML page for generating and browsing codes. Protected by `DEV_API_TOKEN` (entered as a password in the page, stored in `sessionStorage`, sent as `Authorization: Bearer <token>` on every API call). CSP-safe via per-request nonce.

### Generate codes (API)

```
POST /api/v2/invite-codes/admin/generate
Authorization: Bearer <DEV_API_TOKEN>
```

```json
{ "count": 50, "batchLabel": "beta-wave-1" }
```

Response (`201`):
```json
{
  "success": true,
  "data": { "codes": ["XKQBWFMR", "..."], "count": 50, "batchLabel": "beta-wave-1" }
}
```

### List codes (API)

```
GET /api/v2/invite-codes/admin/codes?status=pending&batchLabel=beta-wave-1&limit=100&offset=0
Authorization: Bearer <DEV_API_TOKEN>
```

Response (`200`):
```json
{
  "success": true,
  "data": {
    "codes": [{ "id": "...", "code": "XKQBWFMR", "status": "pending", "batchLabel": "beta-wave-1", "createdAt": "...", "redeemedAt": null }],
    "total": 50,
    "limit": 100,
    "offset": 0
  }
}
```

Query params: `status` (`all` | `pending` | `redeemed`), `batchLabel`, `limit` (1–500), `offset`.

---

## Schema

New `InviteCode` table:

| Column | Type | Notes |
|--------|------|-------|
| `id` | UUID | PK, auto-generated |
| `code` | VARCHAR(8) | Unique, 8 uppercase letters (no O/I) |
| `createdAt` | TIMESTAMP | Auto-set |
| `redeemedAt` | TIMESTAMP | Null until redeemed |
| `batchLabel` | VARCHAR(255) | Optional, for tracking distribution batches |

No `redeemed_by` column — the backend never records who redeemed a code.

Migration: `prisma/migrations/20260325000000_add_invite_codes`

---

## Files changed

- `prisma/schema.prisma` — `InviteCode` model
- `prisma/migrations/20260325000000_add_invite_codes/` — migration
- `src/api/v2/invite-codes/handlers/redeem.ts` — redemption handler
- `src/api/v2/invite-codes/handlers/generate.ts` — bulk generation handler
- `src/api/v2/invite-codes/handlers/list.ts` — listing handler
- `src/api/v2/invite-codes/handlers/admin-page.ts` — admin HTML page (CSP nonce)
- `src/api/v2/invite-codes/invite-codes.router.ts` — router
- `src/api/v2/index.ts` — route mounting
- `src/middleware/rateLimit.ts` — `inviteCodeRedeemLimiter`
- `tests/invite-codes.test.ts` — tests for redemption flow
- `docs/plans/invite-code-gating.md` — PRD


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add invite code gating for Instant Assistant with admin UI and redemption API
> - Adds an `InviteCode` table (via [Prisma migration](https://github.com/ephemeraHQ/convos-backend/pull/183/files#diff-621cb1126323ee66b7832a33f45f6c3dc189d959bda40d755df46d53e186ae8b)) storing 8-character codes with optional batch labels and redemption timestamps.
> - Adds `POST /api/v2/invite-codes/redeem` for JWT-authenticated clients to redeem a code exactly once; duplicate redemptions return 409 and missing codes return 404.
> - Adds an admin router under `/api/v2/invite-codes/admin` with a self-contained HTML UI for generating (up to 500 per request) and listing/filtering codes, protected by `devAuthMiddleware`.
> - Rate-limits redemption attempts to 5 per IP per 15 minutes via `inviteCodeRedeemLimiter`.
> - Risk: the admin page is served without server-side auth (authentication is handled client-side via sessionStorage password), relying solely on `devAuthMiddleware` for the underlying API routes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 296194b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invite code-based unlock mechanism for the iOS "Instant Assistant" feature, allowing users to activate this capability by redeeming a one-time code that permanently unlocks the feature locally on their device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->