### PR TITLE
feat: Multi-use invite codes with viral redemption

### DIFF
--- a/docs/plans/invite-code-multi-use.md
+++ b/docs/plans/invite-code-multi-use.md
@@ -1,0 +1,288 @@
+# Multi-Use Invite Codes with Viral Redemption
+
+> **Status**: Draft
+> **Branch**: `feat/invite-code-multi-use`
+> **Parent PR**: #183 (Invite code gating for Instant Assistant)
+> **Created**: 2026-04-01
+
+## Overview
+
+Expand the invite code system so that codes can be redeemed a configurable number of times, and each redemption automatically generates a new invite code for the redeemer. This creates a controlled viral loop — each person who redeems a code gets their own code to share.
+
+## Summary of Changes
+
+### Current State (PR #183)
+
+- `InviteCode` table has: `id`, `code`, `createdAt`, `redeemedAt`, `batchLabel`
+- Codes are single-use — once `redeemedAt` is set, the code is fully consumed
+- `POST /api/v2/invite-codes/redeem` accepts `{ code }`, returns `{ success: true }`
+- Admin generates codes via `POST /api/v2/invite-codes/admin/generate`
+- Admin lists codes via `GET /api/v2/invite-codes/admin/codes`
+
+### Target State
+
+- Codes have a `maxRedemptions` limit and a tracked `redemptionCount`
+- Codes have an optional `name` for identification
+- Redeeming a code auto-generates a new code for the redeemer (default: 5 uses)
+- New endpoint to check remaining redemptions for a code
+- Admin can set `maxRedemptions` and `name` when generating codes
+
+---
+
+## 1. Database Migration
+
+### Schema Changes to `InviteCode`
+
+| Column             | Type     | Default | Notes                                              |
+| ------------------ | -------- | ------- | -------------------------------------------------- |
+| `name`             | String?  | null    | Optional human-readable label for the code          |
+| `maxRedemptions`   | Int      | 1       | How many times this code can be redeemed            |
+| `redemptionCount`  | Int      | 0       | How many times this code has been redeemed so far   |
+| `parentCodeId`     | UUID?    | null    | FK → InviteCode.id — the code that was redeemed to generate this one |
+
+### New Table: `InviteCodeRedemption`
+
+Track each individual redemption event (for auditability and the viral chain).
+
+| Column         | Type      | Notes                                    |
+| -------------- | --------- | ---------------------------------------- |
+| `id`           | UUID      | Primary key                              |
+| `inviteCodeId` | UUID      | FK → InviteCode.id (the code redeemed)   |
+| `childCodeId`  | UUID?     | FK → InviteCode.id (the code generated for the redeemer) |
+| `redeemedAt`   | Timestamp | When this redemption occurred            |
+
+### Migration Strategy
+
+- Add new columns to `InviteCode` with defaults so existing rows are valid:
+  - `maxRedemptions` defaults to `1`
+  - `redemptionCount` defaults to `0` for unredeemed, `1` for already-redeemed codes
+  - `name` defaults to `null`
+  - `parentCodeId` defaults to `null`
+- Create `InviteCodeRedemption` table
+- **Remove `redeemedAt` from `InviteCode`** — redemption status is now derived:
+  - A code is "fully redeemed" when `redemptionCount >= maxRedemptions`
+  - A code is "available" when `redemptionCount < maxRedemptions`
+  - Individual redemption timestamps live in `InviteCodeRedemption`
+- Migrate existing redeemed codes: for each code where `redeemedAt IS NOT NULL`, set `redemptionCount = 1` and create a corresponding `InviteCodeRedemption` row. Then drop `redeemedAt`.
+
+### Updated Prisma Schema
+
+```prisma
+model InviteCode {
+  id              String    @id @default(uuid()) @db.Uuid
+  code            String    @unique @db.VarChar(8)
+  name            String?   @db.VarChar(255)
+  maxRedemptions  Int       @default(1)
+  redemptionCount Int       @default(0)
+  createdAt       DateTime  @default(now())
+  batchLabel      String?   @db.VarChar(255)
+  parentCodeId    String?   @db.Uuid
+  parentCode      InviteCode?  @relation("CodeLineage", fields: [parentCodeId], references: [id])
+  childCodes      InviteCode[] @relation("CodeLineage")
+  redemptions     InviteCodeRedemption[] @relation("CodeRedemptions")
+  generatedFrom   InviteCodeRedemption[] @relation("GeneratedCode")
+
+  @@index([batchLabel])
+  @@index([parentCodeId])
+}
+
+model InviteCodeRedemption {
+  id           String     @id @default(uuid()) @db.Uuid
+  inviteCodeId String     @db.Uuid
+  inviteCode   InviteCode @relation("CodeRedemptions", fields: [inviteCodeId], references: [id])
+  childCodeId  String?    @db.Uuid
+  childCode    InviteCode? @relation("GeneratedCode", fields: [childCodeId], references: [id])
+  redeemedAt   DateTime   @default(now())
+
+  @@index([inviteCodeId])
+  @@index([childCodeId])
+}
+```
+
+---
+
+## 2. API Changes
+
+### 2a. `POST /api/v2/invite-codes/redeem` — Updated
+
+**Request body** (unchanged):
+```json
+{ "code": "XKQBWFMR" }
+```
+
+**Success response** (`200`) — **updated to include generated code**:
+```json
+{
+  "success": true,
+  "data": {
+    "inviteCode": {
+      "code": "HTYNLBKW",
+      "name": null,
+      "maxRedemptions": 5,
+      "redemptionCount": 0,
+      "remainingRedemptions": 5
+    }
+  }
+}
+```
+
+**Logic changes:**
+1. Look up the code
+2. Check `redemptionCount < maxRedemptions` (replaces the `redeemedAt == null` check)
+3. Atomically increment `redemptionCount` (use `updateMany` with `where: { code, redemptionCount: { lt: maxRedemptions } }` to prevent races)
+4. Generate a new invite code with `maxRedemptions = 5` (configurable default via env `DEFAULT_CHILD_CODE_MAX_REDEMPTIONS`)
+5. Create an `InviteCodeRedemption` row linking the redeemed code to the child code
+6. Return the generated code in the response
+
+**Updated error responses:**
+
+| HTTP status | Error code              | Meaning                                                |
+| ----------- | ----------------------- | ------------------------------------------------------ |
+| 404         | `CODE_NOT_FOUND`        | No code exists with that value                         |
+| 409         | `CODE_FULLY_REDEEMED`   | Code exists but has reached its max redemptions        |
+| 422         | `CODE_INVALID_FORMAT`   | Malformed code string                                  |
+| 401         | —                       | Invalid or missing JWT                                 |
+
+> Note: `CODE_ALREADY_REDEEMED` → `CODE_FULLY_REDEEMED` (semantic change since codes can now be redeemed multiple times). This is a **breaking change** for iOS — coordinate with client team.
+
+### 2b. `GET /api/v2/invite-codes/:code/status` — New Endpoint
+
+Check the remaining redemptions for a given invite code.
+
+**Authentication**: Requires a valid JWT (same as redeem).
+
+**Response** (`200`):
+```json
+{
+  "success": true,
+  "data": {
+    "code": "XKQBWFMR",
+    "name": "Jarod's invite",
+    "maxRedemptions": 5,
+    "redemptionCount": 2,
+    "remainingRedemptions": 3
+  }
+}
+```
+
+**Error responses:**
+
+| HTTP status | Error code       | Meaning                               |
+| ----------- | ---------------- | ------------------------------------- |
+| 404         | `CODE_NOT_FOUND` | No code exists with that value        |
+| 422         | `CODE_INVALID_FORMAT` | Malformed code string            |
+| 401         | —                | Invalid or missing JWT                |
+
+### 2c. `POST /api/v2/invite-codes/admin/generate` — Updated
+
+**Request body** — add optional fields:
+```json
+{
+  "count": 10,
+  "batchLabel": "beta-wave-2",
+  "name": "VIP invite",
+  "maxRedemptions": 20
+}
+```
+
+| Field            | Type    | Default | Notes                                       |
+| ---------------- | ------- | ------- | ------------------------------------------- |
+| `count`          | Int     | —       | Required, 1–500                             |
+| `batchLabel`     | String? | null    | Optional batch label                        |
+| `name`           | String? | null    | Optional name applied to all generated codes|
+| `maxRedemptions` | Int?    | 1       | Max redemptions for each generated code     |
+
+### 2d. `GET /api/v2/invite-codes/admin/codes` — Updated
+
+Add new fields to the response objects:
+
+```json
+{
+  "id": "...",
+  "code": "XKQBWFMR",
+  "name": "VIP invite",
+  "status": "available",
+  "maxRedemptions": 20,
+  "redemptionCount": 7,
+  "remainingRedemptions": 13,
+  "batchLabel": "beta-wave-2",
+  "createdAt": "...",
+  "parentCode": "ABCDEFGH"
+}
+```
+
+**Status values** change from `pending`/`redeemed` to:
+- `available` — `redemptionCount < maxRedemptions`
+- `exhausted` — `redemptionCount >= maxRedemptions`
+
+> This is a breaking change for the admin page filter. The admin page HTML needs updating too.
+
+---
+
+## 3. Admin Page Updates
+
+Update the admin HTML page (`admin-page.ts`) to:
+
+- Show new columns: Name, Max Redemptions, Redemption Count, Remaining, Parent Code
+- Update status filter options: `all`, `available`, `exhausted` (replaces `pending`/`redeemed`)
+- Add `name` and `maxRedemptions` inputs to the generate form
+- Widen table layout to accommodate new columns
+
+---
+
+## 4. Rate Limiting
+
+- The existing `inviteCodeRedeemLimiter` (5 attempts / 15 min / IP) stays
+- The new status endpoint should share the same rate limiter (it's lightweight but shouldn't be abused)
+
+---
+
+## 5. File-by-File Change List
+
+| File | Change |
+|------|--------|
+| `prisma/schema.prisma` | Add `name`, `maxRedemptions`, `redemptionCount`, `parentCodeId` to `InviteCode`; add `InviteCodeRedemption` model; remove `redeemedAt` |
+| `prisma/migrations/2026XXXX_multi_use_invite_codes/migration.sql` | New migration: alter `InviteCode`, create `InviteCodeRedemption`, data migration, drop `redeemedAt` |
+| `src/api/v2/invite-codes/handlers/redeem.ts` | Rewrite redemption logic: check `redemptionCount < maxRedemptions`, atomic increment, generate child code, create redemption row, return child code |
+| `src/api/v2/invite-codes/handlers/status.ts` | **New file** — handler for `GET /:code/status` |
+| `src/api/v2/invite-codes/handlers/generate.ts` | Accept `name` and `maxRedemptions` in body schema; pass to `createMany` |
+| `src/api/v2/invite-codes/handlers/list.ts` | Update response shape (new fields, new status values), update filter logic |
+| `src/api/v2/invite-codes/handlers/admin-page.ts` | Update HTML to show new columns, new filter options, new generate form fields |
+| `src/api/v2/invite-codes/invite-codes.router.ts` | Add `GET /:code/status` route |
+| `src/api/v2/index.ts` | No changes needed (router already mounted) |
+| `tests/invite-codes.test.ts` | Update existing tests, add tests for: multi-use redemption, child code generation, status endpoint, exhausted codes |
+
+---
+
+## 6. Implementation Order
+
+1. **Migration** — schema changes + data migration
+2. **Generate handler** — accept `name` and `maxRedemptions`
+3. **Redeem handler** — multi-use logic + child code generation
+4. **Status handler** — new endpoint
+5. **List handler** — updated response shape
+6. **Admin page** — updated HTML
+7. **Tests** — update + expand
+8. **Router wiring** — add status route
+
+---
+
+## 7. Open Questions
+
+- [ ] Should the default child code `maxRedemptions` (5) be configurable per parent code, or always a global default?
+- [ ] Should the status endpoint return redemption history (list of timestamps), or just the counts?
+- [ ] Should there be a way to revoke/disable a code without deleting it? (e.g., `disabled` boolean)
+- [ ] What should happen if code generation during redemption fails? Should the redemption still succeed (without a child code), or should the whole thing roll back?
+- [ ] Should the `CODE_ALREADY_REDEEMED` → `CODE_FULLY_REDEEMED` rename be coordinated with an iOS release, or should we support both error codes temporarily?
+
+---
+
+## 8. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Race condition on `redemptionCount` increment | High | Use atomic `updateMany` with `where: { redemptionCount: { lt: maxRedemptions } }` — same pattern as current `redeemedAt: null` check |
+| Migration on existing data | Medium | Backfill `redemptionCount` from `redeemedAt` before dropping column; run in transaction |
+| Breaking change for iOS (`CODE_ALREADY_REDEEMED` → `CODE_FULLY_REDEEMED`) | Medium | Coordinate with iOS team; optionally support both error codes for one release cycle |
+| Child code generation failure during redemption | Low | Wrap redemption + child creation in a transaction; roll back both on failure |
+| Unbounded viral chain depth | Low | Not a concern at 5 uses per child; monitor via `parentCodeId` lineage if needed |

--- a/docs/plans/invite-code-multi-use.md
+++ b/docs/plans/invite-code-multi-use.md
@@ -59,11 +59,12 @@ Track each individual redemption event (for auditability and the viral chain).
   - `name` defaults to `null`
   - `parentCodeId` defaults to `null`
 - Create `InviteCodeRedemption` table
-- **Remove `redeemedAt` from `InviteCode`** — redemption status is now derived:
+- **Keep `redeemedAt` on `InviteCode`** for backwards compatibility — updated to the timestamp of the most recent redemption. Redemption status is now primarily derived from counts:
   - A code is "fully redeemed" when `redemptionCount >= maxRedemptions`
   - A code is "available" when `redemptionCount < maxRedemptions`
   - Individual redemption timestamps live in `InviteCodeRedemption`
-- Migrate existing redeemed codes: for each code where `redeemedAt IS NOT NULL`, set `redemptionCount = 1` and create a corresponding `InviteCodeRedemption` row. Then drop `redeemedAt`.
+  - `redeemedAt` is set/updated on each redemption for compatibility with existing queries and admin tooling
+- Migrate existing redeemed codes: for each code where `redeemedAt IS NOT NULL`, set `redemptionCount = 1` and create a corresponding `InviteCodeRedemption` row.
 
 ### Updated Prisma Schema
 
@@ -75,6 +76,7 @@ model InviteCode {
   maxRedemptions  Int       @default(1)
   redemptionCount Int       @default(0)
   createdAt       DateTime  @default(now())
+  redeemedAt      DateTime?           // kept for backwards compat — updated on each redemption
   batchLabel      String?   @db.VarChar(255)
   parentCodeId    String?   @db.Uuid
   parentCode      InviteCode?  @relation("CodeLineage", fields: [parentCodeId], references: [id])
@@ -83,6 +85,7 @@ model InviteCode {
   generatedFrom   InviteCodeRedemption[] @relation("GeneratedCode")
 
   @@index([batchLabel])
+  @@index([redeemedAt])
   @@index([parentCodeId])
 }
 
@@ -134,16 +137,16 @@ model InviteCodeRedemption {
 5. Create an `InviteCodeRedemption` row linking the redeemed code to the child code
 6. Return the generated code in the response
 
-**Updated error responses:**
+**Error responses** (unchanged error codes for backwards compatibility):
 
 | HTTP status | Error code              | Meaning                                                |
 | ----------- | ----------------------- | ------------------------------------------------------ |
 | 404         | `CODE_NOT_FOUND`        | No code exists with that value                         |
-| 409         | `CODE_FULLY_REDEEMED`   | Code exists but has reached its max redemptions        |
+| 409         | `CODE_ALREADY_REDEEMED` | Code exists but has reached its max redemptions        |
 | 422         | `CODE_INVALID_FORMAT`   | Malformed code string                                  |
 | 401         | —                       | Invalid or missing JWT                                 |
 
-> Note: `CODE_ALREADY_REDEEMED` → `CODE_FULLY_REDEEMED` (semantic change since codes can now be redeemed multiple times). This is a **breaking change** for iOS — coordinate with client team.
+> Note: We keep `CODE_ALREADY_REDEEMED` as the error code even though a code can now be redeemed multiple times. The meaning is "this code has already been fully redeemed" — semantically close enough, and avoids a breaking change for existing iOS clients.
 
 ### 2b. `GET /api/v2/invite-codes/:code/status` — New Endpoint
 
@@ -211,11 +214,12 @@ Add new fields to the response objects:
 }
 ```
 
-**Status values** change from `pending`/`redeemed` to:
-- `available` — `redemptionCount < maxRedemptions`
-- `exhausted` — `redemptionCount >= maxRedemptions`
+**Status values** — the list endpoint returns **both** old and new status representations for backwards compatibility:
+- `status`: keeps the original values `"pending"` / `"redeemed"` (derived: `redeemed` if `redemptionCount >= maxRedemptions`, `pending` otherwise)
+- `redeemedAt`: kept — set to the most recent redemption timestamp (or `null`)
+- New additive fields: `maxRedemptions`, `redemptionCount`, `remainingRedemptions`, `name`, `parentCode`
 
-> This is a breaking change for the admin page filter. The admin page HTML needs updating too.
+The admin page filter continues to use `pending`/`redeemed` — no breaking change.
 
 ---
 
@@ -224,7 +228,7 @@ Add new fields to the response objects:
 Update the admin HTML page (`admin-page.ts`) to:
 
 - Show new columns: Name, Max Redemptions, Redemption Count, Remaining, Parent Code
-- Update status filter options: `all`, `available`, `exhausted` (replaces `pending`/`redeemed`)
+- Status filter keeps `all`, `pending`, `redeemed` (no change — semantics remain the same)
 - Add `name` and `maxRedemptions` inputs to the generate form
 - Widen table layout to accommodate new columns
 
@@ -241,12 +245,12 @@ Update the admin HTML page (`admin-page.ts`) to:
 
 | File | Change |
 |------|--------|
-| `prisma/schema.prisma` | Add `name`, `maxRedemptions`, `redemptionCount`, `parentCodeId` to `InviteCode`; add `InviteCodeRedemption` model; remove `redeemedAt` |
-| `prisma/migrations/2026XXXX_multi_use_invite_codes/migration.sql` | New migration: alter `InviteCode`, create `InviteCodeRedemption`, data migration, drop `redeemedAt` |
+| `prisma/schema.prisma` | Add `name`, `maxRedemptions`, `redemptionCount`, `parentCodeId` to `InviteCode`; keep `redeemedAt`; add `InviteCodeRedemption` model |
+| `prisma/migrations/2026XXXX_multi_use_invite_codes/migration.sql` | New migration: alter `InviteCode` (add columns), create `InviteCodeRedemption`, backfill `redemptionCount` from existing `redeemedAt` |
 | `src/api/v2/invite-codes/handlers/redeem.ts` | Rewrite redemption logic: check `redemptionCount < maxRedemptions`, atomic increment, generate child code, create redemption row, return child code |
 | `src/api/v2/invite-codes/handlers/status.ts` | **New file** — handler for `GET /:code/status` |
 | `src/api/v2/invite-codes/handlers/generate.ts` | Accept `name` and `maxRedemptions` in body schema; pass to `createMany` |
-| `src/api/v2/invite-codes/handlers/list.ts` | Update response shape (new fields, new status values), update filter logic |
+| `src/api/v2/invite-codes/handlers/list.ts` | Add new additive fields to response; keep existing `status`/`redeemedAt` fields for compat |
 | `src/api/v2/invite-codes/handlers/admin-page.ts` | Update HTML to show new columns, new filter options, new generate form fields |
 | `src/api/v2/invite-codes/invite-codes.router.ts` | Add `GET /:code/status` route |
 | `src/api/v2/index.ts` | No changes needed (router already mounted) |
@@ -273,7 +277,7 @@ Update the admin HTML page (`admin-page.ts`) to:
 - [ ] Should the status endpoint return redemption history (list of timestamps), or just the counts?
 - [ ] Should there be a way to revoke/disable a code without deleting it? (e.g., `disabled` boolean)
 - [ ] What should happen if code generation during redemption fails? Should the redemption still succeed (without a child code), or should the whole thing roll back?
-- [ ] Should the `CODE_ALREADY_REDEEMED` → `CODE_FULLY_REDEEMED` rename be coordinated with an iOS release, or should we support both error codes temporarily?
+- [x] ~~Should the `CODE_ALREADY_REDEEMED` → `CODE_FULLY_REDEEMED` rename be coordinated with an iOS release?~~ **Resolved: keep `CODE_ALREADY_REDEEMED` for backwards compatibility.**
 
 ---
 
@@ -282,7 +286,7 @@ Update the admin HTML page (`admin-page.ts`) to:
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | Race condition on `redemptionCount` increment | High | Use atomic `updateMany` with `where: { redemptionCount: { lt: maxRedemptions } }` — same pattern as current `redeemedAt: null` check |
-| Migration on existing data | Medium | Backfill `redemptionCount` from `redeemedAt` before dropping column; run in transaction |
-| Breaking change for iOS (`CODE_ALREADY_REDEEMED` → `CODE_FULLY_REDEEMED`) | Medium | Coordinate with iOS team; optionally support both error codes for one release cycle |
+| Migration on existing data | Medium | Backfill `redemptionCount` from `redeemedAt`; keep `redeemedAt` column; run in transaction |
+| ~~Breaking change for iOS~~ | ~~Medium~~ | **Resolved**: keeping `CODE_ALREADY_REDEEMED` error code and `pending`/`redeemed` status values; all new fields are additive |
 | Child code generation failure during redemption | Low | Wrap redemption + child creation in a transaction; roll back both on failure |
 | Unbounded viral chain depth | Low | Not a concern at 5 uses per child; monitor via `parentCodeId` lineage if needed |

--- a/prisma/migrations/20260401000000_multi_use_invite_codes/migration.sql
+++ b/prisma/migrations/20260401000000_multi_use_invite_codes/migration.sql
@@ -1,0 +1,42 @@
+-- AlterTable: Add new columns to InviteCode
+ALTER TABLE "InviteCode" ADD COLUMN "name" VARCHAR(255);
+ALTER TABLE "InviteCode" ADD COLUMN "maxRedemptions" INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE "InviteCode" ADD COLUMN "redemptionCount" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "InviteCode" ADD COLUMN "parentCodeId" UUID;
+
+-- Backfill: set redemptionCount = 1 for already-redeemed codes
+UPDATE "InviteCode" SET "redemptionCount" = 1 WHERE "redeemedAt" IS NOT NULL;
+
+-- CreateTable: InviteCodeRedemption
+CREATE TABLE "InviteCodeRedemption" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "inviteCodeId" UUID NOT NULL,
+    "childCodeId" UUID,
+    "redeemedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "InviteCodeRedemption_pkey" PRIMARY KEY ("id")
+);
+
+-- Backfill: create InviteCodeRedemption rows for already-redeemed codes
+INSERT INTO "InviteCodeRedemption" ("id", "inviteCodeId", "redeemedAt")
+SELECT gen_random_uuid(), "id", "redeemedAt"
+FROM "InviteCode"
+WHERE "redeemedAt" IS NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "InviteCodeRedemption_inviteCodeId_idx" ON "InviteCodeRedemption"("inviteCodeId");
+
+-- CreateIndex
+CREATE INDEX "InviteCodeRedemption_childCodeId_idx" ON "InviteCodeRedemption"("childCodeId");
+
+-- CreateIndex
+CREATE INDEX "InviteCode_parentCodeId_idx" ON "InviteCode"("parentCodeId");
+
+-- AddForeignKey
+ALTER TABLE "InviteCode" ADD CONSTRAINT "InviteCode_parentCodeId_fkey" FOREIGN KEY ("parentCodeId") REFERENCES "InviteCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InviteCodeRedemption" ADD CONSTRAINT "InviteCodeRedemption_inviteCodeId_fkey" FOREIGN KEY ("inviteCodeId") REFERENCES "InviteCode"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InviteCodeRedemption" ADD CONSTRAINT "InviteCodeRedemption_childCodeId_fkey" FOREIGN KEY ("childCodeId") REFERENCES "InviteCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,12 +63,33 @@ model RuntimeConfig {
 }
 
 model InviteCode {
-  id         String    @id @default(uuid()) @db.Uuid
-  code       String    @unique @db.VarChar(8)
-  createdAt  DateTime  @default(now())
-  redeemedAt DateTime?
-  batchLabel String?   @db.VarChar(255)
+  id              String    @id @default(uuid()) @db.Uuid
+  code            String    @unique @db.VarChar(8)
+  name            String?   @db.VarChar(255)
+  maxRedemptions  Int       @default(1)
+  redemptionCount Int       @default(0)
+  createdAt       DateTime  @default(now())
+  redeemedAt      DateTime? // kept for backwards compat — updated on each redemption
+  batchLabel      String?   @db.VarChar(255)
+  parentCodeId    String?   @db.Uuid
+  parentCode      InviteCode?            @relation("CodeLineage", fields: [parentCodeId], references: [id])
+  childCodes      InviteCode[]           @relation("CodeLineage")
+  redemptions     InviteCodeRedemption[] @relation("CodeRedemptions")
+  generatedFrom   InviteCodeRedemption[] @relation("GeneratedCode")
 
   @@index([batchLabel])
   @@index([redeemedAt])
+  @@index([parentCodeId])
+}
+
+model InviteCodeRedemption {
+  id           String      @id @default(uuid()) @db.Uuid
+  inviteCodeId String      @db.Uuid
+  inviteCode   InviteCode  @relation("CodeRedemptions", fields: [inviteCodeId], references: [id])
+  childCodeId  String?     @db.Uuid
+  childCode    InviteCode? @relation("GeneratedCode", fields: [childCodeId], references: [id])
+  redeemedAt   DateTime    @default(now())
+
+  @@index([inviteCodeId])
+  @@index([childCodeId])
 }

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -36,7 +36,7 @@ function buildHTML(nonce: string): string {
 <title>Invite Codes — Convos Admin</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f7; color: #1d1d1f; padding: 2rem; max-width: 960px; margin: 0 auto; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f7; color: #1d1d1f; padding: 2rem; max-width: 1200px; margin: 0 auto; }
   h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; }
   h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 0.75rem; }
   #login { max-width: 360px; margin: 4rem auto; }
@@ -199,12 +199,14 @@ function buildHTML(nonce: string): string {
   function doGenerate() {
     var btn = document.getElementById("gen-btn");
     var count = parseInt(document.getElementById("gen-count").value, 10) || 10;
+    var maxRedemptions = parseInt(document.getElementById("gen-max-redemptions").value, 10) || 1;
+    var name = document.getElementById("gen-name").value.trim() || undefined;
     var label = document.getElementById("gen-label").value.trim() || undefined;
     btn.disabled = true;
     btn.textContent = "Generating…";
     apiFetch("/generate", {
       method: "POST",
-      body: JSON.stringify({ count: count, batchLabel: label })
+      body: JSON.stringify({ count: count, batchLabel: label, name: name, maxRedemptions: maxRedemptions })
     }).then(function (res) { return res.json().then(function (json) { return { ok: res.ok, json: json }; }); })
       .then(function (r) {
         if (r.ok && r.json.success) {
@@ -260,6 +262,10 @@ function buildHTML(nonce: string): string {
             tdCode.appendChild(codeEl);
             tr.appendChild(tdCode);
 
+            var tdName = document.createElement("td");
+            tdName.textContent = c.name || "\u2014";
+            tr.appendChild(tdName);
+
             var tdStatus = document.createElement("td");
             var badge = document.createElement("span");
             badge.classList.add("badge", "badge-" + c.status);
@@ -267,9 +273,23 @@ function buildHTML(nonce: string): string {
             tdStatus.appendChild(badge);
             tr.appendChild(tdStatus);
 
+            var tdRedemptions = document.createElement("td");
+            tdRedemptions.textContent = c.redemptionCount + " / " + c.maxRedemptions;
+            tr.appendChild(tdRedemptions);
+
             var tdBatch = document.createElement("td");
             tdBatch.textContent = c.batchLabel || "\u2014";
             tr.appendChild(tdBatch);
+
+            var tdParent = document.createElement("td");
+            if (c.parentCode) {
+              var parentEl = document.createElement("code");
+              parentEl.textContent = c.parentCode;
+              tdParent.appendChild(parentEl);
+            } else {
+              tdParent.textContent = "\u2014";
+            }
+            tr.appendChild(tdParent);
 
             var tdCreated = document.createElement("td");
             tdCreated.textContent = fmtDate(c.createdAt);

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -208,8 +208,8 @@ function buildHTML(nonce: string): string {
   // --- Generate ---
   function doGenerate() {
     var btn = document.getElementById("gen-btn");
-    var count = parseInt(document.getElementById("gen-count").value, 10) || 10;
-    var maxRedemptions = parseInt(document.getElementById("gen-max-redemptions").value, 10) || 1;
+    var count = parseInt(document.getElementById("gen-count").value, 10) || 1;
+    var maxRedemptions = parseInt(document.getElementById("gen-max-redemptions").value, 10) || 5;
     var name = document.getElementById("gen-name").value.trim() || undefined;
     var label = document.getElementById("gen-label").value.trim() || undefined;
     btn.disabled = true;

--- a/src/api/v2/invite-codes/handlers/admin-page.ts
+++ b/src/api/v2/invite-codes/handlers/admin-page.ts
@@ -89,7 +89,17 @@ function buildHTML(nonce: string): string {
     <div class="row">
       <div>
         <label for="gen-count">Count</label>
-        <input type="number" id="gen-count" value="10" min="1" max="500">
+        <input type="number" id="gen-count" value="1" min="1" max="500">
+      </div>
+      <div>
+        <label for="gen-max-redemptions">Max redemptions</label>
+        <input type="number" id="gen-max-redemptions" value="5" min="1">
+      </div>
+    </div>
+    <div class="row">
+      <div>
+        <label for="gen-name">Name (optional)</label>
+        <input type="text" id="gen-name" placeholder="e.g. VIP invite">
       </div>
       <div>
         <label for="gen-label">Batch label (optional)</label>
@@ -118,7 +128,7 @@ function buildHTML(nonce: string): string {
     </div>
     <div class="table-wrap">
       <table>
-        <thead><tr><th>Code</th><th>Status</th><th>Batch</th><th>Created</th><th>Redeemed</th></tr></thead>
+        <thead><tr><th>Code</th><th>Name</th><th>Status</th><th>Redemptions</th><th>Batch</th><th>Parent</th><th>Created</th><th>Redeemed</th></tr></thead>
         <tbody id="codes-body"></tbody>
       </table>
     </div>
@@ -247,7 +257,7 @@ function buildHTML(nonce: string): string {
         if (codes.length === 0) {
           var emptyRow = document.createElement("tr");
           var emptyCell = document.createElement("td");
-          emptyCell.colSpan = 5;
+          emptyCell.colSpan = 8;
           emptyCell.style.cssText = "text-align:center;color:#6e6e73;padding:1.5rem";
           emptyCell.textContent = "No codes found";
           emptyRow.appendChild(emptyCell);

--- a/src/api/v2/invite-codes/handlers/generate.ts
+++ b/src/api/v2/invite-codes/handlers/generate.ts
@@ -1,11 +1,8 @@
-import crypto from "node:crypto";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
+import { generateUniqueCodes } from "../utils/code-generator";
 
-// Uppercase letters excluding visually ambiguous O and I
-const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ";
-const CODE_LENGTH = 8;
 const MAX_BATCH_SIZE = 500;
 const MAX_GENERATION_RETRIES = 3;
 
@@ -16,28 +13,14 @@ const bodySchema = z.object({
     .min(1, "Count must be at least 1")
     .max(MAX_BATCH_SIZE, `Count must be at most ${MAX_BATCH_SIZE}`),
   batchLabel: z.string().max(255, "Batch label too long").optional().nullable(),
+  name: z.string().max(255, "Name too long").optional().nullable(),
+  maxRedemptions: z
+    .number()
+    .int()
+    .min(1, "Max redemptions must be at least 1")
+    .optional()
+    .default(1),
 });
-
-function generateCode(): string {
-  const bytes = crypto.randomBytes(CODE_LENGTH);
-  let code = "";
-  for (let i = 0; i < CODE_LENGTH; i++) {
-    code += ALPHABET[bytes[i] % ALPHABET.length];
-  }
-  return code;
-}
-
-function generateUniqueCodes(count: number): string[] {
-  const codes = new Set<string>();
-  // Guard against infinite loops with a generous iteration cap
-  const maxIterations = count * 10;
-  let iterations = 0;
-  while (codes.size < count && iterations < maxIterations) {
-    codes.add(generateCode());
-    iterations++;
-  }
-  return Array.from(codes);
-}
 
 /**
  * Handler for POST /api/v2/invite-codes/generate
@@ -62,7 +45,7 @@ export async function generateHandler(req: Request, res: Response) {
     return;
   }
 
-  const { count, batchLabel } = parsed.data;
+  const { count, batchLabel, name, maxRedemptions } = parsed.data;
 
   try {
     let codes: string[] = [];
@@ -86,6 +69,8 @@ export async function generateHandler(req: Request, res: Response) {
         data: candidates.map((code) => ({
           code,
           batchLabel: batchLabel ?? null,
+          name: name ?? null,
+          maxRedemptions,
         })),
         skipDuplicates: true,
       });
@@ -103,7 +88,10 @@ export async function generateHandler(req: Request, res: Response) {
       );
     }
 
-    req.log.info({ count: codes.length, batchLabel }, "Invite codes generated");
+    req.log.info(
+      { count: codes.length, batchLabel, name, maxRedemptions },
+      "Invite codes generated",
+    );
 
     res.status(201).json({
       success: true,
@@ -111,6 +99,8 @@ export async function generateHandler(req: Request, res: Response) {
         codes,
         count: codes.length,
         batchLabel: batchLabel ?? null,
+        name: name ?? null,
+        maxRedemptions,
       },
     });
     return;

--- a/src/api/v2/invite-codes/handlers/list.ts
+++ b/src/api/v2/invite-codes/handlers/list.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
 
@@ -18,6 +19,8 @@ const querySchema = z.object({
  * Query parameters:
  *   - batchLabel: filter by batch label
  *   - status: "pending" | "redeemed" | "all" (default: "all")
+ *     - "pending" = redemptionCount < maxRedemptions (has remaining uses)
+ *     - "redeemed" = redemptionCount >= maxRedemptions (fully exhausted)
  *   - limit: max results (1–500, default: 100)
  *   - offset: pagination offset (default: 0)
  */
@@ -35,41 +38,88 @@ export async function listHandler(req: Request, res: Response) {
   const { batchLabel, status, limit, offset } = parsed.data;
 
   try {
-    const where: Record<string, unknown> = {};
-
-    if (batchLabel !== undefined) {
-      where.batchLabel = batchLabel;
-    }
+    // Build WHERE clauses using Prisma.sql for safe parameterization.
+    // We need raw SQL because Prisma can't compare two columns
+    // (redemptionCount vs maxRedemptions) in a where clause.
+    const conditions: Prisma.Sql[] = [];
 
     if (status === "pending") {
-      where.redeemedAt = null;
+      conditions.push(
+        Prisma.sql`"redemptionCount" < "maxRedemptions"`,
+      );
     } else if (status === "redeemed") {
-      where.redeemedAt = { not: null };
+      conditions.push(
+        Prisma.sql`"redemptionCount" >= "maxRedemptions"`,
+      );
     }
 
-    const [codes, total] = await Promise.all([
-      prisma.inviteCode.findMany({
-        where,
-        orderBy: { createdAt: "desc" },
-        take: limit,
-        skip: offset,
-        select: {
-          id: true,
-          code: true,
-          createdAt: true,
-          redeemedAt: true,
-          batchLabel: true,
-        },
-      }),
-      prisma.inviteCode.count({ where }),
-    ]);
+    if (batchLabel !== undefined) {
+      conditions.push(Prisma.sql`"batchLabel" = ${batchLabel}`);
+    }
+
+    const whereClause =
+      conditions.length > 0
+        ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`
+        : Prisma.empty;
+
+    const codes = await prisma.$queryRaw<
+      Array<{
+        id: string;
+        code: string;
+        name: string | null;
+        maxRedemptions: number;
+        redemptionCount: number;
+        createdAt: Date;
+        redeemedAt: Date | null;
+        batchLabel: string | null;
+        parentCodeId: string | null;
+      }>
+    >(
+      Prisma.sql`SELECT "id", "code", "name", "maxRedemptions", "redemptionCount",
+              "createdAt", "redeemedAt", "batchLabel", "parentCodeId"
+       FROM "InviteCode"
+       ${whereClause}
+       ORDER BY "createdAt" DESC
+       LIMIT ${limit} OFFSET ${offset}`,
+    );
+
+    const totalResult = await prisma.$queryRaw<Array<{ count: bigint }>>(
+      Prisma.sql`SELECT COUNT(*) as count FROM "InviteCode" ${whereClause}`,
+    );
+    const total = Number(totalResult[0]?.count ?? 0);
+
+    // Look up parent codes for display
+    const parentCodeIds = codes
+      .map((c) => c.parentCodeId)
+      .filter((id): id is string => id !== null);
+    const parentCodes =
+      parentCodeIds.length > 0
+        ? await prisma.inviteCode.findMany({
+            where: { id: { in: parentCodeIds } },
+            select: { id: true, code: true },
+          })
+        : [];
+    const parentCodeMap = new Map(parentCodes.map((p) => [p.id, p.code]));
 
     res.status(200).json({
       success: true,
       data: {
         codes: codes.map((c) => ({
-          ...c,
-          status: c.redeemedAt ? "redeemed" : "pending",
+          id: c.id,
+          code: c.code,
+          name: c.name,
+          createdAt: c.createdAt,
+          redeemedAt: c.redeemedAt,
+          batchLabel: c.batchLabel,
+          // Backwards-compatible status: "pending" or "redeemed"
+          status:
+            c.redemptionCount >= c.maxRedemptions ? "redeemed" : "pending",
+          maxRedemptions: c.maxRedemptions,
+          redemptionCount: c.redemptionCount,
+          remainingRedemptions: c.maxRedemptions - c.redemptionCount,
+          parentCode: c.parentCodeId
+            ? parentCodeMap.get(c.parentCodeId) ?? null
+            : null,
         })),
         total,
         limit,

--- a/src/api/v2/invite-codes/handlers/redeem.ts
+++ b/src/api/v2/invite-codes/handlers/redeem.ts
@@ -24,6 +24,19 @@ const bodySchema = z.object({
 });
 
 /**
+ * Sentinel error thrown from inside the redeem transaction when we
+ * exhaust child-code generation retries. Throwing (rather than
+ * returning) ensures the parent code's redemption increment is rolled
+ * back along with everything else in the transaction.
+ */
+class ChildCodeGenerationError extends Error {
+  constructor() {
+    super("Failed to generate unique child code after retries");
+    this.name = "ChildCodeGenerationError";
+  }
+}
+
+/**
  * Handler for POST /api/v2/invite-codes/redeem
  *
  * Redeems an invite code for the "Instant assistant" feature.
@@ -59,28 +72,47 @@ export async function redeemHandler(req: Request, res: Response) {
   }
 
   try {
-    // Atomic compare-and-increment: only redeem if the code exists AND
-    // has remaining redemptions. Uses a raw query because Prisma's
-    // updateMany can't compare two columns in the where clause.
-    // This avoids the TOCTOU race where two concurrent requests both
-    // read redemptionCount and both succeed past the limit.
-    const updateResult: { id: string }[] = await prisma.$queryRaw`
-      UPDATE "InviteCode"
-      SET "redemptionCount" = "redemptionCount" + 1,
-          "redeemedAt" = NOW()
-      WHERE "code" = ${normalised}
-        AND "redemptionCount" < "maxRedemptions"
-      RETURNING "id"
-    `;
+    // Everything below runs in a single transaction so that the parent
+    // code's redemption increment is atomically tied to the existence of
+    // the child code. If anything after the increment fails (child code
+    // generation, child create, redemption-record create, transient DB
+    // error, etc.) the increment is rolled back and the parent code is
+    // not silently consumed.
+    const result = await prisma.$transaction(async (tx) => {
+      // Atomic compare-and-increment: only redeem if the code exists
+      // AND has remaining redemptions. Uses a raw query because
+      // Prisma's updateMany can't compare two columns in the where
+      // clause. This avoids the TOCTOU race where two concurrent
+      // requests both read redemptionCount and both succeed past the
+      // limit.
+      const updateResult: { id: string }[] = await tx.$queryRaw`
+        UPDATE "InviteCode"
+        SET "redemptionCount" = "redemptionCount" + 1,
+            "redeemedAt" = NOW()
+        WHERE "code" = ${normalised}
+          AND "redemptionCount" < "maxRedemptions"
+        RETURNING "id"
+      `;
 
-    if (updateResult.length === 1) {
+      if (updateResult.length === 0) {
+        // Either the code doesn't exist or it's fully redeemed. One
+        // more read to distinguish the two cases.
+        const existing = await tx.inviteCode.findUnique({
+          where: { code: normalised },
+          select: { id: true },
+        });
+        return existing
+          ? ({ kind: "already_redeemed" } as const)
+          : ({ kind: "not_found" } as const);
+      }
+
       const parentCodeId = updateResult[0].id;
 
-      // Generate a unique child code (retry on collision)
+      // Generate a unique child code (retry on collision).
       let childCode: string | null = null;
       for (let i = 0; i < MAX_CODE_GENERATION_ATTEMPTS; i++) {
         const candidate = generateCode();
-        const existing = await prisma.inviteCode.findUnique({
+        const existing = await tx.inviteCode.findUnique({
           where: { code: candidate },
           select: { id: true },
         });
@@ -91,78 +123,31 @@ export async function redeemHandler(req: Request, res: Response) {
       }
 
       if (!childCode) {
-        // Extremely unlikely — roll back the redemption count
-        await prisma.$queryRaw`
-          UPDATE "InviteCode"
-          SET "redemptionCount" = "redemptionCount" - 1
-          WHERE "id" = ${parentCodeId}::uuid
-        `;
-        req.log.error(
-          { code: normalised },
-          "Failed to generate unique child code after retries",
-        );
-        res.status(500).json({
-          success: false,
-          error: "INTERNAL_ERROR",
-          message: "Failed to generate invite code",
-        });
-        return;
+        // Extremely unlikely. Throw to roll back the redemption
+        // increment via the surrounding transaction; the outer catch
+        // turns this into a 500.
+        throw new ChildCodeGenerationError();
       }
 
-      // Create child code and redemption record in a transaction
-      const childInviteCode = await prisma.$transaction(async (tx) => {
-        const child = await tx.inviteCode.create({
-          data: {
-            code: childCode!,
-            maxRedemptions: DEFAULT_CHILD_CODE_MAX_REDEMPTIONS,
-            parentCodeId,
-          },
-        });
-
-        await tx.inviteCodeRedemption.create({
-          data: {
-            inviteCodeId: parentCodeId,
-            childCodeId: child.id,
-          },
-        });
-
-        return child;
-      });
-
-      req.log.info(
-        {
-          code: normalised,
-          childCode: childInviteCode.code,
-          childMaxRedemptions: DEFAULT_CHILD_CODE_MAX_REDEMPTIONS,
-        },
-        "Invite code redeemed, child code generated",
-      );
-
-      res.status(200).json({
-        success: true,
+      const child = await tx.inviteCode.create({
         data: {
-          inviteCode: {
-            code: childInviteCode.code,
-            name: childInviteCode.name,
-            maxRedemptions: childInviteCode.maxRedemptions,
-            redemptionCount: childInviteCode.redemptionCount,
-            remainingRedemptions:
-              childInviteCode.maxRedemptions -
-              childInviteCode.redemptionCount,
-          },
+          code: childCode,
+          maxRedemptions: DEFAULT_CHILD_CODE_MAX_REDEMPTIONS,
+          parentCodeId,
         },
       });
-      return;
-    }
 
-    // updateResult.length === 0: either the code doesn't exist or it's
-    // fully redeemed. One more read to distinguish the two cases.
-    const existing = await prisma.inviteCode.findUnique({
-      where: { code: normalised },
-      select: { redemptionCount: true, maxRedemptions: true },
+      await tx.inviteCodeRedemption.create({
+        data: {
+          inviteCodeId: parentCodeId,
+          childCodeId: child.id,
+        },
+      });
+
+      return { kind: "success", child } as const;
     });
 
-    if (!existing) {
+    if (result.kind === "not_found") {
       res.status(404).json({
         success: false,
         error: "CODE_NOT_FOUND",
@@ -171,15 +156,56 @@ export async function redeemHandler(req: Request, res: Response) {
       return;
     }
 
-    // Code exists but fully redeemed — keep CODE_ALREADY_REDEEMED for
-    // backwards compatibility with existing iOS clients.
-    res.status(409).json({
-      success: false,
-      error: "CODE_ALREADY_REDEEMED",
-      message: "This invite code has already been used",
+    if (result.kind === "already_redeemed") {
+      // Keep CODE_ALREADY_REDEEMED for backwards compatibility with
+      // existing iOS clients.
+      res.status(409).json({
+        success: false,
+        error: "CODE_ALREADY_REDEEMED",
+        message: "This invite code has already been used",
+      });
+      return;
+    }
+
+    const childInviteCode = result.child;
+
+    req.log.info(
+      {
+        code: normalised,
+        childCode: childInviteCode.code,
+        childMaxRedemptions: DEFAULT_CHILD_CODE_MAX_REDEMPTIONS,
+      },
+      "Invite code redeemed, child code generated",
+    );
+
+    res.status(200).json({
+      success: true,
+      data: {
+        inviteCode: {
+          code: childInviteCode.code,
+          name: childInviteCode.name,
+          maxRedemptions: childInviteCode.maxRedemptions,
+          redemptionCount: childInviteCode.redemptionCount,
+          remainingRedemptions:
+            childInviteCode.maxRedemptions - childInviteCode.redemptionCount,
+        },
+      },
     });
     return;
   } catch (error) {
+    if (error instanceof ChildCodeGenerationError) {
+      req.log.error(
+        { code: normalised },
+        "Failed to generate unique child code after retries",
+      );
+      res.status(500).json({
+        success: false,
+        error: "INTERNAL_ERROR",
+        message: "Failed to generate invite code",
+      });
+      return;
+    }
+
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to redeem invite code",

--- a/src/api/v2/invite-codes/handlers/redeem.ts
+++ b/src/api/v2/invite-codes/handlers/redeem.ts
@@ -1,9 +1,17 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
+import { generateCode } from "../utils/code-generator";
 
 // 8 uppercase letters excluding visually ambiguous O and I
 const CODE_PATTERN = /^[A-HJ-NP-Z]{8}$/;
+
+const DEFAULT_CHILD_CODE_MAX_REDEMPTIONS = parseInt(
+  process.env.DEFAULT_CHILD_CODE_MAX_REDEMPTIONS ?? "5",
+  10,
+);
+
+const MAX_CODE_GENERATION_ATTEMPTS = 5;
 
 const bodySchema = z.object({
   code: z.string().min(1, "Code is required").max(8),
@@ -13,8 +21,12 @@ const bodySchema = z.object({
  * Handler for POST /api/v2/invite-codes/redeem
  *
  * Redeems an invite code for the "Instant assistant" feature.
+ * On successful redemption, generates a new child invite code for the
+ * redeemer with a configurable number of max redemptions (default: 5).
+ *
  * The backend does not record who redeemed the code — it only validates
- * the code and marks it as used. The client stores the unlock state locally.
+ * the code, increments the redemption count, and returns the child code.
+ * The client stores the unlock state locally.
  */
 export async function redeemHandler(req: Request, res: Response) {
   const parsed = bodySchema.safeParse(req.body);
@@ -41,25 +53,107 @@ export async function redeemHandler(req: Request, res: Response) {
   }
 
   try {
-    // Atomic update: only redeem if the code exists AND hasn't been redeemed yet.
-    // This avoids the TOCTOU race where two concurrent requests both read
-    // redeemedAt as null and both succeed.
-    const result = await prisma.inviteCode.updateMany({
-      where: { code: normalised, redeemedAt: null },
-      data: { redeemedAt: new Date() },
-    });
+    // Atomic compare-and-increment: only redeem if the code exists AND
+    // has remaining redemptions. Uses a raw query because Prisma's
+    // updateMany can't compare two columns in the where clause.
+    // This avoids the TOCTOU race where two concurrent requests both
+    // read redemptionCount and both succeed past the limit.
+    const updateResult: { id: string }[] = await prisma.$queryRaw`
+      UPDATE "InviteCode"
+      SET "redemptionCount" = "redemptionCount" + 1,
+          "redeemedAt" = NOW()
+      WHERE "code" = ${normalised}
+        AND "redemptionCount" < "maxRedemptions"
+      RETURNING "id"
+    `;
 
-    if (result.count === 1) {
-      req.log.info({ code: normalised }, "Invite code redeemed");
-      res.status(200).json({ success: true });
+    if (updateResult.length === 1) {
+      const parentCodeId = updateResult[0].id;
+
+      // Generate a unique child code (retry on collision)
+      let childCode: string | null = null;
+      for (let i = 0; i < MAX_CODE_GENERATION_ATTEMPTS; i++) {
+        const candidate = generateCode();
+        const existing = await prisma.inviteCode.findUnique({
+          where: { code: candidate },
+          select: { id: true },
+        });
+        if (!existing) {
+          childCode = candidate;
+          break;
+        }
+      }
+
+      if (!childCode) {
+        // Extremely unlikely — roll back the redemption count
+        await prisma.$queryRaw`
+          UPDATE "InviteCode"
+          SET "redemptionCount" = "redemptionCount" - 1
+          WHERE "id" = ${parentCodeId}::uuid
+        `;
+        req.log.error(
+          { code: normalised },
+          "Failed to generate unique child code after retries",
+        );
+        res.status(500).json({
+          success: false,
+          error: "INTERNAL_ERROR",
+          message: "Failed to generate invite code",
+        });
+        return;
+      }
+
+      // Create child code and redemption record in a transaction
+      const childInviteCode = await prisma.$transaction(async (tx) => {
+        const child = await tx.inviteCode.create({
+          data: {
+            code: childCode!,
+            maxRedemptions: DEFAULT_CHILD_CODE_MAX_REDEMPTIONS,
+            parentCodeId,
+          },
+        });
+
+        await tx.inviteCodeRedemption.create({
+          data: {
+            inviteCodeId: parentCodeId,
+            childCodeId: child.id,
+          },
+        });
+
+        return child;
+      });
+
+      req.log.info(
+        {
+          code: normalised,
+          childCode: childInviteCode.code,
+          childMaxRedemptions: DEFAULT_CHILD_CODE_MAX_REDEMPTIONS,
+        },
+        "Invite code redeemed, child code generated",
+      );
+
+      res.status(200).json({
+        success: true,
+        data: {
+          inviteCode: {
+            code: childInviteCode.code,
+            name: childInviteCode.name,
+            maxRedemptions: childInviteCode.maxRedemptions,
+            redemptionCount: childInviteCode.redemptionCount,
+            remainingRedemptions:
+              childInviteCode.maxRedemptions -
+              childInviteCode.redemptionCount,
+          },
+        },
+      });
       return;
     }
 
-    // count === 0: either the code doesn't exist or it was already redeemed.
-    // One more read to distinguish the two cases for the error response.
+    // updateResult.length === 0: either the code doesn't exist or it's
+    // fully redeemed. One more read to distinguish the two cases.
     const existing = await prisma.inviteCode.findUnique({
       where: { code: normalised },
-      select: { redeemedAt: true },
+      select: { redemptionCount: true, maxRedemptions: true },
     });
 
     if (!existing) {
@@ -71,6 +165,8 @@ export async function redeemHandler(req: Request, res: Response) {
       return;
     }
 
+    // Code exists but fully redeemed — keep CODE_ALREADY_REDEEMED for
+    // backwards compatibility with existing iOS clients.
     res.status(409).json({
       success: false,
       error: "CODE_ALREADY_REDEEMED",

--- a/src/api/v2/invite-codes/handlers/redeem.ts
+++ b/src/api/v2/invite-codes/handlers/redeem.ts
@@ -6,10 +6,16 @@ import { generateCode } from "../utils/code-generator";
 // 8 uppercase letters excluding visually ambiguous O and I
 const CODE_PATTERN = /^[A-HJ-NP-Z]{8}$/;
 
-const DEFAULT_CHILD_CODE_MAX_REDEMPTIONS = parseInt(
-  process.env.DEFAULT_CHILD_CODE_MAX_REDEMPTIONS ?? "5",
+const DEFAULT_CHILD_CODE_MAX_REDEMPTIONS_FALLBACK = 5;
+const parsedDefaultChildCodeMaxRedemptions = parseInt(
+  process.env.DEFAULT_CHILD_CODE_MAX_REDEMPTIONS ?? "",
   10,
 );
+const DEFAULT_CHILD_CODE_MAX_REDEMPTIONS = Number.isNaN(
+  parsedDefaultChildCodeMaxRedemptions,
+)
+  ? DEFAULT_CHILD_CODE_MAX_REDEMPTIONS_FALLBACK
+  : parsedDefaultChildCodeMaxRedemptions;
 
 const MAX_CODE_GENERATION_ATTEMPTS = 5;
 

--- a/src/api/v2/invite-codes/handlers/status.ts
+++ b/src/api/v2/invite-codes/handlers/status.ts
@@ -13,7 +13,9 @@ const CODE_PATTERN = /^[A-HJ-NP-Z]{8}$/;
 export async function statusHandler(req: Request, res: Response) {
   const rawCode = req.params.code as string | undefined;
 
-  if (!rawCode || rawCode.length > 8) {
+  const normalised = rawCode?.trim().toUpperCase() ?? "";
+
+  if (!normalised || normalised.length > 8) {
     res.status(422).json({
       success: false,
       error: "CODE_INVALID_FORMAT",
@@ -21,8 +23,6 @@ export async function statusHandler(req: Request, res: Response) {
     });
     return;
   }
-
-  const normalised = rawCode.toUpperCase().trim();
 
   if (!CODE_PATTERN.test(normalised)) {
     res.status(422).json({

--- a/src/api/v2/invite-codes/handlers/status.ts
+++ b/src/api/v2/invite-codes/handlers/status.ts
@@ -1,0 +1,80 @@
+import type { Request, Response } from "express";
+import { prisma } from "@/utils/prisma";
+
+// 8 uppercase letters excluding visually ambiguous O and I
+const CODE_PATTERN = /^[A-HJ-NP-Z]{8}$/;
+
+/**
+ * Handler for GET /api/v2/invite-codes/:code/status
+ *
+ * Returns the redemption status of an invite code, including how many
+ * redemptions remain. Requires JWT authentication.
+ */
+export async function statusHandler(req: Request, res: Response) {
+  const rawCode = req.params.code as string | undefined;
+
+  if (!rawCode || rawCode.length > 8) {
+    res.status(422).json({
+      success: false,
+      error: "CODE_INVALID_FORMAT",
+      message: "Code must be 8 uppercase letters (excluding O and I)",
+    });
+    return;
+  }
+
+  const normalised = rawCode.toUpperCase().trim();
+
+  if (!CODE_PATTERN.test(normalised)) {
+    res.status(422).json({
+      success: false,
+      error: "CODE_INVALID_FORMAT",
+      message: "Code must be 8 uppercase letters (excluding O and I)",
+    });
+    return;
+  }
+
+  try {
+    const inviteCode = await prisma.inviteCode.findUnique({
+      where: { code: normalised },
+      select: {
+        code: true,
+        name: true,
+        maxRedemptions: true,
+        redemptionCount: true,
+      },
+    });
+
+    if (!inviteCode) {
+      res.status(404).json({
+        success: false,
+        error: "CODE_NOT_FOUND",
+        message: "No invite code found with that value",
+      });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      data: {
+        code: inviteCode.code,
+        name: inviteCode.name,
+        maxRedemptions: inviteCode.maxRedemptions,
+        redemptionCount: inviteCode.redemptionCount,
+        remainingRedemptions:
+          inviteCode.maxRedemptions - inviteCode.redemptionCount,
+      },
+    });
+    return;
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to get invite code status",
+    );
+    res.status(500).json({
+      success: false,
+      error: "INTERNAL_ERROR",
+      message: "Failed to get invite code status",
+    });
+    return;
+  }
+}

--- a/src/api/v2/invite-codes/invite-codes.router.ts
+++ b/src/api/v2/invite-codes/invite-codes.router.ts
@@ -4,11 +4,13 @@ import { adminPageHandler } from "./handlers/admin-page";
 import { generateHandler } from "./handlers/generate";
 import { listHandler } from "./handlers/list";
 import { redeemHandler } from "./handlers/redeem";
+import { statusHandler } from "./handlers/status";
 
 export const inviteCodesRouter = Router();
 
-// Public (authenticated) endpoint — clients redeem codes here
+// Public (authenticated) endpoints — clients redeem codes and check status here
 inviteCodesRouter.post("/redeem", redeemHandler);
+inviteCodesRouter.get("/:code/status", statusHandler);
 
 // Admin router — single mount point, auth applied per-route
 export const inviteCodesAdminRouter = Router();

--- a/src/api/v2/invite-codes/utils/code-generator.ts
+++ b/src/api/v2/invite-codes/utils/code-generator.ts
@@ -1,0 +1,26 @@
+import crypto from "node:crypto";
+
+// Uppercase letters excluding visually ambiguous O and I
+const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+const CODE_LENGTH = 8;
+
+export function generateCode(): string {
+  const bytes = crypto.randomBytes(CODE_LENGTH);
+  let code = "";
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    code += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return code;
+}
+
+export function generateUniqueCodes(count: number): string[] {
+  const codes = new Set<string>();
+  // Guard against infinite loops with a generous iteration cap
+  const maxIterations = count * 10;
+  let iterations = 0;
+  while (codes.size < count && iterations < maxIterations) {
+    codes.add(generateCode());
+    iterations++;
+  }
+  return Array.from(codes);
+}

--- a/tests/invite-codes.test.ts
+++ b/tests/invite-codes.test.ts
@@ -181,23 +181,26 @@ describe("Invite Codes API Tests", () => {
       const updated = await prisma.inviteCode.findUnique({
         where: { code: "XKQBWFMR" },
       });
-      expect(updated?.redemptionCount).toBe(1);
-      expect(updated?.redeemedAt).not.toBeNull();
+      if (!updated) throw new Error("Expected parent invite code to exist");
+      expect(updated.redemptionCount).toBe(1);
+      expect(updated.redeemedAt).not.toBeNull();
 
       // Verify the child code exists in DB
       const childCode = await prisma.inviteCode.findUnique({
         where: { code: data.data.inviteCode.code },
       });
-      expect(childCode).not.toBeNull();
-      expect(childCode?.parentCodeId).toBe(updated?.id);
-      expect(childCode?.maxRedemptions).toBe(5);
+      if (!childCode) throw new Error("Expected child invite code to exist");
+      expect(childCode.parentCodeId).toBe(updated.id);
+      expect(childCode.maxRedemptions).toBe(5);
 
       // Verify the redemption record was created
       const redemptions = await prisma.inviteCodeRedemption.findMany({
-        where: { inviteCodeId: updated!.id },
+        where: { inviteCodeId: updated.id },
       });
       expect(redemptions).toHaveLength(1);
-      expect(redemptions[0]!.childCodeId).toBe(childCode!.id);
+      const firstRedemption = redemptions[0];
+      if (!firstRedemption) throw new Error("Expected a redemption record");
+      expect(firstRedemption.childCodeId).toBe(childCode.id);
     });
 
     test("should return 409 for fully redeemed single-use code", async () => {

--- a/tests/invite-codes.test.ts
+++ b/tests/invite-codes.test.ts
@@ -44,6 +44,19 @@ describe("Invite Codes API Tests", () => {
 
   afterEach(async () => {
     // Clean up test codes between tests
+    // Delete redemptions first (FK constraint)
+    await prisma.inviteCodeRedemption.deleteMany({
+      where: {
+        inviteCode: { batchLabel: "test" },
+      },
+    });
+    // Delete child codes (codes with a parent that has batchLabel "test")
+    await prisma.inviteCode.deleteMany({
+      where: {
+        parentCode: { batchLabel: "test" },
+      },
+    });
+    // Delete parent codes
     await prisma.inviteCode.deleteMany({
       where: { batchLabel: "test" },
     });
@@ -130,10 +143,10 @@ describe("Invite Codes API Tests", () => {
       expect(data.error).toBe("CODE_NOT_FOUND");
     });
 
-    test("should return 200 for valid unredeemed code", async () => {
-      // Seed a code
+    test("should return 200 for valid unredeemed code and generate child code", async () => {
+      // Seed a code with maxRedemptions = 1
       await prisma.inviteCode.create({
-        data: { code: "XKQBWFMR", batchLabel: "test" },
+        data: { code: "XKQBWFMR", batchLabel: "test", maxRedemptions: 1 },
       });
 
       const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
@@ -143,22 +156,58 @@ describe("Invite Codes API Tests", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = (await response.json()) as { success: boolean };
+      const data = (await response.json()) as {
+        success: boolean;
+        data: {
+          inviteCode: {
+            code: string;
+            name: string | null;
+            maxRedemptions: number;
+            redemptionCount: number;
+            remainingRedemptions: number;
+          };
+        };
+      };
       expect(data.success).toBe(true);
 
-      // Verify the code was marked as redeemed
+      // Should return a child invite code
+      expect(data.data.inviteCode).toBeDefined();
+      expect(data.data.inviteCode.code).toHaveLength(8);
+      expect(data.data.inviteCode.maxRedemptions).toBe(5); // default child max
+      expect(data.data.inviteCode.redemptionCount).toBe(0);
+      expect(data.data.inviteCode.remainingRedemptions).toBe(5);
+
+      // Verify the parent code was marked as redeemed
       const updated = await prisma.inviteCode.findUnique({
         where: { code: "XKQBWFMR" },
       });
+      expect(updated?.redemptionCount).toBe(1);
       expect(updated?.redeemedAt).not.toBeNull();
+
+      // Verify the child code exists in DB
+      const childCode = await prisma.inviteCode.findUnique({
+        where: { code: data.data.inviteCode.code },
+      });
+      expect(childCode).not.toBeNull();
+      expect(childCode?.parentCodeId).toBe(updated?.id);
+      expect(childCode?.maxRedemptions).toBe(5);
+
+      // Verify the redemption record was created
+      const redemptions = await prisma.inviteCodeRedemption.findMany({
+        where: { inviteCodeId: updated!.id },
+      });
+      expect(redemptions).toHaveLength(1);
+      expect(redemptions[0]!.childCodeId).toBe(childCode!.id);
     });
 
-    test("should return 409 for already redeemed code", async () => {
-      // Seed a redeemed code
+    test("should return 409 for fully redeemed single-use code", async () => {
+      // Seed a code that's already been redeemed
       await prisma.inviteCode.create({
         data: {
           code: "ALRDYUSD",
           batchLabel: "test",
+          maxRedemptions: 1,
+          redemptionCount: 1,
           redeemedAt: new Date(),
         },
       });
@@ -175,12 +224,81 @@ describe("Invite Codes API Tests", () => {
         error: string;
       };
       expect(data.success).toBe(false);
+      // Backwards-compatible error code
       expect(data.error).toBe("CODE_ALREADY_REDEEMED");
+    });
+
+    test("should allow multi-use code to be redeemed multiple times", async () => {
+      // Seed a code with maxRedemptions = 3
+      await prisma.inviteCode.create({
+        data: { code: "MLTUSETX", batchLabel: "test", maxRedemptions: 3 },
+      });
+
+      // First redemption
+      const res1 = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "MLTUSETX" }),
+      });
+      expect(res1.status).toBe(200);
+      const data1 = (await res1.json()) as {
+        success: boolean;
+        data: { inviteCode: { code: string } };
+      };
+      expect(data1.success).toBe(true);
+
+      // Second redemption
+      const res2 = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "MLTUSETX" }),
+      });
+      expect(res2.status).toBe(200);
+      const data2 = (await res2.json()) as {
+        success: boolean;
+        data: { inviteCode: { code: string } };
+      };
+      expect(data2.success).toBe(true);
+
+      // Each redemption should produce a different child code
+      expect(data1.data.inviteCode.code).not.toBe(data2.data.inviteCode.code);
+
+      // Third redemption
+      const res3 = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "MLTUSETX" }),
+      });
+      expect(res3.status).toBe(200);
+
+      // Fourth redemption should fail — max reached
+      const res4 = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "MLTUSETX" }),
+      });
+      expect(res4.status).toBe(409);
+      const data4 = (await res4.json()) as { error: string };
+      expect(data4.error).toBe("CODE_ALREADY_REDEEMED");
+
+      // Verify the redemption count
+      const code = await prisma.inviteCode.findUnique({
+        where: { code: "MLTUSETX" },
+      });
+      expect(code?.redemptionCount).toBe(3);
+      expect(code?.maxRedemptions).toBe(3);
+
+      // Verify redemption records
+      const redemptions = await prisma.inviteCodeRedemption.findMany({
+        where: { inviteCodeId: code!.id },
+        orderBy: { redeemedAt: "asc" },
+      });
+      expect(redemptions).toHaveLength(3);
     });
 
     test("should normalise lowercase input to uppercase", async () => {
       await prisma.inviteCode.create({
-        data: { code: "LWRCSETX", batchLabel: "test" },
+        data: { code: "LWRCSETX", batchLabel: "test", maxRedemptions: 1 },
       });
 
       const response = await fetch(`${baseURL}/api/v2/invite-codes/redeem`, {
@@ -212,6 +330,110 @@ describe("Invite Codes API Tests", () => {
       expect(data.success).toBe(false);
       expect(typeof data.error).toBe("string");
       expect(typeof data.message).toBe("string");
+    });
+  });
+
+  describe("GET /api/v2/invite-codes/:code/status", () => {
+    test("should return status for an available code", async () => {
+      await prisma.inviteCode.create({
+        data: {
+          code: "STATUSTX",
+          batchLabel: "test",
+          name: "Test Code",
+          maxRedemptions: 10,
+          redemptionCount: 3,
+        },
+      });
+
+      const response = await fetch(
+        `${baseURL}/api/v2/invite-codes/STATUSTX/status`,
+      );
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as {
+        success: boolean;
+        data: {
+          code: string;
+          name: string;
+          maxRedemptions: number;
+          redemptionCount: number;
+          remainingRedemptions: number;
+        };
+      };
+      expect(data.success).toBe(true);
+      expect(data.data.code).toBe("STATUSTX");
+      expect(data.data.name).toBe("Test Code");
+      expect(data.data.maxRedemptions).toBe(10);
+      expect(data.data.redemptionCount).toBe(3);
+      expect(data.data.remainingRedemptions).toBe(7);
+    });
+
+    test("should return status for a fully redeemed code", async () => {
+      await prisma.inviteCode.create({
+        data: {
+          code: "FULLRDMD",
+          batchLabel: "test",
+          maxRedemptions: 2,
+          redemptionCount: 2,
+          redeemedAt: new Date(),
+        },
+      });
+
+      const response = await fetch(
+        `${baseURL}/api/v2/invite-codes/FULLRDMD/status`,
+      );
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as {
+        success: boolean;
+        data: {
+          remainingRedemptions: number;
+        };
+      };
+      expect(data.success).toBe(true);
+      expect(data.data.remainingRedemptions).toBe(0);
+    });
+
+    test("should return 404 for non-existent code", async () => {
+      const response = await fetch(
+        `${baseURL}/api/v2/invite-codes/NTFNDXYZ/status`,
+      );
+
+      expect(response.status).toBe(404);
+      const data = (await response.json()) as { error: string };
+      expect(data.error).toBe("CODE_NOT_FOUND");
+    });
+
+    test("should return 422 for invalid code format", async () => {
+      const response = await fetch(
+        `${baseURL}/api/v2/invite-codes/bad/status`,
+      );
+
+      expect(response.status).toBe(422);
+      const data = (await response.json()) as { error: string };
+      expect(data.error).toBe("CODE_INVALID_FORMAT");
+    });
+
+    test("should normalise lowercase code to uppercase", async () => {
+      await prisma.inviteCode.create({
+        data: {
+          code: "LWRSTATS",
+          batchLabel: "test",
+          maxRedemptions: 5,
+        },
+      });
+
+      const response = await fetch(
+        `${baseURL}/api/v2/invite-codes/lwrstats/status`,
+      );
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as {
+        success: boolean;
+        data: { code: string };
+      };
+      expect(data.success).toBe(true);
+      expect(data.data.code).toBe("LWRSTATS");
     });
   });
 


### PR DESCRIPTION
## Summary

Expands the invite code system (from #183) so that codes can be redeemed a configurable number of times, and each redemption automatically generates a new invite code for the redeemer.

## What changed

### Database
- New columns on `InviteCode`: `name`, `maxRedemptions`, `redemptionCount`, `parentCodeId`
- New table `InviteCodeRedemption` for audit trail
- Migration backfills `redemptionCount` from existing `redeemedAt` data
- `redeemedAt` kept for backwards compatibility

### API Changes
- **`POST /invite-codes/redeem`** — now returns a child invite code (default 5 uses) in `data.inviteCode`. Uses atomic SQL to prevent race conditions on redemption count. Error code `CODE_ALREADY_REDEEMED` preserved for backwards compat.
- **`GET /invite-codes/:code/status`** — new endpoint to check remaining redemptions
- **`POST /invite-codes/admin/generate`** — accepts optional `name` and `maxRedemptions` params
- **`GET /invite-codes/admin/codes`** — adds `name`, `maxRedemptions`, `redemptionCount`, `remainingRedemptions`, `parentCode` to response (additive)

### Admin Page
- Generate form: Count, Max redemptions, Name, Batch label
- Table columns: Code, Name, Status, Redemptions, Batch, Parent, Created, Redeemed

### Backwards Compatibility
- ✅ `CODE_ALREADY_REDEEMED` error code preserved
- ✅ `redeemedAt` column kept (updated on each redemption)
- ✅ `pending`/`redeemed` status values kept
- ✅ Redeem response is additive (old clients ignore `data.inviteCode`)
- ✅ List response fields are additive

## Tests
16 tests passing — covers multi-use redemption, child code generation, status endpoint, exhausted codes, format validation, case normalization, error formats.

## Plan
See `docs/plans/invite-code-multi-use.md` for full design details and open questions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-use invite codes with viral child code generation on redemption
> - Extends `InviteCode` with `maxRedemptions`, `redemptionCount`, `name`, and `parentCodeId` fields; adds a new `InviteCodeRedemption` join table to track per-redemption history. See [migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/184/files#diff-7444085b4a9e7dcd73a412761d2d4a4ad0d477dda7bce90af396580165bd8d42).
> - `POST /api/v2/invite-codes/redeem` now atomically increments `redemptionCount` via a raw `UPDATE`, generates a unique child invite code for the redeemer, and records a redemption entry — all within a single transaction.
> - Adds `GET /api/v2/invite-codes/:code/status` to return remaining redemptions and metadata for a code without redeeming it.
> - Admin generate endpoint and UI now accept `name` and `maxRedemptions` per code; the list endpoint returns `remainingRedemptions`, `parentCode`, and status derived from redemption counts.
> - Risk: redeem now returns 409 (fully redeemed) instead of 404 for exhausted codes, and existing `redeemedAt`-based status logic is replaced by `redemptionCount >= maxRedemptions`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05194ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invite codes now support multi-use redemptions with configurable per-code limits, child-code generation on redeem, and a status endpoint showing remaining redemptions.
  * Admin UI: set code names and limits; browse expanded metadata including redemption counts and parent code.

* **Database Migration**
  * Schema and backfill to track redemption events and counts, preserving legacy redeemed semantics.

* **Tests**
  * New and updated tests covering multi-use flows, status endpoint, and exhausted codes.

* **Documentation**
  * Draft design doc describing multi-use invite code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->