### PR TITLE
Add testnet agent invite URLs

### DIFF
--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -1,6 +1,12 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
-import { AGENT_POOL_API_KEY, AGENT_POOL_URL, XMTP_ENV } from "@/config";
+import {
+  AGENT_POOL_API_KEY,
+  AGENT_POOL_URL,
+  shouldUseDevBehavior,
+  XMTP_ENV,
+  type XmtpEnv,
+} from "@/config";
 
 const bodySchema = z.object({
   slug: z.string().min(1, "Slug is required").max(2048),
@@ -27,10 +33,22 @@ const ERRORS = {
   },
 } as const;
 
-function buildInviteUrl(slug: string): string {
-  const domain =
-    XMTP_ENV === "production" ? "popup.convos.org" : "dev.convos.org";
+export function buildInviteUrl(
+  slug: string,
+  xmtpEnv: XmtpEnv = XMTP_ENV,
+): string {
+  const domainByEnv: Record<XmtpEnv, string> = {
+    production: "popup.convos.org",
+    testnet: "testnet.convos.org",
+    dev: "dev.convos.org",
+    local: "dev.convos.org",
+  };
+  const domain = domainByEnv[xmtpEnv];
   return `https://${domain}/v2?i=${encodeURIComponent(slug)}`;
+}
+
+export function shouldAllowForcedErrors(xmtpEnv: XmtpEnv = XMTP_ENV): boolean {
+  return shouldUseDevBehavior(xmtpEnv);
 }
 
 /**
@@ -64,8 +82,9 @@ function buildInviteUrl(slug: string): string {
  */
 export async function joinHandler(req: Request, res: Response) {
   // Force error responses for testing (non-production XMTP env only) — see JSDoc above for usage
-  const forceError =
-    XMTP_ENV !== "production" ? req.headers["x-force-error"] : undefined;
+  const forceError = shouldAllowForcedErrors()
+    ? req.headers["x-force-error"]
+    : undefined;
   const forcedError = Object.values(ERRORS).find(
     (e) => String(e.status) === forceError,
   );

--- a/tests/agent-join.test.ts
+++ b/tests/agent-join.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildInviteUrl,
+  shouldAllowForcedErrors,
+} from "@/api/v2/agents/handlers/join";
+
+describe("buildInviteUrl", () => {
+  test("uses production domain for production", () => {
+    expect(buildInviteUrl("abc123", "production")).toBe(
+      "https://popup.convos.org/v2?i=abc123",
+    );
+  });
+
+  test("uses testnet domain for testnet", () => {
+    expect(buildInviteUrl("abc123", "testnet")).toBe(
+      "https://testnet.convos.org/v2?i=abc123",
+    );
+  });
+
+  test("uses dev domain for all other environments", () => {
+    expect(buildInviteUrl("abc123", "dev")).toBe(
+      "https://dev.convos.org/v2?i=abc123",
+    );
+    expect(buildInviteUrl("abc123", "local")).toBe(
+      "https://dev.convos.org/v2?i=abc123",
+    );
+  });
+
+  test("encodes invite slugs", () => {
+    expect(buildInviteUrl("abc 123/?", "testnet")).toBe(
+      "https://testnet.convos.org/v2?i=abc%20123%2F%3F",
+    );
+  });
+
+  test("allows forced errors in dev-like environments only", () => {
+    expect(shouldAllowForcedErrors("dev")).toBe(true);
+    expect(shouldAllowForcedErrors("testnet")).toBe(true);
+    expect(shouldAllowForcedErrors("local")).toBe(true);
+    expect(shouldAllowForcedErrors("production")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds testnet-aware agent invite URL construction.

- Maps `XMTP_ENV=production` to `popup.convos.org`.
- Maps `XMTP_ENV=testnet` to `testnet.convos.org`.
- Keeps `dev` and `local` on `dev.convos.org`.
- Keeps forced agent error simulation enabled for dev-like environments only.

## Verification

- `bun check`
- `bun test tests/agent-join.test.ts tests/config-environment.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add testnet domain support to `buildInviteUrl` for agent invite URLs
> - Replaces the binary production/non-production domain logic in `buildInviteUrl` with an explicit per-environment map: `production` → `popup.convos.org`, `testnet` → `testnet.convos.org`, `dev`/`local` → `dev.convos.org`.
> - Adds `shouldAllowForcedErrors` to gate forced error simulation in the join handler, replacing a direct `XMTP_ENV !== 'production'` check with `shouldUseDevBehavior`.
> - Adds tests in [agent-join.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/188/files#diff-ca9206e6c14f65d4e0c8806ca58b0015af8cf6b0ffbb1da40154883b8deb9a99) covering domain selection, slug encoding, and forced error gating across all environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5550f93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->