### PR TITLE
feat: Connections v0.1 — proxy /v2/connections to Composio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ AGENT_POOL_URL=
 AGENT_POOL_API_KEY=
 AGENT_ASSETS_API_KEY=
 
+# Composio (optional — /v2/connections/* returns 503 if unset)
+# Auth configs are looked up dynamically from Composio by toolkit slug.
+COMPOSIO_API_KEY=
+COMPOSIO_CONNECTION_CALLBACK_URL=convos://connections/callback
+
 # S3 Lifecycle Test Configuration
 # Bucket for lifecycle testing (24h expiry policy)
 LIFECYCLE_TEST_BUCKET=

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@aws-sdk/client-s3": "^3.750.0",
         "@aws-sdk/s3-request-presigner": "^3.750.0",
         "@bufbuild/protobuf": "^2.2.3",
+        "@composio/core": "^0.6.10",
         "@connectrpc/connect": "^2.0.1",
         "@connectrpc/connect-node": "^2.0.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.200.0",
@@ -36,8 +37,7 @@
         "uint8array-extras": "^1.4.0",
         "uuid": "^11.0.5",
         "viem": "^2.23.2",
-        "zod": "^3.24.1",
-        "zod-prisma-types": "^3.2.4",
+        "zod": "^3.25.76",
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.50.0",
@@ -61,6 +61,7 @@
         "rimraf": "^6.0.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0",
+        "zod-prisma-types": "^3.2.4",
       },
     },
   },
@@ -190,6 +191,12 @@
     "@bufbuild/protoplugin": ["@bufbuild/protoplugin@2.2.3", "", { "dependencies": { "@bufbuild/protobuf": "2.2.3", "@typescript/vfs": "^1.5.2", "typescript": "5.4.5" } }, "sha512-UsV7mj6NJTZrqIYJK+jNFnnj5tOS7wgNXKyMjebFEpf+OX6pfXE+nx+QPjumOfu4GxdVPfEDnKuwISgqlXSQqw=="],
 
     "@coinbase/wallet-sdk": ["@coinbase/wallet-sdk@4.3.0", "", { "dependencies": { "@noble/hashes": "^1.4.0", "clsx": "^1.2.1", "eventemitter3": "^5.0.1", "preact": "^10.24.2" } }, "sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw=="],
+
+    "@composio/client": ["@composio/client@0.1.0-alpha.66", "", {}, "sha512-SDHcTWzz2dgdYAew/gQsRpjHpEzHKm6sW7KM4wCoJWNJuuMuey9Ahje91ZucNjfaqpI8CFW+pXY4nWkZf5LD7Q=="],
+
+    "@composio/core": ["@composio/core@0.6.10", "", { "dependencies": { "@composio/client": "0.1.0-alpha.66", "@composio/json-schema-to-zod": "0.1.20", "@types/json-schema": "^7.0.15", "chalk": "^4.1.2", "openai": "^6.16.0", "pusher-js": "^8.4.0", "semver": "^7.7.2", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-T/9MfYcmPs2EcSXhrJWvm0UFTfa79FcTo1L8vO13d5C5kX8/I4hLYLu+1wc4n7WGBSE9hq7o1g9L3FXJrOrlSQ=="],
+
+    "@composio/json-schema-to-zod": ["@composio/json-schema-to-zod@0.1.20", "", { "peerDependencies": { "zod": ">=3.25.76 <5" } }, "sha512-d4V34itLrUWG/VBh7ciznKcxF/T22MBLHmuEzHoX0zsBOHsUmjYz5qtDh20S2p3FE+HHvLZxpXiv8yfdd4yI+Q=="],
 
     "@connectrpc/connect": ["@connectrpc/connect@2.0.2", "", { "peerDependencies": { "@bufbuild/protobuf": "^2.2.0" } }, "sha512-xZuylIUNvNlH52e/4eQsZvY4QZyDJRtEFEDnn/yBrv5Xi5ZZI/p8X+GAHH35ucVaBvv9u7OzHZo8+tEh1EFTxA=="],
 
@@ -1477,6 +1484,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "openai": ["openai@6.34.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
@@ -1562,6 +1571,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "pusher-js": ["pusher-js@8.5.0", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw=="],
 
     "qrcode": ["qrcode@1.5.3", "", { "dependencies": { "dijkstrajs": "^1.0.1", "encode-utf8": "^1.0.3", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg=="],
 
@@ -1735,6 +1746,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-is": ["type-is@2.0.0", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw=="],
@@ -1815,9 +1828,11 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-prisma-types": ["zod-prisma-types@3.2.4", "", { "dependencies": { "@prisma/generator-helper": "^6.3.0", "code-block-writer": "^12.0.0", "lodash": "^4.17.21", "zod": "^3.24.1" }, "peerDependencies": { "@prisma/client": "^4.x.x || ^5.x.x || ^6.x.x", "prisma": "^4.x.x || ^5.x.x || ^6.x.x" }, "bin": { "zod-prisma-types": "dist/bin.js" } }, "sha512-S4spVBMJAmecLv+aLyRhXK26qW9nWwcsOf1H1fRcEmiI8DPbftZ99u0fhqHlymuTpmMcUpuKxcNNOIqNY0ScSQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
@@ -1828,6 +1843,8 @@
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
 
     "@bufbuild/protoplugin/typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
+
+    "@composio/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1962,6 +1979,8 @@
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "zod-prisma-types/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/client-s3": "^3.750.0",
     "@aws-sdk/s3-request-presigner": "^3.750.0",
     "@bufbuild/protobuf": "^2.2.3",
+    "@composio/core": "^0.6.10",
     "@connectrpc/connect": "^2.0.1",
     "@connectrpc/connect-node": "^2.0.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.200.0",
@@ -58,7 +59,7 @@
     "uint8array-extras": "^1.4.0",
     "uuid": "^11.0.5",
     "viem": "^2.23.2",
-    "zod": "^3.24.1"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.50.0",

--- a/src/api/v2/connections/composio.service.ts
+++ b/src/api/v2/connections/composio.service.ts
@@ -1,0 +1,141 @@
+import {
+  Composio,
+  type ConnectedAccountListResponseItem,
+} from "@composio/core";
+import { COMPOSIO_API_KEY, COMPOSIO_CONNECTION_CALLBACK_URL } from "@/config";
+import logger from "@/utils/logger";
+
+// Auth configs rarely change in Composio; cache the toolkit→authConfigId
+// resolution in-process so most initiate calls skip the extra round trip.
+const AUTH_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type AuthConfigCacheEntry = { authConfigId: string | null; expiresAt: number };
+
+export class ComposioService {
+  private composio: Composio;
+  private authConfigCache = new Map<string, AuthConfigCacheEntry>();
+
+  constructor(args: { composio: Composio }) {
+    this.composio = args.composio;
+  }
+
+  /**
+   * Resolve a toolkit slug (e.g. "googlecalendar") to its Composio authConfigId
+   * by querying Composio. Picks the first ENABLED auth config for that toolkit.
+   * Returns null if no enabled config exists.
+   *
+   * Clients must send Composio's canonical slug (case-insensitive).
+   */
+  async resolveAuthConfigId(toolkit: string): Promise<string | null> {
+    const now = Date.now();
+    const normalized = toolkit.toLowerCase();
+    const hit = this.authConfigCache.get(normalized);
+    if (hit && hit.expiresAt > now) {
+      return hit.authConfigId;
+    }
+
+    const list = await this.composio.authConfigs.list({ toolkit: normalized });
+    const enabled = list.items.find(
+      (item) =>
+        item.toolkit.slug.toLowerCase() === normalized &&
+        item.status === "ENABLED",
+    );
+    const authConfigId = enabled?.id ?? null;
+
+    if (!authConfigId) {
+      logger.warn(
+        {
+          toolkit: normalized,
+          returnedItems: list.items.map((item) => ({
+            id: item.id,
+            slug: item.toolkit.slug,
+            status: item.status,
+            isComposioManaged: item.isComposioManaged,
+          })),
+          totalPages: list.totalPages,
+        },
+        "[Composio] resolveAuthConfigId: no ENABLED config matched",
+      );
+    } else {
+      logger.info(
+        { toolkit: normalized, authConfigId },
+        "[Composio] resolveAuthConfigId: resolved",
+      );
+    }
+
+    this.authConfigCache.set(normalized, {
+      authConfigId,
+      expiresAt: now + AUTH_CONFIG_CACHE_TTL_MS,
+    });
+    return authConfigId;
+  }
+
+  async initiate(args: {
+    userId: string;
+    authConfigId: string;
+    callbackUrl?: string;
+  }) {
+    return this.composio.connectedAccounts.initiate(
+      args.userId,
+      args.authConfigId,
+      {
+        callbackUrl: args.callbackUrl ?? COMPOSIO_CONNECTION_CALLBACK_URL,
+      },
+    );
+  }
+
+  /**
+   * Fetch a connected account only if it belongs to the given userId.
+   * Returns null if it doesn't exist or isn't owned by the caller.
+   *
+   * Composio's retrieve endpoint no longer returns userId on the response,
+   * so ownership is verified by listing the caller's accounts.
+   */
+  async getIfOwned(args: { connectionId: string; userId: string }) {
+    const list = await this.composio.connectedAccounts.list({
+      userIds: [args.userId],
+    });
+    const items: ConnectedAccountListResponseItem[] = list.items;
+    return items.find((item) => item.id === args.connectionId) ?? null;
+  }
+
+  async listForUser(userId: string) {
+    return this.composio.connectedAccounts.list({ userIds: [userId] });
+  }
+
+  async delete(connectionId: string) {
+    return this.composio.connectedAccounts.delete(connectionId);
+  }
+}
+
+let cached: ComposioService | null = null;
+let initialized = false;
+
+export function createComposioService(): ComposioService | null {
+  if (initialized) {
+    return cached;
+  }
+  initialized = true;
+
+  if (!COMPOSIO_API_KEY) {
+    logger.warn("[Composio] COMPOSIO_API_KEY not set, connections disabled");
+    return null;
+  }
+
+  cached = new ComposioService({
+    composio: new Composio({
+      apiKey: COMPOSIO_API_KEY,
+      allowTracking: false,
+    }),
+  });
+  logger.info("[Composio] Initialised service");
+  return cached;
+}
+
+// Exposed for tests — resets the singleton.
+export function __resetComposioServiceForTests(
+  override: ComposioService | null = null,
+) {
+  cached = override;
+  initialized = override !== null;
+}

--- a/src/api/v2/connections/connections.router.ts
+++ b/src/api/v2/connections/connections.router.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { completeHandler } from "./handlers/complete";
+import { deleteHandler } from "./handlers/delete";
+import { initiateHandler } from "./handlers/initiate";
+import { listHandler } from "./handlers/list";
+
+export const connectionsRouter = Router();
+
+connectionsRouter.post("/initiate", initiateHandler);
+connectionsRouter.post("/complete", completeHandler);
+connectionsRouter.get("/", listHandler);
+connectionsRouter.delete("/:id", deleteHandler);

--- a/src/api/v2/connections/handlers/complete.ts
+++ b/src/api/v2/connections/handlers/complete.ts
@@ -1,0 +1,57 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createComposioService } from "../composio.service";
+import { mapComposioToResponse } from "../types";
+
+const bodySchema = z.object({
+  connectionRequestId: z.string().min(1).max(256),
+});
+
+export async function completeHandler(req: Request, res: Response) {
+  const deviceId = res.locals.deviceId;
+  if (!deviceId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    req.log.warn(
+      {
+        deviceId,
+        issues: parsed.error.issues,
+        receivedBody: req.body as unknown,
+        contentType: req.header("content-type"),
+      },
+      "[Composio] complete body validation failed",
+    );
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsed.error.issues,
+    });
+    return;
+  }
+
+  const service = createComposioService();
+  if (!service) {
+    res.status(503).json({ error: "Connections not configured" });
+    return;
+  }
+
+  try {
+    const owned = await service.getIfOwned({
+      connectionId: parsed.data.connectionRequestId,
+      userId: deviceId,
+    });
+    if (!owned) {
+      res.status(403).json({ error: "Connection not owned by this device" });
+      return;
+    }
+    res.status(200).json(mapComposioToResponse(owned, deviceId));
+    return;
+  } catch (error) {
+    req.log.error({ error, deviceId }, "[Composio] complete failed");
+    res.status(502).json({ error: "Failed to complete connection" });
+    return;
+  }
+}

--- a/src/api/v2/connections/handlers/delete.ts
+++ b/src/api/v2/connections/handlers/delete.ts
@@ -1,0 +1,43 @@
+import type { Request, Response } from "express";
+import { createComposioService } from "../composio.service";
+
+export async function deleteHandler(req: Request, res: Response) {
+  const deviceId = res.locals.deviceId;
+  if (!deviceId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const connectionId = req.params.id;
+  if (!connectionId) {
+    res.status(400).json({ error: "Missing connection id" });
+    return;
+  }
+
+  const service = createComposioService();
+  if (!service) {
+    res.status(503).json({ error: "Connections not configured" });
+    return;
+  }
+
+  try {
+    const owned = await service.getIfOwned({
+      connectionId,
+      userId: deviceId,
+    });
+    if (!owned) {
+      res.status(403).json({ error: "Connection not owned by this device" });
+      return;
+    }
+    await service.delete(connectionId);
+    res.status(204).send();
+    return;
+  } catch (error) {
+    req.log.error(
+      { error, deviceId, connectionId },
+      "[Composio] delete failed",
+    );
+    res.status(502).json({ error: "Failed to delete connection" });
+    return;
+  }
+}

--- a/src/api/v2/connections/handlers/initiate.ts
+++ b/src/api/v2/connections/handlers/initiate.ts
@@ -1,0 +1,75 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createComposioService } from "../composio.service";
+
+const bodySchema = z.object({
+  serviceId: z.string().min(1).max(128),
+  // Optional per-environment callback URL (e.g. "convos://connections/callback",
+  // "convos-dev://connections/callback"). Falls back to the backend's default
+  // COMPOSIO_CONNECTION_CALLBACK_URL when absent.
+  redirectUri: z.string().url().max(2048).optional(),
+});
+
+export async function initiateHandler(req: Request, res: Response) {
+  const deviceId = res.locals.deviceId;
+  if (!deviceId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    req.log.warn(
+      {
+        deviceId,
+        issues: parsed.error.issues,
+        receivedBody: req.body as unknown,
+        contentType: req.header("content-type"),
+      },
+      "[Composio] initiate body validation failed",
+    );
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsed.error.issues,
+    });
+    return;
+  }
+
+  const service = createComposioService();
+  if (!service) {
+    res.status(503).json({ error: "Connections not configured" });
+    return;
+  }
+
+  try {
+    const authConfigId = await service.resolveAuthConfigId(
+      parsed.data.serviceId,
+    );
+    if (!authConfigId) {
+      req.log.warn(
+        { deviceId, serviceId: parsed.data.serviceId },
+        "[Composio] no ENABLED auth config found for serviceId",
+      );
+      res.status(400).json({
+        error: "Unknown or disabled serviceId",
+        serviceId: parsed.data.serviceId,
+      });
+      return;
+    }
+
+    const request = await service.initiate({
+      userId: deviceId,
+      authConfigId,
+      callbackUrl: parsed.data.redirectUri,
+    });
+    res.status(200).json({
+      connectionRequestId: request.id,
+      redirectUrl: request.redirectUrl ?? null,
+    });
+    return;
+  } catch (error) {
+    req.log.error({ error, deviceId }, "[Composio] initiate failed");
+    res.status(502).json({ error: "Failed to initiate connection" });
+    return;
+  }
+}

--- a/src/api/v2/connections/handlers/list.ts
+++ b/src/api/v2/connections/handlers/list.ts
@@ -1,0 +1,31 @@
+import type { ConnectedAccountListResponseItem } from "@composio/core";
+import type { Request, Response } from "express";
+import { createComposioService } from "../composio.service";
+import { mapComposioToResponse } from "../types";
+
+export async function listHandler(req: Request, res: Response) {
+  const deviceId = res.locals.deviceId;
+  if (!deviceId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const service = createComposioService();
+  if (!service) {
+    res.status(503).json({ error: "Connections not configured" });
+    return;
+  }
+
+  try {
+    const list = await service.listForUser(deviceId);
+    const items: ConnectedAccountListResponseItem[] = list.items;
+    res.status(200).json({
+      connections: items.map((item) => mapComposioToResponse(item, deviceId)),
+    });
+    return;
+  } catch (error) {
+    req.log.error({ error, deviceId }, "[Composio] list failed");
+    res.status(502).json({ error: "Failed to list connections" });
+    return;
+  }
+}

--- a/src/api/v2/connections/types.ts
+++ b/src/api/v2/connections/types.ts
@@ -1,0 +1,28 @@
+import type {
+  ConnectedAccountListResponseItem,
+  ConnectedAccountRetrieveResponse,
+} from "@composio/core";
+
+export type ConnectionResponse = {
+  connectionId: string;
+  serviceId: string;
+  serviceName: string;
+  composioEntityId: string;
+  composioConnectionId: string;
+  status: string;
+};
+
+export function mapComposioToResponse(
+  conn: ConnectedAccountRetrieveResponse | ConnectedAccountListResponseItem,
+  deviceId: string,
+): ConnectionResponse {
+  const slug = conn.toolkit.slug;
+  return {
+    connectionId: conn.id,
+    serviceId: slug,
+    serviceName: slug,
+    composioEntityId: deviceId,
+    composioConnectionId: conn.id,
+    status: conn.status,
+  };
+}

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -26,6 +26,7 @@ import { renewBatchHandler } from "./assets/handlers/renew-batch";
 import { testLifecycleHandler } from "./assets/handlers/test-lifecycle";
 import { attachmentsRouter } from "./attachments/attachments.router";
 import { authRouter } from "./auth/auth.router";
+import { connectionsRouter } from "./connections/connections.router";
 import { devRouter } from "./dev/dev.router";
 import { deviceRouter } from "./device/device.router";
 import {
@@ -102,6 +103,7 @@ v2Router.use(
 );
 v2Router.use("/agents", agentJoinLimiter, authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
+v2Router.use("/connections", authMiddleware, connectionsRouter);
 v2Router.use("/notifications/xmtp", webhookRouter);
 v2Router.use("/notifications", authMiddleware, notificationsRouter);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,4 +35,11 @@ export const AGENT_POOL_API_KEY = process.env.AGENT_POOL_API_KEY || "";
 // Agent asset upload auth (optional — endpoint returns 503 if not configured)
 export const AGENT_ASSETS_API_KEY = process.env.AGENT_ASSETS_API_KEY || "";
 
+// Composio (optional — /v2/connections/* endpoints return 503 if not configured).
+// Auth configs are resolved dynamically from Composio by toolkit slug; no local mapping.
+export const COMPOSIO_API_KEY = process.env.COMPOSIO_API_KEY || "";
+export const COMPOSIO_CONNECTION_CALLBACK_URL =
+  process.env.COMPOSIO_CONNECTION_CALLBACK_URL ||
+  "convos://connections/callback";
+
 export const XMTP_ENV = process.env.XMTP_ENV || "dev";

--- a/tests/connections.test.ts
+++ b/tests/connections.test.ts
@@ -1,0 +1,534 @@
+import type { Server } from "node:http";
+import type {
+  AuthConfigListParams,
+  AuthConfigListResponse,
+  ConnectedAccountListResponse,
+  ConnectedAccountListResponseItem,
+  ConnectedAccountStatus,
+  ConnectionRequest,
+} from "@composio/core";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import {
+  __resetComposioServiceForTests,
+  ComposioService,
+} from "@/api/v2/connections/composio.service";
+import { connectionsRouter } from "@/api/v2/connections/connections.router";
+import { authMiddleware } from "@/middleware/auth";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { createJwtToken } from "@/utils/jwt";
+
+// Stub shapes — match just what the service touches on the Composio client.
+type ConnectedAccountsStub = {
+  initiate: (
+    userId: string,
+    authConfigId: string,
+    options?: { callbackUrl?: string },
+  ) => Promise<ConnectionRequest>;
+  list: (query: {
+    userIds?: string[] | null;
+  }) => Promise<ConnectedAccountListResponse>;
+  delete: (id: string) => Promise<unknown>;
+};
+
+type AuthConfigsStub = {
+  list: (query?: AuthConfigListParams) => Promise<AuthConfigListResponse>;
+};
+
+type ComposioStub = {
+  connectedAccounts: ConnectedAccountsStub;
+  authConfigs: AuthConfigsStub;
+};
+
+const AUTH_CONFIG_ID = "ac_test_google_calendar";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/connections", authMiddleware, connectionsRouter);
+
+let server: Server;
+const baseURL = "http://localhost:4010";
+
+function makeStub(
+  options: {
+    overrides?: Partial<ConnectedAccountsStub>;
+    authConfigsOverride?: Partial<AuthConfigsStub>;
+  } = {},
+): {
+  stub: ComposioStub;
+  calls: {
+    initiate: Array<{
+      userId: string;
+      authConfigId: string;
+      callbackUrl?: string;
+    }>;
+    list: Array<{ userIds?: string[] | null }>;
+    delete: string[];
+    authConfigsList: AuthConfigListParams[];
+  };
+  accounts: Map<string, ConnectedAccountListResponseItem & { userId: string }>;
+} {
+  const accounts = new Map<
+    string,
+    ConnectedAccountListResponseItem & { userId: string }
+  >();
+  const calls = {
+    initiate: [] as Array<{
+      userId: string;
+      authConfigId: string;
+      callbackUrl?: string;
+    }>,
+    list: [] as Array<{ userIds?: string[] | null }>,
+    delete: [] as string[],
+    authConfigsList: [] as AuthConfigListParams[],
+  };
+  const defaults: ConnectedAccountsStub = {
+    initiate: (userId, authConfigId, options) => {
+      calls.initiate.push({
+        userId,
+        authConfigId,
+        callbackUrl: options?.callbackUrl,
+      });
+      const id = `conn_${accounts.size + 1}`;
+      accounts.set(id, {
+        id,
+        userId,
+        authConfig: {
+          id: authConfigId,
+          isComposioManaged: true,
+          isDisabled: false,
+        },
+        status: "INITIATED" as ConnectedAccountStatus,
+        statusReason: null,
+        toolkit: { slug: "google_calendar" },
+        isDisabled: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      });
+      return Promise.resolve({
+        id,
+        status: "INITIATED" as ConnectedAccountStatus,
+        redirectUrl: "https://composio.example/auth",
+        waitForConnection: () => Promise.reject(new Error("not used in tests")),
+        toJSON: () => ({
+          id,
+          status: "INITIATED" as ConnectedAccountStatus,
+          redirectUrl: "https://composio.example/auth",
+        }),
+        toString: () => id,
+      });
+    },
+    list: (query) => {
+      calls.list.push(query);
+      const wanted = query.userIds ?? [];
+      const items = Array.from(accounts.values())
+        .filter((a) => wanted.length === 0 || wanted.includes(a.userId))
+        .map(({ userId: _userId, ...rest }) => rest);
+      return Promise.resolve({ items, totalPages: 1, nextCursor: null });
+    },
+    delete: (id) => {
+      calls.delete.push(id);
+      accounts.delete(id);
+      return Promise.resolve({ id, deleted: true });
+    },
+  };
+  const connectedAccounts: ConnectedAccountsStub = {
+    ...defaults,
+    ...(options.overrides ?? {}),
+  };
+
+  const authConfigsDefaults: AuthConfigsStub = {
+    list: (query) => {
+      calls.authConfigsList.push(query ?? {});
+      const toolkit = query?.toolkit ?? "google_calendar";
+      return Promise.resolve({
+        items: [
+          {
+            id: AUTH_CONFIG_ID,
+            name: `${toolkit} (test)`,
+            toolkit: { slug: toolkit, logo: "" },
+            noOfConnections: 0,
+            status: "ENABLED",
+            uuid: "uuid-test",
+          },
+        ],
+        nextCursor: null,
+        totalPages: 1,
+      });
+    },
+  };
+  const authConfigs: AuthConfigsStub = {
+    ...authConfigsDefaults,
+    ...(options.authConfigsOverride ?? {}),
+  };
+  return {
+    stub: { connectedAccounts, authConfigs },
+    calls,
+    accounts,
+  };
+}
+
+function installStub(stub: ComposioStub) {
+  const service = new ComposioService({
+    // The service only touches `composio.connectedAccounts` and
+    // `composio.authConfigs`; cast through unknown so we don't need
+    // the full client surface in tests.
+    composio: stub as unknown as ConstructorParameters<
+      typeof ComposioService
+    >[0]["composio"],
+  });
+  __resetComposioServiceForTests(service);
+  return service;
+}
+
+describe("Connections API", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4010, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+    __resetComposioServiceForTests(null);
+  });
+
+  beforeEach(() => {
+    __resetComposioServiceForTests(null);
+  });
+
+  describe("auth", () => {
+    test("initiate returns 401 without auth", async () => {
+      installStub(makeStub().stub);
+      const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ serviceId: "google_calendar" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("complete returns 401 without auth", async () => {
+      installStub(makeStub().stub);
+      const res = await fetch(`${baseURL}/api/v2/connections/complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ connectionRequestId: "conn_1" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("list returns 401 without auth", async () => {
+      installStub(makeStub().stub);
+      const res = await fetch(`${baseURL}/api/v2/connections`, {
+        method: "GET",
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("delete returns 401 without auth", async () => {
+      installStub(makeStub().stub);
+      const res = await fetch(`${baseURL}/api/v2/connections/conn_1`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("happy path", () => {
+    test("initiate forwards deviceId as userId and maps serviceId to authConfigId", async () => {
+      const { stub, calls } = makeStub();
+      installStub(stub);
+      const deviceId = "device-abc";
+      const token = await createJwtToken({ deviceId });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({ serviceId: "google_calendar" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        connectionRequestId: string;
+        redirectUrl: string;
+      };
+      expect(body.connectionRequestId).toBe("conn_1");
+      expect(body.redirectUrl).toBe("https://composio.example/auth");
+      expect(calls.initiate[0]?.userId).toBe(deviceId);
+      expect(calls.initiate[0]?.authConfigId).toBe(AUTH_CONFIG_ID);
+      // No redirectUri in body → service falls back to the env default.
+      expect(calls.initiate[0]?.callbackUrl).toBe(
+        "convos://connections/callback",
+      );
+    });
+
+    test("initiate forwards per-request redirectUri to Composio", async () => {
+      const { stub, calls } = makeStub();
+      installStub(stub);
+      const deviceId = "device-abc";
+      const token = await createJwtToken({ deviceId });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({
+          serviceId: "google_calendar",
+          redirectUri: "convos-dev://connections/callback",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(calls.initiate[0]?.callbackUrl).toBe(
+        "convos-dev://connections/callback",
+      );
+    });
+
+    test("initiate rejects malformed redirectUri", async () => {
+      const { stub } = makeStub();
+      installStub(stub);
+      const token = await createJwtToken({ deviceId: "device-abc" });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({
+          serviceId: "google_calendar",
+          redirectUri: "not a url",
+        }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    test("complete returns mapped response for owned connection", async () => {
+      const { stub, accounts } = makeStub();
+      installStub(stub);
+      const deviceId = "device-abc";
+      accounts.set("conn_owned", {
+        id: "conn_owned",
+        userId: deviceId,
+        authConfig: {
+          id: AUTH_CONFIG_ID,
+          isComposioManaged: true,
+          isDisabled: false,
+        },
+        status: "ACTIVE" as ConnectedAccountStatus,
+        statusReason: null,
+        toolkit: { slug: "google_calendar" },
+        isDisabled: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      });
+      const token = await createJwtToken({ deviceId });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/complete`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({ connectionRequestId: "conn_owned" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        connectionId: string;
+        composioEntityId: string;
+        status: string;
+        serviceId: string;
+      };
+      expect(body.connectionId).toBe("conn_owned");
+      expect(body.composioEntityId).toBe(deviceId);
+      expect(body.serviceId).toBe("google_calendar");
+      expect(body.status).toBe("ACTIVE");
+    });
+
+    test("list returns only this device's connections", async () => {
+      const { stub, accounts } = makeStub();
+      installStub(stub);
+      const deviceId = "device-abc";
+      accounts.set("conn_1", {
+        id: "conn_1",
+        userId: deviceId,
+        authConfig: {
+          id: AUTH_CONFIG_ID,
+          isComposioManaged: true,
+          isDisabled: false,
+        },
+        status: "ACTIVE" as ConnectedAccountStatus,
+        statusReason: null,
+        toolkit: { slug: "google_calendar" },
+        isDisabled: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      });
+      accounts.set("conn_other", {
+        id: "conn_other",
+        userId: "someone-else",
+        authConfig: {
+          id: AUTH_CONFIG_ID,
+          isComposioManaged: true,
+          isDisabled: false,
+        },
+        status: "ACTIVE" as ConnectedAccountStatus,
+        statusReason: null,
+        toolkit: { slug: "google_calendar" },
+        isDisabled: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      });
+      const token = await createJwtToken({ deviceId });
+
+      const res = await fetch(`${baseURL}/api/v2/connections`, {
+        method: "GET",
+        headers: { "X-Convos-AuthToken": token },
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        connections: Array<{ connectionId: string }>;
+      };
+      expect(body.connections.map((c) => c.connectionId)).toEqual(["conn_1"]);
+    });
+
+    test("delete removes owned connection and returns 204", async () => {
+      const { stub, accounts, calls } = makeStub();
+      installStub(stub);
+      const deviceId = "device-abc";
+      accounts.set("conn_owned", {
+        id: "conn_owned",
+        userId: deviceId,
+        authConfig: {
+          id: AUTH_CONFIG_ID,
+          isComposioManaged: true,
+          isDisabled: false,
+        },
+        status: "ACTIVE" as ConnectedAccountStatus,
+        statusReason: null,
+        toolkit: { slug: "google_calendar" },
+        isDisabled: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      });
+      const token = await createJwtToken({ deviceId });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/conn_owned`, {
+        method: "DELETE",
+        headers: { "X-Convos-AuthToken": token },
+      });
+
+      expect(res.status).toBe(204);
+      expect(calls.delete).toEqual(["conn_owned"]);
+    });
+  });
+
+  describe("entity mismatch", () => {
+    test("complete returns 403 when connection belongs to another device", async () => {
+      const { stub, accounts } = makeStub();
+      installStub(stub);
+      accounts.set("conn_other", {
+        id: "conn_other",
+        userId: "some-other-device",
+        authConfig: {
+          id: AUTH_CONFIG_ID,
+          isComposioManaged: true,
+          isDisabled: false,
+        },
+        status: "ACTIVE" as ConnectedAccountStatus,
+        statusReason: null,
+        toolkit: { slug: "google_calendar" },
+        isDisabled: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      });
+      const token = await createJwtToken({ deviceId: "device-abc" });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/complete`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({ connectionRequestId: "conn_other" }),
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    test("delete returns 403 when connection belongs to another device", async () => {
+      const { stub, accounts, calls } = makeStub();
+      installStub(stub);
+      accounts.set("conn_other", {
+        id: "conn_other",
+        userId: "some-other-device",
+        authConfig: {
+          id: AUTH_CONFIG_ID,
+          isComposioManaged: true,
+          isDisabled: false,
+        },
+        status: "ACTIVE" as ConnectedAccountStatus,
+        statusReason: null,
+        toolkit: { slug: "google_calendar" },
+        isDisabled: false,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      });
+      const token = await createJwtToken({ deviceId: "device-abc" });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/conn_other`, {
+        method: "DELETE",
+        headers: { "X-Convos-AuthToken": token },
+      });
+
+      expect(res.status).toBe(403);
+      expect(calls.delete).toEqual([]);
+    });
+  });
+
+  describe("validation", () => {
+    test("initiate returns 400 when Composio has no enabled auth config for serviceId", async () => {
+      const { stub } = makeStub({
+        authConfigsOverride: {
+          list: () =>
+            Promise.resolve({ items: [], nextCursor: null, totalPages: 0 }),
+        },
+      });
+      installStub(stub);
+      const token = await createJwtToken({ deviceId: "device-abc" });
+      const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({ serviceId: "unknown_service" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `/v2/connections/{initiate,complete,list,delete}` as a thin proxy to Composio. Backend holds no state: OAuth tokens live in Composio's vault, `entityId = deviceId` derived from the JWT.
- Auth configs resolved dynamically per request via `composio.authConfigs.list({ toolkit })` — no local service→authConfigId map. 5-min in-process cache.
- `initiate` accepts an optional per-request `redirectUri` so iOS sends its build-specific URL scheme (`convos://`, `convos-dev://`, `convos-local://`). Falls back to `COMPOSIO_CONNECTION_CALLBACK_URL` when absent.

## API

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/api/v2/connections/initiate` | `{ serviceId, redirectUri? }` → `{ connectionRequestId, redirectUrl }` |
| POST | `/api/v2/connections/complete` | `{ connectionRequestId }` → mapped connection |
| GET | `/api/v2/connections` | list caller's connections |
| DELETE | `/api/v2/connections/:id` | revoke |

All routes require `X-Convos-AuthToken`. `complete`/`delete` return 403 when the connection isn't owned by the caller's device (verified by listing, since Composio's retrieve endpoint no longer returns userId).

## Ops

- New env var: `COMPOSIO_API_KEY` (required to enable — endpoints 503 without it)
- Optional: `COMPOSIO_CONNECTION_CALLBACK_URL` (default `convos://connections/callback`)
- Dashboard: whitelist `convos://`, `convos-dev://`, `convos-local://` (all with `/connections/callback` path) in Composio's auth config allowed redirect URIs

## Test plan

- [x] `bun test tests/connections.test.ts` — 13/13 pass (401 × 4, happy paths × 4, 403 × 2, validation × 3)
- [x] `bun typecheck`
- [x] `bun lint` (my files clean; one pre-existing error in `tests/invite-codes.test.ts:202` from commit `1362f70f`, untouched)
- [x] Smoke test against dev Composio project after merge: initiate with `serviceId: "googlecalendar"`, confirm redirect URL opens, complete round-trips

## Out of scope

- Composio dashboard setup (API key + auth configs + redirect URI allowlist)
- Webhooks (Composio → runtime, not backend)
- Persisting grants in XMTP metadata (runtime's job)
- Handling pre-existing lint error in `tests/invite-codes.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Composio integration for managing connections.
  * New API endpoints: initiate connection, complete connection, list user connections, and delete connection.

* **Dependencies**
  * Added `@composio/core` package.
  * Updated `zod` dependency.

* **Tests**
  * Added comprehensive test suite for connections API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add /v2/connections endpoints proxying to Composio for connection management
> - Adds four authenticated REST endpoints under `/api/v2/connections`: `POST /initiate`, `POST /complete`, `GET /`, and `DELETE /:id`, all routed through a new [`connectionsRouter`](https://github.com/ephemeraHQ/convos-backend/pull/190/files#diff-40ee204a90256781a65b1ea82bef08967f13cfff420303c70488d4ad5ec80908).
> - Introduces [`ComposioService`](https://github.com/ephemeraHQ/convos-backend/pull/190/files#diff-6593711c01a3896e6d2a47dc67231944a6a4dca809085915d42f0dc5c0c0a148) to wrap the Composio client, with in-process TTL caching for toolkit-to-authConfig resolution and ownership verification before returning or deleting connections.
> - The feature is gated on the `COMPOSIO_API_KEY` env variable; when unset, all endpoints return 503. A default callback URL falls back to `convos://connections/callback` when `COMPOSIO_CONNECTION_CALLBACK_URL` is not set.
> - Risk: All connection ownership checks rely on Composio's entity/account listing, so upstream failures return 502 rather than a cached or degraded response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b87949.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->