### PR TITLE
fix(tests): move connections.test.ts to port 4012

### DIFF
--- a/tests/connections.test.ts
+++ b/tests/connections.test.ts
@@ -56,7 +56,7 @@ app.use(jsonMiddleware);
 app.use("/api/v2/connections", authMiddleware, connectionsRouter);
 
 let server: Server;
-const baseURL = "http://localhost:4010";
+const baseURL = "http://localhost:4012";
 
 function makeStub(
   options: {
@@ -193,7 +193,7 @@ function installStub(stub: ComposioStub) {
 describe("Connections API", () => {
   beforeAll(async () => {
     await new Promise<void>((resolve) => {
-      server = app.listen(4010, () => {
+      server = app.listen(4012, () => {
         resolve();
       });
     });


### PR DESCRIPTION
## Summary

- Moves `tests/connections.test.ts` server from port `4010` to `4012` so it no longer collides with `tests/pool-auth.test.ts` when `bun test` runs files concurrently.
- Mirrors the renew-batch / invite-codes fix in #186.

## Why

When two test files call `app.listen(4010)` in parallel, the second silently errors with EADDRINUSE; requests sent to `localhost:4010` then hit the first suite's Express app, hit no matching route, and return 404 — surfacing as suite-wide failures in CI under Bun 1.2.10's scheduling order.

## Test plan

- [x] `bun test tests/connections.test.ts tests/pool-auth.test.ts` — 22/22 pass locally.
- [ ] CI green on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `connections.test.ts` server and baseURL from port 4010 to 4012
> Updates [connections.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/192/files#diff-a945eff059c8826c6c6ad4902b3132bef942e78130f62ff45ed1bdd45e1f3a4f) to bind the test Express server and target HTTP requests on port 4012 instead of 4010, likely to avoid a port conflict with another test suite.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 638debe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure configuration for connection API tests to use an updated port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->