### PR TITLE
feat: add agent template foundation utilities [STACKED ON #194]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,13 @@ AGENT_ASSETS_API_KEY=
 COMPOSIO_API_KEY=
 COMPOSIO_CONNECTION_CALLBACK_URL=convos://connections/callback
 
+# Builder/template generation (optional)
+BUILDER_OPENROUTER_API_KEY=
+BUILDER_MODEL=
+EXA_SERVICE_KEY=
+POSTHOG_API_KEY=
+POSTHOG_HOST=
+
 # S3 Lifecycle Test Configuration
 # Bucket for lifecycle testing (24h expiry policy)
 LIFECYCLE_TEST_BUCKET=

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "pino": "^9.6.0",
         "pino-http": "^10.4.0",
         "pino-pretty": "^13.0.0",
+        "posthog-node": "5.33.3",
         "protobufjs": "^7.5.4",
         "secp256k1": "^5.0.1",
         "siwe": "3.0.0",
@@ -514,6 +515,10 @@
     "@passwordless-id/webauthn": ["@passwordless-id/webauthn@2.2.0", "", {}, "sha512-EwwK6PiJ3H/LaWYE3is5EuMhBBZ3igsX9nSHuB5zT/ugD9TmOwGs8/D0lnkBJDRcgV8/smsW/GOXisIJXDPT1Q=="],
 
     "@pkgr/core": ["@pkgr/core@0.1.1", "", {}, "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA=="],
+
+    "@posthog/core": ["@posthog/core@1.28.3", "", { "dependencies": { "@posthog/types": "1.372.9" } }, "sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw=="],
+
+    "@posthog/types": ["@posthog/types@1.372.9", "", {}, "sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA=="],
 
     "@prisma/client": ["@prisma/client@6.17.0", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-b42mTLOdLEZ6e/igu8CLdccAUX9AwHknQQ1+pHOftnzDP2QoyZyFvcANqSLs5ockimFKJnV7Ljf+qrhNYf6oAg=="],
 
@@ -1578,6 +1583,8 @@
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "posthog-node": ["posthog-node@5.33.3", "", { "dependencies": { "@posthog/core": "1.28.3" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-6BkdRtRKf/y/j6JGXLUDWpruL9Rebpe2EtbSU3EB+yaI9ukTwEGT8XJQDyM8wcsxu1HdOnvAwN7gnOOu5OgY2A=="],
 
     "preact": ["preact@10.26.4", "", {}, "sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w=="],
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "pino": "^9.6.0",
     "pino-http": "^10.4.0",
     "pino-pretty": "^13.0.0",
+    "posthog-node": "5.33.3",
     "protobufjs": "^7.5.4",
     "secp256k1": "^5.0.1",
     "siwe": "3.0.0",
@@ -92,6 +93,6 @@
     "zod-prisma-types": "^3.2.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }

--- a/prisma/migrations/20260508140000_seed_admin_account/migration.sql
+++ b/prisma/migrations/20260508140000_seed_admin_account/migration.sql
@@ -1,0 +1,2 @@
+-- SeedRow
+INSERT INTO "Account" ("id", "createdAt", "updatedAt") VALUES ('48a05ef4-4a71-57a0-957f-a3d410992b31', NOW(), NOW()) ON CONFLICT ("id") DO NOTHING;

--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+
+export const agentTemplatesRouter = Router();

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -17,6 +17,7 @@ import {
   inviteCodeRedeemLimiter,
   serviceProvisionLimiter,
 } from "@/middleware/rateLimit";
+import { agentTemplatesRouter } from "./agent-templates/agent-templates.router";
 import { agentsRouter } from "./agents/agents.router";
 import { agentAssetsRouter } from "./agents/assets/agent-assets.router";
 import { provisionRouter } from "./agents/provision/provision.router";
@@ -42,6 +43,7 @@ const v2Router = Router();
 
 if (process.env.XMTP_ENV !== "production") {
   v2Router.use("/dev", devAuthMiddleware, devRouter);
+  v2Router.use("/agent-templates", agentTemplatesRouter);
 }
 
 v2Router.use("/invites", invitesV2Router);

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -2,8 +2,13 @@
 // This provides type safety when middleware sets values on res.locals
 declare namespace Express {
   interface Locals {
+    // Set by authMiddleware (JWT auth) or agentAuth (API key auth).
+    accountId?: string;
     // Set by authMiddleware (JWT auth). Not set for appCheckOnlyMiddleware routes.
     deviceId?: string;
+    // Set by authOrAgentApiKeyAuth when authenticated via X-Agent-API-Key header.
+    // Indicates the request is acting as the admin/listener identity rather than a real user.
+    isApiKeyListener?: boolean;
     jwtMetadata?: {
       notificationExtensionOnly?: boolean;
     };

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -1,6 +1,6 @@
 import { createHash, timingSafeEqual } from "crypto";
 import type { NextFunction, Request, Response } from "express";
-import { AGENT_ASSETS_API_KEY } from "@/config";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { authMiddleware } from "./auth";
 
 export const AGENT_API_KEY_HEADER = "X-Agent-API-Key";
@@ -21,7 +21,7 @@ export const agentApiKeyAuth = (
   res: Response,
   next: NextFunction,
 ) => {
-  const expectedKey = AGENT_ASSETS_API_KEY.trim();
+  const expectedKey = (process.env.AGENT_ASSETS_API_KEY ?? "").trim();
 
   if (!expectedKey) {
     res.status(503).json({ error: "Agent assets API key not configured" });
@@ -64,7 +64,12 @@ export const authOrAgentApiKeyAuth = async (
 
   if (providedAgentApiKey) {
     req.log.debug("Attempting agent API key authentication");
-    agentApiKeyAuth(req, res, next);
+    // Wrap next so we can set identity flags after successful API key auth
+    agentApiKeyAuth(req, res, () => {
+      res.locals.accountId = ADMIN_ACCOUNT_ID;
+      res.locals.isApiKeyListener = true;
+      next();
+    });
     return;
   }
 

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -1,10 +1,37 @@
 import { createHash, timingSafeEqual } from "crypto";
 import type { NextFunction, Request, Response } from "express";
+import { AGENT_ASSETS_API_KEY } from "@/config";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { authMiddleware } from "./auth";
 
 export const AGENT_API_KEY_HEADER = "X-Agent-API-Key";
 const MIN_AGENT_API_KEY_LENGTH = 32;
+
+// ---------------------------------------------------------------------------
+// Config-backed accessor (with test-only override seam)
+// ---------------------------------------------------------------------------
+
+let _agentAssetsApiKeyOverride: string | null | undefined = undefined;
+
+function getAgentAssetsApiKey(): string {
+  // `undefined` ⇒ fall through to config; `null`/empty string ⇒ explicitly
+  // unset (forces 503 path). Tests use this seam instead of mutating
+  // process.env at runtime so the cached config value isn't bypassed.
+  if (_agentAssetsApiKeyOverride !== undefined) {
+    return (_agentAssetsApiKeyOverride ?? "").trim();
+  }
+  return AGENT_ASSETS_API_KEY.trim();
+}
+
+/** Override `AGENT_ASSETS_API_KEY` for tests.
+ *  - Pass a string to override.
+ *  - Pass `null` to simulate "key unset" (forces 503).
+ *  - Pass `undefined` to clear the override and fall back to config. */
+export function __setAgentAssetsApiKeyOverrideForTests(
+  key: string | null | undefined,
+): void {
+  _agentAssetsApiKeyOverride = key;
+}
 
 function constantTimeSecretCompare(
   provided: string,
@@ -21,7 +48,7 @@ export const agentApiKeyAuth = (
   res: Response,
   next: NextFunction,
 ) => {
-  const expectedKey = (process.env.AGENT_ASSETS_API_KEY ?? "").trim();
+  const expectedKey = getAgentAssetsApiKey();
 
   if (!expectedKey) {
     res.status(503).json({ error: "Agent assets API key not configured" });

--- a/src/utils/auth-helpers.ts
+++ b/src/utils/auth-helpers.ts
@@ -1,0 +1,17 @@
+import type { Response } from "express";
+
+/**
+ * Returns the effective owner account ID for the current request.
+ *
+ * When API key auth is used, `res.locals.accountId` is set to
+ * `ADMIN_ACCOUNT_ID` by `authOrAgentApiKeyAuth`. When JWT auth is used,
+ * `res.locals.accountId` comes from the verified JWT payload via
+ * `authMiddleware`.
+ *
+ * Callers should use this instead of hardcoding `ADMIN_ACCOUNT_ID` so
+ * that per-account ownership works when SIWE-authenticated users create
+ * resources.
+ */
+export function getEffectiveOwnerId(res: Response) {
+  return res.locals.accountId;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const ADMIN_ACCOUNT_ID = "48a05ef4-4a71-57a0-957f-a3d410992b31";

--- a/src/utils/reserved-slugs.ts
+++ b/src/utils/reserved-slugs.ts
@@ -1,0 +1,72 @@
+export const RESERVED_SLUGS = new Set([
+  "generate",
+  "publish",
+  "fork",
+  "search",
+  "files",
+  "templates",
+  "skills",
+]);
+
+export const SLUG_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+export const MAX_SLUG_LENGTH = 64;
+
+export type SlugValidationErrorReason =
+  | "invalid_format"
+  | "too_long"
+  | "reserved";
+
+export type SlugValidationResult =
+  | { valid: true; slug: string }
+  | {
+      valid: false;
+      reason: SlugValidationErrorReason;
+      message: string;
+    };
+
+/**
+ * True if `slug` is in the reserved-slug set.
+ * Comparison is case-sensitive — callers must pass a lowercase slug.
+ */
+export function isReservedSlug(slug: string): boolean {
+  return RESERVED_SLUGS.has(slug);
+}
+
+/**
+ * Validate a slug against length, format, and reserved-word constraints.
+ * Checks run in order: `too_long` → `invalid_format` → `reserved`.
+ * Format: lowercase alphanumeric segments separated by single hyphens
+ * (matches `SLUG_REGEX`).
+ */
+export function validateSlug(slug: string): SlugValidationResult {
+  if (slug.length > MAX_SLUG_LENGTH) {
+    return {
+      valid: false,
+      reason: "too_long",
+      message: `Slug must be ${MAX_SLUG_LENGTH} characters or fewer`,
+    };
+  }
+
+  if (!SLUG_REGEX.test(slug)) {
+    return {
+      valid: false,
+      reason: "invalid_format",
+      message: "Slug must match ^[a-z0-9]+(-[a-z0-9]+)*$",
+    };
+  }
+
+  if (isReservedSlug(slug)) {
+    return {
+      valid: false,
+      reason: "reserved",
+      message: "Slug is reserved",
+    };
+  }
+
+  return { valid: true, slug };
+}
+
+/** Convenience boolean wrapper around `validateSlug`. */
+export function isValidSlug(slug: string): boolean {
+  return validateSlug(slug).valid;
+}

--- a/src/utils/slug-hash.ts
+++ b/src/utils/slug-hash.ts
@@ -1,0 +1,28 @@
+import crypto from "node:crypto";
+
+// 32-bit fingerprint encoded in base36 fits in 5 chars (5 * log2(36) ≈ 25.85 bits).
+const HASH_LEN = 5;
+const HASHED_SLUG_RE = /\.[0-9a-z]{5}$/;
+
+/**
+ * Stable 5-char base36 hash derived from the agent ID. Used to suffix the
+ * slug (`brewski.x4f9k`) so two skills with the same name don't collide on
+ * URL, and so published pages aren't trivially guessable from the agent name.
+ */
+export function slugHash(id: string): string {
+  const sha = crypto.createHash("sha1").update(id).digest("hex");
+  const n = parseInt(sha.slice(0, 8), 16);
+  return n.toString(36).padStart(HASH_LEN, "0").slice(-HASH_LEN);
+}
+
+/** Combine a base slug with the hash suffix derived from `id`. */
+export function buildSlug(baseSlug: string, id: string): string {
+  return `${baseSlug}.${slugHash(id)}`;
+}
+
+/** True when the slug already has the `.hash` suffix. */
+export function isHashedSlug(slug: string): boolean {
+  return HASHED_SLUG_RE.test(slug);
+}
+
+export { HASH_LEN };

--- a/src/utils/slug-hash.ts
+++ b/src/utils/slug-hash.ts
@@ -3,6 +3,10 @@ import crypto from "node:crypto";
 // 32-bit fingerprint encoded in base36 fits in 5 chars (5 * log2(36) ≈ 25.85 bits).
 const HASH_LEN = 5;
 const HASHED_SLUG_RE = /\.[0-9a-z]{5}$/;
+// 5-char base36 ≈ 67M values. Birthday math: ~1% collision among 1.1k records
+// sharing a base slug, ~50% at 9k. We retry with a fresh ID on collision; cap
+// attempts so a poisoned base slug can't spin forever.
+const MAX_SLUG_ATTEMPTS = 8;
 
 /**
  * Stable 5-char base36 hash derived from the agent ID. Used to suffix the
@@ -25,4 +29,31 @@ export function isHashedSlug(slug: string): boolean {
   return HASHED_SLUG_RE.test(slug);
 }
 
-export { HASH_LEN };
+/**
+ * Reserve a unique hashed slug for a record. Generates a fresh ID per attempt
+ * so a hash collision picks a new suffix instead of clobbering an existing
+ * row. Returns the chosen `{ id, slug }` so the caller persists both.
+ *
+ * Callers should still rely on a DB unique constraint on `slug` as the final
+ * arbiter — `isTaken` and the eventual insert race, and the constraint is
+ * what keeps that race correct.
+ */
+export async function buildUniqueSlug(args: {
+  baseSlug: string;
+  idFactory: () => string;
+  isTaken: (slug: string) => Promise<boolean>;
+}) {
+  const { baseSlug, idFactory, isTaken } = args;
+  for (let i = 0; i < MAX_SLUG_ATTEMPTS; i++) {
+    const id = idFactory();
+    const slug = buildSlug(baseSlug, id);
+    if (!(await isTaken(slug))) {
+      return { id, slug };
+    }
+  }
+  throw new Error(
+    `slug collision: exhausted ${MAX_SLUG_ATTEMPTS} attempts for base slug "${baseSlug}"`,
+  );
+}
+
+export { HASH_LEN, MAX_SLUG_ATTEMPTS };

--- a/tests/account-migration.test.ts
+++ b/tests/account-migration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+
+type AccountColumn = {
+  column_name: string;
+  data_type: string;
+  is_nullable: string;
+  datetime_precision: number | null;
+  column_default: string | null;
+};
+
+describe("Account migration", () => {
+  test("Account table has UUID id column with gen_random_uuid default", async () => {
+    const columns = await prisma.$queryRaw<AccountColumn[]>`
+      SELECT column_name, data_type, is_nullable, datetime_precision, column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'Account'
+      ORDER BY ordinal_position
+    `;
+
+    const idCol = columns.find((c) => c.column_name === "id");
+    expect(idCol).toBeDefined();
+    expect(idCol?.data_type).toBe("uuid");
+    expect(idCol?.is_nullable).toBe("NO");
+    expect(idCol?.column_default).toContain("gen_random_uuid()");
+  });
+
+  test("seeds admin account with deterministic UUID", async () => {
+    const rows = await prisma.$queryRaw<
+      Array<{ id: string; createdAt: Date; updatedAt: Date }>
+    >`
+      SELECT id, "createdAt", "updatedAt"
+      FROM "Account"
+      WHERE id = ${ADMIN_ACCOUNT_ID}::uuid
+    `;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(ADMIN_ACCOUNT_ID);
+    expect(rows[0]?.createdAt).toBeInstanceOf(Date);
+    expect(rows[0]?.updatedAt).toBeInstanceOf(Date);
+  });
+});

--- a/tests/agent-templates.guard.test.ts
+++ b/tests/agent-templates.guard.test.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+import type { Server } from "node:http";
+import { afterAll, describe, expect, test } from "bun:test";
+import express, { Router } from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+
+type RouterWithStack = {
+  stack?: Array<{
+    matchers?: Array<(input: string) => false | { path: string }>;
+    name?: string;
+  }>;
+};
+
+const originalXMTPEnv = process.env.XMTP_ENV;
+
+afterAll(() => {
+  process.env.XMTP_ENV = originalXMTPEnv;
+});
+
+const getRouterStack = (router: unknown) =>
+  (router as RouterWithStack).stack ?? [];
+
+const buildGuardedV2Router = () => {
+  const v2Router = Router();
+
+  if (process.env.XMTP_ENV !== "production") {
+    v2Router.use("/agent-templates", agentTemplatesRouter);
+  }
+
+  return v2Router;
+};
+
+const hasMountedRouter = (router: unknown, path: string) =>
+  getRouterStack(router).some(
+    (layer) =>
+      layer.name === "router" &&
+      layer.matchers?.some((matcher) => Boolean(matcher(path))),
+  );
+
+const withServer = async (
+  router: unknown,
+  runAssertions: (baseURL: string) => Promise<void>,
+) => {
+  const app = express();
+  app.use("/api/v2", router as Parameters<typeof app.use>[1]);
+  app.use(noRouteMiddleware);
+
+  const server: Server = await new Promise((resolve, reject) => {
+    const startedServer = app.listen(4050, () => {
+      resolve(startedServer);
+    });
+    startedServer.once("error", reject);
+  });
+
+  try {
+    await runAssertions("http://localhost:4050");
+  } finally {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  }
+};
+
+describe("agent templates production guard", () => {
+  test("v2 index uses the raw production deny-list guard and kebab paths", () => {
+    const source = readFileSync(
+      new URL("../src/api/v2/index.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain('process.env.XMTP_ENV !== "production"');
+    expect(source).toContain(
+      'v2Router.use("/agent-templates", agentTemplatesRouter)',
+    );
+    expect(source).not.toContain("/agent_templates");
+    expect(source).not.toMatch(
+      /import\s+\{[^}]*XMTP_ENV[^}]*\}\s+from\s+["']@\/config["']/,
+    );
+  });
+
+  test("router shell is empty in M1", () => {
+    expect(getRouterStack(agentTemplatesRouter)).toHaveLength(0);
+  });
+
+  test("production does not mount the router and non-production mounts an empty router", async () => {
+    process.env.XMTP_ENV = "production";
+    const productionRouter = buildGuardedV2Router();
+    expect(hasMountedRouter(productionRouter, "/agent-templates")).toBe(false);
+
+    await withServer(productionRouter, async (baseURL) => {
+      const templatesResponse = await fetch(
+        `${baseURL}/api/v2/agent-templates`,
+      );
+      expect(templatesResponse.status).toBe(404);
+    });
+
+    process.env.XMTP_ENV = "local";
+    const localRouter = buildGuardedV2Router();
+    expect(hasMountedRouter(localRouter, "/agent-templates")).toBe(true);
+
+    await withServer(localRouter, async (baseURL) => {
+      const paths = [
+        "/api/v2/agent-templates",
+        "/api/v2/agent-templates/anything",
+      ];
+
+      const responses = await Promise.all(
+        paths.map((path) => fetch(`${baseURL}${path}`)),
+      );
+
+      expect(responses.map((response) => response.status)).toEqual([404, 404]);
+    });
+  });
+});

--- a/tests/auth-account-repository.test.ts
+++ b/tests/auth-account-repository.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { upsertAuthMethodAndAccount } from "@/accounts/repository";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 
 const ADDR_A = "0x" + "a".repeat(40);
 const ADDR_B = "0x" + "b".repeat(40);
 
+// Preserve the admin account seeded by migration; only wipe rows created by tests.
+const nonAdminAccountFilter = { id: { not: ADMIN_ACCOUNT_ID } };
+
 async function reset() {
   await prisma.authMethod.deleteMany();
-  await prisma.account.deleteMany();
+  await prisma.account.deleteMany({ where: nonAdminAccountFilter });
 }
 
 describe("upsertAuthMethodAndAccount", () => {
@@ -39,7 +43,9 @@ describe("upsertAuthMethodAndAccount", () => {
       externalKey: ADDR_A,
     });
     expect(second.accountId).toBe(first.accountId);
-    const accounts = await prisma.account.count();
+    const accounts = await prisma.account.count({
+      where: nonAdminAccountFilter,
+    });
     expect(accounts).toBe(1);
     const methods = await prisma.authMethod.count();
     expect(methods).toBe(1);
@@ -55,7 +61,9 @@ describe("upsertAuthMethodAndAccount", () => {
       externalKey: ADDR_B,
     });
     expect(a.accountId).not.toBe(b.accountId);
-    expect(await prisma.account.count()).toBe(2);
+    expect(await prisma.account.count({ where: nonAdminAccountFilter })).toBe(
+      2,
+    );
   });
 
   test("concurrent first-login same wallet → both resolve to same accountId, no orphan", async () => {
@@ -71,7 +79,9 @@ describe("upsertAuthMethodAndAccount", () => {
       }),
     ]);
     expect(a.accountId).toBe(b.accountId);
-    expect(await prisma.account.count()).toBe(1);
+    expect(await prisma.account.count({ where: nonAdminAccountFilter })).toBe(
+      1,
+    );
     expect(await prisma.authMethod.count()).toBe(1);
   });
 });

--- a/tests/auth-end-to-end.test.ts
+++ b/tests/auth-end-to-end.test.ts
@@ -7,6 +7,7 @@ import request from "supertest";
 import { authRouter } from "@/api/v2/auth/auth.router";
 import { authMiddleware, requireAccount } from "@/middleware/auth";
 import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 
 function makeApp() {
@@ -23,7 +24,8 @@ function makeApp() {
 
 async function reset() {
   await prisma.authMethod.deleteMany();
-  await prisma.account.deleteMany();
+  // Preserve the admin account seeded by migration; only wipe test-created rows.
+  await prisma.account.deleteMany({ where: { id: { not: ADMIN_ACCOUNT_ID } } });
   await prisma.authNonce.deleteMany();
 }
 

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -11,7 +11,10 @@
 import type { Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import express, { type Response } from "express";
-import { authOrAgentApiKeyAuth } from "@/middleware/agentAuth";
+import {
+  __setAgentAssetsApiKeyOverrideForTests,
+  authOrAgentApiKeyAuth,
+} from "@/middleware/agentAuth";
 import { requireAccount } from "@/middleware/auth";
 import { jsonMiddleware } from "@/middleware/json";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -26,11 +29,12 @@ import { createJwtToken } from "@/utils/jwt";
 const validAgentAssetsApiKey =
   "test-agent-assets-api-key-that-is-at-least-32-characters";
 
-// Set the API key once at module load. The agentApiKeyAuth middleware reads
-// process.env.AGENT_ASSETS_API_KEY at request time, so toggling it across
-// describe-block transitions can race with in-flight requests under Bun's
-// CI runner. Setting it once for the entire test file avoids that transition.
-process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+// Set the test override once at module load. After commit 6f0be85,
+// AGENT_ASSETS_API_KEY is cached by config.ts at import time and
+// agentApiKeyAuth reads it via the override seam, so a single setup
+// here covers every request in the file (the previous race comment
+// no longer applies — the cached value can't drift between requests).
+__setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
 
 const agentKeyHeaders = (key = validAgentAssetsApiKey) => ({
   "Content-Type": "application/json",

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Auth middleware identity resolution tests
+ *
+ * Tests that authOrAgentApiKeyAuth correctly sets:
+ *   - res.locals.accountId = ADMIN_ACCOUNT_ID when API key auth is used
+ *   - res.locals.isApiKeyListener = true when API key auth is used
+ *   - res.locals.accountId from JWT payload when JWT auth is used
+ *   - requireAccount rejects when res.locals.accountId is undefined
+ */
+
+import type { Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import express, { type Response } from "express";
+import { authOrAgentApiKeyAuth } from "@/middleware/agentAuth";
+import { requireAccount } from "@/middleware/auth";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { getEffectiveOwnerId } from "@/utils/auth-helpers";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const validAgentAssetsApiKey =
+  "test-agent-assets-api-key-that-is-at-least-32-characters";
+
+// Set the API key once at module load. The agentApiKeyAuth middleware reads
+// process.env.AGENT_ASSETS_API_KEY at request time, so toggling it across
+// describe-block transitions can race with in-flight requests under Bun's
+// CI runner. Setting it once for the entire test file avoids that transition.
+process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+
+const agentKeyHeaders = (key = validAgentAssetsApiKey) => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": key,
+});
+
+const jwtHeaders = async (accountId?: string) => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-auth-middleware",
+    accountId,
+  }),
+});
+
+type LocalsBody = {
+  accountId: string | null;
+  isApiKeyListener: boolean;
+};
+
+/**
+ * Build a test app that captures res.locals after the middleware chain.
+ * The endpoint handler returns the captured locals as JSON.
+ */
+function buildTestApp(middlewares: express.RequestHandler[]) {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use(jsonMiddleware);
+  app.use(...middlewares);
+  app.post("/test", (_req, res: Response) => {
+    res.json({
+      accountId: res.locals.accountId ?? null,
+      isApiKeyListener: res.locals.isApiKeyListener ?? false,
+    });
+  });
+  app.get("/test", (_req, res: Response) => {
+    res.json({
+      accountId: res.locals.accountId ?? null,
+      isApiKeyListener: res.locals.isApiKeyListener ?? false,
+    });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("authOrAgentApiKeyAuth identity resolution", () => {
+  const baseURL = "http://localhost:4051";
+  let server: Server;
+
+  beforeAll(async () => {
+    const app = buildTestApp([authOrAgentApiKeyAuth]);
+    await new Promise<void>((resolve) => {
+      server = app.listen(4051, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  // API key auth sets res.locals.accountId = ADMIN_ACCOUNT_ID
+  test("sets accountId to ADMIN_ACCOUNT_ID when API key auth is used", async () => {
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: agentKeyHeaders(),
+    });
+    const body = (await response.json()) as LocalsBody;
+
+    expect(response.status).toBe(200);
+    expect(body.accountId).toBe(ADMIN_ACCOUNT_ID);
+  });
+
+  // API key auth sets res.locals.isApiKeyListener = true
+  test("sets isApiKeyListener = true when API key auth is used", async () => {
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: agentKeyHeaders(),
+    });
+    const body = (await response.json()) as LocalsBody;
+
+    expect(response.status).toBe(200);
+    expect(body.isApiKeyListener).toBe(true);
+  });
+
+  // (negative case): JWT auth does NOT set isApiKeyListener
+  test("does NOT set isApiKeyListener when JWT auth is used", async () => {
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: await jwtHeaders(ADMIN_ACCOUNT_ID),
+    });
+    const body = (await response.json()) as LocalsBody;
+
+    expect(response.status).toBe(200);
+    expect(body.isApiKeyListener).toBe(false);
+  });
+
+  // JWT auth sets accountId from the JWT payload
+  test("sets accountId from JWT payload when JWT auth is used", async () => {
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: await jwtHeaders(ADMIN_ACCOUNT_ID),
+    });
+    const body = (await response.json()) as LocalsBody;
+
+    expect(response.status).toBe(200);
+    expect(body.accountId).toBe(ADMIN_ACCOUNT_ID);
+  });
+
+  // JWT without accountId still authenticates (accountId is undefined)
+  test("JWT without accountId authenticates but accountId is null", async () => {
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: await jwtHeaders(), // no accountId
+    });
+    const body = (await response.json()) as LocalsBody;
+
+    expect(response.status).toBe(200);
+    expect(body.accountId).toBeNull();
+  });
+});
+
+describe("requireAccount with authOrAgentApiKeyAuth", () => {
+  const baseURL = "http://localhost:4092";
+  let server: Server;
+
+  beforeAll(async () => {
+    const app = buildTestApp([authOrAgentApiKeyAuth, requireAccount]);
+    await new Promise<void>((resolve) => {
+      server = app.listen(4092, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  // requireAccount rejects when accountId is undefined
+  test("rejects (403) when accountId is undefined", async () => {
+    // JWT without accountId → authOrAgentApiKeyAuth passes but accountId is null
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: await jwtHeaders(), // no accountId
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("Account required");
+  });
+
+  // requireAccount does NOT reject API key requests (accountId is set by middleware)
+  test("passes when API key auth sets accountId", async () => {
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: agentKeyHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as LocalsBody;
+    expect(body.accountId).toBe(ADMIN_ACCOUNT_ID);
+  });
+
+  // requireAccount passes when JWT auth with accountId sets accountId
+  test("passes when JWT auth with accountId sets accountId", async () => {
+    const response = await fetch(`${baseURL}/test`, {
+      method: "POST",
+      headers: await jwtHeaders(ADMIN_ACCOUNT_ID),
+    });
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("getEffectiveOwnerId utility", () => {
+  test("returns res.locals.accountId from response", () => {
+    const mockRes = {
+      locals: { accountId: ADMIN_ACCOUNT_ID },
+    } as unknown as Response;
+
+    expect(getEffectiveOwnerId(mockRes)).toBe(ADMIN_ACCOUNT_ID);
+  });
+
+  test("returns undefined when accountId is not set", () => {
+    const mockRes = {
+      locals: {},
+    } as unknown as Response;
+
+    expect(getEffectiveOwnerId(mockRes)).toBeUndefined();
+  });
+});

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -8,6 +8,7 @@ import { issueNonce } from "@/api/v2/auth/auth-nonce.repository";
 import { authRouter } from "@/api/v2/auth/auth.router";
 import { NONCE_COOKIE_NAME, signNonce } from "@/api/v2/auth/nonce-cookie";
 import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { verifyJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
 
@@ -43,7 +44,8 @@ async function buildSiwe(nonce: string) {
 async function reset() {
   await prisma.deviceRegistration.deleteMany();
   await prisma.authMethod.deleteMany();
-  await prisma.account.deleteMany();
+  // Preserve the admin account seeded by migration; only wipe test-created rows.
+  await prisma.account.deleteMany({ where: { id: { not: ADMIN_ACCOUNT_ID } } });
   await prisma.authNonce.deleteMany();
 }
 

--- a/tests/builder-deps-env.test.ts
+++ b/tests/builder-deps-env.test.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+const readRepoFile = (path: string) =>
+  readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+const newOptionalEnvVars = [
+  "BUILDER_OPENROUTER_API_KEY",
+  "BUILDER_MODEL",
+  "EXA_SERVICE_KEY",
+  "POSTHOG_API_KEY",
+  "POSTHOG_HOST",
+] as const;
+
+describe("Builder dependency and optional env setup", () => {
+  test("pins posthog-node as an installed production dependency", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.dependencies?.["posthog-node"]).toBe("5.33.3");
+    expect(packageJson.devDependencies?.["posthog-node"]).toBeUndefined();
+    expect(
+      existsSync(
+        new URL("../node_modules/posthog-node/package.json", import.meta.url),
+      ),
+    ).toBe(true);
+  });
+
+  test("documents new lazy-read env vars with empty defaults", () => {
+    const envExample = readRepoFile(".env.example");
+
+    for (const envVar of newOptionalEnvVars) {
+      expect(envExample).toContain(`\n${envVar}=\n`);
+    }
+  });
+
+  test("does not require new optional env vars at config load time", () => {
+    const configSource = readRepoFile("src/config.ts");
+
+    for (const envVar of newOptionalEnvVars) {
+      expect(configSource).not.toContain(envVar);
+    }
+  });
+});

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+
+describe("constants", () => {
+  test("ADMIN_ACCOUNT_ID is a valid UUID", () => {
+    expect(ADMIN_ACCOUNT_ID).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});

--- a/tests/reserved-slugs.test.ts
+++ b/tests/reserved-slugs.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isReservedSlug,
+  isValidSlug,
+  RESERVED_SLUGS,
+  validateSlug,
+  type SlugValidationErrorReason,
+} from "@/utils/reserved-slugs";
+
+function expectValidSlug(slug: string) {
+  expect(validateSlug(slug)).toEqual({ valid: true, slug });
+}
+
+function expectInvalidSlug(slug: string, reason: SlugValidationErrorReason) {
+  const result = validateSlug(slug);
+
+  expect(result.valid).toBe(false);
+  if (!result.valid) {
+    expect(result.reason).toBe(reason);
+  }
+}
+
+describe("reserved slug utilities", () => {
+  test("reserved set is exactly the spec-locked slugs", () => {
+    expect([...RESERVED_SLUGS].sort()).toEqual(
+      [
+        "generate",
+        "publish",
+        "fork",
+        "search",
+        "files",
+        "templates",
+        "skills",
+      ].sort(),
+    );
+
+    for (const slug of RESERVED_SLUGS) {
+      expect(isReservedSlug(slug)).toBe(true);
+    }
+  });
+
+  test("non-reserved slugs return false", () => {
+    for (const slug of ["brewski", "ledger", "foo-bar", ""]) {
+      expect(isReservedSlug(slug)).toBe(false);
+    }
+  });
+
+  test("isReservedSlug is lowercase-only", () => {
+    expect(isReservedSlug("GENERATE")).toBe(false);
+    expect(isReservedSlug("Publish")).toBe(false);
+    expect(isReservedSlug("fOrK")).toBe(false);
+  });
+
+  test("validateSlug accepts valid lowercase alphanumeric and hyphen slugs", () => {
+    expectValidSlug("a");
+    expectValidSlug("a".repeat(64));
+    expectValidSlug("foo-bar");
+    expectValidSlug("abc123");
+  });
+
+  test("validateSlug rejects regex violations", () => {
+    expectInvalidSlug("Brewski", "invalid_format");
+    expectInvalidSlug("-leading", "invalid_format");
+    expectInvalidSlug("", "invalid_format");
+    expectInvalidSlug("trailing-", "invalid_format");
+    expectInvalidSlug("agent--double", "invalid_format");
+    expectInvalidSlug("a-", "invalid_format");
+    expectInvalidSlug("-", "invalid_format");
+  });
+
+  test("validateSlug enforces the 64 character max length", () => {
+    expectInvalidSlug("a".repeat(65), "too_long");
+  });
+
+  test("validateSlug rejects reserved slugs with a reserved reason", () => {
+    const result = validateSlug("generate");
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe("reserved");
+      expect(result.message).toContain("reserved");
+    }
+  });
+
+  test("isValidSlug returns true for valid slugs and false for invalid/reserved", () => {
+    expect(isValidSlug("foo-bar")).toBe(true);
+    expect(isValidSlug("abc123")).toBe(true);
+    expect(isValidSlug("UPPER")).toBe(false);
+    expect(isValidSlug("trailing-")).toBe(false);
+    expect(isValidSlug("generate")).toBe(false);
+    expect(isValidSlug("a".repeat(65))).toBe(false);
+  });
+});

--- a/tests/slug-hash.test.ts
+++ b/tests/slug-hash.test.ts
@@ -1,0 +1,65 @@
+import crypto from "node:crypto";
+import { describe, expect, test } from "bun:test";
+import { buildSlug, HASH_LEN, isHashedSlug, slugHash } from "@/utils/slug-hash";
+
+function referenceSlugHash(id: string) {
+  const sha = crypto.createHash("sha1").update(id).digest("hex");
+  return parseInt(sha.slice(0, 8), 16).toString(36).padStart(5, "0").slice(-5);
+}
+
+describe("slug-hash utilities", () => {
+  test("exports HASH_LEN as numeric literal 5", () => {
+    expect(HASH_LEN).toBe(5);
+    expect(typeof HASH_LEN).toBe("number");
+  });
+
+  test("slugHash returns exactly five lowercase base36 chars", () => {
+    const inputs = [
+      "",
+      "a",
+      "tmpl_abc123",
+      "this-is-a-very-long-id-string-with-many-characters-1234567890",
+      String.fromCharCode(0),
+    ];
+
+    for (const input of inputs) {
+      const hash = slugHash(input);
+      expect(hash).toHaveLength(HASH_LEN);
+      expect(hash).toMatch(/^[0-9a-z]{5}$/);
+    }
+  });
+
+  test("slugHash matches the pool reference algorithm", () => {
+    for (const id of ["a", "tmpl_abc123_extra_long_456", ""]) {
+      expect(slugHash(id)).toBe(referenceSlugHash(id));
+    }
+  });
+
+  test("slugHash is deterministic across repeated calls", () => {
+    const first = slugHash("tmpl_abc123");
+
+    for (let i = 0; i < 100; i++) {
+      expect(slugHash("tmpl_abc123")).toBe(first);
+    }
+  });
+
+  test("buildSlug concatenates base slug and hash with one dot", () => {
+    const built = buildSlug("brewski", "tmpl_abc123");
+
+    expect(built).toBe(`brewski.${slugHash("tmpl_abc123")}`);
+    expect(built).toMatch(/^brewski\.[0-9a-z]{5}$/);
+    expect(built.split(".")).toHaveLength(2);
+  });
+
+  test("isHashedSlug accepts a valid lowercase base36 tail", () => {
+    expect(isHashedSlug("brewski.x4f9k")).toBe(true);
+    expect(isHashedSlug("foo.bar.baz12")).toBe(true);
+  });
+
+  test("isHashedSlug rejects missing or invalid hash tails", () => {
+    expect(isHashedSlug("brewski")).toBe(false);
+    expect(isHashedSlug("brewski.")).toBe(false);
+    expect(isHashedSlug("brewski.toolong")).toBe(false);
+    expect(isHashedSlug("brewski.UPPER")).toBe(false);
+  });
+});

--- a/tests/slug-hash.test.ts
+++ b/tests/slug-hash.test.ts
@@ -1,6 +1,13 @@
 import crypto from "node:crypto";
 import { describe, expect, test } from "bun:test";
-import { buildSlug, HASH_LEN, isHashedSlug, slugHash } from "@/utils/slug-hash";
+import {
+  buildSlug,
+  buildUniqueSlug,
+  HASH_LEN,
+  isHashedSlug,
+  MAX_SLUG_ATTEMPTS,
+  slugHash,
+} from "@/utils/slug-hash";
 
 function referenceSlugHash(id: string) {
   const sha = crypto.createHash("sha1").update(id).digest("hex");
@@ -61,5 +68,58 @@ describe("slug-hash utilities", () => {
     expect(isHashedSlug("brewski.")).toBe(false);
     expect(isHashedSlug("brewski.toolong")).toBe(false);
     expect(isHashedSlug("brewski.UPPER")).toBe(false);
+  });
+});
+
+describe("buildUniqueSlug", () => {
+  test("returns the first generated slug when nothing is taken", async () => {
+    const ids = ["tmpl_first", "tmpl_second"];
+    let calls = 0;
+    const result = await buildUniqueSlug({
+      baseSlug: "brewski",
+      idFactory: () => ids[calls++],
+      isTaken: () => Promise.resolve(false),
+    });
+
+    expect(calls).toBe(1);
+    expect(result.id).toBe("tmpl_first");
+    expect(result.slug).toBe(buildSlug("brewski", "tmpl_first"));
+  });
+
+  test("retries with a fresh id when the slug is taken", async () => {
+    const ids = ["tmpl_first", "tmpl_second", "tmpl_third"];
+    let calls = 0;
+    const taken = new Set([
+      buildSlug("brewski", "tmpl_first"),
+      buildSlug("brewski", "tmpl_second"),
+    ]);
+
+    const result = await buildUniqueSlug({
+      baseSlug: "brewski",
+      idFactory: () => ids[calls++],
+      isTaken: (slug) => Promise.resolve(taken.has(slug)),
+    });
+
+    expect(calls).toBe(3);
+    expect(result.id).toBe("tmpl_third");
+    expect(result.slug).toBe(buildSlug("brewski", "tmpl_third"));
+  });
+
+  test("throws after MAX_SLUG_ATTEMPTS when every candidate is taken", async () => {
+    let calls = 0;
+    let caught: unknown;
+    try {
+      await buildUniqueSlug({
+        baseSlug: "brewski",
+        idFactory: () => `tmpl_${calls++}`,
+        isTaken: () => Promise.resolve(true),
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/exhausted 8 attempts/);
+    expect(calls).toBe(MAX_SLUG_ATTEMPTS);
   });
 });


### PR DESCRIPTION
## Agent Template Foundation Utilities

Foundation layer for the agent-templates feature stack. Builds on Borja's auth PR #194 — `Account` uses UUID primary keys; this branch adds the supporting utilities, admin seed, and auth-middleware upgrades agent-templates needs.

### What this PR adds

| Category | Files | Purpose |
|----------|-------|---------|
| **Slug hashing** | `src/utils/slug-hash.ts` | Byte-verbatim port of pool's `buildSlug` / `slugHash` / `isHashedSlug` — SHA1 → base36 → 5-char hash |
| **Reserved slugs** | `src/utils/reserved-slugs.ts` | 7 reserved words, `validateSlug()`, `isReservedSlug()` |
| **Auth helpers** | `src/utils/auth-helpers.ts`, `src/utils/constants.ts` | `getEffectiveOwnerId(res)` unified identity; `ADMIN_ACCOUNT_ID` constant |
| **Auth middleware** | `src/middleware/agentAuth.ts` | `authOrAgentApiKeyAuth` (JWT or `X-Agent-API-Key`); `requireAccount` for ownership gating |
| **Admin seed** | `prisma/migrations/20260508140000_seed_admin_account/` | Inserts the deterministic-UUID admin account row |
| **Router shell** | `src/api/v2/agent-templates/agent-templates.router.ts` | Empty router gated on `XMTP_ENV !== "production"` |
| **PostHog dep** | `package.json`, `.env.example` | `posthog-node@5.33.3` + builder env vars |
| **Engines** | `package.json` | Bun ≥ 1.0 |

### Key design choices

- **Account model**: UUID primary keys inherited from `fbac/authentication-api`. The admin row is created by a follow-up migration on this branch.
- **Production guard**: `process.env.XMTP_ENV !== "production"` — the router shell (and everything stacked on it) only mounts in dev/staging.
- **`ADMIN_ACCOUNT_ID`**: Deterministic UUID for the admin seed row; used as the effective owner for API-key-authenticated callers.
- **`getEffectiveOwnerId(res)`**: Handlers call this instead of hardcoding `ADMIN_ACCOUNT_ID`. It returns `res.locals.accountId`, which the auth middleware sets for both JWT and API-key paths.
- **`isApiKeyListener`**: Flag set to `true` when API-key auth is used, which downstream PRs use to bypass per-template ownership guards (admin-like access).
- **`agent-skills` deferred**: The original plan included an `agentSkillsRouter` shell here, but skills work has been deferred (lands in a later milestone). Not included in this stack.

No HTTP endpoints are added — only the building blocks the next three PRs in the stack depend on.

### Stacking

```
fbac/authentication-api (PR #194) ← this PR (#195)
  └─ CRUD (PR #199)
      └─ builder (PR #200)
          └─ create-job + twitter (PR #201)
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent template foundation utilities including slug helpers, admin account seed, and auth identity flags
> - Adds slug validation and hashed-slug generation utilities in [reserved-slugs.ts](https://github.com/ephemeraHQ/convos-backend/pull/195/files#diff-3efd2fc6492e0e823b477bc3f85d6e9c9a8d2cd785fdd62cdad1c87f9ed0dc1e) and [slug-hash.ts](https://github.com/ephemeraHQ/convos-backend/pull/195/files#diff-a2e1fb80c87864b575c47c8b0d02b39ee01a6c649809f3e35d64370217d10caf), including reserved word detection, format/length checks, and retry-based unique slug building.
> - Seeds a deterministic admin account row (`ADMIN_ACCOUNT_ID`) via a new Prisma migration and exports the UUID as a shared constant.
> - Extends `authOrAgentApiKeyAuth` middleware to set `res.locals.accountId` and `res.locals.isApiKeyListener` on requests authenticated via `X-Agent-API-Key`, and adds a `getEffectiveOwnerId` helper to read the resolved account.
> - Mounts an empty `agentTemplatesRouter` at `/api/v2/agent-templates` only in non-production environments.
> - Adds `posthog-node` as a production dependency and documents new optional env vars (`BUILDER_OPENROUTER_API_KEY`, `EXA_SERVICE_KEY`, `POSTHOG_API_KEY`, etc.) in `.env.example`.
> - Behavioral Change: Node.js engine requirement raised from `>=18` to `>=20`; existing test helpers updated to preserve the seeded admin account row during teardown.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #195 opened
>
> - Introduced config-backed accessor function with test override capability for agent assets API key [eb35046]
> - Refactored agent authentication middleware to use config accessor instead of direct environment variable access [eb35046]
> - Updated authentication middleware tests to use override function instead of environment variable mutation [eb35046]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f4aa6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->