### PR TITLE
feat: add agent template CRUD with per-account ownership [STACKED ON #195]

### DIFF
--- a/prisma/migrations/20260508120813_add_agent_template_schema/migration.sql
+++ b/prisma/migrations/20260508120813_add_agent_template_schema/migration.sql
@@ -1,0 +1,50 @@
+-- CreateEnum
+CREATE TYPE "PublishStatus" AS ENUM ('draft', 'published', 'unlisted', 'archived');
+
+-- CreateTable
+CREATE TABLE "AgentTemplate" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "slug" TEXT NOT NULL,
+    "ownerAccountId" UUID NOT NULL,
+    "forkedFromId" UUID,
+    "agentName" TEXT NOT NULL,
+    "description" TEXT,
+    "prompt" TEXT NOT NULL,
+    "category" TEXT,
+    "emoji" TEXT,
+    "avatarUrl" TEXT,
+    "tools" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "connections" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "firstPublishedAt" TIMESTAMP(3),
+    "status" "PublishStatus" NOT NULL DEFAULT 'draft',
+    "featured" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AgentTemplate_slug_idx" ON "AgentTemplate"("slug");
+
+-- CreateIndex
+CREATE INDEX "AgentTemplate_status_createdAt_id_idx" ON "AgentTemplate"("status", "createdAt", "id");
+
+-- CreateIndex
+CREATE INDEX "AgentTemplate_status_category_createdAt_id_idx" ON "AgentTemplate"("status", "category", "createdAt", "id");
+
+-- CreateIndex
+CREATE INDEX "AgentTemplate_status_featured_createdAt_id_idx" ON "AgentTemplate"("status", "featured", "createdAt", "id");
+
+-- CreateIndex
+CREATE INDEX "AgentTemplate_forkedFromId_idx" ON "AgentTemplate"("forkedFromId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentTemplate_ownerAccountId_slug_key" ON "AgentTemplate"("ownerAccountId", "slug");
+
+-- AddForeignKey
+ALTER TABLE "AgentTemplate" ADD CONSTRAINT "AgentTemplate_ownerAccountId_fkey" FOREIGN KEY ("ownerAccountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentTemplate" ADD CONSTRAINT "AgentTemplate_forkedFromId_fkey" FOREIGN KEY ("forkedFromId") REFERENCES "AgentTemplate"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,7 @@
 // This is your Prisma schema file,
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Looking for ways to speed up your queries, or scale easily with serverless or edge functions?
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
@@ -99,7 +99,47 @@ model Account {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  authMethods AuthMethod[]
+  authMethods    AuthMethod[]
+  agentTemplates AgentTemplate[]
+}
+
+enum PublishStatus {
+  draft
+  published
+  unlisted
+  archived
+}
+
+model AgentTemplate {
+  id               String        @id @default(uuid()) @db.Uuid
+  slug             String
+  ownerAccountId   String        @db.Uuid
+  forkedFromId     String?       @db.Uuid
+  agentName        String
+  description      String?
+  prompt           String        @db.Text
+  category         String?
+  emoji            String?
+  avatarUrl        String?
+  tools            String[]      @default([])
+  connections      String[]      @default([])
+  version          Int           @default(1)
+  firstPublishedAt DateTime?
+  status           PublishStatus @default(draft)
+  featured         Boolean       @default(false)
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+
+  owner      Account         @relation(fields: [ownerAccountId], references: [id])
+  forkedFrom AgentTemplate?  @relation("Forks", fields: [forkedFromId], references: [id])
+  forks      AgentTemplate[] @relation("Forks")
+
+  @@unique([ownerAccountId, slug])
+  @@index([slug])
+  @@index([status, createdAt, id])
+  @@index([status, category, createdAt, id])
+  @@index([status, featured, createdAt, id])
+  @@index([forkedFromId])
 }
 
 model AuthMethod {

--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -1,3 +1,48 @@
 import { Router } from "express";
+import { authOrAgentApiKeyAuth } from "@/middleware/agentAuth";
+import { requireAccount } from "@/middleware/auth";
+import { createHandler } from "./handlers/create";
+import { deleteHandler } from "./handlers/delete";
+import { detailHandler } from "./handlers/detail";
+import { listHandler } from "./handlers/list";
+import { patchHandler } from "./handlers/patch";
+import { publishHandler } from "./handlers/publish";
 
 export const agentTemplatesRouter = Router();
+
+agentTemplatesRouter.get(
+  "/",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  listHandler,
+);
+agentTemplatesRouter.post(
+  "/",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  createHandler,
+);
+agentTemplatesRouter.patch(
+  "/:id",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  patchHandler,
+);
+agentTemplatesRouter.delete(
+  "/:id",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  deleteHandler,
+);
+agentTemplatesRouter.post(
+  "/:id/publish",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  publishHandler,
+);
+agentTemplatesRouter.get(
+  "/:idOrHashedSlug",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  detailHandler,
+);

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -52,7 +52,9 @@ const bodySchema = z
     featured: z.boolean().optional(),
     prompt: z
       .string()
-      .max(50_000, { message: "prompt exceeds maximum length of 50_000 characters" })
+      .max(50_000, {
+        message: "prompt exceeds maximum length of 50_000 characters",
+      })
       .refine((value) => value.trim().length > 0, {
         message: "prompt is required",
       }),

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -50,9 +50,12 @@ const bodySchema = z
     description: z.string().nullable().optional(),
     emoji: z.string().nullable().optional(),
     featured: z.boolean().optional(),
-    prompt: z.string().refine((value) => value.trim().length > 0, {
-      message: "prompt is required",
-    }),
+    prompt: z
+      .string()
+      .max(50_000, { message: "prompt exceeds maximum length of 50_000 characters" })
+      .refine((value) => value.trim().length > 0, {
+        message: "prompt is required",
+      }),
     slug: z.string().optional(),
     tools: z.array(z.string()).optional(),
   })

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
@@ -5,6 +6,38 @@ import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-a
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
+import { buildUniqueSlug, slugHash } from "@/utils/slug-hash";
+
+// Picks a row id whose slugHash doesn't collide with any existing row sharing
+// `baseSlug` across owners. The DB constraint is per-owner, but the public URL
+// `<base>.<hash5>` is cross-owner, so two owners on the same base slug can mint
+// indistinguishable URLs unless we pre-pick a non-colliding id.
+//
+// Residual race: between this read and the subsequent create, a concurrent
+// transaction could insert a row whose hash collides with our pick. The
+// per-owner unique constraint won't catch it (different owners). For that to
+// produce a real collision, two writes need to land in the same sub-ms window,
+// share the same base slug, and have UUIDs that hash to the same 5 chars
+// (~67M space). Compound probability is negligible at our scale; revisit with
+// a SERIALIZABLE transaction or a stored urlHash unique index if collisions
+// ever surface in monitoring.
+const pickCollisionFreeId = async (args: { baseSlug: string }) => {
+  const { id } = await buildUniqueSlug({
+    baseSlug: args.baseSlug,
+    idFactory: () => crypto.randomUUID(),
+    isTaken: async (candidate) => {
+      const dot = candidate.lastIndexOf(".");
+      const base = candidate.slice(0, dot);
+      const hash = candidate.slice(dot + 1);
+      const rows = await prisma.agentTemplate.findMany({
+        where: { slug: base },
+        select: { id: true },
+      });
+      return rows.some((row) => slugHash(row.id) === hash);
+    },
+  });
+  return id;
+};
 
 const MAX_AUTO_SLUG_ATTEMPTS = 50;
 
@@ -87,11 +120,13 @@ const hasSlugConflict = async (args: {
 
 const createTemplateRow = (args: {
   body: CreateBody;
+  id: string;
   slug: string;
   ownerAccountId: string;
 }) =>
   prisma.agentTemplate.create({
     data: {
+      id: args.id,
       slug: args.slug,
       ownerAccountId: args.ownerAccountId,
       forkedFromId: null,
@@ -133,8 +168,10 @@ const createWithExplicitSlug = async (args: {
   }
 
   try {
+    const id = await pickCollisionFreeId({ baseSlug: validation.slug });
     return await createTemplateRow({
       body: args.body,
+      id,
       slug: validation.slug,
       ownerAccountId: args.ownerAccountId,
     });
@@ -189,8 +226,12 @@ const createWithAutoSlug = async (args: {
     }
 
     try {
+      const id = await pickCollisionFreeId({
+        baseSlug: candidateValidation.slug,
+      });
       return await createTemplateRow({
         body: args.body,
+        id,
         slug: candidateValidation.slug,
         ownerAccountId: args.ownerAccountId,
       });

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -1,0 +1,253 @@
+import { Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
+import { getEffectiveOwnerId } from "@/utils/auth-helpers";
+import { prisma } from "@/utils/prisma";
+import { validateSlug } from "@/utils/reserved-slugs";
+
+const MAX_AUTO_SLUG_ATTEMPTS = 50;
+
+const bodySchema = z
+  .object({
+    agentName: z.string().trim().min(1),
+    avatarUrl: z.string().nullable().optional(),
+    category: z.string().nullable().optional(),
+    connections: z.array(z.string()).optional(),
+    description: z.string().nullable().optional(),
+    emoji: z.string().nullable().optional(),
+    featured: z.boolean().optional(),
+    prompt: z.string().refine((value) => value.trim().length > 0, {
+      message: "prompt is required",
+    }),
+    slug: z.string().optional(),
+    tools: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+type CreateBody = z.infer<typeof bodySchema>;
+
+const deriveSlugFromAgentName = (agentName: string) =>
+  agentName.toLowerCase().replace(/\s+/g, "-");
+
+const slugErrorCode = (reason: string) =>
+  reason === "reserved" ? "RESERVED_SLUG" : "INVALID_SLUG";
+
+const sendSlugValidationError = (
+  res: Response,
+  validation: Exclude<ReturnType<typeof validateSlug>, { valid: true }>,
+) => {
+  res.status(400).json({
+    error: {
+      code: slugErrorCode(validation.reason),
+      message: validation.message,
+    },
+  });
+};
+
+const sendSlugConflict = (res: Response) => {
+  res.status(409).json({
+    error: {
+      code: "SLUG_CONFLICT",
+      message: "Slug already exists for this owner",
+    },
+  });
+};
+
+const isSlugUniqueConstraintError = (error: unknown) => {
+  if (
+    !(error instanceof Prisma.PrismaClientKnownRequestError) ||
+    error.code !== "P2002"
+  ) {
+    return false;
+  }
+
+  const target = error.meta?.target;
+  if (Array.isArray(target)) {
+    return target.includes("ownerAccountId") && target.includes("slug");
+  }
+
+  return typeof target === "string" && target.includes("slug");
+};
+
+const hasSlugConflict = async (args: {
+  ownerAccountId: string;
+  slug: string;
+}) => {
+  const existing = await prisma.agentTemplate.findFirst({
+    where: {
+      ownerAccountId: args.ownerAccountId,
+      slug: args.slug,
+    },
+    select: { id: true },
+  });
+
+  return existing !== null;
+};
+
+const createTemplateRow = (args: {
+  body: CreateBody;
+  slug: string;
+  ownerAccountId: string;
+}) =>
+  prisma.agentTemplate.create({
+    data: {
+      slug: args.slug,
+      ownerAccountId: args.ownerAccountId,
+      forkedFromId: null,
+      agentName: args.body.agentName,
+      description: args.body.description ?? null,
+      prompt: args.body.prompt,
+      category: args.body.category ?? null,
+      emoji: args.body.emoji ?? null,
+      avatarUrl: args.body.avatarUrl ?? null,
+      tools: args.body.tools ?? [],
+      connections: args.body.connections ?? [],
+      version: 1,
+      firstPublishedAt: null,
+      status: "draft",
+      featured: args.body.featured ?? false,
+    },
+  });
+
+const createWithExplicitSlug = async (args: {
+  body: CreateBody;
+  res: Response;
+  slug: string;
+  ownerAccountId: string;
+}) => {
+  const validation = validateSlug(args.slug);
+  if (!validation.valid) {
+    sendSlugValidationError(args.res, validation);
+    return null;
+  }
+
+  if (
+    await hasSlugConflict({
+      ownerAccountId: args.ownerAccountId,
+      slug: validation.slug,
+    })
+  ) {
+    sendSlugConflict(args.res);
+    return null;
+  }
+
+  try {
+    return await createTemplateRow({
+      body: args.body,
+      slug: validation.slug,
+      ownerAccountId: args.ownerAccountId,
+    });
+  } catch (error) {
+    if (isSlugUniqueConstraintError(error)) {
+      sendSlugConflict(args.res);
+      return null;
+    }
+
+    throw error;
+  }
+};
+
+const createWithAutoSlug = async (args: {
+  body: CreateBody;
+  res: Response;
+  ownerAccountId: string;
+}) => {
+  const baseSlug = deriveSlugFromAgentName(args.body.agentName);
+  const baseValidation = validateSlug(baseSlug);
+  if (!baseValidation.valid) {
+    sendSlugValidationError(args.res, baseValidation);
+    return null;
+  }
+
+  // attempt 0 → bare base slug; attempt 2+ → baseSlug-N (skip -1)
+  const startAttempt = 0;
+
+  for (
+    let attempt = startAttempt;
+    attempt <= MAX_AUTO_SLUG_ATTEMPTS;
+    attempt++
+  ) {
+    if (attempt === 1) {
+      continue; // skip -1 suffix; first suffix is -2
+    }
+
+    const candidate = attempt === 0 ? baseSlug : `${baseSlug}-${attempt}`;
+    const candidateValidation = validateSlug(candidate);
+    if (!candidateValidation.valid) {
+      sendSlugValidationError(args.res, candidateValidation);
+      return null;
+    }
+
+    if (
+      await hasSlugConflict({
+        ownerAccountId: args.ownerAccountId,
+        slug: candidateValidation.slug,
+      })
+    ) {
+      continue;
+    }
+
+    try {
+      return await createTemplateRow({
+        body: args.body,
+        slug: candidateValidation.slug,
+        ownerAccountId: args.ownerAccountId,
+      });
+    } catch (error) {
+      if (isSlugUniqueConstraintError(error)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  sendSlugConflict(args.res);
+  return null;
+};
+
+export async function createHandler(req: Request, res: Response) {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsed.error.issues,
+    });
+    return;
+  }
+
+  const ownerAccountId = getEffectiveOwnerId(res);
+  if (!ownerAccountId) {
+    res.status(403).json({ error: "Account required" });
+    return;
+  }
+
+  try {
+    const template =
+      parsed.data.slug === undefined
+        ? await createWithAutoSlug({
+            body: parsed.data,
+            res,
+            ownerAccountId,
+          })
+        : await createWithExplicitSlug({
+            body: parsed.data,
+            res,
+            slug: parsed.data.slug,
+            ownerAccountId,
+          });
+
+    if (template === null) {
+      return;
+    }
+
+    res.status(201).json(serializeAgentTemplate(template));
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to create agent template",
+    );
+    res.status(500).json({ error: "Failed to create agent template" });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/delete.ts
+++ b/src/api/v2/agent-templates/handlers/delete.ts
@@ -1,0 +1,86 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const paramsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const sendAlreadyPublished = (res: Response) => {
+  res.status(409).json({
+    error: {
+      code: "ALREADY_PUBLISHED",
+      message:
+        "Agent templates with firstPublishedAt set cannot be hard-deleted",
+    },
+  });
+};
+
+export async function deleteHandler(req: Request, res: Response) {
+  const parsedParams = paramsSchema.safeParse(req.params);
+  if (!parsedParams.success) {
+    res.status(400).json({
+      error: "Invalid request params",
+      details: parsedParams.error.issues,
+    });
+    return;
+  }
+
+  try {
+    const template = await prisma.agentTemplate.findUnique({
+      where: { id: parsedParams.data.id },
+      select: { id: true, ownerAccountId: true, firstPublishedAt: true },
+    });
+
+    if (template === null) {
+      res.status(404).json({ error: "Agent template not found" });
+      return;
+    }
+
+    // Ownership guard: reject if caller is not the owner AND not an API key listener
+    const callerAccountId = res.locals.accountId;
+    const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+    if (template.ownerAccountId !== callerAccountId && !isApiKeyListener) {
+      res.status(403).json({ error: "Not authorized to delete this template" });
+      return;
+    }
+
+    if (template.firstPublishedAt !== null) {
+      sendAlreadyPublished(res);
+      return;
+    }
+
+    // Atomic delete: a concurrent publish could set firstPublishedAt between
+    // the read above and the delete here, so re-check the invariant in the
+    // delete WHERE clause and return 409 if a publish slipped in.
+    const deleted = await prisma.agentTemplate.deleteMany({
+      where: { id: template.id, firstPublishedAt: null },
+    });
+
+    if (deleted.count === 0) {
+      const stillExists = await prisma.agentTemplate.findUnique({
+        where: { id: template.id },
+        select: { id: true },
+      });
+
+      if (stillExists !== null) {
+        sendAlreadyPublished(res);
+      } else {
+        res.status(404).json({ error: "Agent template not found" });
+      }
+      return;
+    }
+
+    res.status(200).json({
+      object: "agent_template",
+      id: template.id,
+      deleted: true,
+    });
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to delete agent template",
+    );
+    res.status(500).json({ error: "Failed to delete agent template" });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/delete.ts
+++ b/src/api/v2/agent-templates/handlers/delete.ts
@@ -31,6 +31,15 @@ export async function deleteHandler(req: Request, res: Response) {
     const callerAccountId = res.locals.accountId;
     const isApiKeyListener = res.locals.isApiKeyListener ?? false;
     if (template.ownerAccountId !== callerAccountId && !isApiKeyListener) {
+      req.log.warn(
+        {
+          callerAccountId,
+          templateId: template.id,
+          ownerAccountId: template.ownerAccountId,
+          action: "delete",
+        },
+        "Unauthorized agent-template access attempt",
+      );
       res.status(403).json({ error: "Not authorized to delete this template" });
       return;
     }

--- a/src/api/v2/agent-templates/handlers/delete.ts
+++ b/src/api/v2/agent-templates/handlers/delete.ts
@@ -6,16 +6,6 @@ const paramsSchema = z.object({
   id: z.string().uuid(),
 });
 
-const sendAlreadyPublished = (res: Response) => {
-  res.status(409).json({
-    error: {
-      code: "ALREADY_PUBLISHED",
-      message:
-        "Agent templates with firstPublishedAt set cannot be hard-deleted",
-    },
-  });
-};
-
 export async function deleteHandler(req: Request, res: Response) {
   const parsedParams = paramsSchema.safeParse(req.params);
   if (!parsedParams.success) {
@@ -29,7 +19,7 @@ export async function deleteHandler(req: Request, res: Response) {
   try {
     const template = await prisma.agentTemplate.findUnique({
       where: { id: parsedParams.data.id },
-      select: { id: true, ownerAccountId: true, firstPublishedAt: true },
+      select: { id: true, ownerAccountId: true },
     });
 
     if (template === null) {
@@ -45,29 +35,18 @@ export async function deleteHandler(req: Request, res: Response) {
       return;
     }
 
-    if (template.firstPublishedAt !== null) {
-      sendAlreadyPublished(res);
-      return;
-    }
-
-    // Atomic delete: a concurrent publish could set firstPublishedAt between
-    // the read above and the delete here, so re-check the invariant in the
-    // delete WHERE clause and return 409 if a publish slipped in.
+    // Hard delete is permitted in any publish state. Forks of this template
+    // have `forkedFromId` set to null (FK is ON DELETE SET NULL); generations
+    // (PR #204+) have `templateId` cleared the same way. The owner accepts
+    // that any cached/bookmarked URL pointing at this template will start
+    // 404'ing after delete.
     const deleted = await prisma.agentTemplate.deleteMany({
-      where: { id: template.id, firstPublishedAt: null },
+      where: { id: template.id },
     });
 
     if (deleted.count === 0) {
-      const stillExists = await prisma.agentTemplate.findUnique({
-        where: { id: template.id },
-        select: { id: true },
-      });
-
-      if (stillExists !== null) {
-        sendAlreadyPublished(res);
-      } else {
-        res.status(404).json({ error: "Agent template not found" });
-      }
+      // Lost a race with another concurrent delete.
+      res.status(404).json({ error: "Agent template not found" });
       return;
     }
 

--- a/src/api/v2/agent-templates/handlers/detail.ts
+++ b/src/api/v2/agent-templates/handlers/detail.ts
@@ -1,0 +1,122 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+import { resolveAgentTemplateByIdOrHashedSlug } from "../lib/resolve-id-or-hashed-slug";
+import { serializeAgentTemplate } from "../lib/serialize-agent-template";
+
+const paramsSchema = z
+  .object({
+    idOrHashedSlug: z.string().min(1),
+  })
+  .strict();
+
+const expandValueSchema = z.union([z.string(), z.array(z.string())]);
+
+const querySchema = z
+  .object({
+    expand: expandValueSchema.optional(),
+    "expand[]": expandValueSchema.optional(),
+  })
+  .passthrough();
+
+const toArray = (value: string | string[] | undefined) => {
+  if (value === undefined) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value];
+};
+
+const parseExpandValues = (query: z.infer<typeof querySchema>) => [
+  ...toArray(query.expand),
+  ...toArray(query["expand[]"]),
+];
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function detailHandler(req: Request, res: Response) {
+  const parsedParams = paramsSchema.safeParse(req.params);
+  if (!parsedParams.success) {
+    res.status(404).json({ error: "Agent template not found" });
+    return;
+  }
+
+  const parsedQuery = querySchema.safeParse(req.query);
+  if (!parsedQuery.success) {
+    res.status(400).json({
+      error: "Invalid request query",
+      details: parsedQuery.error.issues,
+    });
+    return;
+  }
+
+  try {
+    // First try to resolve via the standard path (published/unlisted/archived only)
+    let template = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: parsedParams.data.idOrHashedSlug,
+    });
+
+    // If not found, check if it's a draft template accessible to the caller.
+    // accountId is guaranteed by the router (authOrAgentApiKeyAuth + requireAccount).
+    if (
+      template === null &&
+      uuidPattern.test(parsedParams.data.idOrHashedSlug)
+    ) {
+      const accountId = res.locals.accountId as string;
+      const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+
+      const draftTemplate = await prisma.agentTemplate.findUnique({
+        where: { id: parsedParams.data.idOrHashedSlug },
+      });
+
+      if (draftTemplate !== null && draftTemplate.status === "draft") {
+        // Draft is only visible to the owner or API key listener
+        if (draftTemplate.ownerAccountId === accountId || isApiKeyListener) {
+          template = draftTemplate;
+        }
+        // If not authorized, template stays null → 404
+      }
+    }
+
+    if (template === null) {
+      res.status(404).json({ error: "Agent template not found" });
+      return;
+    }
+
+    const expandValues = parseExpandValues(parsedQuery.data);
+    const expandOwner = expandValues.includes("owner");
+    const includeSkills =
+      expandValues.includes("skills") || expandValues.includes("skills.files");
+
+    const owner = expandOwner
+      ? await prisma.account.findUnique({
+          where: { id: template.ownerAccountId },
+        })
+      : undefined;
+
+    if (expandOwner && owner === null) {
+      req.log.error(
+        { ownerAccountId: template.ownerAccountId, templateId: template.id },
+        "Agent template owner account not found",
+      );
+      res.status(500).json({ error: "Failed to load template owner" });
+      return;
+    }
+
+    res
+      .status(200)
+      .json(
+        serializeAgentTemplate(
+          template,
+          owner ? { includeSkills, owner } : { includeSkills },
+        ),
+      );
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to get agent template detail",
+    );
+    res.status(500).json({ error: "Failed to get agent template" });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -1,0 +1,250 @@
+import type { AgentTemplate, Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+import { serializeAgentTemplate } from "../lib/serialize-agent-template";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const VALID_STATUS_FILTERS = [
+  "draft",
+  "published",
+  "unlisted",
+  "archived",
+] as const;
+
+const querySchema = z
+  .object({
+    category: z.string().optional(),
+    cursor: z.string().optional(),
+    featured: z.string().optional(),
+    limit: z.string().optional(),
+    owner: z.string().optional(),
+    status: z.string().optional(),
+  })
+  .passthrough();
+
+const cursorPayloadSchema = z
+  .object({
+    id: z.string().min(1),
+    createdAt: z.string().min(1),
+  })
+  .strict();
+
+const sendInvalidQuery = (res: Response, message: string) => {
+  res.status(400).json({
+    error: "Invalid request query",
+    message,
+  });
+};
+
+const parseLimit = (value: string | undefined) => {
+  if (value === undefined) {
+    return DEFAULT_LIMIT;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return Math.min(parsed, MAX_LIMIT);
+};
+
+const encodeCursor = (template: AgentTemplate) =>
+  Buffer.from(
+    JSON.stringify({
+      id: template.id,
+      createdAt: template.createdAt.toISOString(),
+    }),
+  ).toString("base64url");
+
+const decodeCursor = (cursor: string | undefined) => {
+  if (cursor === undefined) {
+    return null;
+  }
+
+  if (cursor.length === 0 || !/^[A-Za-z0-9_-]+$/.test(cursor)) {
+    return undefined;
+  }
+
+  try {
+    const decoded: unknown = JSON.parse(
+      Buffer.from(cursor, "base64url").toString(),
+    );
+    const parsed = cursorPayloadSchema.safeParse(decoded);
+
+    if (!parsed.success) {
+      return undefined;
+    }
+
+    const createdAt = new Date(parsed.data.createdAt);
+    if (Number.isNaN(createdAt.getTime())) {
+      return undefined;
+    }
+
+    return {
+      id: parsed.data.id,
+      createdAt,
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+export async function listHandler(req: Request, res: Response) {
+  // The router pins this route to authOrAgentApiKeyAuth + requireAccount, so
+  // accountId is always set by the time we get here. We don't expose the list
+  // surface to unauthenticated callers — there's no public discovery API.
+  const accountId = res.locals.accountId as string;
+  const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+
+  // Status filter handling
+  const hasStatusFilter = Object.prototype.hasOwnProperty.call(
+    req.query,
+    "status",
+  );
+  const statusFilter = req.query.status as string | undefined;
+
+  if (hasStatusFilter) {
+    if (
+      statusFilter === undefined ||
+      !VALID_STATUS_FILTERS.includes(
+        statusFilter as (typeof VALID_STATUS_FILTERS)[number],
+      )
+    ) {
+      sendInvalidQuery(res, "Invalid status filter value");
+      return;
+    }
+  }
+
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    sendInvalidQuery(res, parsed.error.issues[0]?.message ?? "Invalid query");
+    return;
+  }
+
+  const limit = parseLimit(parsed.data.limit);
+  if (limit === null) {
+    sendInvalidQuery(res, "limit must be a positive integer");
+    return;
+  }
+
+  const cursor = decodeCursor(parsed.data.cursor);
+  if (cursor === undefined) {
+    sendInvalidQuery(res, "cursor is malformed");
+    return;
+  }
+
+  // Build the where clause based on caller type (regular user vs API key).
+  const where: Prisma.AgentTemplateWhereInput = {};
+
+  if (hasStatusFilter && statusFilter) {
+    // API key listeners see all templates with that status (admin-like access);
+    // regular users see only their own templates with the requested status.
+    if (isApiKeyListener) {
+      where.status = statusFilter as Prisma.EnumPublishStatusFilter;
+    } else {
+      where.AND = [
+        { status: statusFilter as Prisma.EnumPublishStatusFilter },
+        { ownerAccountId: accountId },
+      ];
+    }
+  } else if (isApiKeyListener) {
+    // API key listener sees everything (admin-like access). No filter needed.
+  } else {
+    // Regular authenticated user without status filter:
+    // Published templates from any owner + own drafts/unlisted/archived.
+    where.OR = [
+      { status: "published" },
+      {
+        status: { in: ["draft", "unlisted", "archived"] },
+        ownerAccountId: accountId,
+      },
+    ];
+  }
+
+  if (parsed.data.category !== undefined) {
+    where.category = parsed.data.category;
+  }
+
+  // The `owner` filter must compose with the visibility OR clause.
+  // If there's a visibility OR clause, we need to apply ownerAccountId
+  // as an additional AND constraint within each OR branch.
+  if (parsed.data.owner !== undefined) {
+    // Non-UUID owner values can't match any row; short-circuit with an empty
+    // result rather than handing Prisma a malformed UUID (which throws).
+    const UUID_RE =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(parsed.data.owner)) {
+      res.status(200).json({ data: [], hasMore: false, nextCursor: null });
+      return;
+    }
+
+    const ownerFilter = { ownerAccountId: parsed.data.owner };
+    if (where.OR) {
+      // Apply owner filter to each OR branch by converting to AND inside each
+      where.OR = where.OR.map((branch) => ({
+        AND: [branch, ownerFilter],
+      }));
+    } else {
+      where.ownerAccountId = parsed.data.owner;
+    }
+  }
+
+  if (parsed.data.featured === "true") {
+    where.featured = true;
+  }
+
+  // Cursor pagination: compose with existing AND/OR clauses
+  if (cursor !== null) {
+    const cursorFilter = {
+      OR: [
+        { createdAt: { lt: cursor.createdAt } },
+        {
+          createdAt: cursor.createdAt,
+          id: { lt: cursor.id },
+        },
+      ],
+    };
+
+    if (where.AND) {
+      // Already have an AND clause from visibility rules — append cursor filter
+      (where.AND as Prisma.AgentTemplateWhereInput[]).push(cursorFilter);
+    } else {
+      where.AND = [cursorFilter];
+    }
+  }
+
+  try {
+    const templates = await prisma.agentTemplate.findMany({
+      where,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: limit + 1,
+    });
+
+    const page = templates.slice(0, limit);
+    const hasMore = templates.length > limit;
+    const lastTemplate = page.at(-1);
+
+    res.status(200).json({
+      data: page.map((template) => serializeAgentTemplate(template)),
+      hasMore,
+      nextCursor:
+        hasMore && lastTemplate !== undefined
+          ? encodeCursor(lastTemplate)
+          : null,
+    });
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to list agent templates",
+    );
+    res.status(500).json({ error: "Failed to list agent templates" });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -104,12 +104,18 @@ export async function listHandler(req: Request, res: Response) {
   const accountId = res.locals.accountId as string;
   const isApiKeyListener = res.locals.isApiKeyListener ?? false;
 
-  // Status filter handling
+  // Status filter handling. Express + qs can deliver `?status=draft` as a
+  // string OR `?status=draft&status=published` as an array of strings (and
+  // bracket-notation `?status[foo]=bar` as a nested object). Narrow to a
+  // single string explicitly so a repeated/object form is rejected with
+  // the same 400 as an invalid enum value instead of slipping through a
+  // silent cast.
   const hasStatusFilter = Object.prototype.hasOwnProperty.call(
     req.query,
     "status",
   );
-  const statusFilter = req.query.status as string | undefined;
+  const rawStatus = req.query.status;
+  const statusFilter = typeof rawStatus === "string" ? rawStatus : undefined;
 
   if (hasStatusFilter) {
     if (

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -21,7 +21,9 @@ const bodySchema = z
     emoji: z.string().nullable().optional(),
     prompt: z
       .string()
-      .max(50_000, { message: "prompt exceeds maximum length of 50_000 characters" })
+      .max(50_000, {
+        message: "prompt exceeds maximum length of 50_000 characters",
+      })
       .refine((value) => value.trim().length > 0, {
         message: "prompt must not be empty",
       })

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -145,9 +145,11 @@ const validateStatusTransition = (args: {
     return "Draft templates must be published with POST /publish";
   }
 
-  if (args.firstPublishedAt !== null && args.nextStatus === "draft") {
-    return "Published templates cannot transition back to draft";
-  }
+  // Published → draft IS allowed: lets a caller take a previously-public
+  // template out of public view (resolver only matches non-draft, so the
+  // canonical URL stops resolving for non-owners). `firstPublishedAt`
+  // stays set, so the slug remains locked and the next /publish call
+  // takes the re-publish path (version bump rather than version reset).
 
   return null;
 };

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -134,7 +134,6 @@ const applyContentFields = (
 
 const validateStatusTransition = (args: {
   currentStatus: PublishStatus;
-  firstPublishedAt: Date | null;
   nextStatus: PublishStatus;
 }) => {
   if (args.nextStatus === args.currentStatus) {
@@ -226,7 +225,6 @@ export async function patchHandler(req: Request, res: Response) {
     if (parsedBody.data.status !== undefined) {
       const transitionError = validateStatusTransition({
         currentStatus: template.status,
-        firstPublishedAt: template.firstPublishedAt,
         nextStatus: parsedBody.data.status,
       });
 

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -1,0 +1,303 @@
+import { Prisma, type PublishStatus } from "@prisma/client";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
+import { prisma } from "@/utils/prisma";
+import { validateSlug } from "@/utils/reserved-slugs";
+
+const paramsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const statusSchema = z.enum(["draft", "published", "unlisted", "archived"]);
+
+const bodySchema = z
+  .object({
+    agentName: z.string().trim().min(1).optional(),
+    avatarUrl: z.string().nullable().optional(),
+    category: z.string().nullable().optional(),
+    connections: z.array(z.string()).optional(),
+    description: z.string().nullable().optional(),
+    emoji: z.string().nullable().optional(),
+    prompt: z
+      .string()
+      .refine((value) => value.trim().length > 0, {
+        message: "prompt must not be empty",
+      })
+      .optional(),
+    slug: z.string().optional(),
+    status: statusSchema.optional(),
+    tools: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+type PatchBody = z.infer<typeof bodySchema>;
+
+const slugErrorCode = (reason: string) =>
+  reason === "reserved" ? "RESERVED_SLUG" : "INVALID_SLUG";
+
+const sendSlugValidationError = (
+  res: Response,
+  validation: Exclude<ReturnType<typeof validateSlug>, { valid: true }>,
+) => {
+  res.status(400).json({
+    error: {
+      code: slugErrorCode(validation.reason),
+      message: validation.message,
+    },
+  });
+};
+
+const sendSlugConflict = (res: Response) => {
+  res.status(409).json({
+    error: {
+      code: "SLUG_CONFLICT",
+      message: "Slug already exists for this owner",
+    },
+  });
+};
+
+const sendBadRequest = (
+  res: Response,
+  args: { code: string; message: string },
+) => {
+  res.status(400).json({
+    error: {
+      code: args.code,
+      message: args.message,
+    },
+  });
+};
+
+const isSlugUniqueConstraintError = (error: unknown) => {
+  if (
+    !(error instanceof Prisma.PrismaClientKnownRequestError) ||
+    error.code !== "P2002"
+  ) {
+    return false;
+  }
+
+  const target = error.meta?.target;
+  if (Array.isArray(target)) {
+    return target.includes("ownerAccountId") && target.includes("slug");
+  }
+
+  return typeof target === "string" && target.includes("slug");
+};
+
+const hasSlugConflict = async (args: {
+  ownerAccountId: string;
+  slug: string;
+  templateId: string;
+}) => {
+  const existing = await prisma.agentTemplate.findFirst({
+    where: {
+      ownerAccountId: args.ownerAccountId,
+      slug: args.slug,
+      id: { not: args.templateId },
+    },
+    select: { id: true },
+  });
+
+  return existing !== null;
+};
+
+const applyContentFields = (
+  data: Prisma.AgentTemplateUncheckedUpdateInput,
+  body: PatchBody,
+) => {
+  if (body.agentName !== undefined) {
+    data.agentName = body.agentName;
+  }
+  if (body.avatarUrl !== undefined) {
+    data.avatarUrl = body.avatarUrl;
+  }
+  if (body.category !== undefined) {
+    data.category = body.category;
+  }
+  if (body.connections !== undefined) {
+    data.connections = body.connections;
+  }
+  if (body.description !== undefined) {
+    data.description = body.description;
+  }
+  if (body.emoji !== undefined) {
+    data.emoji = body.emoji;
+  }
+  if (body.prompt !== undefined) {
+    data.prompt = body.prompt;
+  }
+  if (body.tools !== undefined) {
+    data.tools = body.tools;
+  }
+};
+
+const validateStatusTransition = (args: {
+  currentStatus: PublishStatus;
+  firstPublishedAt: Date | null;
+  nextStatus: PublishStatus;
+}) => {
+  if (args.nextStatus === args.currentStatus) {
+    return null;
+  }
+
+  if (args.currentStatus === "draft") {
+    return "Draft templates must be published with POST /publish";
+  }
+
+  if (args.firstPublishedAt !== null && args.nextStatus === "draft") {
+    return "Published templates cannot transition back to draft";
+  }
+
+  return null;
+};
+
+export async function patchHandler(req: Request, res: Response) {
+  const parsedParams = paramsSchema.safeParse(req.params);
+  if (!parsedParams.success) {
+    res.status(400).json({
+      error: "Invalid request params",
+      details: parsedParams.error.issues,
+    });
+    return;
+  }
+
+  const parsedBody = bodySchema.safeParse(req.body);
+  if (!parsedBody.success) {
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsedBody.error.issues,
+    });
+    return;
+  }
+
+  try {
+    const template = await prisma.agentTemplate.findUnique({
+      where: { id: parsedParams.data.id },
+    });
+
+    if (template === null) {
+      res.status(404).json({ error: "Agent template not found" });
+      return;
+    }
+
+    // Ownership guard: reject if caller is not the owner AND not an API key listener
+    const callerAccountId = res.locals.accountId;
+    const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+    if (template.ownerAccountId !== callerAccountId && !isApiKeyListener) {
+      res.status(403).json({ error: "Not authorized to modify this template" });
+      return;
+    }
+
+    const data: Prisma.AgentTemplateUncheckedUpdateInput = {};
+    applyContentFields(data, parsedBody.data);
+
+    if (parsedBody.data.slug !== undefined) {
+      if (template.firstPublishedAt !== null) {
+        sendBadRequest(res, {
+          code: "SLUG_IMMUTABLE",
+          message: "Slug is immutable once the template has been published",
+        });
+        return;
+      }
+
+      const validation = validateSlug(parsedBody.data.slug);
+      if (!validation.valid) {
+        sendSlugValidationError(res, validation);
+        return;
+      }
+
+      if (
+        await hasSlugConflict({
+          ownerAccountId: template.ownerAccountId,
+          slug: validation.slug,
+          templateId: template.id,
+        })
+      ) {
+        sendSlugConflict(res);
+        return;
+      }
+
+      data.slug = validation.slug;
+    }
+
+    if (parsedBody.data.status !== undefined) {
+      const transitionError = validateStatusTransition({
+        currentStatus: template.status,
+        firstPublishedAt: template.firstPublishedAt,
+        nextStatus: parsedBody.data.status,
+      });
+
+      if (transitionError !== null) {
+        sendBadRequest(res, {
+          code: "INVALID_STATUS_TRANSITION",
+          message: transitionError,
+        });
+        return;
+      }
+
+      data.status = parsedBody.data.status;
+    }
+
+    if (Object.keys(data).length === 0) {
+      res.status(200).json(serializeAgentTemplate(template));
+      return;
+    }
+
+    try {
+      // Pin the WHERE clause to the row state we just validated. A concurrent
+      // publish, slug rename, ownership transfer or status flip would
+      // invalidate our invariant checks above, so any such mutation drops us
+      // into the count === 0 branch and surfaces as a 409 (or 404 if the row
+      // was deleted).
+      const result = await prisma.agentTemplate.updateMany({
+        where: {
+          id: template.id,
+          ownerAccountId: template.ownerAccountId,
+          slug: template.slug,
+          status: template.status,
+          firstPublishedAt: template.firstPublishedAt,
+        },
+        data,
+      });
+
+      if (result.count === 0) {
+        const stillExists = await prisma.agentTemplate.findUnique({
+          where: { id: template.id },
+          select: { id: true },
+        });
+        if (stillExists === null) {
+          res.status(404).json({ error: "Agent template not found" });
+        } else {
+          res.status(409).json({
+            error: {
+              code: "TEMPLATE_MODIFIED",
+              message:
+                "Agent template was modified by another request; reload and retry",
+            },
+          });
+        }
+        return;
+      }
+
+      const updated = await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      });
+
+      res.status(200).json(serializeAgentTemplate(updated));
+    } catch (error) {
+      if (isSlugUniqueConstraintError(error)) {
+        sendSlugConflict(res);
+        return;
+      }
+
+      throw error;
+    }
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to patch agent template",
+    );
+    res.status(500).json({ error: "Failed to patch agent template" });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -21,6 +21,7 @@ const bodySchema = z
     emoji: z.string().nullable().optional(),
     prompt: z
       .string()
+      .max(50_000, { message: "prompt exceeds maximum length of 50_000 characters" })
       .refine((value) => value.trim().length > 0, {
         message: "prompt must not be empty",
       })
@@ -186,6 +187,15 @@ export async function patchHandler(req: Request, res: Response) {
     const callerAccountId = res.locals.accountId;
     const isApiKeyListener = res.locals.isApiKeyListener ?? false;
     if (template.ownerAccountId !== callerAccountId && !isApiKeyListener) {
+      req.log.warn(
+        {
+          callerAccountId,
+          templateId: template.id,
+          ownerAccountId: template.ownerAccountId,
+          action: "patch",
+        },
+        "Unauthorized agent-template access attempt",
+      );
       res.status(403).json({ error: "Not authorized to modify this template" });
       return;
     }

--- a/src/api/v2/agent-templates/handlers/publish.ts
+++ b/src/api/v2/agent-templates/handlers/publish.ts
@@ -52,6 +52,15 @@ export async function publishHandler(req: Request, res: Response) {
     const callerAccountId = res.locals.accountId;
     const isApiKeyListener = res.locals.isApiKeyListener ?? false;
     if (template.ownerAccountId !== callerAccountId && !isApiKeyListener) {
+      req.log.warn(
+        {
+          callerAccountId,
+          templateId: template.id,
+          ownerAccountId: template.ownerAccountId,
+          action: "publish",
+        },
+        "Unauthorized agent-template access attempt",
+      );
       res
         .status(403)
         .json({ error: "Not authorized to publish this template" });

--- a/src/api/v2/agent-templates/handlers/publish.ts
+++ b/src/api/v2/agent-templates/handlers/publish.ts
@@ -1,0 +1,98 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
+import { prisma } from "@/utils/prisma";
+
+const paramsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const querySchema = z
+  .object({
+    status: z.enum(["published", "unlisted"]).optional(),
+  })
+  .passthrough();
+
+const sendInvalidStatus = (res: Response) => {
+  res.status(400).json({
+    error: {
+      code: "INVALID_PUBLISH_STATUS",
+      message: "Publish status must be published or unlisted",
+    },
+  });
+};
+
+export async function publishHandler(req: Request, res: Response) {
+  const parsedParams = paramsSchema.safeParse(req.params);
+  if (!parsedParams.success) {
+    res.status(400).json({
+      error: "Invalid request params",
+      details: parsedParams.error.issues,
+    });
+    return;
+  }
+
+  const parsedQuery = querySchema.safeParse(req.query);
+  if (!parsedQuery.success) {
+    sendInvalidStatus(res);
+    return;
+  }
+
+  try {
+    const template = await prisma.agentTemplate.findUnique({
+      where: { id: parsedParams.data.id },
+    });
+
+    if (template === null) {
+      res.status(404).json({ error: "Agent template not found" });
+      return;
+    }
+
+    // Ownership guard: reject if caller is not the owner AND not an API key listener
+    const callerAccountId = res.locals.accountId;
+    const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+    if (template.ownerAccountId !== callerAccountId && !isApiKeyListener) {
+      res
+        .status(403)
+        .json({ error: "Not authorized to publish this template" });
+      return;
+    }
+
+    // First-publish path is atomic via WHERE-pinned updateMany: it only
+    // succeeds if firstPublishedAt is still null at write time, so two
+    // concurrent first-publishes can't both initialize the timestamp.
+    const firstPublishResult = await prisma.agentTemplate.updateMany({
+      where: { id: template.id, firstPublishedAt: null },
+      data: {
+        firstPublishedAt: new Date(),
+        status: parsedQuery.data.status ?? "published",
+      },
+    });
+
+    if (firstPublishResult.count === 0) {
+      // Already published (or row deleted). Re-publish atomically — only
+      // matches when firstPublishedAt is non-null, so we won't accidentally
+      // overlap with the first-publish branch.
+      const repubResult = await prisma.agentTemplate.updateMany({
+        where: { id: template.id, firstPublishedAt: { not: null } },
+        data: { version: { increment: 1 } },
+      });
+      if (repubResult.count === 0) {
+        res.status(404).json({ error: "Agent template not found" });
+        return;
+      }
+    }
+
+    const updated = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+
+    res.status(200).json(serializeAgentTemplate(updated));
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to publish agent template",
+    );
+    res.status(500).json({ error: "Failed to publish agent template" });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/publish.ts
+++ b/src/api/v2/agent-templates/handlers/publish.ts
@@ -73,9 +73,28 @@ export async function publishHandler(req: Request, res: Response) {
       // Already published (or row deleted). Re-publish atomically — only
       // matches when firstPublishedAt is non-null, so we won't accidentally
       // overlap with the first-publish branch.
+      //
+      // Status is normally preserved on re-publish (an unlisted template
+      // stays unlisted, archived stays archived; `?status=` is ignored to
+      // keep public-state mutations centralised in PATCH). The one
+      // exception is when the template is currently in `draft`, which is
+      // only reachable for a firstPublishedAt-set row via PATCH (see
+      // patch.ts — "published → draft is allowed"). In that case
+      // re-publish must take it back out of draft, so we honour
+      // `?status=` and default to `published` the same way first-publish
+      // does. Otherwise leaving the row at `draft` after the user called
+      // /publish would be a no-op surprise.
+      const desiredStatus =
+        template.status === "draft"
+          ? (parsedQuery.data.status ?? "published")
+          : template.status;
+
       const repubResult = await prisma.agentTemplate.updateMany({
         where: { id: template.id, firstPublishedAt: { not: null } },
-        data: { version: { increment: 1 } },
+        data: {
+          version: { increment: 1 },
+          status: desiredStatus,
+        },
       });
       if (repubResult.count === 0) {
         res.status(404).json({ error: "Agent template not found" });

--- a/src/api/v2/agent-templates/lib/resolve-id-or-hashed-slug.ts
+++ b/src/api/v2/agent-templates/lib/resolve-id-or-hashed-slug.ts
@@ -1,0 +1,58 @@
+import type { PublishStatus } from "@prisma/client";
+import { prisma } from "@/utils/prisma";
+import { slugHash } from "@/utils/slug-hash";
+
+const visibleStatuses = [
+  "published",
+  "unlisted",
+  "archived",
+] satisfies PublishStatus[];
+
+const hashPattern = /^[0-9a-z]{5}$/;
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function resolveAgentTemplateByIdOrHashedSlug(args: {
+  idOrHashedSlug: string;
+  slugHasher?: (id: string) => string;
+}) {
+  const slugHasher = args.slugHasher ?? slugHash;
+
+  if (uuidPattern.test(args.idOrHashedSlug)) {
+    return prisma.agentTemplate.findFirst({
+      where: {
+        id: args.idOrHashedSlug,
+        status: { in: visibleStatuses },
+      },
+    });
+  }
+
+  const lastDotIndex = args.idOrHashedSlug.lastIndexOf(".");
+  if (lastDotIndex <= 0) {
+    return null;
+  }
+
+  const baseSlug = args.idOrHashedSlug.slice(0, lastDotIndex);
+  const hash = args.idOrHashedSlug.slice(lastDotIndex + 1);
+
+  if (!hashPattern.test(hash)) {
+    return null;
+  }
+
+  const candidates = await prisma.agentTemplate.findMany({
+    where: {
+      slug: baseSlug,
+      status: { in: visibleStatuses },
+    },
+  });
+  const matches = candidates.filter(
+    (candidate) => slugHasher(candidate.id) === hash,
+  );
+
+  if (matches.length !== 1) {
+    return null;
+  }
+
+  return matches[0] ?? null;
+}

--- a/src/api/v2/agent-templates/lib/serialize-agent-template.ts
+++ b/src/api/v2/agent-templates/lib/serialize-agent-template.ts
@@ -1,0 +1,34 @@
+import type { Account, AgentTemplate } from "@prisma/client";
+
+export const serializeAccount = (account: Account) => ({
+  object: "account",
+  id: account.id,
+  createdAt: account.createdAt.toISOString(),
+});
+
+export const serializeAgentTemplate = (
+  template: AgentTemplate,
+  options: { includeSkills?: boolean; owner?: Account } = {},
+) => ({
+  object: "agent_template",
+  id: template.id,
+  slug: template.slug,
+  ...(options.owner === undefined
+    ? { ownerAccountId: template.ownerAccountId }
+    : { owner: serializeAccount(options.owner) }),
+  forkedFromId: template.forkedFromId,
+  agentName: template.agentName,
+  description: template.description,
+  prompt: template.prompt,
+  category: template.category,
+  emoji: template.emoji,
+  avatarUrl: template.avatarUrl,
+  tools: template.tools,
+  connections: template.connections,
+  version: template.version,
+  firstPublishedAt: template.firstPublishedAt?.toISOString() ?? null,
+  status: template.status,
+  featured: template.featured,
+  createdAt: template.createdAt.toISOString(),
+  ...(options.includeSkills === true ? { skills: [] } : {}),
+});

--- a/src/api/v2/agent-templates/lib/serialize-agent-template.ts
+++ b/src/api/v2/agent-templates/lib/serialize-agent-template.ts
@@ -6,6 +6,17 @@ export const serializeAccount = (account: Account) => ({
   createdAt: account.createdAt.toISOString(),
 });
 
+/**
+ * Pure formatter — must NOT perform I/O. Pass related rows through
+ * `options`.
+ *
+ * Called per-row inside the list handler's `page.map(...)`, so any
+ * Prisma call added inside this function would turn a single bounded
+ * query into an N+1 fan-out. For list endpoints, materialise relations
+ * via Prisma's `include` on the initial `findMany` and read them off
+ * each row before calling this; do not call this from inside an async
+ * map.
+ */
 export const serializeAgentTemplate = (
   template: AgentTemplate,
   options: { includeSkills?: boolean; owner?: Account } = {},

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -103,36 +103,3 @@ export const authOrAgentApiKeyAuth = async (
   req.log.debug("Attempting JWT authentication");
   await authMiddleware(req, res, next);
 };
-
-/**
- * Optional auth middleware for public read endpoints (list, detail).
- *
- * Sets res.locals.accountId and res.locals.isApiKeyListener when auth
- * headers are present, but does NOT reject if no auth is provided.
- * This allows unauthenticated users to access published templates
- * while giving authenticated users visibility into their own drafts.
- *
- * When no auth headers are present, res.locals.accountId remains
- * undefined and res.locals.isApiKeyListener defaults to false.
- *
- * If auth headers ARE present but invalid, the standard 401 rejection
- * applies — presenting credentials means they must be valid.
- */
-export const optionalAuthOrAgentApiKeyAuth = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  const providedAgentApiKey = req.header(AGENT_API_KEY_HEADER)?.trim();
-  const providedAuthToken = req.header("X-Convos-AuthToken")?.trim();
-
-  // No auth headers at all — proceed as unauthenticated
-  if (!providedAgentApiKey && !providedAuthToken) {
-    next();
-    return;
-  }
-
-  // Auth headers present — delegate to the full auth chain
-  // (which will set locals on success or 401 on failure)
-  await authOrAgentApiKeyAuth(req, res, next);
-};

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -103,3 +103,36 @@ export const authOrAgentApiKeyAuth = async (
   req.log.debug("Attempting JWT authentication");
   await authMiddleware(req, res, next);
 };
+
+/**
+ * Optional auth middleware for public read endpoints (list, detail).
+ *
+ * Sets res.locals.accountId and res.locals.isApiKeyListener when auth
+ * headers are present, but does NOT reject if no auth is provided.
+ * This allows unauthenticated users to access published templates
+ * while giving authenticated users visibility into their own drafts.
+ *
+ * When no auth headers are present, res.locals.accountId remains
+ * undefined and res.locals.isApiKeyListener defaults to false.
+ *
+ * If auth headers ARE present but invalid, the standard 401 rejection
+ * applies — presenting credentials means they must be valid.
+ */
+export const optionalAuthOrAgentApiKeyAuth = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const providedAgentApiKey = req.header(AGENT_API_KEY_HEADER)?.trim();
+  const providedAuthToken = req.header("X-Convos-AuthToken")?.trim();
+
+  // No auth headers at all — proceed as unauthenticated
+  if (!providedAgentApiKey && !providedAuthToken) {
+    next();
+    return;
+  }
+
+  // Auth headers present — delegate to the full auth chain
+  // (which will set locals on success or 401 on failure)
+  await authOrAgentApiKeyAuth(req, res, next);
+};

--- a/tests/agent-templates.auth.test.ts
+++ b/tests/agent-templates.auth.test.ts
@@ -9,24 +9,16 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
 import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type TemplateBody = Record<string, unknown>;
 type RequestHeaders = Record<string, string>;
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4067";

--- a/tests/agent-templates.auth.test.ts
+++ b/tests/agent-templates.auth.test.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { Prisma } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type TemplateBody = Record<string, unknown>;
+type RequestHeaders = Record<string, string>;
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4067";
+const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
+const validAgentAssetsApiKey =
+  "test-agent-assets-api-key-that-is-at-least-32-characters";
+const createdAt = new Date("2026-01-31T12:00:00.000Z");
+
+const testTemplateIds: string[] = [];
+
+const cleanupTemplates = async () => {
+  if (testTemplateIds.length > 0) {
+    await prisma.agentTemplate.deleteMany({
+      where: { id: { in: testTemplateIds } },
+    });
+  }
+  await prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "auth-test-" } },
+        { agentName: { startsWith: "Auth Test" } },
+      ],
+    },
+  });
+  testTemplateIds.length = 0;
+};
+
+const restoreAgentAssetsApiKey = () => {
+  if (originalAgentAssetsApiKey === undefined) {
+    delete process.env.AGENT_ASSETS_API_KEY;
+    return;
+  }
+
+  process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
+};
+
+const jwtHeaders = async (token?: string) => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken":
+    token ??
+    (await createJwtToken({
+      deviceId: "test-device-agent-templates-auth",
+      accountId: ADMIN_ACCOUNT_ID,
+    })),
+});
+
+const agentKeyHeaders = ({
+  headerName = "X-Agent-API-Key",
+  key = validAgentAssetsApiKey,
+}: {
+  headerName?: string;
+  key?: string;
+} = {}) => ({
+  "Content-Type": "application/json",
+  [headerName]: key,
+});
+
+const bothHeaders = ({
+  agentKey = validAgentAssetsApiKey,
+  jwt = "malformed.jwt.token",
+}: {
+  agentKey?: string;
+  jwt?: string;
+} = {}) => ({
+  ...agentKeyHeaders({ key: agentKey }),
+  "X-Convos-AuthToken": jwt,
+});
+
+const seedTemplate = async (
+  label: string,
+  kind: string,
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput> = {},
+) => {
+  const id = randomUUID();
+  testTemplateIds.push(id);
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug: `auth-test-${label}-${kind}`,
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      forkedFromId: null,
+      agentName: `Auth Test ${label} ${kind}`,
+      description: `initial ${kind}`,
+      prompt: `Initial prompt for ${label} ${kind}`,
+      category: null,
+      emoji: null,
+      avatarUrl: null,
+      tools: [],
+      connections: [],
+      version: 1,
+      firstPublishedAt: null,
+      status: "draft",
+      featured: false,
+      createdAt,
+      ...overrides,
+    },
+  });
+};
+
+const postTemplate = async (
+  label: string,
+  headers: RequestHeaders,
+  slug = `auth-test-${label}-create`,
+) =>
+  fetch(`${baseURL}/api/v2/agent-templates`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      agentName: `Auth Test ${label} Create`,
+      prompt: `Prompt for ${label}`,
+      slug,
+    }),
+  });
+
+const patchTemplate = async (id: string, headers: RequestHeaders) =>
+  fetch(`${baseURL}/api/v2/agent-templates/${id}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({ description: "patched by auth test" }),
+  });
+
+const deleteTemplate = async (id: string, headers: RequestHeaders) =>
+  fetch(`${baseURL}/api/v2/agent-templates/${id}`, {
+    method: "DELETE",
+    headers,
+  });
+
+const publishTemplate = async (id: string, headers: RequestHeaders) =>
+  fetch(`${baseURL}/api/v2/agent-templates/${id}/publish`, {
+    method: "POST",
+    headers,
+  });
+
+const exerciseAllWrites = async (label: string, headers: RequestHeaders) => {
+  const patchRow = await seedTemplate(label, "patch");
+  const deleteRow = await seedTemplate(label, "delete");
+  const publishRow = await seedTemplate(label, "publish");
+
+  const create = await postTemplate(label, headers);
+  const patch = await patchTemplate(patchRow.id, headers);
+  const del = await deleteTemplate(deleteRow.id, headers);
+  const publish = await publishTemplate(publishRow.id, headers);
+
+  return { create, patch, del, publish, patchRow, deleteRow, publishRow };
+};
+
+const expectNoMutationAfterRejectedWrites = async (args: {
+  label: string;
+  patchRowId: string;
+  deleteRowId: string;
+  publishRowId: string;
+}) => {
+  expect(
+    await prisma.agentTemplate.count({
+      where: { slug: `auth-test-${args.label}-create` },
+    }),
+  ).toBe(0);
+
+  const patchRow = await prisma.agentTemplate.findUniqueOrThrow({
+    where: { id: args.patchRowId },
+  });
+  expect(patchRow.description).toBe("initial patch");
+
+  expect(
+    await prisma.agentTemplate.count({ where: { id: args.deleteRowId } }),
+  ).toBe(1);
+
+  const publishRow = await prisma.agentTemplate.findUniqueOrThrow({
+    where: { id: args.publishRowId },
+  });
+  expect(publishRow.status).toBe("draft");
+  expect(publishRow.firstPublishedAt).toBeNull();
+};
+
+describe("Agent template write auth", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4067, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    restoreAgentAssetsApiKey();
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await cleanupTemplates();
+  });
+
+  test("rejects every write without auth and leaves rows unchanged", async () => {
+    const label = "missing";
+    const { create, patch, del, publish, patchRow, deleteRow, publishRow } =
+      await exerciseAllWrites(label, { "Content-Type": "application/json" });
+
+    expect([create.status, patch.status, del.status, publish.status]).toEqual([
+      401, 401, 401, 401,
+    ]);
+    await expectNoMutationAfterRejectedWrites({
+      label,
+      patchRowId: patchRow.id,
+      deleteRowId: deleteRow.id,
+      publishRowId: publishRow.id,
+    });
+  });
+
+  test("accepts a valid JWT on all write endpoints", async () => {
+    const label = "jwt";
+    const { create, patch, del, publish, patchRow, deleteRow, publishRow } =
+      await exerciseAllWrites(label, await jwtHeaders());
+
+    expect([create.status, patch.status, del.status, publish.status]).toEqual([
+      201, 200, 200, 200,
+    ]);
+
+    const createBody = (await create.json()) as TemplateBody;
+    expect(createBody.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+
+    const patched = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: patchRow.id },
+    });
+    expect(patched.description).toBe("patched by auth test");
+    expect(
+      await prisma.agentTemplate.count({ where: { id: deleteRow.id } }),
+    ).toBe(0);
+    const published = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: publishRow.id },
+    });
+    expect(published.status).toBe("published");
+    expect(published.firstPublishedAt).not.toBeNull();
+  });
+
+  test("accepts a valid X-Agent-API-Key on all write endpoints", async () => {
+    const label = "agent-key";
+    const { create, patch, del, publish } = await exerciseAllWrites(
+      label,
+      agentKeyHeaders(),
+    );
+
+    expect([create.status, patch.status, del.status, publish.status]).toEqual([
+      201, 200, 200, 200,
+    ]);
+  });
+
+  test("does not fall back to JWT when an invalid agent key header is present", async () => {
+    const label = "invalid-agent-key";
+    const response = await postTemplate(
+      label,
+      bothHeaders({
+        agentKey: "wrong-value",
+        jwt: (await jwtHeaders())["X-Convos-AuthToken"],
+      }),
+    );
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(401);
+    expect(body.error).toContain("Invalid or missing agent API key");
+    expect(
+      await prisma.agentTemplate.count({
+        where: { slug: `auth-test-${label}-create` },
+      }),
+    ).toBe(0);
+  });
+
+  test("lets a valid agent key win even when the JWT header is malformed", async () => {
+    const label = "both-agent-wins";
+    const response = await postTemplate(label, bothHeaders());
+    const body = (await response.json()) as TemplateBody;
+
+    expect(response.status).toBe(201);
+    expect(body.slug).toBe(`auth-test-${label}-create`);
+  });
+
+  test("returns 503 on the agent-key path when the configured key is unset or too short", async () => {
+    process.env.AGENT_ASSETS_API_KEY = "";
+    const unset = await postTemplate("unset-key", agentKeyHeaders());
+    expect(unset.status).toBe(503);
+    expect(await unset.json()).toEqual({
+      error: "Agent assets API key not configured",
+    });
+
+    process.env.AGENT_ASSETS_API_KEY = "too-short";
+    const short = await postTemplate("short-key", agentKeyHeaders());
+    expect(short.status).toBe(503);
+    expect(await short.json()).toEqual({
+      error: "Agent assets API key not configured",
+    });
+  });
+
+  test("rejects malformed JWT-only requests on all write endpoints without mutations", async () => {
+    const label = "malformed-jwt";
+    const { create, patch, del, publish, patchRow, deleteRow, publishRow } =
+      await exerciseAllWrites(label, await jwtHeaders("not-a-real-jwt"));
+
+    expect([create.status, patch.status, del.status, publish.status]).toEqual([
+      401, 401, 401, 401,
+    ]);
+    await expectNoMutationAfterRejectedWrites({
+      label,
+      patchRowId: patchRow.id,
+      deleteRowId: deleteRow.id,
+      publishRowId: publishRow.id,
+    });
+  });
+
+  test("matches X-Agent-API-Key header names case-insensitively", async () => {
+    const cases = [
+      { label: "lowercase", headerName: "x-agent-api-key" },
+      { label: "uppercase", headerName: "X-AGENT-API-KEY" },
+      { label: "mixedcase", headerName: "X-Agent-Api-Key" },
+    ];
+
+    for (const headerCase of cases) {
+      const response = await postTemplate(
+        `header-${headerCase.label}`,
+        agentKeyHeaders({ headerName: headerCase.headerName }),
+      );
+      expect(response.status).toBe(201);
+    }
+
+    expect(
+      await prisma.agentTemplate.count({
+        where: { slug: { startsWith: "auth-test-header-" } },
+      }),
+    ).toBe(3);
+  });
+});

--- a/tests/agent-templates.auth.test.ts
+++ b/tests/agent-templates.auth.test.ts
@@ -11,6 +11,7 @@ import {
 } from "bun:test";
 import express from "express";
 import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { jsonMiddleware } from "@/middleware/json";
 import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -29,7 +30,6 @@ app.use(noRouteMiddleware);
 
 let server: Server;
 const baseURL = "http://localhost:4067";
-const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
 const validAgentAssetsApiKey =
   "test-agent-assets-api-key-that-is-at-least-32-characters";
 const createdAt = new Date("2026-01-31T12:00:00.000Z");
@@ -55,12 +55,7 @@ const cleanupTemplates = async () => {
 };
 
 const restoreAgentAssetsApiKey = () => {
-  if (originalAgentAssetsApiKey === undefined) {
-    delete process.env.AGENT_ASSETS_API_KEY;
-    return;
-  }
-
-  process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
+  __setAgentAssetsApiKeyOverrideForTests(undefined);
 };
 
 const jwtHeaders = async (token?: string) => ({
@@ -221,7 +216,7 @@ describe("Agent template write auth", () => {
   });
 
   beforeEach(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await cleanupTemplates();
   });
 
@@ -309,14 +304,14 @@ describe("Agent template write auth", () => {
   });
 
   test("returns 503 on the agent-key path when the configured key is unset or too short", async () => {
-    process.env.AGENT_ASSETS_API_KEY = "";
+    __setAgentAssetsApiKeyOverrideForTests("");
     const unset = await postTemplate("unset-key", agentKeyHeaders());
     expect(unset.status).toBe(503);
     expect(await unset.json()).toEqual({
       error: "Agent assets API key not configured",
     });
 
-    process.env.AGENT_ASSETS_API_KEY = "too-short";
+    __setAgentAssetsApiKeyOverrideForTests("too-short");
     const short = await postTemplate("short-key", agentKeyHeaders());
     expect(short.status).toBe(503);
     expect(await short.json()).toEqual({

--- a/tests/agent-templates.conventions.test.ts
+++ b/tests/agent-templates.conventions.test.ts
@@ -1,0 +1,321 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { Prisma } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type JsonObject = Record<string, unknown>;
+
+const app = express();
+app.use(pinoMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4054";
+
+const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+const camelCaseKeyPattern = /^[a-z][A-Za-z0-9]*$/;
+const forbiddenKeys = [
+  "agent_name",
+  "first_published_at",
+  "created_at",
+  "updated_at",
+  "forked_from_id",
+  "owner_account_id",
+  "avatar_url",
+  "has_more",
+  "next_cursor",
+  "updatedAt",
+];
+
+const hasOwn = (args: { value: object; key: string }) =>
+  Object.prototype.hasOwnProperty.call(args.value, args.key);
+
+const testTemplateIds: string[] = [];
+
+const cleanupTemplates = async () => {
+  if (testTemplateIds.length > 0) {
+    await prisma.agentTemplate.deleteMany({
+      where: { id: { in: testTemplateIds } },
+    });
+  }
+  testTemplateIds.length = 0;
+};
+
+const createTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput> = {},
+) => {
+  const id = overrides.id ?? randomUUID();
+  testTemplateIds.push(id);
+  const firstPublishedAt = hasOwn({ value: overrides, key: "firstPublishedAt" })
+    ? overrides.firstPublishedAt
+    : new Date("2026-01-20T00:00:00.000Z");
+
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug: overrides.slug ?? `conv-${id.slice(0, 8)}`,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? `Template ${id}`,
+      description: overrides.description ?? "Convention fixture",
+      prompt: overrides.prompt ?? `Prompt for ${id}`,
+      category: overrides.category ?? "conventions",
+      emoji: overrides.emoji ?? "🤖",
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt,
+      status: overrides.status ?? "published",
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? new Date("2026-01-19T00:00:00.000Z"),
+    },
+  });
+};
+
+// Non-owner reader: read endpoints now require auth, but visibility for a
+// non-owner caller matches the old unauthenticated behavior (only published
+// templates visible).
+const READER_ACCOUNT_ID = "00000000-0000-4000-8000-cccccccc0002";
+
+const readerAuthHeaders = async (): Promise<Record<string, string>> => ({
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-conventions",
+    accountId: READER_ACCOUNT_ID,
+  }),
+});
+
+const readJson = async (args: { path: string }) => {
+  const response = await fetch(`${baseURL}${args.path}`, {
+    headers: await readerAuthHeaders(),
+  });
+  const body = (await response.json()) as JsonObject;
+
+  return { body, response };
+};
+
+const collectKeys = (value: unknown, keys = new Set<string>()) => {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectKeys(item, keys));
+    return keys;
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return keys;
+  }
+
+  Object.entries(value).forEach(([key, child]) => {
+    keys.add(key);
+    collectKeys(child, keys);
+  });
+
+  return keys;
+};
+
+const collectTimestampValues = (
+  value: unknown,
+  timestamps: Array<{ key: string; value: unknown }> = [],
+) => {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectTimestampValues(item, timestamps));
+    return timestamps;
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return timestamps;
+  }
+
+  Object.entries(value).forEach(([key, child]) => {
+    if (key.endsWith("At")) {
+      timestamps.push({ key, value: child });
+    }
+    collectTimestampValues(child, timestamps);
+  });
+
+  return timestamps;
+};
+
+const expectConventionalKeys = (body: unknown) => {
+  const keys = [...collectKeys(body)];
+
+  for (const key of keys) {
+    expect(key).toMatch(camelCaseKeyPattern);
+  }
+
+  for (const key of forbiddenKeys) {
+    expect(keys).not.toContain(key);
+  }
+};
+
+const expectTimestampValues = (body: unknown) => {
+  for (const timestamp of collectTimestampValues(body)) {
+    if (timestamp.key === "firstPublishedAt" && timestamp.value === null) {
+      continue;
+    }
+
+    expect(timestamp.value).toEqual(expect.stringMatching(isoTimestampPattern));
+  }
+};
+
+describe("Agent template read response conventions", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4054, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("serializes list and detail bodies with camelCase keys, discriminators, booleans, and Z timestamps", async () => {
+    const parent = await createTemplate({
+      category: "parent-only",
+    });
+    const child = await createTemplate({
+      forkedFromId: parent.id,
+      featured: true,
+      tools: ["web"],
+      connections: ["github"],
+      createdAt: new Date("2026-01-20T01:02:03.456Z"),
+      firstPublishedAt: new Date("2026-01-20T00:00:00.000Z"),
+    });
+
+    const list = await readJson({
+      path: "/api/v2/agent-templates?category=conventions",
+    });
+    const detail = await readJson({
+      path: `/api/v2/agent-templates/${child.id}`,
+    });
+
+    expect(list.response.status).toBe(200);
+    expect(list.response.headers.get("content-type")).toContain(
+      "application/json",
+    );
+    expect(Object.keys(list.body).sort()).toEqual([
+      "data",
+      "hasMore",
+      "nextCursor",
+    ]);
+    expectConventionalKeys(list.body);
+    expectTimestampValues(list.body);
+
+    const rows = list.body.data as JsonObject[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      object: "agent_template",
+      id: child.id,
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      forkedFromId: parent.id,
+      featured: true,
+      status: "published",
+    });
+    expect(typeof rows[0]?.ownerAccountId).toBe("string");
+    expect(typeof rows[0]?.forkedFromId).toBe("string");
+    expect(typeof rows[0]?.featured).toBe("boolean");
+
+    expect(detail.response.status).toBe(200);
+    expect(detail.response.headers.get("content-type")).toContain(
+      "application/json",
+    );
+    expectConventionalKeys(detail.body);
+    expectTimestampValues(detail.body);
+    expect(detail.body).toMatchObject({
+      object: "agent_template",
+      id: child.id,
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      forkedFromId: parent.id,
+      featured: true,
+    });
+    expect(detail.body).not.toHaveProperty("owner");
+  });
+
+  test("expands owner as a minimal account resource and preserves null firstPublishedAt", async () => {
+    const tmpl = await createTemplate({
+      slug: "conventions-owner-expand",
+      status: "unlisted",
+      firstPublishedAt: null,
+    });
+
+    const { body, response } = await readJson({
+      path: `/api/v2/agent-templates/${tmpl.id}?expand[]=owner`,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expectConventionalKeys(body);
+    expectTimestampValues(body);
+    expect(body.object).toBe("agent_template");
+    expect(body.firstPublishedAt).toBeNull();
+    expect(body).not.toHaveProperty("ownerAccountId");
+
+    const owner = body.owner as JsonObject;
+    expect(owner).toBeDefined();
+    expect(owner.object).toBe("account");
+    expect(owner.id).toBe(ADMIN_ACCOUNT_ID);
+    expect(owner.createdAt).toEqual(expect.stringMatching(isoTimestampPattern));
+    expect(Object.keys(owner).sort()).toEqual(["createdAt", "id", "object"]);
+  });
+
+  test("returns JSON content type and parseable JSON bodies for read errors", async () => {
+    const fakeUuid = randomUUID();
+    const cases = [
+      // `status=bogus` is not a valid enum value → 400; `status=draft` is a
+      // valid enum now (auth is required, so the old "auth required" 400 path
+      // no longer applies for valid enum values).
+      { path: "/api/v2/agent-templates?status=bogus", status: 400 },
+      { path: "/api/v2/agent-templates?cursor=!!!", status: 400 },
+      { path: `/api/v2/agent-templates/${fakeUuid}`, status: 404 },
+      { path: "/api/v2/agent-templates/missing.aaaaa", status: 404 },
+    ];
+
+    for (const errorCase of cases) {
+      const { body, response } = await readJson({ path: errorCase.path });
+
+      expect(response.status).toBe(errorCase.status);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+      expect(typeof body).toBe("object");
+      expect(body).not.toBeNull();
+      expectConventionalKeys(body);
+    }
+  });
+
+  test("keeps underscore read paths unmounted", async () => {
+    const tmpl = await createTemplate();
+
+    const responses = await Promise.all([
+      fetch(`${baseURL}/api/v2/agent_templates`),
+      fetch(`${baseURL}/api/v2/agent_templates/${tmpl.id}`),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([404, 404]);
+  });
+});

--- a/tests/agent-templates.conventions.test.ts
+++ b/tests/agent-templates.conventions.test.ts
@@ -9,20 +9,14 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type JsonObject = Record<string, unknown>;
 
-const app = express();
-app.use(pinoMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4054";

--- a/tests/agent-templates.create.test.ts
+++ b/tests/agent-templates.create.test.ts
@@ -1,0 +1,411 @@
+import type { Server } from "node:http";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type TemplateBody = Record<string, unknown>;
+
+const OTHER_ACCOUNT_ID = "bbbbbbbb-cccc-4ddd-eeee-ffffffff0001";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4055";
+
+const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+const snakeCasePattern = /_/;
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "create-test-" } },
+        { agentName: { startsWith: "Create Test" } },
+        { agentName: "Generate" },
+      ],
+    },
+  });
+
+const makeAuthHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-create",
+    accountId: ADMIN_ACCOUNT_ID,
+  }),
+});
+
+const createTemplate = async (body: Record<string, unknown>) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
+    method: "POST",
+    headers: await makeAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  const parsedBody = (await response.json()) as TemplateBody;
+
+  return { body: parsedBody, response };
+};
+
+const expectTemplateShape = (body: TemplateBody) => {
+  expect(body.object).toBe("agent_template");
+  expect(body.id).toEqual(
+    expect.stringMatching(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    ),
+  );
+  expect(body.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+  expect(body.status).toBe("draft");
+  expect(body.version).toBe(1);
+  expect(body.firstPublishedAt).toBeNull();
+  expect(body.forkedFromId).toBeNull();
+  expect(body.createdAt).toEqual(expect.stringMatching(isoTimestampPattern));
+  expect(body).not.toHaveProperty("updatedAt");
+  expect(Object.keys(body).every((key) => !snakeCasePattern.test(key))).toBe(
+    true,
+  );
+};
+
+const countCreateTestTemplates = () =>
+  prisma.agentTemplate.count({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "create-test-" } },
+        { agentName: { startsWith: "Create Test" } },
+        { agentName: "Generate" },
+      ],
+    },
+  });
+
+describe("Agent template create endpoint", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4055, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("requires auth and creates a template with explicit slug and camelCase pinned defaults", async () => {
+    const unauthenticated = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agentName: "Create Test No Auth",
+        prompt: "You are helpful",
+        slug: "create-test-no-auth",
+      }),
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const { body, response } = await createTemplate({
+      agentName: "Create Test Helper",
+      prompt: "You are helpful",
+      slug: "create-test-helper-bot",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expectTemplateShape(body);
+    expect(body).toMatchObject({
+      slug: "create-test-helper-bot",
+      agentName: "Create Test Helper",
+      prompt: "You are helpful",
+      description: null,
+      category: null,
+      emoji: null,
+      avatarUrl: null,
+      tools: [],
+      connections: [],
+      featured: false,
+    });
+    expect(body).not.toHaveProperty("owner_account_id");
+    expect(body).not.toHaveProperty("first_published_at");
+  });
+
+  test("ignores server-pinned fields from the body and persists pinned values", async () => {
+    const { body, response } = await createTemplate({
+      agentName: "Create Test Sneaky",
+      prompt: "You are still a draft",
+      slug: "create-test-sneaky",
+      ownerAccountId: OTHER_ACCOUNT_ID,
+      status: "published",
+      version: 99,
+      firstPublishedAt: "2020-01-01T00:00:00.000Z",
+      forkedFromId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    });
+
+    expect(response.status).toBe(201);
+    expectTemplateShape(body);
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: body.id as string },
+    });
+    expect(row.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+    expect(row.status).toBe("draft");
+    expect(row.version).toBe(1);
+    expect(row.firstPublishedAt).toBeNull();
+    expect(row.forkedFromId).toBeNull();
+  });
+
+  test("auto-derives slugs and retries collisions with numeric suffixes", async () => {
+    const slugs: string[] = [];
+
+    for (let i = 0; i < 3; i++) {
+      const { body, response } = await createTemplate({
+        agentName: "Create Test My Cool Helper",
+        prompt: `Prompt ${i}`,
+      });
+
+      expect(response.status).toBe(201);
+      expect(typeof body.slug).toBe("string");
+      slugs.push(body.slug as string);
+    }
+
+    expect(slugs).toEqual([
+      "create-test-my-cool-helper",
+      "create-test-my-cool-helper-2",
+      "create-test-my-cool-helper-3",
+    ]);
+
+    const rows = await prisma.agentTemplate.findMany({
+      where: {
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+        slug: { in: slugs },
+      },
+      orderBy: { createdAt: "asc" },
+      select: { slug: true },
+    });
+    expect(rows.map((row) => row.slug)).toEqual(slugs);
+  });
+
+  test("rejects auto-derived reserved slugs with 400 and rejects reserved explicit slugs", async () => {
+    // Auto-derived slug from agentName='Generate' → baseSlug='generate' (reserved)
+    // Server MUST reject with 400 RESERVED_SLUG, NOT silently suffix to 'generate-2'
+    const autoReserved = await createTemplate({
+      agentName: "Generate",
+      prompt: "Should be rejected because auto-derived slug is reserved",
+    });
+    expect(autoReserved.response.status).toBe(400);
+    expect(autoReserved.body.error).toMatchObject({ code: "RESERVED_SLUG" });
+
+    // All seven reserved words as auto-derived slugs must be rejected
+    for (const word of [
+      "generate",
+      "publish",
+      "fork",
+      "search",
+      "files",
+      "templates",
+      "skills",
+    ]) {
+      const agentName = word[0].toUpperCase() + word.slice(1);
+      const { body, response } = await createTemplate({
+        agentName,
+        prompt: "Should be rejected because auto-derived slug is reserved",
+      });
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatchObject({ code: "RESERVED_SLUG" });
+    }
+
+    // Explicit reserved slugs are also rejected
+    for (const slug of [
+      "generate",
+      "publish",
+      "fork",
+      "search",
+      "files",
+      "templates",
+      "skills",
+    ]) {
+      const { body, response } = await createTemplate({
+        agentName: `Create Test Reserved ${slug}`,
+        prompt: "Should be rejected",
+        slug,
+      });
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatchObject({ code: "RESERVED_SLUG" });
+    }
+
+    // No rows created for any reserved-slug attempt
+    expect(await countCreateTestTemplates()).toBe(0);
+  });
+
+  test("rejects invalid user-supplied slugs and preserves row count", async () => {
+    const startingCount = await countCreateTestTemplates();
+
+    for (const slug of [
+      "Has-Caps",
+      "-leading-hyphen",
+      "trailing-dot.",
+      "with space",
+      "",
+      "a".repeat(65),
+    ]) {
+      const { body, response } = await createTemplate({
+        agentName: `Create Test Invalid ${slug || "empty"}`,
+        prompt: "Should be rejected",
+        slug,
+      });
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBeDefined();
+      expect(await countCreateTestTemplates()).toBe(startingCount);
+    }
+  });
+
+  test("returns 409 for same-owner slug conflicts", async () => {
+    const first = await createTemplate({
+      agentName: "Create Test Taken A",
+      prompt: "First",
+      slug: "create-test-taken",
+    });
+    expect(first.response.status).toBe(201);
+
+    const second = await createTemplate({
+      agentName: "Create Test Taken B",
+      prompt: "Second",
+      slug: "create-test-taken",
+    });
+    expect(second.response.status).toBe(409);
+    expect(second.body.error).toMatchObject({ code: "SLUG_CONFLICT" });
+
+    const rows = await prisma.agentTemplate.count({
+      where: { ownerAccountId: ADMIN_ACCOUNT_ID, slug: "create-test-taken" },
+    });
+    expect(rows).toBe(1);
+  });
+
+  test("rejects missing or empty agentName and prompt", async () => {
+    for (const body of [
+      { prompt: "Missing agentName", slug: "create-test-missing-name" },
+      {
+        agentName: "Create Test Missing Prompt",
+        slug: "create-test-no-prompt",
+      },
+      {
+        agentName: "",
+        prompt: "Empty agentName",
+        slug: "create-test-empty-name",
+      },
+      {
+        agentName: "Create Test Empty Prompt",
+        prompt: "",
+        slug: "create-test-empty-prompt",
+      },
+    ]) {
+      const result = await createTemplate(body);
+
+      expect(result.response.status).toBe(400);
+      expect(result.body.error).toBe("Invalid request body");
+    }
+
+    expect(await countCreateTestTemplates()).toBe(0);
+  });
+
+  test("defaults optional fields and durably persists the created row", async () => {
+    const { body, response } = await createTemplate({
+      agentName: "Create Test Minimal",
+      prompt: "Persist me",
+    });
+
+    expect(response.status).toBe(201);
+    expect(body).toMatchObject({
+      description: null,
+      category: null,
+      emoji: null,
+      avatarUrl: null,
+      tools: [],
+      connections: [],
+      featured: false,
+      forkedFromId: null,
+    });
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: body.id as string },
+    });
+    expect(row.slug).toBe("create-test-minimal");
+    expect(row.agentName).toBe("Create Test Minimal");
+    expect(row.prompt).toBe("Persist me");
+    expect(row.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+    expect(row.status).toBe("draft");
+    expect(row.version).toBe(1);
+    expect(row.firstPublishedAt).toBeNull();
+    expect(row.description).toBeNull();
+    expect(row.category).toBeNull();
+    expect(row.emoji).toBeNull();
+    expect(row.avatarUrl).toBeNull();
+    expect(row.tools).toEqual([]);
+    expect(row.connections).toEqual([]);
+    expect(row.featured).toBe(false);
+  });
+
+  test("accepts tools and connections arrays of strings and rejects non-array values", async () => {
+    const { body, response } = await createTemplate({
+      agentName: "Create Test Integrations",
+      prompt: "Use tools",
+      slug: "create-test-integrations",
+      tools: ["web_search", "calc"],
+      connections: ["composio:google_calendar", "apple_health"],
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.tools).toEqual(["web_search", "calc"]);
+    expect(body.connections).toEqual([
+      "composio:google_calendar",
+      "apple_health",
+    ]);
+
+    for (const invalidBody of [
+      {
+        agentName: "Create Test Invalid Tools",
+        prompt: "Invalid tools",
+        slug: "create-test-invalid-tools",
+        tools: "web_search",
+      },
+      {
+        agentName: "Create Test Invalid Connections",
+        prompt: "Invalid connections",
+        slug: "create-test-invalid-connections",
+        connections: "apple_health",
+      },
+    ]) {
+      const result = await createTemplate(invalidBody);
+
+      expect(result.response.status).toBe(400);
+      expect(result.body.error).toBe("Invalid request body");
+    }
+  });
+});

--- a/tests/agent-templates.create.test.ts
+++ b/tests/agent-templates.create.test.ts
@@ -7,24 +7,16 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type TemplateBody = Record<string, unknown>;
 
 const OTHER_ACCOUNT_ID = "bbbbbbbb-cccc-4ddd-eeee-ffffffff0001";
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4055";

--- a/tests/agent-templates.cross.auth.test.ts
+++ b/tests/agent-templates.cross.auth.test.ts
@@ -1,0 +1,131 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  agentKeyHeaders,
+  createTemplate,
+  jsonHeaders,
+  jwtHeaders,
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "cross-auth-" } },
+        { agentName: { startsWith: "Cross Auth" } },
+      ],
+    },
+  });
+
+const restoreAgentAssetsApiKey = () => {
+  if (originalAgentAssetsApiKey === undefined) {
+    delete process.env.AGENT_ASSETS_API_KEY;
+    return;
+  }
+
+  process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
+};
+
+describe("Agent template cross auth flow", () => {
+  beforeAll(async () => {
+    const server = await startAgentTemplatesServer(4070);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    restoreAgentAssetsApiKey();
+    await cleanupTemplates();
+    await closeServer();
+  });
+
+  beforeEach(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await cleanupTemplates();
+  });
+
+  test("JWT and agent API key create equivalent draft rows while unauthenticated POST is rejected", async () => {
+    const jwtCreated = await createTemplate({
+      baseURL,
+      headers: await jwtHeaders(),
+      body: {
+        agentName: "Cross Auth Jwt",
+        prompt: "Created with JWT",
+        slug: "cross-auth-jwt",
+      },
+    });
+
+    const keyCreated = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Cross Auth Key",
+        prompt: "Created with agent key",
+        slug: "cross-auth-key",
+      },
+    });
+
+    expect(jwtCreated.response.status).toBe(201);
+    expect(keyCreated.response.status).toBe(201);
+    expect(jwtCreated.body).toMatchObject({
+      object: "agent_template",
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      status: "draft",
+      version: 1,
+    });
+    expect(keyCreated.body).toMatchObject({
+      object: "agent_template",
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      status: "draft",
+      version: 1,
+    });
+    expect(jwtCreated.body.id).not.toBe(keyCreated.body.id);
+
+    const rows = await prisma.agentTemplate.findMany({
+      where: {
+        id: {
+          in: [jwtCreated.body.id as string, keyCreated.body.id as string],
+        },
+      },
+      orderBy: { slug: "asc" },
+      select: { id: true, ownerAccountId: true, status: true },
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.ownerAccountId === ADMIN_ACCOUNT_ID)).toBe(
+      true,
+    );
+    expect(rows.every((row) => row.status === "draft")).toBe(true);
+
+    const missingAuth = await createTemplate({
+      baseURL,
+      headers: jsonHeaders,
+      body: {
+        agentName: "Cross Auth None",
+        prompt: "Should not persist",
+        slug: "cross-auth-none",
+      },
+    });
+
+    expect(missingAuth.response.status).toBe(401);
+    expect(
+      await prisma.agentTemplate.count({
+        where: { slug: "cross-auth-none" },
+      }),
+    ).toBe(0);
+  });
+});

--- a/tests/agent-templates.cross.auth.test.ts
+++ b/tests/agent-templates.cross.auth.test.ts
@@ -6,6 +6,7 @@ import {
   expect,
   test,
 } from "bun:test";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import {
@@ -19,7 +20,6 @@ import {
 
 let baseURL: string;
 let closeServer: () => Promise<void>;
-const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
 
 const cleanupTemplates = () =>
   prisma.agentTemplate.deleteMany({
@@ -32,15 +32,6 @@ const cleanupTemplates = () =>
     },
   });
 
-const restoreAgentAssetsApiKey = () => {
-  if (originalAgentAssetsApiKey === undefined) {
-    delete process.env.AGENT_ASSETS_API_KEY;
-    return;
-  }
-
-  process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
-};
-
 describe("Agent template cross auth flow", () => {
   beforeAll(async () => {
     const server = await startAgentTemplatesServer(4070);
@@ -49,13 +40,13 @@ describe("Agent template cross auth flow", () => {
   });
 
   afterAll(async () => {
-    restoreAgentAssetsApiKey();
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
     await cleanupTemplates();
     await closeServer();
   });
 
   beforeEach(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await cleanupTemplates();
   });
 

--- a/tests/agent-templates.cross.helpers.ts
+++ b/tests/agent-templates.cross.helpers.ts
@@ -1,0 +1,173 @@
+import type { Server } from "node:http";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { buildSlug } from "@/utils/slug-hash";
+
+export type TemplateBody = Record<string, unknown>;
+export type ListBody = {
+  data: TemplateBody[];
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
+export const validAgentAssetsApiKey =
+  "test-agent-assets-api-key-that-is-at-least-32-characters";
+
+export const startAgentTemplatesServer = async (port: number) => {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use(jsonMiddleware);
+  app.use("/api/v2/agent-templates", agentTemplatesRouter);
+  app.use(noRouteMiddleware);
+
+  let server: Server;
+  await new Promise<void>((resolve) => {
+    server = app.listen(port, () => {
+      resolve();
+    });
+  });
+
+  return {
+    baseURL: `http://localhost:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve();
+        });
+      }),
+  };
+};
+
+export const jwtHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-cross",
+    accountId: ADMIN_ACCOUNT_ID,
+  }),
+});
+
+// Non-owner reader used for list/detail by default. Read endpoints now
+// require auth, but the visibility rules differ for owner vs non-owner:
+// non-owners see only published templates from any account. Using a distinct
+// reader keeps cross-flow tests' visibility assertions stable — drafts and
+// archived templates remain invisible in the listing.
+const READER_ACCOUNT_ID = "00000000-0000-4000-8000-cccccccc0001";
+
+export const readerHeaders = async (): Promise<Record<string, string>> => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-cross-reader",
+    accountId: READER_ACCOUNT_ID,
+  }),
+});
+
+export const agentKeyHeaders = () => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+});
+
+export const jsonHeaders = { "Content-Type": "application/json" };
+
+export const createTemplate = async (args: {
+  baseURL: string;
+  body: Record<string, unknown>;
+  headers?: Record<string, string>;
+}) => {
+  const response = await fetch(`${args.baseURL}/api/v2/agent-templates`, {
+    method: "POST",
+    headers: args.headers ?? (await jwtHeaders()),
+    body: JSON.stringify(args.body),
+  });
+  const body = (await response.json()) as TemplateBody;
+
+  return { body, response };
+};
+
+export const publishTemplate = async (args: {
+  baseURL: string;
+  id: string;
+  headers?: Record<string, string>;
+}) => {
+  const response = await fetch(
+    `${args.baseURL}/api/v2/agent-templates/${args.id}/publish`,
+    {
+      method: "POST",
+      headers: args.headers ?? (await jwtHeaders()),
+    },
+  );
+  const body = (await response.json()) as TemplateBody;
+
+  return { body, response };
+};
+
+export const patchTemplate = async (args: {
+  baseURL: string;
+  id: string;
+  body: Record<string, unknown>;
+  headers?: Record<string, string>;
+}) => {
+  const response = await fetch(
+    `${args.baseURL}/api/v2/agent-templates/${args.id}`,
+    {
+      method: "PATCH",
+      headers: args.headers ?? (await jwtHeaders()),
+      body: JSON.stringify(args.body),
+    },
+  );
+  const body = (await response.json()) as TemplateBody;
+
+  return { body, response };
+};
+
+export const deleteTemplate = async (args: {
+  baseURL: string;
+  id: string;
+  headers?: Record<string, string>;
+}) => {
+  const response = await fetch(
+    `${args.baseURL}/api/v2/agent-templates/${args.id}`,
+    {
+      method: "DELETE",
+      headers: args.headers ?? (await jwtHeaders()),
+    },
+  );
+  const body = (await response.json()) as TemplateBody;
+
+  return { body, response };
+};
+
+export const listTemplates = async (args: {
+  baseURL: string;
+  query?: string;
+  headers?: Record<string, string>;
+}) => {
+  const response = await fetch(
+    `${args.baseURL}/api/v2/agent-templates${args.query ?? ""}`,
+    { headers: args.headers ?? (await readerHeaders()) },
+  );
+  const body = (await response.json()) as ListBody;
+
+  return { body, response };
+};
+
+export const getTemplate = async (args: {
+  baseURL: string;
+  path: string;
+  headers?: Record<string, string>;
+}) => {
+  const response = await fetch(
+    `${args.baseURL}/api/v2/agent-templates/${args.path}`,
+    { headers: args.headers ?? (await readerHeaders()) },
+  );
+  const body = (await response.json()) as TemplateBody;
+
+  return { body, response };
+};
+
+export const hashedSlugFor = (template: TemplateBody) =>
+  buildSlug(template.slug as string, template.id as string);

--- a/tests/agent-templates.cross.helpers.ts
+++ b/tests/agent-templates.cross.helpers.ts
@@ -18,12 +18,27 @@ export type ListBody = {
 export const validAgentAssetsApiKey =
   "test-agent-assets-api-key-that-is-at-least-32-characters";
 
-export const startAgentTemplatesServer = async (port: number) => {
+/**
+ * Build the standard agent-templates Express app used across in-process
+ * test files. Wires up the four middlewares + the `/api/v2/agent-templates`
+ * router mount that every router-level test needs:
+ *
+ *   pinoMiddleware → jsonMiddleware → agentTemplatesRouter → noRouteMiddleware
+ *
+ * Caller is responsible for `app.listen()` (or driving via `request(app)`).
+ * For an http-server-based setup, use `startAgentTemplatesServer` below.
+ */
+export const buildAgentTemplatesApp = (): express.Express => {
   const app = express();
   app.use(pinoMiddleware);
   app.use(jsonMiddleware);
   app.use("/api/v2/agent-templates", agentTemplatesRouter);
   app.use(noRouteMiddleware);
+  return app;
+};
+
+export const startAgentTemplatesServer = async (port: number) => {
+  const app = buildAgentTemplatesApp();
 
   let server: Server;
   await new Promise<void>((resolve) => {

--- a/tests/agent-templates.cross.lifecycle.test.ts
+++ b/tests/agent-templates.cross.lifecycle.test.ts
@@ -57,7 +57,7 @@ describe("Agent template cross lifecycle flow", () => {
     await cleanupTemplates();
   });
 
-  test("publish locks delete, archive hides from list, and hashed-slug GET stays resolvable", async () => {
+  test("publish → archive hides from list, hashed-slug GET stays resolvable, and DELETE succeeds in any state", async () => {
     const created = await createTemplate({
       baseURL,
       body: {
@@ -78,21 +78,6 @@ describe("Agent template cross lifecycle flow", () => {
     expect(published.response.status).toBe(200);
     expect(published.body.status).toBe("published");
     expect(published.body.firstPublishedAt).toEqual(expect.any(String));
-
-    const deleteAttempt = await deleteTemplate({
-      baseURL,
-      id: created.body.id as string,
-    });
-
-    expect(deleteAttempt.response.status).toBe(409);
-    expect(JSON.stringify(deleteAttempt.body.error)).toContain(
-      "firstPublishedAt",
-    );
-    expect(
-      await prisma.agentTemplate.count({
-        where: { id: created.body.id as string },
-      }),
-    ).toBe(1);
 
     const archived = await patchTemplate({
       baseURL,
@@ -118,5 +103,20 @@ describe("Agent template cross lifecycle flow", () => {
       id: created.body.id,
       status: "archived",
     } satisfies Partial<TemplateBody>);
+
+    // DELETE is now permitted in any publish state (see commit a0a6861 —
+    // the previous ALREADY_PUBLISHED gate was removed). Owner accepts that
+    // the canonical URL will start 404'ing.
+    const deleted = await deleteTemplate({
+      baseURL,
+      id: created.body.id as string,
+    });
+
+    expect(deleted.response.status).toBe(200);
+    expect(
+      await prisma.agentTemplate.count({
+        where: { id: created.body.id as string },
+      }),
+    ).toBe(0);
   });
 });

--- a/tests/agent-templates.cross.lifecycle.test.ts
+++ b/tests/agent-templates.cross.lifecycle.test.ts
@@ -1,0 +1,122 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  createTemplate,
+  deleteTemplate,
+  getTemplate,
+  hashedSlugFor,
+  listTemplates,
+  patchTemplate,
+  publishTemplate,
+  startAgentTemplatesServer,
+  type TemplateBody,
+} from "./agent-templates.cross.helpers";
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "cross-lifecycle-" } },
+        { agentName: { startsWith: "Cross Lifecycle" } },
+      ],
+    },
+  });
+
+const expectListOmits = async (id: string) => {
+  const listed = await listTemplates({ baseURL, query: "?limit=100" });
+
+  expect(listed.response.status).toBe(200);
+  expect(listed.body.data.map((row) => row.id)).not.toContain(id);
+};
+
+describe("Agent template cross lifecycle flow", () => {
+  beforeAll(async () => {
+    const server = await startAgentTemplatesServer(4068);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await closeServer();
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("publish locks delete, archive hides from list, and hashed-slug GET stays resolvable", async () => {
+    const created = await createTemplate({
+      baseURL,
+      body: {
+        agentName: "Cross Lifecycle Brew",
+        prompt: "Keep track of the brew lifecycle",
+        slug: "cross-lifecycle-brew",
+      },
+    });
+
+    expect(created.response.status).toBe(201);
+    expect(created.body.status).toBe("draft");
+
+    const published = await publishTemplate({
+      baseURL,
+      id: created.body.id as string,
+    });
+
+    expect(published.response.status).toBe(200);
+    expect(published.body.status).toBe("published");
+    expect(published.body.firstPublishedAt).toEqual(expect.any(String));
+
+    const deleteAttempt = await deleteTemplate({
+      baseURL,
+      id: created.body.id as string,
+    });
+
+    expect(deleteAttempt.response.status).toBe(409);
+    expect(JSON.stringify(deleteAttempt.body.error)).toContain(
+      "firstPublishedAt",
+    );
+    expect(
+      await prisma.agentTemplate.count({
+        where: { id: created.body.id as string },
+      }),
+    ).toBe(1);
+
+    const archived = await patchTemplate({
+      baseURL,
+      id: created.body.id as string,
+      body: { status: "archived" },
+    });
+
+    expect(archived.response.status).toBe(200);
+    expect(archived.body.status).toBe("archived");
+    expect(archived.body.firstPublishedAt).toBe(
+      published.body.firstPublishedAt,
+    );
+
+    await expectListOmits(created.body.id as string);
+
+    const direct = await getTemplate({
+      baseURL,
+      path: hashedSlugFor(created.body),
+    });
+
+    expect(direct.response.status).toBe(200);
+    expect(direct.body).toMatchObject({
+      id: created.body.id,
+      status: "archived",
+    } satisfies Partial<TemplateBody>);
+  });
+});

--- a/tests/agent-templates.cross.pagination.test.ts
+++ b/tests/agent-templates.cross.pagination.test.ts
@@ -1,0 +1,122 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  createTemplate,
+  listTemplates,
+  publishTemplate,
+  startAgentTemplatesServer,
+} from "./agent-templates.cross.helpers";
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const category = "cross-pagination-category";
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { category },
+        { slug: { startsWith: "cross-pagination-" } },
+        { agentName: { startsWith: "Cross Pagination" } },
+      ],
+    },
+  });
+
+describe("Agent template cross pagination flow", () => {
+  beforeAll(async () => {
+    const server = await startAgentTemplatesServer(4076);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await closeServer();
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("cursor pagination across 25 published rows returns 10 + 10 + 5 with no duplicates", async () => {
+    const seededIds: string[] = [];
+
+    for (let index = 1; index <= 25; index++) {
+      const created = await createTemplate({
+        baseURL,
+        body: {
+          agentName: `Cross Pagination ${index}`,
+          prompt: `Pagination prompt ${index}`,
+          slug: `cross-pagination-${index}`,
+          category,
+        },
+      });
+      expect(created.response.status).toBe(201);
+
+      const published = await publishTemplate({
+        baseURL,
+        id: created.body.id as string,
+      });
+      expect(published.response.status).toBe(200);
+      seededIds.push(created.body.id as string);
+    }
+
+    const first = await listTemplates({
+      baseURL,
+      query: `?limit=10&category=${category}`,
+    });
+    const firstCursor = String(first.body.nextCursor);
+
+    const second = await listTemplates({
+      baseURL,
+      query: `?limit=10&category=${category}&cursor=${encodeURIComponent(
+        firstCursor,
+      )}`,
+    });
+    const secondCursor = String(second.body.nextCursor);
+
+    const third = await listTemplates({
+      baseURL,
+      query: `?limit=10&category=${category}&cursor=${encodeURIComponent(
+        secondCursor,
+      )}`,
+    });
+
+    expect(first.response.status).toBe(200);
+    expect(second.response.status).toBe(200);
+    expect(third.response.status).toBe(200);
+    expect(first.body.data).toHaveLength(10);
+    expect(second.body.data).toHaveLength(10);
+    expect(third.body.data).toHaveLength(5);
+    expect(first.body.hasMore).toBe(true);
+    expect(second.body.hasMore).toBe(true);
+    expect(third.body.hasMore).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    expect(first.body.nextCursor).toEqual(expect.any(String));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    expect(second.body.nextCursor).toEqual(expect.any(String));
+    expect(second.body.nextCursor).not.toBe(firstCursor);
+    expect(third.body.nextCursor).toBeNull();
+
+    const returnedIds = [
+      ...first.body.data,
+      ...second.body.data,
+      ...third.body.data,
+    ].map((row) => row.id as string);
+    const returnedSet = new Set(returnedIds);
+
+    expect(returnedIds).toHaveLength(25);
+    expect(returnedSet.size).toBe(25);
+    expect(returnedSet).toEqual(new Set(seededIds));
+  });
+});

--- a/tests/agent-templates.cross.slug.test.ts
+++ b/tests/agent-templates.cross.slug.test.ts
@@ -1,0 +1,172 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import { buildSlug } from "@/utils/slug-hash";
+import {
+  createTemplate,
+  getTemplate,
+  hashedSlugFor,
+  patchTemplate,
+  publishTemplate,
+  startAgentTemplatesServer,
+} from "./agent-templates.cross.helpers";
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const reservedWords = [
+  "generate",
+  "publish",
+  "fork",
+  "search",
+  "files",
+  "templates",
+  "skills",
+] as const;
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { in: ["brewski", "brewski-2"] } },
+        { slug: { startsWith: "cross-reserved-" } },
+        { slug: { in: reservedWords.flatMap((word) => [word, `${word}-2`]) } },
+        { agentName: "Brewski" },
+        { agentName: { startsWith: "Cross Reserved" } },
+        {
+          agentName: {
+            in: reservedWords.map(
+              (word) => word[0].toUpperCase() + word.slice(1),
+            ),
+          },
+        },
+      ],
+    },
+  });
+
+describe("Agent template cross slug flow", () => {
+  beforeAll(async () => {
+    const server = await startAgentTemplatesServer(4072);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await closeServer();
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("duplicate agentName auto-suffixes, publishes, and hashed-slug URLs do not alias", async () => {
+    const first = await createTemplate({
+      baseURL,
+      body: { agentName: "Brewski", prompt: "First brew helper" },
+    });
+    const second = await createTemplate({
+      baseURL,
+      body: { agentName: "Brewski", prompt: "Second brew helper" },
+    });
+
+    expect(first.response.status).toBe(201);
+    expect(second.response.status).toBe(201);
+    expect(first.body.slug).toBe("brewski");
+    expect(second.body.slug).toBe("brewski-2");
+    expect(first.body.id).not.toBe(second.body.id);
+
+    expect(
+      (await publishTemplate({ baseURL, id: first.body.id as string })).response
+        .status,
+    ).toBe(200);
+    expect(
+      (await publishTemplate({ baseURL, id: second.body.id as string }))
+        .response.status,
+    ).toBe(200);
+
+    const firstDirect = await getTemplate({
+      baseURL,
+      path: hashedSlugFor(first.body),
+    });
+    const secondDirect = await getTemplate({
+      baseURL,
+      path: hashedSlugFor(second.body),
+    });
+    const crossAliased = await getTemplate({
+      baseURL,
+      path: buildSlug(first.body.slug as string, second.body.id as string),
+    });
+
+    expect(firstDirect.response.status).toBe(200);
+    expect(firstDirect.body.id).toBe(first.body.id);
+    expect(secondDirect.response.status).toBe(200);
+    expect(secondDirect.body.id).toBe(second.body.id);
+    expect(crossAliased.response.status).toBe(404);
+  });
+
+  test("auto-derived reserved words are rejected with 400 RESERVED_SLUG", async () => {
+    for (const word of reservedWords) {
+      const agentName = word[0].toUpperCase() + word.slice(1);
+      const created = await createTemplate({
+        baseURL,
+        body: {
+          agentName,
+          prompt: `Reserved word ${word} should be rejected`,
+        },
+      });
+
+      expect(created.response.status).toBe(400);
+      expect(created.body.error).toMatchObject({ code: "RESERVED_SLUG" });
+    }
+  });
+
+  test("reserved slugs are rejected on explicit POST and every slug-changing PATCH surface", async () => {
+    for (const word of reservedWords) {
+      const explicit = await createTemplate({
+        baseURL,
+        body: {
+          agentName: `Cross Reserved Explicit ${word}`,
+          prompt: "Should be rejected",
+          slug: word,
+        },
+      });
+
+      expect(explicit.response.status).toBe(400);
+      expect(explicit.body.error).toMatchObject({ code: "RESERVED_SLUG" });
+    }
+
+    const draft = await createTemplate({
+      baseURL,
+      body: {
+        agentName: "Cross Reserved Patch",
+        prompt: "Stay a draft for slug patching",
+        slug: "cross-reserved-patch",
+      },
+    });
+    expect(draft.response.status).toBe(201);
+
+    for (const word of reservedWords) {
+      const patched = await patchTemplate({
+        baseURL,
+        id: draft.body.id as string,
+        body: { slug: word },
+      });
+      const row = await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: draft.body.id as string },
+      });
+
+      expect(patched.response.status).toBe(400);
+      expect(patched.body.error).toMatchObject({ code: "RESERVED_SLUG" });
+      expect(row.slug).toBe("cross-reserved-patch");
+    }
+  });
+});

--- a/tests/agent-templates.cross.visibility.test.ts
+++ b/tests/agent-templates.cross.visibility.test.ts
@@ -1,0 +1,101 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  createTemplate,
+  getTemplate,
+  hashedSlugFor,
+  listTemplates,
+  patchTemplate,
+  publishTemplate,
+  startAgentTemplatesServer,
+} from "./agent-templates.cross.helpers";
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "cross-visibility-" } },
+        { agentName: { startsWith: "Cross Visibility" } },
+      ],
+    },
+  });
+
+const listContains = async (id: string) => {
+  const listed = await listTemplates({ baseURL, query: "?limit=100" });
+
+  expect(listed.response.status).toBe(200);
+
+  return listed.body.data.some((row) => row.id === id);
+};
+
+describe("Agent template cross visibility flow", () => {
+  beforeAll(async () => {
+    const server = await startAgentTemplatesServer(4075);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await closeServer();
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("draft is invisible, published is visible, and archived is list-hidden but directly resolvable", async () => {
+    const created = await createTemplate({
+      baseURL,
+      body: {
+        agentName: "Cross Visibility Template",
+        prompt: "Show and hide me across states",
+        slug: "cross-visibility-template",
+      },
+    });
+    const id = created.body.id as string;
+    const hashedSlug = hashedSlugFor(created.body);
+
+    expect(created.response.status).toBe(201);
+    expect(created.body.status).toBe("draft");
+    expect(await listContains(id)).toBe(false);
+    expect(
+      (await getTemplate({ baseURL, path: hashedSlug })).response.status,
+    ).toBe(404);
+
+    const published = await publishTemplate({ baseURL, id });
+    expect(published.response.status).toBe(200);
+    expect(published.body.status).toBe("published");
+    expect(published.body.firstPublishedAt).toEqual(expect.any(String));
+    expect(await listContains(id)).toBe(true);
+
+    const publishedDetail = await getTemplate({ baseURL, path: hashedSlug });
+    expect(publishedDetail.response.status).toBe(200);
+    expect(publishedDetail.body.status).toBe("published");
+
+    const archived = await patchTemplate({
+      baseURL,
+      id,
+      body: { status: "archived" },
+    });
+    expect(archived.response.status).toBe(200);
+    expect(archived.body.status).toBe("archived");
+    expect(await listContains(id)).toBe(false);
+
+    const archivedDetail = await getTemplate({ baseURL, path: hashedSlug });
+    expect(archivedDetail.response.status).toBe(200);
+    expect(archivedDetail.body.status).toBe("archived");
+  });
+});

--- a/tests/agent-templates.delete.test.ts
+++ b/tests/agent-templates.delete.test.ts
@@ -9,22 +9,14 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type TemplateBody = Record<string, unknown>;
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4063";

--- a/tests/agent-templates.delete.test.ts
+++ b/tests/agent-templates.delete.test.ts
@@ -165,7 +165,7 @@ describe("Agent template delete endpoint", () => {
     ).toBe(0);
   });
 
-  test("rejects deleting a published row with ALREADY_PUBLISHED and preserves it", async () => {
+  test("deletes a published row (no more ALREADY_PUBLISHED gate)", async () => {
     const template = await seedTemplate({
       slug: "delete-test-published",
       status: "published",
@@ -174,49 +174,45 @@ describe("Agent template delete endpoint", () => {
 
     const { body, response } = await deleteTemplate(template.id);
 
-    expect(response.status).toBe(409);
-    expect(body.error).toMatchObject({ code: "ALREADY_PUBLISHED" });
-    expect(typeof (body.error as { message?: unknown }).message).toBe("string");
-    expect((body.error as { message: string }).message.length).toBeGreaterThan(
-      0,
-    );
-
-    const row = await prisma.agentTemplate.findUniqueOrThrow({
-      where: { id: template.id },
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      object: "agent_template",
+      id: template.id,
+      deleted: true,
     });
-    expect(row.firstPublishedAt).not.toBeNull();
+    expect(
+      await prisma.agentTemplate.count({ where: { id: template.id } }),
+    ).toBe(0);
   });
 
-  test("rejects deleting an unlisted formerly published row", async () => {
+  test("deletes an unlisted formerly published row", async () => {
     const template = await seedTemplate({
       slug: "delete-test-unlisted",
       status: "unlisted",
       firstPublishedAt: publishedAt,
     });
 
-    const { body, response } = await deleteTemplate(template.id);
+    const { response } = await deleteTemplate(template.id);
 
-    expect(response.status).toBe(409);
-    expect(body.error).toMatchObject({ code: "ALREADY_PUBLISHED" });
+    expect(response.status).toBe(200);
     expect(
       await prisma.agentTemplate.count({ where: { id: template.id } }),
-    ).toBe(1);
+    ).toBe(0);
   });
 
-  test("rejects deleting an archived formerly published row", async () => {
+  test("deletes an archived formerly published row", async () => {
     const template = await seedTemplate({
       slug: "delete-test-archived",
       status: "archived",
       firstPublishedAt: publishedAt,
     });
 
-    const { body, response } = await deleteTemplate(template.id);
+    const { response } = await deleteTemplate(template.id);
 
-    expect(response.status).toBe(409);
-    expect(body.error).toMatchObject({ code: "ALREADY_PUBLISHED" });
+    expect(response.status).toBe(200);
     expect(
       await prisma.agentTemplate.count({ where: { id: template.id } }),
-    ).toBe(1);
+    ).toBe(0);
   });
 
   test("keeps forked children and clears forkedFromId when deleting a draft parent", async () => {

--- a/tests/agent-templates.delete.test.ts
+++ b/tests/agent-templates.delete.test.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { Prisma } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type TemplateBody = Record<string, unknown>;
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4063";
+const publishedAt = new Date("2026-02-01T12:00:00.000Z");
+const createdAt = new Date("2026-01-31T12:00:00.000Z");
+
+const testTemplateIds: string[] = [];
+
+const cleanupTemplates = async () => {
+  if (testTemplateIds.length > 0) {
+    await prisma.agentTemplate.deleteMany({
+      where: { id: { in: testTemplateIds } },
+    });
+  }
+  await prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "delete-test-" } },
+        { agentName: { startsWith: "Delete Test" } },
+      ],
+    },
+  });
+  testTemplateIds.length = 0;
+};
+
+const makeAuthHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-delete",
+    accountId: ADMIN_ACCOUNT_ID,
+  }),
+});
+
+const seedTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput> = {},
+) => {
+  const id = overrides.id ?? randomUUID();
+  testTemplateIds.push(id);
+  const status = overrides.status ?? "draft";
+  const defaultFirstPublishedAt =
+    status === "draft" ? null : new Date(publishedAt);
+
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug: overrides.slug ?? `delete-test-${id.slice(0, 8)}`,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? "Delete Test Template",
+      description: overrides.description ?? null,
+      prompt: overrides.prompt ?? "Initial prompt",
+      category: overrides.category ?? null,
+      emoji: overrides.emoji ?? null,
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt:
+        overrides.firstPublishedAt === undefined
+          ? defaultFirstPublishedAt
+          : overrides.firstPublishedAt,
+      status,
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? createdAt,
+    },
+  });
+};
+
+const deleteTemplate = async (id: string) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-templates/${id}`, {
+    method: "DELETE",
+    headers: await makeAuthHeaders(),
+  });
+  const body = (await response.json()) as TemplateBody;
+
+  return { body, response };
+};
+
+const createTemplate = async (body: Record<string, unknown>) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
+    method: "POST",
+    headers: await makeAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  const parsedBody = (await response.json()) as TemplateBody;
+
+  return { body: parsedBody, response };
+};
+
+describe("Agent template delete endpoint", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4063, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("returns 404 for an unknown template id", async () => {
+    const missingId = randomUUID();
+    const { body, response } = await deleteTemplate(missingId);
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBeDefined();
+  });
+
+  test("hard-deletes a draft and returns the exact JSON tombstone shape", async () => {
+    const template = await seedTemplate({
+      slug: "delete-test-draft",
+    });
+
+    const { body, response } = await deleteTemplate(template.id);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(Object.keys(body).sort()).toEqual(["deleted", "id", "object"]);
+    expect(body).toEqual({
+      object: "agent_template",
+      id: template.id,
+      deleted: true,
+    });
+    expect(
+      await prisma.agentTemplate.count({ where: { id: template.id } }),
+    ).toBe(0);
+  });
+
+  test("rejects deleting a published row with ALREADY_PUBLISHED and preserves it", async () => {
+    const template = await seedTemplate({
+      slug: "delete-test-published",
+      status: "published",
+      firstPublishedAt: publishedAt,
+    });
+
+    const { body, response } = await deleteTemplate(template.id);
+
+    expect(response.status).toBe(409);
+    expect(body.error).toMatchObject({ code: "ALREADY_PUBLISHED" });
+    expect(typeof (body.error as { message?: unknown }).message).toBe("string");
+    expect((body.error as { message: string }).message.length).toBeGreaterThan(
+      0,
+    );
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.firstPublishedAt).not.toBeNull();
+  });
+
+  test("rejects deleting an unlisted formerly published row", async () => {
+    const template = await seedTemplate({
+      slug: "delete-test-unlisted",
+      status: "unlisted",
+      firstPublishedAt: publishedAt,
+    });
+
+    const { body, response } = await deleteTemplate(template.id);
+
+    expect(response.status).toBe(409);
+    expect(body.error).toMatchObject({ code: "ALREADY_PUBLISHED" });
+    expect(
+      await prisma.agentTemplate.count({ where: { id: template.id } }),
+    ).toBe(1);
+  });
+
+  test("rejects deleting an archived formerly published row", async () => {
+    const template = await seedTemplate({
+      slug: "delete-test-archived",
+      status: "archived",
+      firstPublishedAt: publishedAt,
+    });
+
+    const { body, response } = await deleteTemplate(template.id);
+
+    expect(response.status).toBe(409);
+    expect(body.error).toMatchObject({ code: "ALREADY_PUBLISHED" });
+    expect(
+      await prisma.agentTemplate.count({ where: { id: template.id } }),
+    ).toBe(1);
+  });
+
+  test("keeps forked children and clears forkedFromId when deleting a draft parent", async () => {
+    const parent = await seedTemplate({
+      slug: "delete-test-parent",
+    });
+    const child = await seedTemplate({
+      slug: "delete-test-child",
+      forkedFromId: parent.id,
+    });
+
+    expect(
+      await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: child.id },
+        select: { forkedFromId: true },
+      }),
+    ).toMatchObject({ forkedFromId: parent.id });
+
+    const { response } = await deleteTemplate(parent.id);
+
+    expect(response.status).toBe(200);
+    expect(
+      await prisma.agentTemplate.findUnique({ where: { id: parent.id } }),
+    ).toBeNull();
+    expect(
+      await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: child.id },
+        select: { forkedFromId: true },
+      }),
+    ).toMatchObject({ forkedFromId: null });
+  });
+
+  test("allows reusing a slug after its draft row is hard-deleted", async () => {
+    const first = await createTemplate({
+      agentName: "Delete Test Reuse",
+      prompt: "First prompt",
+      slug: "delete-test-reuse",
+    });
+    expect(first.response.status).toBe(201);
+
+    const deleted = await deleteTemplate(first.body.id as string);
+    expect(deleted.response.status).toBe(200);
+
+    const second = await createTemplate({
+      agentName: "Delete Test Reuse Again",
+      prompt: "Second prompt",
+      slug: "delete-test-reuse",
+    });
+
+    expect(second.response.status).toBe(201);
+    expect(second.body.slug).toBe("delete-test-reuse");
+    expect(
+      await prisma.agentTemplate.count({
+        where: { ownerAccountId: ADMIN_ACCOUNT_ID, slug: "delete-test-reuse" },
+      }),
+    ).toBe(1);
+  });
+});

--- a/tests/agent-templates.detail.test.ts
+++ b/tests/agent-templates.detail.test.ts
@@ -9,21 +9,15 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
 import { slugHash } from "@/utils/slug-hash";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type DetailBody = Record<string, unknown>;
 
-const app = express();
-app.use(pinoMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4053";

--- a/tests/agent-templates.detail.test.ts
+++ b/tests/agent-templates.detail.test.ts
@@ -1,0 +1,284 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { Prisma } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+import { slugHash } from "@/utils/slug-hash";
+
+type DetailBody = Record<string, unknown>;
+
+const app = express();
+app.use(pinoMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4053";
+
+const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: { ownerAccountId: ADMIN_ACCOUNT_ID },
+  });
+
+const createTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput>,
+) => {
+  const id = overrides.id ?? randomUUID();
+  const slug = overrides.slug ?? id.replace(/-/g, "").slice(0, 12);
+
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? `Template ${id}`,
+      description: overrides.description ?? "A useful template",
+      prompt: overrides.prompt ?? `Prompt for ${id}`,
+      category: overrides.category ?? "utility",
+      emoji: overrides.emoji ?? "🤖",
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt:
+        overrides.firstPublishedAt ?? new Date("2026-01-10T00:00:00.000Z"),
+      status: overrides.status ?? "published",
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? new Date("2026-01-09T00:00:00.000Z"),
+    },
+  });
+};
+
+// Non-admin reader so draft visibility rules still distinguish caller from
+// owner — templates are owned by ADMIN_ACCOUNT_ID; the reader sees only
+// published/unlisted/archived from other owners.
+const READER_ACCOUNT_ID = "00000000-0000-4000-8000-000000000002";
+
+const readerAuthHeaders = async (): Promise<Record<string, string>> => ({
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-detail",
+    accountId: READER_ACCOUNT_ID,
+  }),
+});
+
+const readDetail = async (args: { path: string }) => {
+  const response = await fetch(`${baseURL}${args.path}`, {
+    headers: await readerAuthHeaders(),
+  });
+  const contentType = response.headers.get("content-type") ?? "";
+  const body = contentType.includes("application/json")
+    ? ((await response.json()) as DetailBody)
+    : null;
+
+  return { body, response };
+};
+
+describe("Agent template detail endpoint", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4053, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("resolves a published template by direct id with public camelCase shape", async () => {
+    const tmpl = await createTemplate({
+      slug: "detail-direct",
+      featured: true,
+      tools: ["web"],
+      connections: ["github"],
+    });
+
+    const { body, response } = await readDetail({
+      path: `/api/v2/agent-templates/${tmpl.id}`,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(body).toMatchObject({
+      object: "agent_template",
+      id: tmpl.id,
+      slug: "detail-direct",
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      forkedFromId: null,
+      agentName: `Template ${tmpl.id}`,
+      prompt: `Prompt for ${tmpl.id}`,
+      category: "utility",
+      emoji: "🤖",
+      tools: ["web"],
+      connections: ["github"],
+      version: 1,
+      status: "published",
+      featured: true,
+    });
+    expect(body).not.toHaveProperty("owner");
+    expect(body).not.toHaveProperty("skills");
+    expect(body).not.toHaveProperty("updatedAt");
+    expect(body).not.toHaveProperty("updated_at");
+    expect(typeof body?.featured).toBe("boolean");
+    expect(body?.createdAt).toMatch(isoTimestampPattern);
+    expect(body?.firstPublishedAt).toMatch(isoTimestampPattern);
+
+    // Snake-cased path stays unmounted — no router matches → 404 from
+    // noRouteMiddleware before any auth middleware runs.
+    const snakeResponse = await fetch(
+      `${baseURL}/api/v2/agent_templates/${tmpl.id}`,
+    );
+    expect(snakeResponse.status).toBe(404);
+  });
+
+  test("resolves by hashed slug and rejects slug-only or mismatched hash lookups", async () => {
+    const tmpl = await createTemplate({
+      slug: "brewski",
+    });
+
+    const hash = slugHash(tmpl.id);
+    const hashed = await readDetail({
+      path: `/api/v2/agent-templates/brewski.${hash}`,
+    });
+
+    expect(hashed.response.status).toBe(200);
+    expect(hashed.body).toMatchObject({
+      id: tmpl.id,
+      slug: "brewski",
+    });
+
+    const headers = await readerAuthHeaders();
+    const slugOnly = await fetch(`${baseURL}/api/v2/agent-templates/brewski`, {
+      headers,
+    });
+    expect(slugOnly.status).toBe(404);
+
+    const wrongHash = await fetch(
+      `${baseURL}/api/v2/agent-templates/brewski.aaaaa`,
+      { headers },
+    );
+    expect(wrongHash.status).toBe(404);
+  });
+
+  test("hides drafts but returns unlisted and archived templates by id and hashed slug", async () => {
+    const draft = await createTemplate({
+      slug: "detail-draft",
+      status: "draft",
+      firstPublishedAt: null,
+    });
+    const unlisted = await createTemplate({
+      slug: "detail-unlisted",
+      status: "unlisted",
+    });
+    const archived = await createTemplate({
+      slug: "detail-archived",
+      status: "archived",
+    });
+
+    const headers = await readerAuthHeaders();
+    for (const path of [
+      `/api/v2/agent-templates/${draft.id}`,
+      `/api/v2/agent-templates/detail-draft.${slugHash(draft.id)}`,
+    ]) {
+      const response = await fetch(`${baseURL}${path}`, { headers });
+      expect(response.status).toBe(404);
+    }
+
+    for (const fixture of [
+      { tmpl: unlisted, slug: "detail-unlisted", status: "unlisted" },
+      { tmpl: archived, slug: "detail-archived", status: "archived" },
+    ]) {
+      const byId = await readDetail({
+        path: `/api/v2/agent-templates/${fixture.tmpl.id}`,
+      });
+      expect(byId.response.status).toBe(200);
+      expect(byId.body?.status).toBe(fixture.status);
+
+      const byHash = await readDetail({
+        path: `/api/v2/agent-templates/${fixture.slug}.${slugHash(fixture.tmpl.id)}`,
+      });
+      expect(byHash.response.status).toBe(200);
+      expect(byHash.body?.status).toBe(fixture.status);
+    }
+  });
+
+  test("supports owner and skills expansions while ignoring unknown expansion values", async () => {
+    const tmpl = await createTemplate({
+      slug: "detail-expand",
+    });
+
+    const defaultDetail = await readDetail({
+      path: `/api/v2/agent-templates/${tmpl.id}`,
+    });
+    expect(defaultDetail.response.status).toBe(200);
+    expect(defaultDetail.body?.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+    expect(defaultDetail.body).not.toHaveProperty("owner");
+    expect(defaultDetail.body).not.toHaveProperty("skills");
+
+    const ownerExpanded = await readDetail({
+      path: `/api/v2/agent-templates/${tmpl.id}?expand[]=owner`,
+    });
+    expect(ownerExpanded.response.status).toBe(200);
+    expect(ownerExpanded.body).not.toHaveProperty("ownerAccountId");
+    const owner = ownerExpanded.body?.owner as Record<string, unknown>;
+    expect(owner.object).toBe("account");
+    expect(owner.id).toBe(ADMIN_ACCOUNT_ID);
+    expect(owner.createdAt).toEqual(expect.stringMatching(isoTimestampPattern));
+    expect(Object.keys(owner).sort()).toEqual(["createdAt", "id", "object"]);
+
+    const skillsExpanded = await readDetail({
+      path: `/api/v2/agent-templates/${tmpl.id}?expand[]=skills`,
+    });
+    expect(skillsExpanded.response.status).toBe(200);
+    expect(skillsExpanded.body?.skills).toEqual([]);
+
+    const skillsFilesExpanded = await readDetail({
+      path: `/api/v2/agent-templates/${tmpl.id}?expand[]=skills.files`,
+    });
+    expect(skillsFilesExpanded.response.status).toBe(200);
+    expect(skillsFilesExpanded.body?.skills).toEqual([]);
+
+    const combined = await readDetail({
+      path: `/api/v2/agent-templates/${tmpl.id}?expand[]=owner&expand[]=skills`,
+    });
+    expect(combined.response.status).toBe(200);
+    expect(combined.body).not.toHaveProperty("ownerAccountId");
+    expect(combined.body?.owner).toMatchObject({
+      object: "account",
+      id: ADMIN_ACCOUNT_ID,
+    });
+    expect(combined.body?.skills).toEqual([]);
+
+    const unknown = await readDetail({
+      path: `/api/v2/agent-templates/${tmpl.id}?expand[]=bogus`,
+    });
+    expect(unknown.response.status).toBe(200);
+    expect(unknown.body).toEqual(defaultDetail.body);
+  });
+});

--- a/tests/agent-templates.guard.test.ts
+++ b/tests/agent-templates.guard.test.ts
@@ -4,6 +4,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import express, { Router } from "express";
 import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
 import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
 
 type RouterWithStack = {
   stack?: Array<{
@@ -43,18 +44,24 @@ const withServer = async (
   runAssertions: (baseURL: string) => Promise<void>,
 ) => {
   const app = express();
+  app.use(pinoMiddleware);
   app.use("/api/v2", router as Parameters<typeof app.use>[1]);
   app.use(noRouteMiddleware);
 
   const server: Server = await new Promise((resolve, reject) => {
-    const startedServer = app.listen(4050, () => {
+    const startedServer = app.listen(0, () => {
       resolve(startedServer);
     });
     startedServer.once("error", reject);
   });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to determine server port");
+  }
+  const baseURL = `http://localhost:${address.port}`;
 
   try {
-    await runAssertions("http://localhost:4050");
+    await runAssertions(baseURL);
   } finally {
     await new Promise<void>((resolve) => {
       server.close(() => {
@@ -81,16 +88,18 @@ describe("agent templates production guard", () => {
     );
   });
 
-  test("router shell is empty in M1", () => {
-    expect(getRouterStack(agentTemplatesRouter)).toHaveLength(0);
+  test("router registrations match the current milestone", () => {
+    expect(getRouterStack(agentTemplatesRouter).length).toBeGreaterThan(0);
   });
 
-  test("production does not mount the router and non-production mounts an empty router", async () => {
+  test("production does not mount the router and non-production mounts the current router", async () => {
     process.env.XMTP_ENV = "production";
     const productionRouter = buildGuardedV2Router();
     expect(hasMountedRouter(productionRouter, "/agent-templates")).toBe(false);
 
     await withServer(productionRouter, async (baseURL) => {
+      // In production the router isn't mounted at all → noRouteMiddleware
+      // returns 404 before any auth runs.
       const templatesResponse = await fetch(
         `${baseURL}/api/v2/agent-templates`,
       );
@@ -102,6 +111,10 @@ describe("agent templates production guard", () => {
     expect(hasMountedRouter(localRouter, "/agent-templates")).toBe(true);
 
     await withServer(localRouter, async (baseURL) => {
+      // The agent-templates list/detail routes are auth-required, so an
+      // unauthenticated read returns 401 (not 200/404). 401 here means the
+      // router is mounted but auth gated; 404 in production above means the
+      // router isn't mounted at all.
       const paths = [
         "/api/v2/agent-templates",
         "/api/v2/agent-templates/anything",
@@ -111,7 +124,7 @@ describe("agent templates production guard", () => {
         paths.map((path) => fetch(`${baseURL}${path}`)),
       );
 
-      expect(responses.map((response) => response.status)).toEqual([404, 404]);
+      expect(responses.map((response) => response.status)).toEqual([401, 401]);
     });
   });
 });

--- a/tests/agent-templates.list.test.ts
+++ b/tests/agent-templates.list.test.ts
@@ -1,0 +1,475 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { AgentTemplate, Prisma } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type ListEnvelope = {
+  data: Array<Record<string, unknown>>;
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4052";
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: { ownerAccountId: ADMIN_ACCOUNT_ID },
+  });
+
+const encodeCursor = (cursor: { id: string; createdAt: string }) =>
+  Buffer.from(JSON.stringify(cursor)).toString("base64url");
+
+// Use a distinct, non-admin account so visibility semantics match the
+// pre-auth-required tests: the caller is NOT the template owner, so they
+// see only published templates owned by ADMIN.
+const READER_ACCOUNT_ID = "00000000-0000-4000-8000-000000000001";
+
+const readerAuthHeaders = async (): Promise<Record<string, string>> => ({
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-list",
+    accountId: READER_ACCOUNT_ID,
+  }),
+});
+
+const readList = async (path = "/api/v2/agent-templates") => {
+  const response = await fetch(`${baseURL}${path}`, {
+    headers: await readerAuthHeaders(),
+  });
+  const body = (await response.json()) as ListEnvelope;
+
+  return { body, response };
+};
+
+const createTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput> = {},
+) => {
+  const id = overrides.id ?? randomUUID();
+  const slug = overrides.slug ?? `test-${id.slice(0, 8)}`;
+
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? `Template ${id}`,
+      description: overrides.description ?? null,
+      prompt: overrides.prompt ?? `Prompt for ${id}`,
+      category: overrides.category ?? null,
+      emoji: overrides.emoji ?? null,
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt: overrides.firstPublishedAt ?? null,
+      status: overrides.status ?? "published",
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? new Date(),
+    },
+  });
+};
+
+const ids = (rows: Array<{ id?: unknown }>) => rows.map((row) => row.id);
+
+describe("Agent template list endpoint", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4052, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("returns a public camelCase envelope from the kebab path and keeps snake path unmounted", async () => {
+    const tmpl = await createTemplate();
+
+    const { body, response } = await readList();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(Object.keys(body).sort()).toEqual(["data", "hasMore", "nextCursor"]);
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(typeof body.hasMore).toBe("boolean");
+    expect(
+      body.nextCursor === null || typeof body.nextCursor === "string",
+    ).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toMatchObject({
+      object: "agent_template",
+      id: tmpl.id,
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      status: "published",
+    });
+    expect(body.data[0]?.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(body.data[0]).not.toHaveProperty("updatedAt");
+
+    // Independent authed call (token minted inline) returns the same shape
+    // and data as the helper.
+    const authToken = await createJwtToken({
+      deviceId: "test-device-agent-templates-list",
+      accountId: READER_ACCOUNT_ID,
+    });
+    const authedResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      headers: { "X-Convos-AuthToken": authToken },
+    });
+    const authedBody = (await authedResponse.json()) as ListEnvelope;
+    expect(authedResponse.status).toBe(200);
+    expect(ids(authedBody.data)).toEqual(ids(body.data));
+
+    // Snake-cased path stays unmounted — no router matches → 404 from
+    // noRouteMiddleware before any auth middleware runs.
+    const snakeResponse = await fetch(`${baseURL}/api/v2/agent_templates`);
+    expect(snakeResponse.status).toBe(404);
+  });
+
+  test("omits non-published rows and composes category owner and featured filters", async () => {
+    await createTemplate({
+      status: "draft",
+      category: "utility",
+      featured: true,
+    });
+    const tmplPubFeatured = await createTemplate({
+      status: "published",
+      category: "utility",
+      featured: true,
+    });
+    const tmplPubPlain = await createTemplate({
+      status: "published",
+      category: "entertainment",
+      featured: false,
+    });
+    await createTemplate({
+      status: "unlisted",
+      category: "utility",
+      featured: true,
+    });
+    await createTemplate({
+      status: "archived",
+      category: "utility",
+      featured: true,
+    });
+
+    const defaultList = await readList();
+    expect(defaultList.response.status).toBe(200);
+    expect(ids(defaultList.body.data).sort()).toEqual(
+      [tmplPubFeatured.id, tmplPubPlain.id].sort(),
+    );
+
+    const utility = await readList("/api/v2/agent-templates?category=utility");
+    expect(ids(utility.body.data)).toEqual([tmplPubFeatured.id]);
+
+    const entertainment = await readList(
+      "/api/v2/agent-templates?category=entertainment",
+    );
+    expect(ids(entertainment.body.data)).toEqual([tmplPubPlain.id]);
+
+    const missingCategory = await readList(
+      "/api/v2/agent-templates?category=nonexistent",
+    );
+    expect(missingCategory.body).toEqual({
+      data: [],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    const owner = await readList(
+      `/api/v2/agent-templates?owner=${ADMIN_ACCOUNT_ID}`,
+    );
+    expect(ids(owner.body.data).sort()).toEqual(
+      ids(defaultList.body.data).sort(),
+    );
+
+    const missingOwner = await readList(
+      "/api/v2/agent-templates?owner=00000000-0000-0000-0000-000000000000",
+    );
+    expect(missingOwner.body).toEqual({
+      data: [],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    const featured = await readList("/api/v2/agent-templates?featured=true");
+    expect(ids(featured.body.data)).toEqual([tmplPubFeatured.id]);
+
+    const featuredFalse = await readList(
+      "/api/v2/agent-templates?featured=false",
+    );
+    expect(ids(featuredFalse.body.data).sort()).toEqual(
+      ids(defaultList.body.data).sort(),
+    );
+
+    const featuredAnything = await readList(
+      "/api/v2/agent-templates?featured=anything",
+    );
+    expect(ids(featuredAnything.body.data).sort()).toEqual(
+      ids(defaultList.body.data).sort(),
+    );
+
+    const composed = await readList(
+      `/api/v2/agent-templates?category=utility&owner=${ADMIN_ACCOUNT_ID}&featured=true`,
+    );
+    expect(ids(composed.body.data)).toEqual([tmplPubFeatured.id]);
+  });
+
+  test("rejects invalid status values, invalid limits, and malformed cursors with 400", async () => {
+    const headers = await readerAuthHeaders();
+
+    // Valid enum values are accepted (200); only unknown / empty strings 400.
+    for (const status of ["draft", "published", "unlisted", "archived"]) {
+      const response = await fetch(
+        `${baseURL}/api/v2/agent-templates?status=${status}`,
+        { headers },
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+    }
+    for (const status of ["anything", ""]) {
+      const response = await fetch(
+        `${baseURL}/api/v2/agent-templates?status=${status}`,
+        { headers },
+      );
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+    }
+
+    for (const limit of ["0", "-1", "abc", "1.5"]) {
+      const response = await fetch(
+        `${baseURL}/api/v2/agent-templates?limit=${limit}`,
+        { headers },
+      );
+      expect(response.status).toBe(400);
+    }
+
+    const malformedJsonCursor = Buffer.from(
+      JSON.stringify({ malformed: true }),
+    ).toString("base64url");
+
+    for (const cursor of [
+      "not-a-real-cursor",
+      "!!!",
+      "",
+      malformedJsonCursor,
+    ]) {
+      const response = await fetch(
+        `${baseURL}/api/v2/agent-templates?cursor=${cursor}`,
+        { headers },
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  test("orders by createdAt descending then id descending", async () => {
+    const tieCreatedAt = new Date("2026-01-01T00:00:00.000Z");
+    const [_older, _newer, tieA, tieB] = await Promise.all([
+      createTemplate({
+        createdAt: new Date("2025-12-31T23:59:58.000Z"),
+      }),
+      createTemplate({
+        createdAt: new Date("2025-12-31T23:59:59.000Z"),
+      }),
+      createTemplate({
+        createdAt: tieCreatedAt,
+      }),
+      createTemplate({
+        createdAt: tieCreatedAt,
+      }),
+    ]);
+
+    const { body } = await readList();
+
+    // tieB and tieA: tieB.id > tieA.id because UUIDs sort lexicographically
+    // We just verify the ordering rules: createdAt desc, then id desc
+    expect(body.data).toHaveLength(4);
+    const resultIds = ids(body.data);
+    // Newer timestamps first
+    expect(
+      new Date(body.data[0]?.createdAt as string).getTime(),
+    ).toBeGreaterThanOrEqual(
+      new Date(body.data[1]?.createdAt as string).getTime(),
+    );
+    // The two tied ones should be adjacent
+    const tiedStartIdx = resultIds.findIndex(
+      (id) => id === tieA.id || id === tieB.id,
+    );
+    expect(
+      [resultIds[tiedStartIdx], resultIds[tiedStartIdx + 1]].sort().reverse(),
+    ).toEqual([tieB.id, tieA.id].sort().reverse());
+  });
+
+  test("uses default limit 20, clamps to 100, and returns cursor echoing the last row", async () => {
+    const baseTime = Date.parse("2026-01-02T00:00:00.000Z");
+    const rows: AgentTemplate[] = [];
+
+    for (let index = 0; index < 120; index += 1) {
+      rows.push(
+        await createTemplate({
+          createdAt: new Date(baseTime + index * 1000),
+        }),
+      );
+    }
+
+    const defaultPage = await readList();
+    expect(defaultPage.body.data).toHaveLength(20);
+    expect(defaultPage.body.hasMore).toBe(true);
+    expect(typeof defaultPage.body.nextCursor).toBe("string");
+
+    const lastDefaultRow = defaultPage.body.data[19] as {
+      id: string;
+      createdAt: string;
+    };
+    const decodedDefaultCursor = JSON.parse(
+      Buffer.from(defaultPage.body.nextCursor ?? "", "base64url").toString(),
+    ) as { id: string; createdAt: string };
+    expect(decodedDefaultCursor.id).toBe(lastDefaultRow.id);
+    expect(decodedDefaultCursor.createdAt).toBe(lastDefaultRow.createdAt);
+
+    const clamped = await readList("/api/v2/agent-templates?limit=200");
+    expect(clamped.body.data).toHaveLength(100);
+    expect(clamped.body.hasMore).toBe(true);
+
+    const explicitMax = await readList("/api/v2/agent-templates?limit=100");
+    expect(explicitMax.body.data).toHaveLength(100);
+  });
+
+  test("round-trips a keyset cursor without duplicates or skips", async () => {
+    const baseTime = Date.parse("2026-01-03T00:00:00.000Z");
+
+    const created: string[] = [];
+    for (let index = 0; index < 25; index += 1) {
+      const tmpl = await createTemplate({
+        createdAt: new Date(baseTime + index * 1000),
+      });
+      created.push(tmpl.id);
+    }
+
+    const firstPage = await readList("/api/v2/agent-templates?limit=20");
+    expect(firstPage.body.data).toHaveLength(20);
+    expect(firstPage.body.hasMore).toBe(true);
+    expect(firstPage.body.nextCursor).not.toBeNull();
+
+    const secondPage = await readList(
+      `/api/v2/agent-templates?limit=20&cursor=${firstPage.body.nextCursor}`,
+    );
+    expect(secondPage.body.data).toHaveLength(5);
+    expect(secondPage.body.hasMore).toBe(false);
+    expect(secondPage.body.nextCursor).toBeNull();
+
+    const firstIds = new Set(ids(firstPage.body.data));
+    const secondIds = new Set(ids(secondPage.body.data));
+    const allIds = new Set([...firstIds, ...secondIds]);
+
+    expect([...firstIds].some((id) => secondIds.has(id as string))).toBe(false);
+    expect(allIds).toEqual(new Set(created));
+  });
+
+  test("applies cursors inside active filters", async () => {
+    const baseTime = Date.parse("2026-01-04T00:00:00.000Z");
+
+    for (let index = 0; index < 21; index += 1) {
+      await createTemplate({
+        category: "utility",
+        createdAt: new Date(baseTime + index * 1000),
+      });
+    }
+
+    for (let index = 0; index < 5; index += 1) {
+      await createTemplate({
+        category: "entertainment",
+        createdAt: new Date(baseTime + (100 + index) * 1000),
+      });
+    }
+
+    const firstPage = await readList(
+      "/api/v2/agent-templates?category=utility&limit=20",
+    );
+    expect(firstPage.body.data).toHaveLength(20);
+    expect(firstPage.body.nextCursor).not.toBeNull();
+    expect(firstPage.body.data.every((row) => row.category === "utility")).toBe(
+      true,
+    );
+
+    const secondPage = await readList(
+      `/api/v2/agent-templates?category=utility&limit=20&cursor=${firstPage.body.nextCursor}`,
+    );
+    expect(secondPage.body.data).toHaveLength(1);
+    expect(secondPage.body.data[0]?.category).toBe("utility");
+    expect(secondPage.body.hasMore).toBe(false);
+    expect(secondPage.body.nextCursor).toBeNull();
+  });
+
+  test("returns a well-formed empty envelope for no results and cursors past the end", async () => {
+    const empty = await readList();
+    expect(empty.response.status).toBe(200);
+    expect(empty.body).toEqual({
+      data: [],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    const baseTime = Date.parse("2026-01-05T00:00:00.000Z");
+    for (let index = 0; index < 5; index += 1) {
+      await createTemplate({
+        createdAt: new Date(baseTime + index * 1000),
+      });
+    }
+
+    const fullPage = await readList("/api/v2/agent-templates?limit=5");
+    expect(fullPage.body.data).toHaveLength(5);
+    expect(fullPage.body.hasMore).toBe(false);
+    expect(fullPage.body.nextCursor).toBeNull();
+
+    const pastEndCursor = encodeCursor({
+      id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+      createdAt: "1970-01-01T00:00:00.000Z",
+    });
+    const pastEnd = await readList(
+      `/api/v2/agent-templates?cursor=${pastEndCursor}`,
+    );
+    expect(pastEnd.body).toEqual({
+      data: [],
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+});

--- a/tests/agent-templates.list.test.ts
+++ b/tests/agent-templates.list.test.ts
@@ -9,14 +9,10 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type ListEnvelope = {
   data: Array<Record<string, unknown>>;
@@ -24,11 +20,7 @@ type ListEnvelope = {
   nextCursor: string | null;
 };
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4052";

--- a/tests/agent-templates.patch.test.ts
+++ b/tests/agent-templates.patch.test.ts
@@ -1,0 +1,562 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { Prisma } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type TemplateBody = Record<string, unknown>;
+
+const OTHER_ACCOUNT_ID = "bbbbbbbb-cccc-4ddd-eeee-ffffffff0001";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4061";
+const publishedAt = new Date("2026-02-01T12:00:00.000Z");
+const createdAt = new Date("2026-01-31T12:00:00.000Z");
+const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+const testTemplateIds: string[] = [];
+
+const cleanupTemplates = async () => {
+  if (testTemplateIds.length > 0) {
+    await prisma.agentTemplate.deleteMany({
+      where: { id: { in: testTemplateIds } },
+    });
+  }
+  testTemplateIds.length = 0;
+};
+
+const makeAuthHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-patch",
+    accountId: ADMIN_ACCOUNT_ID,
+  }),
+});
+
+const seedTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput> = {},
+) => {
+  const id = overrides.id ?? randomUUID();
+  testTemplateIds.push(id);
+  const status = overrides.status ?? "draft";
+  const defaultFirstPublishedAt =
+    status === "draft" ? null : new Date(publishedAt);
+
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug: overrides.slug ?? `patch-test-${id.slice(0, 8)}`,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? "Patch Test Template",
+      description: overrides.description ?? null,
+      prompt: overrides.prompt ?? "Initial prompt",
+      category: overrides.category ?? null,
+      emoji: overrides.emoji ?? null,
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt:
+        overrides.firstPublishedAt === undefined
+          ? defaultFirstPublishedAt
+          : overrides.firstPublishedAt,
+      status,
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? createdAt,
+    },
+  });
+};
+
+const patchTemplate = async (args: {
+  id: string;
+  body: Record<string, unknown>;
+}) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-templates/${args.id}`, {
+    method: "PATCH",
+    headers: await makeAuthHeaders(),
+    body: JSON.stringify(args.body),
+  });
+  const parsedBody = (await response.json()) as TemplateBody;
+
+  return { body: parsedBody, response };
+};
+
+const expectTemplateShape = (body: TemplateBody) => {
+  expect(Object.keys(body).sort()).toEqual([
+    "agentName",
+    "avatarUrl",
+    "category",
+    "connections",
+    "createdAt",
+    "description",
+    "emoji",
+    "featured",
+    "firstPublishedAt",
+    "forkedFromId",
+    "id",
+    "object",
+    "ownerAccountId",
+    "prompt",
+    "slug",
+    "status",
+    "tools",
+    "version",
+  ]);
+  expect(body.object).toBe("agent_template");
+  expect(body.createdAt).toEqual(expect.stringMatching(isoTimestampPattern));
+  expect(body).not.toHaveProperty("updatedAt");
+};
+
+describe("Agent template patch endpoint", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4061, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("returns 404 for an unknown template id", async () => {
+    const missingId = randomUUID();
+    const { body, response } = await patchTemplate({
+      id: missingId,
+      body: {
+        description: "x",
+      },
+    });
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBeDefined();
+  });
+
+  test("updates content fields immediately without bumping version or firstPublishedAt", async () => {
+    const template = await seedTemplate({
+      slug: "patch-test-content",
+      status: "published",
+      firstPublishedAt: publishedAt,
+      version: 7,
+    });
+
+    const { body, response } = await patchTemplate({
+      id: template.id,
+      body: {
+        prompt: "New prompt",
+        tools: ["web_search", "calculator"],
+        connections: ["calendar", "gmail"],
+        avatarUrl: "https://example.com/avatar.png",
+        agentName: "Renamed Patch Test",
+        description: "Updated description",
+        category: "productivity",
+        emoji: "🤖",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expectTemplateShape(body);
+    expect(body).toMatchObject({
+      prompt: "New prompt",
+      tools: ["web_search", "calculator"],
+      connections: ["calendar", "gmail"],
+      avatarUrl: "https://example.com/avatar.png",
+      agentName: "Renamed Patch Test",
+      description: "Updated description",
+      category: "productivity",
+      emoji: "🤖",
+      version: 7,
+      firstPublishedAt: publishedAt.toISOString(),
+    });
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.version).toBe(7);
+    expect(row.firstPublishedAt?.toISOString()).toBe(publishedAt.toISOString());
+    expect(row.prompt).toBe("New prompt");
+    expect(row.agentName).toBe("Renamed Patch Test");
+    expect(row.tools).toEqual(["web_search", "calculator"]);
+    expect(row.connections).toEqual(["calendar", "gmail"]);
+  });
+
+  test("allows valid pre-publish slug patches and enforces the 64 character boundary", async () => {
+    const template = await seedTemplate({
+      slug: "patch-test-old",
+    });
+    const maxLengthSlug = "a".repeat(64);
+
+    const renamed = await patchTemplate({
+      id: template.id,
+      body: {
+        slug: "patch-test-new",
+      },
+    });
+    expect(renamed.response.status).toBe(200);
+    expect(renamed.body.slug).toBe("patch-test-new");
+
+    const tooLong = await patchTemplate({
+      id: template.id,
+      body: { slug: "a".repeat(65) },
+    });
+    expect(tooLong.response.status).toBe(400);
+    expect(
+      await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      }),
+    ).toMatchObject({ slug: "patch-test-new" });
+
+    const boundary = await patchTemplate({
+      id: template.id,
+      body: { slug: maxLengthSlug },
+    });
+    expect(boundary.response.status).toBe(200);
+    expect(boundary.body.slug).toBe(maxLengthSlug);
+    expect(
+      await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      }),
+    ).toMatchObject({ slug: maxLengthSlug });
+  });
+
+  test("validates draft slug patches and leaves the row unchanged on invalid or conflicting slugs", async () => {
+    await seedTemplate({
+      slug: "patch-test-taken",
+    });
+    const template = await seedTemplate({
+      slug: "patch-test-original",
+    });
+
+    for (const slug of ["Has-Caps", "with space", "", "generate"]) {
+      const result = await patchTemplate({ id: template.id, body: { slug } });
+      expect(result.response.status).toBe(400);
+      expect(
+        await prisma.agentTemplate.findUniqueOrThrow({
+          where: { id: template.id },
+        }),
+      ).toMatchObject({ slug: "patch-test-original" });
+    }
+
+    const conflict = await patchTemplate({
+      id: template.id,
+      body: {
+        slug: "patch-test-taken",
+      },
+    });
+    expect(conflict.response.status).toBe(409);
+    expect(
+      await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      }),
+    ).toMatchObject({ slug: "patch-test-original" });
+  });
+
+  test("rejects slug changes after first publish and preserves the existing slug", async () => {
+    const template = await seedTemplate({
+      slug: "patch-test-immutable",
+      status: "published",
+      firstPublishedAt: publishedAt,
+    });
+
+    const result = await patchTemplate({
+      id: template.id,
+      body: {
+        slug: "patch-test-moved",
+      },
+    });
+
+    expect(result.response.status).toBe(400);
+    expect(
+      await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      }),
+    ).toMatchObject({ slug: "patch-test-immutable" });
+  });
+
+  test("applies the allowed post-publish status transition matrix", async () => {
+    const published = await seedTemplate({
+      slug: "patch-test-status-published",
+      status: "published",
+    });
+
+    const toUnlisted = await patchTemplate({
+      id: published.id,
+      body: {
+        status: "unlisted",
+      },
+    });
+    expect(toUnlisted.response.status).toBe(200);
+    expect(toUnlisted.body.status).toBe("unlisted");
+
+    const backToPublished = await patchTemplate({
+      id: published.id,
+      body: {
+        status: "published",
+      },
+    });
+    expect(backToPublished.response.status).toBe(200);
+    expect(backToPublished.body.status).toBe("published");
+
+    const publishedToArchived = await patchTemplate({
+      id: published.id,
+      body: {
+        status: "archived",
+      },
+    });
+    expect(publishedToArchived.response.status).toBe(200);
+    expect(publishedToArchived.body.status).toBe("archived");
+
+    const unlisted = await seedTemplate({
+      slug: "patch-test-status-unlisted",
+      status: "unlisted",
+    });
+    const unlistedToArchived = await patchTemplate({
+      id: unlisted.id,
+      body: {
+        status: "archived",
+      },
+    });
+    expect(unlistedToArchived.response.status).toBe(200);
+    expect(unlistedToArchived.body.status).toBe("archived");
+
+    const archivedToPublished = await patchTemplate({
+      id: unlisted.id,
+      body: {
+        status: "published",
+      },
+    });
+    expect(archivedToPublished.response.status).toBe(200);
+    expect(archivedToPublished.body.status).toBe("published");
+
+    const archived = await seedTemplate({
+      slug: "patch-test-status-archived",
+      status: "archived",
+    });
+    const archivedToUnlisted = await patchTemplate({
+      id: archived.id,
+      body: {
+        status: "unlisted",
+      },
+    });
+    expect(archivedToUnlisted.response.status).toBe(200);
+    expect(archivedToUnlisted.body.status).toBe("unlisted");
+  });
+
+  test("rejects status transitions into draft after publish and out of draft via PATCH", async () => {
+    for (const status of ["published", "unlisted", "archived"] as const) {
+      const template = await seedTemplate({
+        slug: `patch-test-to-draft-${status}`,
+        status,
+      });
+
+      const result = await patchTemplate({
+        id: template.id,
+        body: { status: "draft" },
+      });
+      expect(result.response.status).toBe(400);
+      expect(
+        await prisma.agentTemplate.findUniqueOrThrow({
+          where: { id: template.id },
+        }),
+      ).toMatchObject({ status });
+    }
+
+    for (const target of ["published", "unlisted", "archived"] as const) {
+      const template = await seedTemplate({
+        slug: `patch-test-from-draft-${target}`,
+        status: "draft",
+        firstPublishedAt: null,
+      });
+
+      const result = await patchTemplate({
+        id: template.id,
+        body: { status: target },
+      });
+      expect(result.response.status).toBe(400);
+      expect(
+        await prisma.agentTemplate.findUniqueOrThrow({
+          where: { id: template.id },
+        }),
+      ).toMatchObject({ status: "draft", firstPublishedAt: null });
+    }
+  });
+
+  test("ignores server-pinned fields and keeps the database row unchanged", async () => {
+    const template = await seedTemplate({
+      slug: "patch-test-pinned",
+      status: "published",
+      firstPublishedAt: publishedAt,
+      version: 3,
+      createdAt,
+    });
+
+    const fakeOtherId = randomUUID();
+    const result = await patchTemplate({
+      id: template.id,
+      body: {
+        ownerAccountId: OTHER_ACCOUNT_ID,
+        version: 42,
+        firstPublishedAt: "2020-01-01T00:00:00.000Z",
+        forkedFromId: fakeOtherId,
+        createdAt: "2000-01-01T00:00:00.000Z",
+        id: fakeOtherId,
+      },
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(result.body).toMatchObject({
+      id: template.id,
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      version: 3,
+      firstPublishedAt: publishedAt.toISOString(),
+      forkedFromId: null,
+      createdAt: createdAt.toISOString(),
+    });
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+    expect(row.version).toBe(3);
+    expect(row.firstPublishedAt?.toISOString()).toBe(publishedAt.toISOString());
+    expect(row.forkedFromId).toBeNull();
+    expect(row.createdAt.toISOString()).toBe(createdAt.toISOString());
+    expect(
+      await prisma.agentTemplate.findUnique({
+        where: { id: fakeOtherId },
+      }),
+    ).toBeNull();
+  });
+
+  test("returns the full template object and preserves it on an empty body no-op", async () => {
+    const template = await seedTemplate({
+      slug: "patch-test-empty",
+      status: "published",
+      firstPublishedAt: publishedAt,
+    });
+
+    const first = await patchTemplate({ id: template.id, body: {} });
+    expect(first.response.status).toBe(200);
+    expectTemplateShape(first.body);
+    expect(first.body.firstPublishedAt).toEqual(
+      expect.stringMatching(isoTimestampPattern),
+    );
+
+    const second = await patchTemplate({ id: template.id, body: {} });
+    expect(second.response.status).toBe(200);
+    expect(second.body).toEqual(first.body);
+  });
+
+  test("a slug PATCH whose pinned WHERE state has shifted underneath it surfaces as 409", async () => {
+    const template = await seedTemplate({
+      slug: "patch-test-race",
+      status: "draft",
+    });
+
+    // Stage a request, then before its updateMany lands, mutate the row out
+    // from under it. The handler observed slug "patch-test-race" so its
+    // WHERE clause pins on that value; once the slug is rewritten by a
+    // concurrent client, the WHERE no longer matches and the patch must
+    // surface 409 instead of silently overwriting against stale state.
+    const concurrentMutation = (async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await prisma.agentTemplate.update({
+        where: { id: template.id },
+        data: { slug: "patch-test-race-rewritten" },
+      });
+    })();
+
+    const [patchResult] = await Promise.all([
+      patchTemplate({
+        id: template.id,
+        body: { description: "racing description" },
+      }),
+      concurrentMutation,
+    ]);
+
+    if (patchResult.response.status === 409) {
+      expect(patchResult.body).toMatchObject({
+        error: { code: "TEMPLATE_MODIFIED" },
+      });
+      const row = await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      });
+      expect(row.slug).toBe("patch-test-race-rewritten");
+      expect(row.description).toBeNull();
+    } else {
+      expect(patchResult.response.status).toBe(200);
+      const row = await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      });
+      expect(row.slug).toBe("patch-test-race-rewritten");
+      expect(row.description).toBe("racing description");
+    }
+  });
+
+  test("multiple concurrent slug PATCHes converge to one winner with conflicting peers reporting 409", async () => {
+    const template = await seedTemplate({
+      slug: "patch-test-race-many",
+      status: "draft",
+    });
+
+    const candidates = Array.from(
+      { length: 6 },
+      (_, index) => `patch-test-race-many-${index}`,
+    );
+    const results = await Promise.all(
+      candidates.map((slug) =>
+        patchTemplate({ id: template.id, body: { slug } }),
+      ),
+    );
+
+    const successes = results.filter((r) => r.response.status === 200);
+    const conflicts = results.filter((r) => r.response.status === 409);
+    // Each handler reads its own snapshot before the WHERE-pinned write, so
+    // multiple PATCHes can succeed when their reads observe different
+    // committed states. The invariant: every response is either a clean 200
+    // or a TEMPLATE_MODIFIED 409, and at least one peer wins.
+    expect(successes.length).toBeGreaterThanOrEqual(1);
+    expect(successes.length + conflicts.length).toBe(results.length);
+    for (const conflict of conflicts) {
+      expect(conflict.body).toMatchObject({
+        error: { code: "TEMPLATE_MODIFIED" },
+      });
+    }
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(candidates).toContain(row.slug);
+  });
+});

--- a/tests/agent-templates.patch.test.ts
+++ b/tests/agent-templates.patch.test.ts
@@ -9,24 +9,16 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type TemplateBody = Record<string, unknown>;
 
 const OTHER_ACCOUNT_ID = "bbbbbbbb-cccc-4ddd-eeee-ffffffff0001";
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4061";

--- a/tests/agent-templates.patch.test.ts
+++ b/tests/agent-templates.patch.test.ts
@@ -373,25 +373,40 @@ describe("Agent template patch endpoint", () => {
     expect(archivedToUnlisted.body.status).toBe("unlisted");
   });
 
-  test("rejects status transitions into draft after publish and out of draft via PATCH", async () => {
+  test("allows published / unlisted / archived → draft (firstPublishedAt preserved, slug stays locked)", async () => {
     for (const status of ["published", "unlisted", "archived"] as const) {
       const template = await seedTemplate({
         slug: `patch-test-to-draft-${status}`,
         status,
       });
+      const originalFirstPublishedAt = template.firstPublishedAt;
 
       const result = await patchTemplate({
         id: template.id,
         body: { status: "draft" },
       });
-      expect(result.response.status).toBe(400);
-      expect(
-        await prisma.agentTemplate.findUniqueOrThrow({
-          where: { id: template.id },
-        }),
-      ).toMatchObject({ status });
-    }
+      expect(result.response.status).toBe(200);
+      expect(result.body.status).toBe("draft");
 
+      const row = await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      });
+      expect(row.status).toBe("draft");
+      // firstPublishedAt is preserved so the slug stays locked and the
+      // next POST /publish takes the re-publish (version-bump) path.
+      expect(row.firstPublishedAt).toEqual(originalFirstPublishedAt);
+
+      // Slug is still immutable while back in draft.
+      const slugAttempt = await patchTemplate({
+        id: template.id,
+        body: { slug: `renamed-after-draft-${status}` },
+      });
+      expect(slugAttempt.response.status).toBe(400);
+      expect(slugAttempt.body.error).toMatchObject({ code: "SLUG_IMMUTABLE" });
+    }
+  });
+
+  test("rejects status transitions out of draft via PATCH (must use POST /publish)", async () => {
     for (const target of ["published", "unlisted", "archived"] as const) {
       const template = await seedTemplate({
         slug: `patch-test-from-draft-${target}`,

--- a/tests/agent-templates.publish.test.ts
+++ b/tests/agent-templates.publish.test.ts
@@ -9,22 +9,14 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type TemplateBody = Record<string, unknown>;
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 let server: Server;
 const baseURL = "http://localhost:4065";

--- a/tests/agent-templates.publish.test.ts
+++ b/tests/agent-templates.publish.test.ts
@@ -323,4 +323,52 @@ describe("Agent template publish endpoint", () => {
     expect(row.version).toBe(9);
     expect(row.firstPublishedAt?.toISOString()).toBe(publishedAt.toISOString());
   });
+
+  test("re-publish on a published-then-drafted row brings it back out of draft", async () => {
+    // Models the round-trip: status was set to `draft` via PATCH after a
+    // first publish (allowed once firstPublishedAt is set — see patch.ts).
+    // /publish must take it back out of draft, honour ?status= when
+    // provided, and bump version. firstPublishedAt is preserved (it was
+    // already non-null from the original publish).
+    const template = await seedTemplate({
+      slug: "publish-test-redraft-republish",
+      status: "draft",
+      firstPublishedAt: publishedAt,
+      version: 1,
+    });
+
+    const { body, response } = await publishTemplate(template.id);
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "published",
+      version: 2,
+      firstPublishedAt: publishedAt.toISOString(),
+    });
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.status).toBe("published");
+    expect(row.version).toBe(2);
+  });
+
+  test("re-publish on a published-then-drafted row honours ?status=unlisted", async () => {
+    const template = await seedTemplate({
+      slug: "publish-test-redraft-republish-unlisted",
+      status: "draft",
+      firstPublishedAt: publishedAt,
+      version: 3,
+    });
+
+    const { body, response } = await publishTemplate(
+      template.id,
+      "?status=unlisted",
+    );
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "unlisted",
+      version: 4,
+      firstPublishedAt: publishedAt.toISOString(),
+    });
+  });
 });

--- a/tests/agent-templates.publish.test.ts
+++ b/tests/agent-templates.publish.test.ts
@@ -1,0 +1,326 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { Prisma } from "@prisma/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type TemplateBody = Record<string, unknown>;
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4065";
+const publishedAt = new Date("2026-02-01T12:00:00.000Z");
+const createdAt = new Date("2026-01-31T12:00:00.000Z");
+const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+const testTemplateIds: string[] = [];
+
+const cleanupTemplates = async () => {
+  if (testTemplateIds.length > 0) {
+    await prisma.agentTemplate.deleteMany({
+      where: { id: { in: testTemplateIds } },
+    });
+  }
+  testTemplateIds.length = 0;
+};
+
+const makeAuthHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-publish",
+    accountId: ADMIN_ACCOUNT_ID,
+  }),
+});
+
+const seedTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput> = {},
+) => {
+  const id = overrides.id ?? randomUUID();
+  testTemplateIds.push(id);
+  const status = overrides.status ?? "draft";
+  const defaultFirstPublishedAt =
+    status === "draft" ? null : new Date(publishedAt);
+
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug: overrides.slug ?? `publish-test-${id.slice(0, 8)}`,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? "Publish Test Template",
+      description: overrides.description ?? null,
+      prompt: overrides.prompt ?? "Initial prompt",
+      category: overrides.category ?? null,
+      emoji: overrides.emoji ?? null,
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt:
+        overrides.firstPublishedAt === undefined
+          ? defaultFirstPublishedAt
+          : overrides.firstPublishedAt,
+      status,
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? createdAt,
+    },
+  });
+};
+
+const publishTemplate = async (id: string, query = "") => {
+  const response = await fetch(
+    `${baseURL}/api/v2/agent-templates/${id}/publish${query}`,
+    {
+      method: "POST",
+      headers: await makeAuthHeaders(),
+    },
+  );
+  const body = (await response.json()) as TemplateBody;
+
+  return { body, response };
+};
+
+const expectTemplateShape = (body: TemplateBody) => {
+  expect(Object.keys(body).sort()).toEqual([
+    "agentName",
+    "avatarUrl",
+    "category",
+    "connections",
+    "createdAt",
+    "description",
+    "emoji",
+    "featured",
+    "firstPublishedAt",
+    "forkedFromId",
+    "id",
+    "object",
+    "ownerAccountId",
+    "prompt",
+    "slug",
+    "status",
+    "tools",
+    "version",
+  ]);
+  expect(body.object).toBe("agent_template");
+  expect(body.createdAt).toEqual(expect.stringMatching(isoTimestampPattern));
+  expect(body.firstPublishedAt).toEqual(
+    expect.stringMatching(isoTimestampPattern),
+  );
+  expect(body).not.toHaveProperty("updatedAt");
+};
+
+describe("Agent template publish endpoint", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4065, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTemplates();
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanupTemplates();
+  });
+
+  test("returns 404 for an unknown template id", async () => {
+    const missingId = randomUUID();
+    const { body, response } = await publishTemplate(missingId);
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBeDefined();
+  });
+
+  test("first publish defaults draft to published, sets firstPublishedAt, and keeps version 1", async () => {
+    const template = await seedTemplate({
+      slug: "publish-test-default",
+    });
+    const startedAt = Date.now();
+
+    const { body, response } = await publishTemplate(template.id);
+
+    expect(response.status).toBe(200);
+    expectTemplateShape(body);
+    expect(body).toMatchObject({
+      id: template.id,
+      status: "published",
+      version: 1,
+    });
+    expect(
+      new Date(body.firstPublishedAt as string).getTime(),
+    ).toBeGreaterThanOrEqual(startedAt);
+    expect(
+      new Date(body.firstPublishedAt as string).getTime(),
+    ).toBeLessThanOrEqual(Date.now());
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.status).toBe("published");
+    expect(row.version).toBe(1);
+    expect(row.firstPublishedAt).not.toBeNull();
+  });
+
+  test("first publish honors status=unlisted without bumping version", async () => {
+    const template = await seedTemplate({
+      slug: "publish-test-unlisted-first",
+    });
+
+    const { body, response } = await publishTemplate(
+      template.id,
+      "?status=unlisted",
+    );
+
+    expect(response.status).toBe(200);
+    expectTemplateShape(body);
+    expect(body).toMatchObject({
+      id: template.id,
+      status: "unlisted",
+      version: 1,
+    });
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.status).toBe("unlisted");
+    expect(row.version).toBe(1);
+    expect(row.firstPublishedAt).not.toBeNull();
+  });
+
+  test("first publish rejects invalid status params and leaves draft rows unchanged", async () => {
+    for (const status of ["draft", "archived", "garbage"]) {
+      const template = await seedTemplate({
+        slug: `publish-test-invalid-${status}`,
+      });
+
+      const { body, response } = await publishTemplate(
+        template.id,
+        `?status=${status}`,
+      );
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBeDefined();
+      expect(
+        await prisma.agentTemplate.findUniqueOrThrow({
+          where: { id: template.id },
+        }),
+      ).toMatchObject({
+        status: "draft",
+        version: 1,
+        firstPublishedAt: null,
+      });
+    }
+  });
+
+  test("subsequent publish increments version and preserves published status and firstPublishedAt", async () => {
+    const template = await seedTemplate({
+      slug: "publish-test-subsequent",
+      status: "published",
+      firstPublishedAt: publishedAt,
+      version: 1,
+    });
+
+    const { body, response } = await publishTemplate(template.id);
+
+    expect(response.status).toBe(200);
+    expectTemplateShape(body);
+    expect(body).toMatchObject({
+      status: "published",
+      version: 2,
+      firstPublishedAt: publishedAt.toISOString(),
+    });
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.status).toBe("published");
+    expect(row.version).toBe(2);
+    expect(row.firstPublishedAt?.toISOString()).toBe(publishedAt.toISOString());
+  });
+
+  test("subsequent publish preserves unlisted and archived statuses while bumping version", async () => {
+    for (const status of ["unlisted", "archived"] as const) {
+      const template = await seedTemplate({
+        slug: `publish-test-preserve-${status}`,
+        status,
+        firstPublishedAt: publishedAt,
+        version: 4,
+      });
+
+      const { body, response } = await publishTemplate(template.id);
+
+      expect(response.status).toBe(200);
+      expectTemplateShape(body);
+      expect(body).toMatchObject({
+        status,
+        version: 5,
+        firstPublishedAt: publishedAt.toISOString(),
+      });
+
+      const row = await prisma.agentTemplate.findUniqueOrThrow({
+        where: { id: template.id },
+      });
+      expect(row.status).toBe(status);
+      expect(row.version).toBe(5);
+      expect(row.firstPublishedAt?.toISOString()).toBe(
+        publishedAt.toISOString(),
+      );
+    }
+  });
+
+  test("subsequent publish ignores status=unlisted and keeps the current status", async () => {
+    const template = await seedTemplate({
+      slug: "publish-test-ignore-status-param",
+      status: "published",
+      firstPublishedAt: publishedAt,
+      version: 8,
+    });
+
+    const { body, response } = await publishTemplate(
+      template.id,
+      "?status=unlisted",
+    );
+
+    expect(response.status).toBe(200);
+    expectTemplateShape(body);
+    expect(body).toMatchObject({
+      status: "published",
+      version: 9,
+      firstPublishedAt: publishedAt.toISOString(),
+    });
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: template.id },
+    });
+    expect(row.status).toBe("published");
+    expect(row.version).toBe(9);
+    expect(row.firstPublishedAt?.toISOString()).toBe(publishedAt.toISOString());
+  });
+});

--- a/tests/agent-templates.read-guard.test.ts
+++ b/tests/agent-templates.read-guard.test.ts
@@ -1,0 +1,234 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type { Server } from "node:http";
+import type { Prisma } from "@prisma/client";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import express, { Router } from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+type ListEnvelope = {
+  data: Array<Record<string, unknown>>;
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
+const originalXMTPEnv = process.env.XMTP_ENV;
+
+const testTemplateIds: string[] = [];
+
+const cleanupTemplates = async () => {
+  if (testTemplateIds.length > 0) {
+    await prisma.agentTemplate.deleteMany({
+      where: { id: { in: testTemplateIds } },
+    });
+  }
+  testTemplateIds.length = 0;
+};
+
+const createTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput> = {},
+) => {
+  const id = overrides.id ?? randomUUID();
+  testTemplateIds.push(id);
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug: overrides.slug ?? `guard-${id.slice(0, 8)}`,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? `Template ${id}`,
+      description: overrides.description ?? null,
+      prompt: overrides.prompt ?? `Prompt for ${id}`,
+      category: overrides.category ?? null,
+      emoji: overrides.emoji ?? null,
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt:
+        overrides.firstPublishedAt ?? new Date("2026-01-21T00:00:00.000Z"),
+      status: overrides.status ?? "published",
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? new Date("2026-01-21T00:00:00.000Z"),
+    },
+  });
+};
+
+const restoreXMTPEnv = () => {
+  if (originalXMTPEnv === undefined) {
+    delete process.env.XMTP_ENV;
+    return;
+  }
+
+  process.env.XMTP_ENV = originalXMTPEnv;
+};
+
+const setXMTPEnv = (value: string | undefined) => {
+  if (value === undefined) {
+    delete process.env.XMTP_ENV;
+    return;
+  }
+
+  process.env.XMTP_ENV = value;
+};
+
+const buildGuardedV2Router = () => {
+  const v2Router = Router();
+
+  if (process.env.XMTP_ENV !== "production") {
+    v2Router.use("/agent-templates", agentTemplatesRouter);
+  }
+
+  return v2Router;
+};
+
+const withGuardedServer = async (
+  envValue: string | undefined,
+  runAssertions: (baseURL: string) => Promise<void>,
+) => {
+  setXMTPEnv(envValue);
+
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use("/api/v2", buildGuardedV2Router());
+  app.use(noRouteMiddleware);
+
+  const server: Server = await new Promise((resolve, reject) => {
+    const startedServer = app.listen(0, () => {
+      resolve(startedServer);
+    });
+    startedServer.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to determine server port");
+  }
+  const baseURL = `http://localhost:${address.port}`;
+
+  try {
+    await runAssertions(baseURL);
+  } finally {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+    restoreXMTPEnv();
+  }
+};
+
+describe("Agent template read production guard", () => {
+  afterAll(async () => {
+    restoreXMTPEnv();
+    await cleanupTemplates();
+  });
+
+  beforeEach(async () => {
+    restoreXMTPEnv();
+    await cleanupTemplates();
+  });
+
+  test("v2 mount block uses a raw process.env production deny-list and no config constant", () => {
+    const source = readFileSync(
+      new URL("../src/api/v2/index.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain('process.env.XMTP_ENV !== "production"');
+    expect(source).toContain(
+      'v2Router.use("/agent-templates", agentTemplatesRouter)',
+    );
+    expect(source).not.toContain("/agent_templates");
+    expect(source).not.toMatch(
+      /import\s+\{[^}]*XMTP_ENV[^}]*\}\s+from\s+["']@\/config["']/,
+    );
+  });
+
+  test("production unmounts list, detail, hashed-slug, query, and underscore read paths through noRouteMiddleware", async () => {
+    await withGuardedServer("production", async (baseURL) => {
+      const fakeUuid = randomUUID();
+      const paths = [
+        "/api/v2/agent-templates",
+        "/api/v2/agent-templates/",
+        `/api/v2/agent-templates/${fakeUuid}`,
+        "/api/v2/agent-templates/slug.aaaaa",
+        "/api/v2/agent-templates?limit=20",
+        "/api/v2/agent_templates",
+        `/api/v2/agent_templates/${fakeUuid}`,
+      ];
+
+      const responses = await Promise.all(
+        paths.map((path) => fetch(`${baseURL}${path}`)),
+      );
+      const bodies = await Promise.all(
+        responses.map((response) => response.text()),
+      );
+
+      expect(responses.map((response) => response.status)).toEqual(
+        paths.map(() => 404),
+      );
+      expect(new Set(bodies).size).toBe(1);
+      expect(bodies[0]).toBe("");
+    });
+  });
+
+  test("dev, staging, local, unset, and mixed-case Production keep the list route reachable", async () => {
+    const tmpl = await createTemplate({
+      slug: "read-guard-reachable",
+    });
+
+    // Reader token — list requires auth now. Non-owner reader sees only
+    // published, which matches what this test creates.
+    const READER_ID = "00000000-0000-4000-8000-cccccccc0003";
+    const authToken = await createJwtToken({
+      deviceId: "test-device-agent-templates-read-guard",
+      accountId: READER_ID,
+    });
+    const authHeader: Record<string, string> = {
+      "X-Convos-AuthToken": authToken,
+    };
+
+    const envCases = [
+      { label: "dev", value: "dev" },
+      { label: "staging", value: "staging" },
+      { label: "local", value: "local" },
+      { label: "unset", value: undefined },
+      { label: "Production", value: "Production" },
+    ];
+
+    for (const envCase of envCases) {
+      await withGuardedServer(envCase.value, async (baseURL) => {
+        const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
+          headers: authHeader,
+        });
+        const body = (await response.json()) as ListEnvelope;
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toContain(
+          "application/json",
+        );
+        expect(Object.keys(body).sort()).toEqual([
+          "data",
+          "hasMore",
+          "nextCursor",
+        ]);
+        expect(body.data.some((row) => row.id === tmpl.id)).toBe(true);
+
+        // Underscore paths stay unmounted — no route, no auth — 404.
+        const underscoreResponses = await Promise.all([
+          fetch(`${baseURL}/api/v2/agent_templates`),
+          fetch(`${baseURL}/api/v2/agent_templates/${tmpl.id}`),
+        ]);
+
+        expect(underscoreResponses.map((res) => res.status)).toEqual([
+          404, 404,
+        ]);
+      });
+    }
+  });
+});

--- a/tests/agent-templates.resolver.test.ts
+++ b/tests/agent-templates.resolver.test.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from "node:crypto";
+import type { Prisma } from "@prisma/client";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { resolveAgentTemplateByIdOrHashedSlug } from "@/api/v2/agent-templates/lib/resolve-id-or-hashed-slug";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import { slugHash } from "@/utils/slug-hash";
+
+const OTHER_OWNER_ID = "bbbbbbbb-cccc-4ddd-eeee-ffffffff0002";
+
+const testIds: string[] = [];
+
+const cleanup = async () => {
+  if (testIds.length > 0) {
+    await prisma.agentTemplate.deleteMany({
+      where: { id: { in: testIds } },
+    });
+  }
+  await prisma.agentTemplate.deleteMany({
+    where: { ownerAccountId: OTHER_OWNER_ID },
+  });
+  await prisma.account.deleteMany({ where: { id: OTHER_OWNER_ID } });
+};
+
+const createAccount = (args: { id: string }) =>
+  prisma.account.upsert({
+    where: { id: args.id },
+    update: {},
+    create: { id: args.id },
+  });
+
+const createTemplate = async (
+  overrides: Partial<Prisma.AgentTemplateUncheckedCreateInput>,
+) => {
+  const id = overrides.id ?? randomUUID();
+  testIds.push(id);
+  const slug = overrides.slug ?? id.replace(/-/g, "").slice(0, 12);
+
+  return prisma.agentTemplate.create({
+    data: {
+      id,
+      slug,
+      ownerAccountId: overrides.ownerAccountId ?? ADMIN_ACCOUNT_ID,
+      forkedFromId: overrides.forkedFromId ?? null,
+      agentName: overrides.agentName ?? `Template ${id}`,
+      description: overrides.description ?? null,
+      prompt: overrides.prompt ?? `Prompt for ${id}`,
+      category: overrides.category ?? null,
+      emoji: overrides.emoji ?? null,
+      avatarUrl: overrides.avatarUrl ?? null,
+      tools: overrides.tools ?? [],
+      connections: overrides.connections ?? [],
+      version: overrides.version ?? 1,
+      firstPublishedAt:
+        overrides.firstPublishedAt ?? new Date("2026-01-11T00:00:00.000Z"),
+      status: overrides.status ?? "published",
+      featured: overrides.featured ?? false,
+      createdAt: overrides.createdAt ?? new Date("2026-01-11T00:00:00.000Z"),
+    },
+  });
+};
+
+describe("agent template id-or-hashed-slug resolver", () => {
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    testIds.length = 0;
+  });
+
+  test("resolves direct UUID ids and never falls back to bare slug lookups", async () => {
+    const tmplId = await createTemplate({ slug: "unrelated" });
+    await createTemplate({ slug: "brewski" });
+
+    const byId = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: tmplId.id,
+    });
+    expect(byId?.id).toBe(tmplId.id);
+
+    const bareSlug = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: "brewski",
+    });
+    expect(bareSlug).toBeNull();
+  });
+
+  test("splits hashed slugs on the last dot and validates hash syntax exactly", async () => {
+    const tmpl = await createTemplate({ slug: "my-thing" });
+
+    const correctHash = slugHash(tmpl.id);
+    const valid = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `my-thing.${correctHash}`,
+    });
+    expect(valid?.id).toBe(tmpl.id);
+
+    const extraBaseDot = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `extra.my-thing.${correctHash}`,
+    });
+    expect(extraBaseDot).toBeNull();
+
+    for (const suffix of [
+      correctHash.slice(0, 4),
+      `${correctHash}a`,
+      "ABCDE",
+      "!@#$%",
+      "",
+    ]) {
+      const invalid = await resolveAgentTemplateByIdOrHashedSlug({
+        idOrHashedSlug: `my-thing.${suffix}`,
+      });
+      expect(invalid).toBeNull();
+    }
+  });
+
+  test("resolves duplicate base slugs by each owner's hash and rejects collisions", async () => {
+    await createAccount({ id: OTHER_OWNER_ID });
+    const [tmplA, tmplB] = await Promise.all([
+      createTemplate({
+        slug: "shared",
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+      }),
+      createTemplate({
+        slug: "shared",
+        ownerAccountId: OTHER_OWNER_ID,
+      }),
+    ]);
+
+    const hashA = slugHash(tmplA.id);
+    const hashB = slugHash(tmplB.id);
+
+    const rowA = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `shared.${hashA}`,
+    });
+    expect(rowA?.id).toBe(tmplA.id);
+
+    const rowB = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `shared.${hashB}`,
+    });
+    expect(rowB?.id).toBe(tmplB.id);
+
+    const wrongHash = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `shared.${slugHash(randomUUID())}`,
+    });
+    expect(wrongHash).toBeNull();
+
+    const collision = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: "shared.zzzzz",
+      slugHasher: () => "zzzzz",
+    });
+    expect(collision).toBeNull();
+  });
+
+  test("enforces public status visibility for both id and hashed-slug inputs", async () => {
+    const draft = await createTemplate({
+      slug: "resolver-draft",
+      status: "draft",
+      firstPublishedAt: null,
+    });
+    const unlisted = await createTemplate({
+      slug: "resolver-unlisted",
+      status: "unlisted",
+    });
+    const archived = await createTemplate({
+      slug: "resolver-archived",
+      status: "archived",
+    });
+
+    const draftById = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: draft.id,
+    });
+    expect(draftById).toBeNull();
+
+    const draftByHash = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `resolver-draft.${slugHash(draft.id)}`,
+    });
+    expect(draftByHash).toBeNull();
+
+    const visibleFixtures = [
+      { tmpl: unlisted, slug: "resolver-unlisted", status: "unlisted" },
+      { tmpl: archived, slug: "resolver-archived", status: "archived" },
+    ] as const;
+
+    for (const fixture of visibleFixtures) {
+      const byId = await resolveAgentTemplateByIdOrHashedSlug({
+        idOrHashedSlug: fixture.tmpl.id,
+      });
+      expect(byId?.status).toBe(fixture.status);
+
+      const byHash = await resolveAgentTemplateByIdOrHashedSlug({
+        idOrHashedSlug: `${fixture.slug}.${slugHash(fixture.tmpl.id)}`,
+      });
+      expect(byHash?.status).toBe(fixture.status);
+    }
+  });
+
+  test("rejects hashes from different ids", async () => {
+    const tmplPrefixedSlug = await createTemplate({
+      slug: "something-inside",
+    });
+    const tmplHashA = await createTemplate({
+      slug: "aaa",
+    });
+    const tmplHashB = await createTemplate({
+      slug: "bbb",
+    });
+
+    // Hashed slug with matching id resolves correctly
+    const prefixedSlug = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `something-inside.${slugHash(tmplPrefixedSlug.id)}`,
+    });
+    expect(prefixedSlug?.id).toBe(tmplPrefixedSlug.id);
+
+    // Direct UUID lookup still works
+    const prefixedId = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: tmplPrefixedSlug.id,
+    });
+    expect(prefixedId?.id).toBe(tmplPrefixedSlug.id);
+
+    // Hash from tmplHashA on slug "bbb" (which belongs to tmplHashB) → null
+    const hashAOnB = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `bbb.${slugHash(tmplHashA.id)}`,
+    });
+    expect(hashAOnB).toBeNull();
+
+    // Hash from tmplHashB on slug "aaa" (which belongs to tmplHashA) → null
+    const hashBOnA = await resolveAgentTemplateByIdOrHashedSlug({
+      idOrHashedSlug: `aaa.${slugHash(tmplHashB.id)}`,
+    });
+    expect(hashBOnA).toBeNull();
+  });
+});

--- a/tests/agent-templates.schema.test.ts
+++ b/tests/agent-templates.schema.test.ts
@@ -1,0 +1,243 @@
+import { readFileSync } from "node:fs";
+import { Prisma } from "@prisma/client";
+import { describe, expect, test } from "bun:test";
+import { prisma } from "@/utils/prisma";
+
+const schema = readFileSync(
+  new URL("../prisma/schema.prisma", import.meta.url),
+  "utf8",
+);
+
+const getSchemaBlock = (args: { kind: "enum" | "model"; name: string }) => {
+  const match = schema.match(
+    new RegExp(`${args.kind}\\s+${args.name}\\s+\\{([\\s\\S]*?)\\n\\}`),
+  );
+
+  return match?.[1] ?? "";
+};
+
+describe("AgentTemplate schema", () => {
+  test("declares PublishStatus enum and Account.agentTemplates relation", () => {
+    const publishStatusBlock = getSchemaBlock({
+      kind: "enum",
+      name: "PublishStatus",
+    });
+    const publishStatusValues = publishStatusBlock.split(/\s+/).filter(Boolean);
+
+    expect(publishStatusValues).toEqual([
+      "draft",
+      "published",
+      "unlisted",
+      "archived",
+    ]);
+
+    const accountBlock = getSchemaBlock({ kind: "model", name: "Account" });
+    expect(accountBlock).toMatch(/\bagentTemplates\s+AgentTemplate\[\]/);
+  });
+
+  test("declares AgentTemplate fields, relations, and all six required indexes", () => {
+    const agentTemplateBlock = getSchemaBlock({
+      kind: "model",
+      name: "AgentTemplate",
+    });
+
+    const requiredFields = [
+      /\bid\s+String\s+@id\s+@default\(uuid\(\)\)\s+@db\.Uuid\b/,
+      /\bslug\s+String\b/,
+      /\bownerAccountId\s+String\s+@db\.Uuid\b/,
+      /\bforkedFromId\s+String\?\s+@db\.Uuid/,
+      /\bagentName\s+String\b/,
+      /\bdescription\s+String\?/,
+      /\bprompt\s+String\s+@db\.Text\b/,
+      /\bcategory\s+String\?/,
+      /\bemoji\s+String\?/,
+      /\bavatarUrl\s+String\?/,
+      /\btools\s+String\[\]\s+@default\(\[\]\)/,
+      /\bconnections\s+String\[\]\s+@default\(\[\]\)/,
+      /\bversion\s+Int\s+@default\(1\)/,
+      /\bfirstPublishedAt\s+DateTime\?/,
+      /\bstatus\s+PublishStatus\s+@default\(draft\)/,
+      /\bfeatured\s+Boolean\s+@default\(false\)/,
+      /\bcreatedAt\s+DateTime\s+@default\(now\(\)\)/,
+      /\bupdatedAt\s+DateTime\s+@updatedAt\b/,
+    ];
+
+    for (const fieldPattern of requiredFields) {
+      expect(agentTemplateBlock).toMatch(fieldPattern);
+    }
+
+    expect(agentTemplateBlock).toMatch(
+      /\bowner\s+Account\s+@relation\(fields: \[ownerAccountId\], references: \[id\]\)/,
+    );
+
+    const forkedFromRelation = agentTemplateBlock.match(
+      /\bforkedFrom\s+AgentTemplate\?\s+@relation\("Forks", fields: \[forkedFromId\], references: \[id\][^)]*\)/,
+    );
+    expect(forkedFromRelation?.[0].replace(/\s+/g, " ")).toBe(
+      'forkedFrom AgentTemplate? @relation("Forks", fields: [forkedFromId], references: [id])',
+    );
+    expect(agentTemplateBlock).toMatch(
+      /\bforks\s+AgentTemplate\[\]\s+@relation\("Forks"\)/,
+    );
+
+    const requiredIndexes = [
+      "@@unique([ownerAccountId, slug])",
+      "@@index([slug])",
+      "@@index([status, createdAt, id])",
+      "@@index([status, category, createdAt, id])",
+      "@@index([status, featured, createdAt, id])",
+      "@@index([forkedFromId])",
+    ];
+
+    for (const indexDeclaration of requiredIndexes) {
+      expect(agentTemplateBlock).toContain(indexDeclaration);
+    }
+
+    expect(agentTemplateBlock.match(/@@(?:unique|index)\(/g)).toHaveLength(6);
+  });
+
+  test("applies PublishStatus enum, foreign keys, and required indexes in Postgres", async () => {
+    const enumValues = await prisma.$queryRaw<Array<{ enumlabel: string }>>`
+      SELECT e.enumlabel
+      FROM pg_type t
+      JOIN pg_enum e ON e.enumtypid = t.oid
+      WHERE t.typname = 'PublishStatus'
+      ORDER BY e.enumsortorder
+    `;
+
+    expect(enumValues.map((row) => row.enumlabel)).toEqual([
+      "draft",
+      "published",
+      "unlisted",
+      "archived",
+    ]);
+
+    const foreignKeys = await prisma.$queryRaw<
+      Array<{
+        constraint_name: string;
+        delete_rule: string;
+        foreign_column: string;
+        foreign_table: string;
+        source_column: string;
+        update_rule: string;
+      }>
+    >`
+      SELECT
+        tc.constraint_name,
+        kcu.column_name AS source_column,
+        ccu.table_name AS foreign_table,
+        ccu.column_name AS foreign_column,
+        rc.delete_rule,
+        rc.update_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name
+       AND ccu.table_schema = tc.table_schema
+      JOIN information_schema.referential_constraints rc
+        ON rc.constraint_name = tc.constraint_name
+       AND rc.constraint_schema = tc.table_schema
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'AgentTemplate'
+        AND tc.constraint_type = 'FOREIGN KEY'
+      ORDER BY kcu.column_name
+    `;
+
+    const ownerForeignKey = foreignKeys.find(
+      (foreignKey) => foreignKey.source_column === "ownerAccountId",
+    );
+    const forkedFromForeignKey = foreignKeys.find(
+      (foreignKey) => foreignKey.source_column === "forkedFromId",
+    );
+
+    expect(ownerForeignKey?.foreign_column).toBe("id");
+    expect(ownerForeignKey?.foreign_table).toBe("Account");
+    expect(ownerForeignKey?.delete_rule).toBe("RESTRICT");
+    expect(forkedFromForeignKey?.delete_rule).toBe("SET NULL");
+    expect(forkedFromForeignKey?.foreign_column).toBe("id");
+    expect(forkedFromForeignKey?.foreign_table).toBe("AgentTemplate");
+
+    const indexes = await prisma.$queryRaw<
+      Array<{ indexdef: string; indexname: string }>
+    >`
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'AgentTemplate'
+        AND indexname <> 'AgentTemplate_pkey'
+      ORDER BY indexname
+    `;
+
+    expect(indexes.map((index) => index.indexname).sort()).toEqual([
+      "AgentTemplate_forkedFromId_idx",
+      "AgentTemplate_ownerAccountId_slug_key",
+      "AgentTemplate_slug_idx",
+      "AgentTemplate_status_category_createdAt_id_idx",
+      "AgentTemplate_status_createdAt_id_idx",
+      "AgentTemplate_status_featured_createdAt_id_idx",
+    ]);
+
+    const indexDefinitions = indexes.map((index) =>
+      index.indexdef.replace(/\s+/g, " "),
+    );
+
+    expect(
+      indexDefinitions.some(
+        (indexDefinition) =>
+          indexDefinition.includes(
+            'UNIQUE INDEX "AgentTemplate_ownerAccountId_slug_key"',
+          ) && indexDefinition.includes('("ownerAccountId", slug)'),
+      ),
+    ).toBe(true);
+    expect(
+      indexDefinitions.some((indexDefinition) =>
+        indexDefinition.includes("(slug)"),
+      ),
+    ).toBe(true);
+    expect(
+      indexDefinitions.some((indexDefinition) =>
+        indexDefinition.includes('(status, "createdAt", id)'),
+      ),
+    ).toBe(true);
+    expect(
+      indexDefinitions.some((indexDefinition) =>
+        indexDefinition.includes('(status, category, "createdAt", id)'),
+      ),
+    ).toBe(true);
+    expect(
+      indexDefinitions.some((indexDefinition) =>
+        indexDefinition.includes('(status, featured, "createdAt", id)'),
+      ),
+    ).toBe(true);
+    expect(
+      indexDefinitions.some((indexDefinition) =>
+        indexDefinition.includes('("forkedFromId")'),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects AgentTemplate rows whose ownerAccountId does not exist", async () => {
+    let caughtError: unknown;
+
+    try {
+      await prisma.agentTemplate.create({
+        data: {
+          id: "00000000-0000-4000-8000-000000000099",
+          slug: "fk-violation",
+          ownerAccountId: "00000000-0000-0000-0000-000000000000",
+          agentName: "FK Violation",
+          prompt: "This insert should fail before it is persisted.",
+        },
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+    expect((caughtError as Prisma.PrismaClientKnownRequestError).code).toBe(
+      "P2003",
+    );
+  });
+});

--- a/tests/agent-templates.write-guard.test.ts
+++ b/tests/agent-templates.write-guard.test.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type { Server } from "node:http";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import express, { Router } from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+const originalXMTPEnv = process.env.XMTP_ENV;
+
+const cleanupTemplates = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "write-guard-" } },
+        { agentName: { startsWith: "Write Guard" } },
+      ],
+    },
+  });
+
+const restoreXMTPEnv = () => {
+  if (originalXMTPEnv === undefined) {
+    delete process.env.XMTP_ENV;
+    return;
+  }
+
+  process.env.XMTP_ENV = originalXMTPEnv;
+};
+
+const setXMTPEnv = (value: string | undefined) => {
+  if (value === undefined) {
+    delete process.env.XMTP_ENV;
+    return;
+  }
+
+  process.env.XMTP_ENV = value;
+};
+
+const buildGuardedV2Router = () => {
+  const v2Router = Router();
+
+  if (process.env.XMTP_ENV !== "production") {
+    v2Router.use("/agent-templates", agentTemplatesRouter);
+  }
+
+  return v2Router;
+};
+
+const withGuardedServer = async (
+  envValue: string | undefined,
+  runAssertions: (baseURL: string) => Promise<void>,
+) => {
+  setXMTPEnv(envValue);
+
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use(jsonMiddleware);
+  app.use("/api/v2", buildGuardedV2Router());
+  app.use(noRouteMiddleware);
+
+  const server: Server = await new Promise((resolve, reject) => {
+    const startedServer = app.listen(0, () => {
+      resolve(startedServer);
+    });
+    startedServer.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to determine server port");
+  }
+  const baseURL = `http://localhost:${address.port}`;
+
+  try {
+    await runAssertions(baseURL);
+  } finally {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+    restoreXMTPEnv();
+  }
+};
+
+const authHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-templates-write-guard",
+    accountId: ADMIN_ACCOUNT_ID,
+  }),
+});
+
+const createBody = (label: string) =>
+  JSON.stringify({
+    agentName: `Write Guard ${label}`,
+    prompt: `Prompt for ${label}`,
+    slug: `write-guard-${label}`,
+  });
+
+describe("Agent template write production guard", () => {
+  afterAll(async () => {
+    restoreXMTPEnv();
+    await cleanupTemplates();
+  });
+
+  beforeEach(async () => {
+    restoreXMTPEnv();
+    await cleanupTemplates();
+  });
+
+  test("v2 mount block uses the raw process.env production deny-list for agent template routes", () => {
+    const source = readFileSync(
+      new URL("../src/api/v2/index.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain('process.env.XMTP_ENV !== "production"');
+    expect(source).toContain(
+      'v2Router.use("/agent-templates", agentTemplatesRouter)',
+    );
+    expect(source).not.toMatch(
+      /import\s+\{[^}]*XMTP_ENV[^}]*\}\s+from\s+["']@\/config["']/,
+    );
+  });
+
+  test("production unmounts POST, PATCH, DELETE, and publish through noRouteMiddleware", async () => {
+    await withGuardedServer("production", async (baseURL) => {
+      const headers = await authHeaders();
+      const fakeUuid = randomUUID();
+      const requests = [
+        fetch(`${baseURL}/api/v2/agent-templates`, {
+          method: "POST",
+          headers,
+          body: createBody("production-post"),
+        }),
+        fetch(`${baseURL}/api/v2/agent-templates/${fakeUuid}`, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ description: "blocked" }),
+        }),
+        fetch(`${baseURL}/api/v2/agent-templates/${fakeUuid}`, {
+          method: "DELETE",
+          headers,
+        }),
+        fetch(`${baseURL}/api/v2/agent-templates/${fakeUuid}/publish`, {
+          method: "POST",
+          headers,
+        }),
+      ];
+
+      const responses = await Promise.all(requests);
+      const bodies = await Promise.all(
+        responses.map((response) => response.text()),
+      );
+
+      expect(responses.map((response) => response.status)).toEqual([
+        404, 404, 404, 404,
+      ]);
+      expect(bodies).toEqual(["", "", "", ""]);
+      expect(
+        await prisma.agentTemplate.count({
+          where: { slug: "write-guard-production-post" },
+        }),
+      ).toBe(0);
+    });
+  });
+
+  test("local, staging, and unset XMTP_ENV keep write endpoints reachable", async () => {
+    const envCases = [
+      { label: "local", value: "local" },
+      { label: "staging", value: "staging" },
+      { label: "unset", value: undefined },
+    ];
+
+    for (const envCase of envCases) {
+      await withGuardedServer(envCase.value, async (baseURL) => {
+        const authed = await fetch(`${baseURL}/api/v2/agent-templates`, {
+          method: "POST",
+          headers: await authHeaders(),
+          body: createBody(envCase.label),
+        });
+        const authedBody = (await authed.json()) as { id?: string };
+        expect(authed.status).toBe(201);
+        expect(typeof authedBody.id).toBe("string");
+        expect(authedBody.id).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        );
+
+        const unauthed = await fetch(`${baseURL}/api/v2/agent-templates`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: createBody(`${envCase.label}-unauthed`),
+        });
+        expect(unauthed.status).toBe(401);
+      });
+    }
+  });
+});

--- a/tests/auth-cross.test.ts
+++ b/tests/auth-cross.test.ts
@@ -17,15 +17,11 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
 import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 // ---------------------------------------------------------------------------
 // Test account IDs
@@ -66,11 +62,7 @@ const agentKeyHeaders = () => ({
 let server: Server;
 const baseURL = "http://localhost:4089";
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 // ---------------------------------------------------------------------------
 // DB setup / cleanup

--- a/tests/auth-cross.test.ts
+++ b/tests/auth-cross.test.ts
@@ -19,6 +19,7 @@ import {
 } from "bun:test";
 import express from "express";
 import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { jsonMiddleware } from "@/middleware/json";
 import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -39,8 +40,6 @@ const USER_B_ID = "11111111-2222-4333-4444-555555666667";
 
 const validAgentAssetsApiKey =
   "test-agent-assets-api-key-that-is-at-least-32-characters";
-
-const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
 
 const jwtHeadersFor = async (accountId: string) => ({
   "Content-Type": "application/json",
@@ -111,7 +110,7 @@ const deleteAccounts = async () => {
 
 describe("Cross-area auth flows", () => {
   beforeAll(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await ensureUserBAccount();
     await new Promise<void>((resolve) => {
       server = app.listen(4089, () => {
@@ -121,11 +120,7 @@ describe("Cross-area auth flows", () => {
   });
 
   afterAll(async () => {
-    if (originalAgentAssetsApiKey === undefined) {
-      delete process.env.AGENT_ASSETS_API_KEY;
-    } else {
-      process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
-    }
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
     await new Promise<void>((resolve) => {
       server.close(() => {
         resolve();
@@ -136,7 +131,7 @@ describe("Cross-area auth flows", () => {
   });
 
   beforeEach(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await cleanupTestRows();
   });
 

--- a/tests/auth-cross.test.ts
+++ b/tests/auth-cross.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Cross-area auth flow tests
+ *
+ * Tests that:
+ *   - User A creates draft → User B cannot see/mutate; User A and API key listener can
+ *   - User A publishes → User B can see but cannot mutate
+ *   - Unauthenticated callers cannot list or detail any template
+ *   - JWT-only user (no accountId) is rejected from write routes with 403
+ */
+
+import type { Server } from "node:http";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+// ---------------------------------------------------------------------------
+// Test account IDs
+// ---------------------------------------------------------------------------
+
+const USER_A_ID = ADMIN_ACCOUNT_ID;
+const USER_B_ID = "11111111-2222-4333-4444-555555666667";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const validAgentAssetsApiKey =
+  "test-agent-assets-api-key-that-is-at-least-32-characters";
+
+const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
+
+const jwtHeadersFor = async (accountId: string) => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-auth-cross",
+    accountId,
+  }),
+});
+
+/** JWT without accountId — simulates JWT-only auth (no SIWE) */
+const jwtOnlyHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-auth-cross-no-account",
+    // No accountId
+  }),
+});
+
+const agentKeyHeaders = () => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+});
+
+let server: Server;
+const baseURL = "http://localhost:4089";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+// ---------------------------------------------------------------------------
+// DB setup / cleanup
+// ---------------------------------------------------------------------------
+
+const cleanupTestRows = async () => {
+  await prisma.agentTemplate.deleteMany({
+    where: {
+      OR: [
+        { slug: { startsWith: "cross-auth-" } },
+        { agentName: { startsWith: "Cross Auth" } },
+      ],
+    },
+  });
+};
+
+const ensureUserBAccount = async () => {
+  const existing = await prisma.account.findUnique({
+    where: { id: USER_B_ID },
+  });
+  if (!existing) {
+    await prisma.account.create({ data: { id: USER_B_ID } });
+  }
+};
+
+const deleteAccounts = async () => {
+  try {
+    await prisma.account.delete({ where: { id: USER_B_ID } });
+  } catch {
+    // Account may not exist
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("Cross-area auth flows", () => {
+  beforeAll(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await ensureUserBAccount();
+    await new Promise<void>((resolve) => {
+      server = app.listen(4089, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (originalAgentAssetsApiKey === undefined) {
+      delete process.env.AGENT_ASSETS_API_KEY;
+    } else {
+      process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+    await cleanupTestRows();
+    await deleteAccounts();
+  });
+
+  beforeEach(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await cleanupTestRows();
+  });
+
+  // User A creates draft → User B cannot see/mutate; User A and API key listener can
+  test("User A creates draft — User B cannot see/mutate; User A and API key listener can", async () => {
+    // Step 1: User A creates draft
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Cross Auth Draft A",
+        prompt: "A's draft",
+        slug: "cross-auth-draft-a",
+      }),
+    });
+    expect(createResponse.status).toBe(201);
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // Step 2: User B cannot see it in list
+    const bListResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=100`,
+      { headers: await jwtHeadersFor(USER_B_ID) },
+    );
+    const bListBody = (await bListResponse.json()) as {
+      data: Record<string, unknown>[];
+    };
+    expect(bListBody.data.some((t) => t.id === templateId)).toBe(false);
+
+    // Step 3: User B cannot see it in detail — 404
+    const bDetailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: await jwtHeadersFor(USER_B_ID) },
+    );
+    expect(bDetailResponse.status).toBe(404);
+
+    // Step 4: User B cannot PATCH — 403
+    const bPatchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "PATCH",
+        headers: await jwtHeadersFor(USER_B_ID),
+        body: JSON.stringify({ agentName: "Hacked by B" }),
+      },
+    );
+    expect(bPatchResponse.status).toBe(403);
+
+    // Step 5: User A can see it in list
+    const aListResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=100`,
+      { headers: await jwtHeadersFor(USER_A_ID) },
+    );
+    const aListBody = (await aListResponse.json()) as {
+      data: Record<string, unknown>[];
+    };
+    expect(aListBody.data.some((t) => t.id === templateId)).toBe(true);
+
+    // Step 6: User A can see it in detail
+    const aDetailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: await jwtHeadersFor(USER_A_ID) },
+    );
+    expect(aDetailResponse.status).toBe(200);
+
+    // Step 7: User A can PATCH
+    const aPatchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "PATCH",
+        headers: await jwtHeadersFor(USER_A_ID),
+        body: JSON.stringify({ agentName: "Updated by A" }),
+      },
+    );
+    expect(aPatchResponse.status).toBe(200);
+
+    // Step 8: API key listener can see in detail
+    const keyDetailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: agentKeyHeaders() },
+    );
+    expect(keyDetailResponse.status).toBe(200);
+
+    // Step 9: API key listener can PATCH
+    const keyPatchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "PATCH",
+        headers: agentKeyHeaders(),
+        body: JSON.stringify({ agentName: "Patched by API key" }),
+      },
+    );
+    expect(keyPatchResponse.status).toBe(200);
+  });
+
+  // User A publishes → User B can see but cannot mutate
+  test("User A publishes — User B can see but cannot mutate", async () => {
+    // Step 1: User A creates and publishes
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Cross Auth Pub A",
+        prompt: "A's published",
+        slug: "cross-auth-pub-a",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    await fetch(`${baseURL}/api/v2/agent-templates/${templateId}/publish`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+    });
+
+    // Step 2: User B can see it in list
+    const bListResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=100`,
+      { headers: await jwtHeadersFor(USER_B_ID) },
+    );
+    const bListBody = (await bListResponse.json()) as {
+      data: Record<string, unknown>[];
+    };
+    expect(bListBody.data.some((t) => t.id === templateId)).toBe(true);
+
+    // Step 3: User B can see it in detail
+    const bDetailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: await jwtHeadersFor(USER_B_ID) },
+    );
+    expect(bDetailResponse.status).toBe(200);
+
+    // Step 4: User B cannot PATCH
+    const bPatchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "PATCH",
+        headers: await jwtHeadersFor(USER_B_ID),
+        body: JSON.stringify({ agentName: "Hacked by B" }),
+      },
+    );
+    expect(bPatchResponse.status).toBe(403);
+
+    // Step 5: User B cannot DELETE
+    const bDeleteResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "DELETE",
+        headers: await jwtHeadersFor(USER_B_ID),
+      },
+    );
+    expect(bDeleteResponse.status).toBe(403);
+
+    // Step 6: User B cannot PUBLISH (re-publish)
+    const bPublishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}/publish`,
+      {
+        method: "POST",
+        headers: await jwtHeadersFor(USER_B_ID),
+      },
+    );
+    expect(bPublishResponse.status).toBe(403);
+  });
+
+  // Unauthenticated callers are rejected from every
+  // agent-templates route — no public discovery surface.
+  test("Unauthenticated callers cannot list or detail any template", async () => {
+    // Seed a draft template so we have a concrete URL to attempt.
+    const draftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: agentKeyHeaders(),
+      body: JSON.stringify({
+        agentName: "Cross Auth Unauth Draft",
+        prompt: "Draft",
+        slug: "cross-auth-unauth-draft",
+      }),
+    });
+    const draftBody = (await draftResponse.json()) as Record<string, unknown>;
+    const draftId = draftBody.id as string;
+
+    // (1) Unauthenticated GET list — 401
+    const listResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=100`,
+    );
+    expect(listResponse.status).toBe(401);
+
+    // (2) Unauthenticated GET ?status=draft — 401 (auth check runs before
+    // query validation, so this is the same code path as #1)
+    const statusFilterResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?status=draft`,
+    );
+    expect(statusFilterResponse.status).toBe(401);
+
+    // (3) Unauthenticated GET detail — 401
+    const draftDetailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${draftId}`,
+    );
+    expect(draftDetailResponse.status).toBe(401);
+  });
+
+  // JWT-only user (no accountId) is rejected from write routes with 403
+  test("JWT-only user (no accountId) is rejected from write routes", async () => {
+    // POST /agent-templates
+    const postResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtOnlyHeaders(),
+      body: JSON.stringify({
+        agentName: "Cross Auth No Account",
+        prompt: "Should not persist",
+        slug: "cross-auth-no-account",
+      }),
+    });
+    expect(postResponse.status).toBe(403);
+
+    // PATCH /agent-templates/:id
+    const patchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/00000000-0000-4000-8000-000000000000`,
+      {
+        method: "PATCH",
+        headers: await jwtOnlyHeaders(),
+        body: JSON.stringify({ agentName: "Hacked" }),
+      },
+    );
+    expect(patchResponse.status).toBe(403);
+
+    // DELETE /agent-templates/:id
+    const deleteResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/00000000-0000-4000-8000-000000000000`,
+      {
+        method: "DELETE",
+        headers: await jwtOnlyHeaders(),
+      },
+    );
+    expect(deleteResponse.status).toBe(403);
+
+    // POST /agent-templates/:id/publish
+    const publishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/00000000-0000-4000-8000-000000000000/publish`,
+      {
+        method: "POST",
+        headers: await jwtOnlyHeaders(),
+      },
+    );
+    expect(publishResponse.status).toBe(403);
+
+    // POST /agent-templates/generate
+    // NOTE: The generate route doesn't exist on this branch (feat/agent-templates-crud).
+    // This assertion will be covered on feat/agent-templates-create-job when it
+    // incorporates these ownership changes. The requireAccount guard already
+    // applies to the generate route on that branch.
+  });
+});

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -8,6 +8,7 @@
  *   - requireAccount rejects when res.locals.accountId is undefined
  */
 
+import { readFileSync } from "node:fs";
 import type { Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import express, { type Response } from "express";
@@ -236,5 +237,35 @@ describe("getEffectiveOwnerId utility", () => {
     } as unknown as Response;
 
     expect(getEffectiveOwnerId(mockRes)).toBeUndefined();
+  });
+});
+
+describe("requireAccount chained on every agent-templates route", () => {
+  test("router source chains requireAccount on read and write routes", () => {
+    const source = readFileSync(
+      new URL(
+        "../src/api/v2/agent-templates/agent-templates.router.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    // Check that requireAccount is imported
+    expect(source).toContain("requireAccount");
+    expect(source).toContain('from "@/middleware/auth"');
+
+    // Every route on this router requires an account, so the chain is always
+    // `authOrAgentApiKeyAuth, requireAccount, handler`. No public discovery
+    // surface — there is no unauth list/detail branch.
+    const requireAccountCount = (source.match(/requireAccount/g) ?? []).length;
+
+    // 4 write routes (POST, PATCH, DELETE, POST /:id/publish) + 2 read routes
+    // (GET /, GET /:idOrHashedSlug) + 1 import = 7 occurrences.
+    // (generate and create-job routes are on later branches.)
+    expect(requireAccountCount).toBe(7);
+
+    // Read routes DO have requireAccount chained.
+    expect(source).toContain("requireAccount,\n  listHandler");
+    expect(source).toContain("requireAccount,\n  detailHandler");
   });
 });

--- a/tests/auth-ownership.test.ts
+++ b/tests/auth-ownership.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Per-account ownership guard tests
+ *
+ * Tests that:
+ *   - POST /agent-templates creates template with ownerAccountId = getEffectiveOwnerId(res)
+ *   - PATCH /agent-templates/:id returns 403 if not owner AND not API key listener
+ *   - DELETE /agent-templates/:id returns 403 if not owner AND not API key listener
+ *   - POST /agent-templates/:id/publish returns 403 if not owner AND not API key listener
+ *   - API key listeners can patch/delete/publish any template
+ *   - POST /agent-templates/generate creates template owned by authenticated account
+ */
+
+import type { Server } from "node:http";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+// ---------------------------------------------------------------------------
+// Test account IDs
+// ---------------------------------------------------------------------------
+
+/** User A — the admin account (already exists in DB) */
+const USER_A_ID = ADMIN_ACCOUNT_ID;
+
+/** User B — a different SIWE-authenticated account */
+const USER_B_ID = "11111111-2222-4333-4444-555555666667";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const validAgentAssetsApiKey =
+  "test-agent-assets-api-key-that-is-at-least-32-characters";
+
+const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
+
+const jwtHeadersFor = async (args: { accountId: string }) => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-auth-ownership",
+    accountId: args.accountId,
+  }),
+});
+
+const agentKeyHeaders = () => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+});
+
+let server: Server;
+const baseURL = "http://localhost:4087";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+// ---------------------------------------------------------------------------
+// DB setup / cleanup
+// ---------------------------------------------------------------------------
+
+const cleanupTestRows = async () => {
+  await prisma.agentTemplate.deleteMany({
+    where: {
+      OR: [
+        { slug: { startsWith: "own-test-" } },
+        { agentName: { startsWith: "Own Test" } },
+      ],
+    },
+  });
+};
+
+const ensureUserBAccount = async () => {
+  const existing = await prisma.account.findUnique({
+    where: { id: USER_B_ID },
+  });
+  if (!existing) {
+    await prisma.account.create({
+      data: { id: USER_B_ID },
+    });
+  }
+};
+
+const deleteAccounts = async () => {
+  // Only delete accounts we created (not the admin account)
+  try {
+    await prisma.account.delete({ where: { id: USER_B_ID } });
+  } catch {
+    // Account may not exist or have related records
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("Per-account ownership guards", () => {
+  beforeAll(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await ensureUserBAccount();
+    await new Promise<void>((resolve) => {
+      server = app.listen(4087, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (originalAgentAssetsApiKey === undefined) {
+      delete process.env.AGENT_ASSETS_API_KEY;
+    } else {
+      process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+    await cleanupTestRows();
+    await deleteAccounts();
+  });
+
+  beforeEach(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await cleanupTestRows();
+  });
+
+  // POST creates template with ownerAccountId from res.locals.accountId
+  test("POST creates template with ownerAccountId from authenticated user (JWT)", async () => {
+    const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test User A Template",
+        prompt: "You are a test",
+        slug: "own-test-user-a-template",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.ownerAccountId).toBe(USER_A_ID);
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: body.id as string },
+    });
+    expect(row.ownerAccountId).toBe(USER_A_ID);
+  });
+
+  test("POST creates template with User B's accountId when User B is authenticated", async () => {
+    const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_B_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test User B Template",
+        prompt: "You are user B's test",
+        slug: "own-test-user-b-template",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.ownerAccountId).toBe(USER_B_ID);
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: body.id as string },
+    });
+    expect(row.ownerAccountId).toBe(USER_B_ID);
+  });
+
+  test("POST creates template with ADMIN_ACCOUNT_ID when API key auth is used", async () => {
+    const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: agentKeyHeaders(),
+      body: JSON.stringify({
+        agentName: "Own Test API Key Template",
+        prompt: "You are an API key template",
+        slug: "own-test-api-key-template",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+  });
+
+  // PATCH returns 403 if not owner AND not API key listener
+  test("PATCH returns 403 if caller is not the owner and not an API key listener", async () => {
+    // User A creates a template
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test Patch Template",
+        prompt: "You are a test",
+        slug: "own-test-patch-template",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User B tries to patch it
+    const patchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "PATCH",
+        headers: await jwtHeadersFor({ accountId: USER_B_ID }),
+        body: JSON.stringify({ agentName: "Patched by User B" }),
+      },
+    );
+
+    expect(patchResponse.status).toBe(403);
+    const patchBody = (await patchResponse.json()) as { error: string };
+    expect(patchBody.error).toMatch(/not authorized|forbidden|owner/i);
+  });
+
+  // DELETE returns 403 if not owner AND not API key listener
+  test("DELETE returns 403 if caller is not the owner and not an API key listener", async () => {
+    // User A creates a template
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test Delete Template",
+        prompt: "You are a test",
+        slug: "own-test-delete-template",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User B tries to delete it
+    const deleteResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "DELETE",
+        headers: await jwtHeadersFor({ accountId: USER_B_ID }),
+      },
+    );
+
+    expect(deleteResponse.status).toBe(403);
+    const deleteBody = (await deleteResponse.json()) as { error: string };
+    expect(deleteBody.error).toMatch(/not authorized|forbidden|owner/i);
+  });
+
+  // POST publish returns 403 if not owner AND not API key listener
+  test("POST publish returns 403 if caller is not the owner and not an API key listener", async () => {
+    // User A creates a draft template
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test Publish Template",
+        prompt: "You are a test",
+        slug: "own-test-publish-template",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User B tries to publish it
+    const publishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}/publish`,
+      {
+        method: "POST",
+        headers: await jwtHeadersFor({ accountId: USER_B_ID }),
+      },
+    );
+
+    expect(publishResponse.status).toBe(403);
+    const publishBody = (await publishResponse.json()) as { error: string };
+    expect(publishBody.error).toMatch(/not authorized|forbidden|owner/i);
+  });
+
+  // API key listeners can patch/delete/publish any template
+  test("API key listener can PATCH any template regardless of ownership", async () => {
+    // User A creates a template (owned by User A)
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test API Patch",
+        prompt: "You are a test",
+        slug: "own-test-api-patch",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // API key listener patches it
+    const patchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "PATCH",
+        headers: agentKeyHeaders(),
+        body: JSON.stringify({ agentName: "Patched by API Key" }),
+      },
+    );
+
+    expect(patchResponse.status).toBe(200);
+    const patchBody = (await patchResponse.json()) as Record<string, unknown>;
+    expect(patchBody.agentName).toBe("Patched by API Key");
+  });
+
+  test("API key listener can DELETE any template regardless of ownership", async () => {
+    // User A creates a draft template (owned by User A)
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test API Delete",
+        prompt: "You are a test",
+        slug: "own-test-api-delete",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // API key listener deletes it
+    const deleteResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "DELETE",
+        headers: agentKeyHeaders(),
+      },
+    );
+
+    expect(deleteResponse.status).toBe(200);
+  });
+
+  test("API key listener can PUBLISH any template regardless of ownership", async () => {
+    // User A creates a draft template (owned by User A)
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test API Publish",
+        prompt: "You are a test",
+        slug: "own-test-api-publish",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // API key listener publishes it
+    const publishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}/publish`,
+      {
+        method: "POST",
+        headers: agentKeyHeaders(),
+      },
+    );
+
+    expect(publishResponse.status).toBe(200);
+    const publishBody = (await publishResponse.json()) as Record<
+      string,
+      unknown
+    >;
+    expect(publishBody.status).toBe("published");
+  });
+
+  // Owner can mutate their own templates
+  test("Owner can PATCH their own template", async () => {
+    // User A creates a template
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test Owner Patch",
+        prompt: "You are a test",
+        slug: "own-test-owner-patch",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User A patches their own template
+    const patchResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "PATCH",
+        headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+        body: JSON.stringify({ agentName: "Patched by Owner" }),
+      },
+    );
+
+    expect(patchResponse.status).toBe(200);
+  });
+
+  test("Owner can DELETE their own template", async () => {
+    // User A creates a template
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test Owner Delete",
+        prompt: "You are a test",
+        slug: "own-test-owner-delete",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User A deletes their own template
+    const deleteResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      {
+        method: "DELETE",
+        headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      },
+    );
+
+    expect(deleteResponse.status).toBe(200);
+  });
+
+  test("Owner can PUBLISH their own template", async () => {
+    // User A creates a draft template
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      body: JSON.stringify({
+        agentName: "Own Test Owner Publish",
+        prompt: "You are a test",
+        slug: "own-test-owner-publish",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User A publishes their own template
+    const publishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}/publish`,
+      {
+        method: "POST",
+        headers: await jwtHeadersFor({ accountId: USER_A_ID }),
+      },
+    );
+
+    expect(publishResponse.status).toBe(200);
+  });
+
+  // POST /generate creates template owned by authenticated account
+  // NOTE: The generate-template handler doesn't exist on this branch
+  // (it's on feat/agent-templates-create-job). This assertion will be
+  // covered there when that branch incorporates these ownership changes.
+  // The key point is that create.ts now uses getEffectiveOwnerId(res)
+  // which applies uniformly to all handlers that persist templates.
+});

--- a/tests/auth-ownership.test.ts
+++ b/tests/auth-ownership.test.ts
@@ -21,6 +21,7 @@ import {
 } from "bun:test";
 import express from "express";
 import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { jsonMiddleware } from "@/middleware/json";
 import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -44,8 +45,6 @@ const USER_B_ID = "11111111-2222-4333-4444-555555666667";
 
 const validAgentAssetsApiKey =
   "test-agent-assets-api-key-that-is-at-least-32-characters";
-
-const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
 
 const jwtHeadersFor = async (args: { accountId: string }) => ({
   "Content-Type": "application/json",
@@ -110,7 +109,7 @@ const deleteAccounts = async () => {
 
 describe("Per-account ownership guards", () => {
   beforeAll(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await ensureUserBAccount();
     await new Promise<void>((resolve) => {
       server = app.listen(4087, () => {
@@ -120,11 +119,7 @@ describe("Per-account ownership guards", () => {
   });
 
   afterAll(async () => {
-    if (originalAgentAssetsApiKey === undefined) {
-      delete process.env.AGENT_ASSETS_API_KEY;
-    } else {
-      process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
-    }
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
     await new Promise<void>((resolve) => {
       server.close(() => {
         resolve();
@@ -135,7 +130,7 @@ describe("Per-account ownership guards", () => {
   });
 
   beforeEach(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await cleanupTestRows();
   });
 

--- a/tests/auth-ownership.test.ts
+++ b/tests/auth-ownership.test.ts
@@ -19,15 +19,11 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
 import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 // ---------------------------------------------------------------------------
 // Test account IDs
@@ -62,11 +58,7 @@ const agentKeyHeaders = () => ({
 let server: Server;
 const baseURL = "http://localhost:4087";
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 // ---------------------------------------------------------------------------
 // DB setup / cleanup

--- a/tests/auth-visibility.test.ts
+++ b/tests/auth-visibility.test.ts
@@ -1,0 +1,439 @@
+/**
+ * List/detail visibility rule tests
+ *
+ * The list and detail endpoints both require auth — there is no public
+ * discovery surface. Unauthenticated callers always receive 401.
+ *
+ * Tests that:
+ *   - Unauthenticated GET /agent-templates returns 401
+ *   - Authenticated GET /agent-templates returns published + own drafts/unlisted/archived
+ *   - GET /agent-templates?status=draft returns 401 for unauthenticated users
+ *   - GET /agent-templates?status=draft returns caller's own drafts for authenticated users
+ *   - GET /agent-templates/:id returns 404 for draft templates not owned by caller
+ *   - GET /agent-templates/:id returns template for drafts owned by caller
+ */
+
+import type { Server } from "node:http";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import express from "express";
+import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+// ---------------------------------------------------------------------------
+// Test account IDs
+// ---------------------------------------------------------------------------
+
+const USER_A_ID = ADMIN_ACCOUNT_ID;
+const USER_B_ID = "11111111-2222-4333-4444-555555666667";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const validAgentAssetsApiKey =
+  "test-agent-assets-api-key-that-is-at-least-32-characters";
+
+const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
+
+const jwtHeadersFor = async (accountId: string) => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-auth-visibility",
+    accountId,
+  }),
+});
+
+const agentKeyHeaders = () => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+});
+
+let server: Server;
+const baseURL = "http://localhost:4088";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-templates", agentTemplatesRouter);
+app.use(noRouteMiddleware);
+
+// ---------------------------------------------------------------------------
+// DB setup / cleanup
+// ---------------------------------------------------------------------------
+
+const cleanupTestRows = async () => {
+  await prisma.agentTemplate.deleteMany({
+    where: {
+      OR: [
+        { slug: { startsWith: "vis-test-" } },
+        { agentName: { startsWith: "Vis Test" } },
+      ],
+    },
+  });
+};
+
+const ensureUserBAccount = async () => {
+  const existing = await prisma.account.findUnique({
+    where: { id: USER_B_ID },
+  });
+  if (!existing) {
+    await prisma.account.create({ data: { id: USER_B_ID } });
+  }
+};
+
+const deleteAccounts = async () => {
+  try {
+    await prisma.account.delete({ where: { id: USER_B_ID } });
+  } catch {
+    // Account may not exist
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("List/detail visibility rules", () => {
+  beforeAll(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await ensureUserBAccount();
+    server = app.listen(4088);
+  });
+
+  afterAll(async () => {
+    if (originalAgentAssetsApiKey === undefined) {
+      delete process.env.AGENT_ASSETS_API_KEY;
+    } else {
+      process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
+    }
+    server.close();
+    await cleanupTestRows();
+    await deleteAccounts();
+  });
+
+  beforeEach(async () => {
+    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    await cleanupTestRows();
+  });
+
+  // Unauthenticated GET returns 401
+  test("Unauthenticated GET /agent-templates returns 401", async () => {
+    const listResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=100`,
+    );
+    expect(listResponse.status).toBe(401);
+  });
+
+  // Authenticated GET returns published + own drafts/unlisted/archived
+  test("Authenticated GET returns published + own drafts/unlisted/archived", async () => {
+    // Create a published template (owned by admin)
+    const pubResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Pub A",
+        prompt: "Published",
+        slug: "vis-test-pub-a",
+      }),
+    });
+    const pubBody = (await pubResponse.json()) as Record<string, unknown>;
+    const pubId = pubBody.id as string;
+    await fetch(`${baseURL}/api/v2/agent-templates/${pubId}/publish`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+    });
+
+    // User B creates a draft
+    const bDraftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_B_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Draft B",
+        prompt: "Draft by B",
+        slug: "vis-test-draft-b",
+      }),
+    });
+    const bDraftBody = (await bDraftResponse.json()) as Record<string, unknown>;
+    const bDraftId = bDraftBody.id as string;
+
+    // User A creates a draft
+    const aDraftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Draft A",
+        prompt: "Draft by A",
+        slug: "vis-test-draft-a",
+      }),
+    });
+    const aDraftBody = (await aDraftResponse.json()) as Record<string, unknown>;
+    const aDraftId = aDraftBody.id as string;
+
+    // User B lists — should see published + own draft, NOT User A's draft
+    const bListResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=100`,
+      { headers: await jwtHeadersFor(USER_B_ID) },
+    );
+    expect(bListResponse.status).toBe(200);
+    const bListBody = (await bListResponse.json()) as {
+      data: Record<string, unknown>[];
+    };
+
+    // User B should see published template
+    expect(bListBody.data.some((t) => t.id === pubId)).toBe(true);
+
+    // User B should see their own draft
+    expect(bListBody.data.some((t) => t.id === bDraftId)).toBe(true);
+
+    // User B should NOT see User A's draft
+    expect(bListBody.data.some((t) => t.id === aDraftId)).toBe(false);
+  });
+
+  // GET ?status=draft returns 401 for unauthenticated users
+  test("GET ?status=draft returns 401 for unauthenticated users", async () => {
+    const response = await fetch(
+      `${baseURL}/api/v2/agent-templates?status=draft`,
+    );
+    expect(response.status).toBe(401);
+  });
+
+  // GET ?status=draft returns caller's own drafts for authed users
+  test("GET ?status=draft returns caller's own drafts for authenticated users", async () => {
+    // User A creates a draft
+    const aDraftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Status Filter A",
+        prompt: "Draft by A",
+        slug: "vis-test-status-filter-a",
+      }),
+    });
+    const aDraftBody = (await aDraftResponse.json()) as Record<string, unknown>;
+    const aDraftId = aDraftBody.id as string;
+
+    // User B creates a draft
+    const bDraftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_B_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Status Filter B",
+        prompt: "Draft by B",
+        slug: "vis-test-status-filter-b",
+      }),
+    });
+    const bDraftBody = (await bDraftResponse.json()) as Record<string, unknown>;
+    const bDraftId = bDraftBody.id as string;
+
+    // User A queries ?status=draft
+    const aListResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?status=draft`,
+      { headers: await jwtHeadersFor(USER_A_ID) },
+    );
+    expect(aListResponse.status).toBe(200);
+    const aListBody = (await aListResponse.json()) as {
+      data: Record<string, unknown>[];
+    };
+
+    // Should contain User A's draft
+    expect(aListBody.data.some((t) => t.id === aDraftId)).toBe(true);
+
+    // Should NOT contain User B's draft
+    expect(aListBody.data.some((t) => t.id === bDraftId)).toBe(false);
+
+    // All returned templates should be drafts owned by User A
+    for (const t of aListBody.data) {
+      expect(t.status).toBe("draft");
+      expect(t.ownerAccountId).toBe(USER_A_ID);
+    }
+  });
+
+  // Detail returns 404 for drafts not owned by caller
+  test("GET /:id returns 404 for draft templates not owned by the caller", async () => {
+    // User A creates a draft
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Detail 404",
+        prompt: "Draft by A",
+        slug: "vis-test-detail-404",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User B tries to get it — should return 404 (not 403)
+    const detailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: await jwtHeadersFor(USER_B_ID) },
+    );
+
+    expect(detailResponse.status).toBe(404);
+  });
+
+  test("GET /:id returns 401 for unauthenticated users", async () => {
+    // User A creates a draft
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Detail Unauth",
+        prompt: "Draft by A",
+        slug: "vis-test-detail-unauth",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // Unauthenticated user — should be rejected at the auth layer regardless
+    // of template status (draft or published). 401, not 404.
+    const detailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+    );
+
+    expect(detailResponse.status).toBe(401);
+  });
+
+  // Detail returns template for drafts owned by the caller
+  test("GET /:id returns template for drafts owned by the caller", async () => {
+    // User A creates a draft
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Detail Own",
+        prompt: "Draft by A",
+        slug: "vis-test-detail-own",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // User A gets their own draft — should return 200
+    const detailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: await jwtHeadersFor(USER_A_ID) },
+    );
+
+    expect(detailResponse.status).toBe(200);
+    const detailBody = (await detailResponse.json()) as Record<string, unknown>;
+    expect(detailBody.id).toBe(templateId);
+    expect(detailBody.status).toBe("draft");
+  });
+
+  // API key listener can see draft templates (admin-like access)
+  test("API key listener can GET draft templates regardless of ownership", async () => {
+    // User A creates a draft
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test API Key Detail",
+        prompt: "Draft by A",
+        slug: "vis-test-api-key-detail",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // API key listener gets the draft — should return 200
+    const detailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: agentKeyHeaders() },
+    );
+
+    expect(detailResponse.status).toBe(200);
+    const detailBody = (await detailResponse.json()) as Record<string, unknown>;
+    expect(detailBody.id).toBe(templateId);
+    expect(detailBody.status).toBe("draft");
+  });
+
+  // Published templates visible to everyone via detail
+  test("Published template is visible to all users via detail", async () => {
+    // User A creates and publishes
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Pub Detail",
+        prompt: "Published by A",
+        slug: "vis-test-pub-detail",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    await fetch(`${baseURL}/api/v2/agent-templates/${templateId}/publish`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+    });
+
+    // Any authenticated user can see it
+    const bDetailResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+      { headers: await jwtHeadersFor(USER_B_ID) },
+    );
+    expect(bDetailResponse.status).toBe(200);
+
+    // Unauthenticated callers are rejected at the auth layer — published
+    // templates are not publicly discoverable through this API.
+    const unauthResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}`,
+    );
+    expect(unauthResponse.status).toBe(401);
+  });
+
+  // Status filter with unlisted/archived for authenticated users
+  test("Authenticated GET ?status=unlisted returns own unlisted templates", async () => {
+    // Create and publish, then change to unlisted
+    const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Unlisted",
+        prompt: "Unlisted by A",
+        slug: "vis-test-unlisted",
+      }),
+    });
+    const createBody = (await createResponse.json()) as Record<string, unknown>;
+    const templateId = createBody.id as string;
+
+    // Publish first (draft → published)
+    await fetch(`${baseURL}/api/v2/agent-templates/${templateId}/publish`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+    });
+
+    // Then set to unlisted
+    await fetch(`${baseURL}/api/v2/agent-templates/${templateId}`, {
+      method: "PATCH",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({ status: "unlisted" }),
+    });
+
+    // User A queries ?status=unlisted
+    const listResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates?status=unlisted`,
+      { headers: await jwtHeadersFor(USER_A_ID) },
+    );
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as {
+      data: Record<string, unknown>[];
+    };
+
+    expect(listBody.data.some((t) => t.id === templateId)).toBe(true);
+  });
+});

--- a/tests/auth-visibility.test.ts
+++ b/tests/auth-visibility.test.ts
@@ -22,15 +22,11 @@ import {
   expect,
   test,
 } from "bun:test";
-import express from "express";
-import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
 import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
-import { jsonMiddleware } from "@/middleware/json";
-import { noRouteMiddleware } from "@/middleware/noRoute";
-import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 // ---------------------------------------------------------------------------
 // Test account IDs
@@ -62,11 +58,7 @@ const agentKeyHeaders = () => ({
 let server: Server;
 const baseURL = "http://localhost:4088";
 
-const app = express();
-app.use(pinoMiddleware);
-app.use(jsonMiddleware);
-app.use("/api/v2/agent-templates", agentTemplatesRouter);
-app.use(noRouteMiddleware);
+const app = buildAgentTemplatesApp();
 
 // ---------------------------------------------------------------------------
 // DB setup / cleanup

--- a/tests/auth-visibility.test.ts
+++ b/tests/auth-visibility.test.ts
@@ -24,6 +24,7 @@ import {
 } from "bun:test";
 import express from "express";
 import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { jsonMiddleware } from "@/middleware/json";
 import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -44,8 +45,6 @@ const USER_B_ID = "11111111-2222-4333-4444-555555666667";
 
 const validAgentAssetsApiKey =
   "test-agent-assets-api-key-that-is-at-least-32-characters";
-
-const originalAgentAssetsApiKey = process.env.AGENT_ASSETS_API_KEY;
 
 const jwtHeadersFor = async (accountId: string) => ({
   "Content-Type": "application/json",
@@ -107,24 +106,20 @@ const deleteAccounts = async () => {
 
 describe("List/detail visibility rules", () => {
   beforeAll(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await ensureUserBAccount();
     server = app.listen(4088);
   });
 
   afterAll(async () => {
-    if (originalAgentAssetsApiKey === undefined) {
-      delete process.env.AGENT_ASSETS_API_KEY;
-    } else {
-      process.env.AGENT_ASSETS_API_KEY = originalAgentAssetsApiKey;
-    }
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
     server.close();
     await cleanupTestRows();
     await deleteAccounts();
   });
 
   beforeEach(async () => {
-    process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     await cleanupTestRows();
   });
 


### PR DESCRIPTION
## Agent Template CRUD with Per-Account Ownership

Adds the `AgentTemplate` model and full CRUD surface under `/api/v2/agent-templates`. Replaces the merged-too-early PR #196 with proper auth integration baked in from the start.

### What this PR adds

| Category | Files | Purpose |
|----------|-------|---------|
| **Schema** | `prisma/schema.prisma`, migration | `AgentTemplate` model with UUID `ownerAccountId`, `PublishStatus` enum (`draft` / `published` / `unlisted` / `archived`), unique `(ownerAccountId, slug)`, self-referential `forkedFromId` |
| **CRUD handlers** | `handlers/create.ts`, `patch.ts`, `delete.ts`, `publish.ts`, `list.ts`, `detail.ts` | Full lifecycle with ownership + draft-visibility rules |
| **Slug logic** | `lib/resolve-id-or-hashed-slug.ts`, `lib/serialize-agent-template.ts` | Hashed-slug resolution (5-char base36 suffix), serialization |
| **Router** | `agent-templates.router.ts` | Every route chains `authOrAgentApiKeyAuth + requireAccount` |

### Endpoints

| Method | Path | Behavior |
|---|---|---|
| `POST` | `/` | Create draft (auto-slug from `agentName`, or explicit) |
| `GET` | `/` | List with cursor pagination + `?status=`, `?category=`, `?featured=true`, `?owner=` filters |
| `GET` | `/:idOrHashedSlug` | Resolve by UUID, slug, or hashed-slug (`slug.hash`) |
| `PATCH` | `/:id` | Partial update with ownership guard; slug becomes immutable once `firstPublishedAt` is set. `published` / `unlisted` / `archived` → `draft` is allowed (takes the template out of public view; `firstPublishedAt` preserved so the slug stays locked). `draft` → non-draft is rejected with `INVALID_STATUS_TRANSITION` — use `POST /:id/publish` instead. |
| `DELETE` | `/:id` | Hard-delete in any publish state. Forks lose `forkedFromId` (FK `ON DELETE SET NULL`); generations on later branches lose `templateId` the same way. Owner accepts that any cached/bookmarked URL pointing at this template will start 404'ing. |
| `POST` | `/:id/publish` | First-publish stamps `firstPublishedAt` + sets status from `?status=` (default `published`). Re-publish on already-public rows bumps `version` and preserves status (`?status=` ignored). Re-publish on a `firstPublishedAt`-set row currently in `draft` brings it back out of draft, honouring `?status=` or defaulting to `published`. |

### Auth model

- **Every endpoint requires auth** (`authOrAgentApiKeyAuth + requireAccount`). No public discovery surface — unauthenticated callers get 401, regardless of template status.
- **JWT callers** see `published` / `unlisted` / `archived` templates from any owner, plus their own drafts. Status filter (`?status=draft`, etc.) scopes to caller's own templates.
- **API-key listeners** (`X-Agent-API-Key`) see everything (admin-like access) and can mutate any template.
- **Ownership guards** on `PATCH` / `DELETE` / `POST /:id/publish`: 403 unless caller is the owner or an API-key listener. 403s emit `req.log.warn` with `{callerAccountId, templateId, ownerAccountId, action}` for security monitoring.

### Concurrency safety

All mutations use `updateMany` with `WHERE` pinned to the row state observed at validation time. Concurrent publish / edit / delete on the same template surfaces as 409 `TEMPLATE_MODIFIED` (or 404 if the row was deleted out from under us) rather than corrupting state.

### Stacking

PRs #194 (auth API) and #195 (foundation utilities) are now merged to `otr-dev`. Active stack on top of `otr-dev`:

```
otr-dev
  └─ this PR (#199 CRUD)
      └─ PR #204 (generations pipeline)
          └─ PR #205 (twitter integration)
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent template CRUD endpoints with per-account ownership and slug hashing
> - Adds a new `AgentTemplate` Prisma model with a `PublishStatus` enum and a database migration, establishing relations to `Account` and a self-referential fork relation.
> - Registers six authenticated REST endpoints on the `agentTemplatesRouter`: `GET /`, `POST /`, `PATCH /:id`, `DELETE /:id`, `POST /:id/publish`, and `GET /:idOrHashedSlug`.
> - Implements slug uniqueness per owner with auto-suffix fallback (e.g. `brewski`, `brewski-2`) and cross-owner collision avoidance via a 5-character ID-derived hash appended to slugs.
> - Visibility rules restrict draft/unlisted/archived templates to owners and API key listeners; published templates are publicly listed.
> - Adds a comprehensive integration test suite covering CRUD, auth, ownership guards, pagination, slug behavior, lifecycle transitions, and environment-gated route mounting.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #199 opened
>
> - Added documentation comment to `serializeAgentTemplate` function specifying it as a pure formatter [6bf7286]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 452fa1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->