### PR TITLE
feat(auth): add GET /api/v2/account-auth-check

### DIFF
--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -4,6 +4,7 @@ import {
   appCheckOnlyMiddleware,
   authMiddleware,
   authMiddlewareAllowNSE,
+  requireAccount,
 } from "@/middleware/auth";
 import { devAuthMiddleware } from "@/middleware/devAuth";
 import { lifecycleTestAuthMiddleware } from "@/middleware/lifecycleTestAuth";
@@ -114,5 +115,20 @@ v2Router.get("/auth-check", authMiddlewareAllowNSE, (_req, res) => {
   });
   return;
 });
+
+// Account auth check - rejects legacy device-only and NSE-only JWTs.
+// Used by the iOS app to confirm a SIWE-bound JWT is in hand. Returns
+// 401 (missing/invalid token), 403 "Account required" (legacy device
+// JWT), 403 "NSE tokens not allowed on this route" (NSE JWT), or 200.
+v2Router.get(
+  "/account-auth-check",
+  authMiddleware,
+  requireAccount,
+  (_req, res) => {
+    res.status(200).json({
+      success: true,
+    });
+  },
+);
 
 export default v2Router;

--- a/tests/auth-account-auth-check.test.ts
+++ b/tests/auth-account-auth-check.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import express from "express";
+import request from "supertest";
+import { authMiddleware, requireAccount } from "@/middleware/auth";
+import { pinoMiddleware } from "@/middleware/pino";
+import { createJwtToken } from "@/utils/jwt";
+
+/**
+ * Behavioral tests for `GET /api/v2/account-auth-check`.
+ *
+ * The route is mounted in `src/api/v2/index.ts` with the
+ * `authMiddleware + requireAccount` chain. These tests pin the
+ * end-to-end contract iOS depends on:
+ *
+ *  - SIWE-bound JWT (carries `accountId`)          → 200
+ *  - legacy device-only JWT (no `accountId`)       → 403 Account required
+ *  - NSE-only JWT (`notificationExtensionOnly`)    → 403 NSE tokens not
+ *                                                    allowed on this route
+ *  - missing or invalid JWT                         → 401
+ *
+ * We mount the same middleware chain on a minimal Express app rather
+ * than booting the full `v2Router` so the test stays focused on
+ * middleware behavior; registration in `index.ts` is a single line and
+ * easy to eyeball.
+ */
+function makeApp() {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.get(
+    "/account-auth-check",
+    authMiddleware,
+    requireAccount,
+    (_req, res) => {
+      res.status(200).json({ success: true });
+    },
+  );
+  return app;
+}
+
+describe("GET /account-auth-check", () => {
+  test("200 with a SIWE-bound JWT (accountId present)", async () => {
+    const accountId = "11111111-1111-1111-1111-111111111111";
+    const token = await createJwtToken({ deviceId: "dev-siwe", accountId });
+
+    const res = await request(makeApp())
+      .get("/account-auth-check")
+      .set("X-Convos-AuthToken", token);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+  });
+
+  test("403 Account required with a legacy device-only JWT", async () => {
+    const token = await createJwtToken({ deviceId: "dev-legacy" });
+
+    const res = await request(makeApp())
+      .get("/account-auth-check")
+      .set("X-Convos-AuthToken", token);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Account required" });
+  });
+
+  test("403 NSE tokens not allowed with an NSE-only JWT", async () => {
+    // Backend mints these for the Notification Service Extension with
+    // metadata.notificationExtensionOnly = true. They can hit
+    // /auth-check (authMiddlewareAllowNSE) but must be rejected by
+    // authMiddleware before they ever reach requireAccount.
+    const token = await createJwtToken({
+      deviceId: "dev-nse",
+      metadata: { notificationExtensionOnly: true },
+    });
+
+    const res = await request(makeApp())
+      .get("/account-auth-check")
+      .set("X-Convos-AuthToken", token);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "NSE tokens not allowed on this route",
+    });
+  });
+
+  test("401 when the X-Convos-AuthToken header is missing", async () => {
+    const res = await request(makeApp()).get("/account-auth-check");
+    expect(res.status).toBe(401);
+  });
+
+  test("401 when the token is not a valid JWT", async () => {
+    const res = await request(makeApp())
+      .get("/account-auth-check")
+      .set("X-Convos-AuthToken", "not.a.jwt");
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on top of `fbac/authentication-api`. Adds the gated route iOS uses to confirm a SIWE-bound JWT is in hand.

`GET /api/v2/account-auth-check`, mounted with `authMiddleware + requireAccount`:

| Token type                                 | Status                                      |
| ------------------------------------------ | ------------------------------------------- |
| SIWE-bound JWT (`accountId` claim present) | `200 { success: true }`                     |
| Legacy device-only JWT                     | `403 { error: "Account required" }`         |
| NSE-only JWT (`metadata.notificationExtensionOnly`) | `403 { error: "NSE tokens not allowed on this route" }` |
| Missing / invalid JWT                       | `401`                                       |

Mirrors the existing `/api/v2/auth-check` (`authMiddlewareAllowNSE`) but rejects every non-SIWE class of token, so iOS can use it as a positive signal that the SIWE round-trip actually produced an `accountId`-carrying token.

## Test plan

- [x] All four behaviors covered by `tests/auth-account-auth-check.test.ts` (5 tests, pass).
- [x] Full auth test suite still green (57 pass, 0 fail).

The iOS side of this lives in xmtplabs/convos-ios#827 (`louis/auth-siwe-plan`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account authentication verification endpoint for authenticated users to check account status.

* **Tests**
  * Added comprehensive tests for account authentication endpoint across multiple authentication scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GET /api/v2/account-auth-check endpoint
> Adds a new authenticated route that returns `200 { success: true }` when the request carries a valid JWT with an associated account. The route chains `authMiddleware` and `requireAccount`, rejecting device-only JWTs with 403, NSE-only tokens with 403, and missing or invalid tokens with 401. Tests cover all five cases in [tests/auth-account-auth-check.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/202/files#diff-39092a8e0cff393b4d9543e545023c2b55aa2ee0a18ca987a145cda8e4a4d47b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 551a8e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->