### PR TITLE
chore: align .cursorrules logging guidance with repo convention

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -66,7 +66,7 @@ When asked to enter "Planner Mode" deeply reflect upon the changes being asked a
 
 - Use custom AppError class for application errors
 - Implement consistent error responses
-- Log errors with context using logError utility
+- Log via req.log inside request handlers and the logger from @/utils/logger elsewhere
 - Handle validation errors separately from other errors
 - Return appropriate HTTP status codes
 


### PR DESCRIPTION
## Summary

`.cursorrules` line 69 said *"Log errors with context using logError utility"*, but `logError` (defined in `src/utils/errors.ts`) has **zero callers anywhere in the repo** — pure dead code.

The actual convention (verified by audit):

| Where | Logger |
|---|---|
| Inside a request handler / middleware | `req.log.*` (pino-http child with reqId) — ~160 call sites across `src/api/v2/**` |
| Outside request context (startup, module init, background jobs) | `import logger from \"@/utils/logger\"` — used in `src/index.ts`, `src/utils/jwt.ts`, etc. |

Replaced the dead-code recommendation with a single declarative line that matches what the codebase actually does, so the guidance and the code agree.

## Diff

\`\`\`diff
-- Log errors with context using logError utility
+- Log via req.log inside request handlers and the logger from @/utils/logger elsewhere
\`\`\`

## Test plan

- [x] Verified \`logError\` has zero invocations: \`grep -rn 'logError(' src/ | grep -v errors.ts\` returns nothing.
- [x] Verified \`req.log\` is the dominant convention in v2 handlers (~160 sites).
- [x] Verified \`@/utils/logger\` is used outside request scope (\`src/index.ts\`, \`src/utils/jwt.ts\`).
- No code change; nothing to test at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `.cursorrules` logging guidance to match repo convention
> Updates the logging instruction in [.cursorrules](.cursorrules) to recommend `req.log` inside request handlers and the `logger` from `@/utils/logger` elsewhere, replacing the previous reference to a `logError` utility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized daf7ea6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development guidelines for error-logging practices.

**Note:** This release contains no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->