### PR TITLE
feat: extend generations surface with twitter integration [STACKED ON #204]

### DIFF
--- a/prisma/migrations/20260512000110_add_generation_twitter_fields/migration.sql
+++ b/prisma/migrations/20260512000110_add_generation_twitter_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "AgentTemplateGeneration"
+  ADD COLUMN "twitterContext" JSONB,
+  ADD COLUMN "reply" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -157,8 +157,10 @@ model AgentTemplateGeneration {
   source          String
   idempotencyKey  String
   inputs          Json
+  twitterContext  Json?
   templateId      String?          @db.Uuid
   publishStatus   PublishStatus    @default(draft)
+  reply           String?          @db.Text
   status          GenerationStatus @default(pending)
   error           String?          @db.Text
   expiresAt       DateTime?

--- a/src/api/v2/agent-templates/handlers/generations-get.ts
+++ b/src/api/v2/agent-templates/handlers/generations-get.ts
@@ -62,6 +62,7 @@ interface GenerationRow {
   id: string;
   status: string;
   templateId: string | null;
+  reply: string | null;
   error: string | null;
   expiresAt: Date | null;
   createdAt: Date;
@@ -72,6 +73,7 @@ interface GenerationResponse {
   generationId: string;
   status: string;
   templateId?: string;
+  reply?: { text: string };
   error?: string;
   createdAt: string;
   updatedAt: string;
@@ -91,6 +93,7 @@ function toResponse(row: GenerationRow): GenerationResponse {
     updatedAt: row.updatedAt.toISOString(),
   };
   if (row.templateId) out.templateId = row.templateId;
+  if (row.reply) out.reply = { text: row.reply };
   if (row.error) out.error = row.error;
   return out;
 }
@@ -105,6 +108,7 @@ async function fetchOwnedRow(
       id: true,
       status: true,
       templateId: true,
+      reply: true,
       error: true,
       expiresAt: true,
       createdAt: true,

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -115,12 +115,10 @@ const inputsSchema = z
 
 const twitterContextSchema = z
   .object({
-    twitterHandle: z
-      .string()
-      .regex(/^@?[A-Za-z0-9_]{1,15}$/, {
-        message:
-          "twitterHandle must match /^@?[A-Za-z0-9_]{1,15}$/ (1-15 alphanumeric/underscore, optional @ prefix)",
-      }),
+    twitterHandle: z.string().regex(/^@?[A-Za-z0-9_]{1,15}$/, {
+      message:
+        "twitterHandle must match /^@?[A-Za-z0-9_]{1,15}$/ (1-15 alphanumeric/underscore, optional @ prefix)",
+    }),
     tweetId: z.string().regex(/^\d+$/, {
       message: "tweetId must be a numeric string",
     }),
@@ -142,7 +140,6 @@ const bodySchema = z
 
 type Body = z.infer<typeof bodySchema>;
 type Inputs = z.infer<typeof inputsSchema>;
-type TwitterContext = z.infer<typeof twitterContextSchema>;
 
 // ---------------------------------------------------------------------------
 // Coalescing — for length validation; also used in executor at runtime
@@ -646,7 +643,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
         idempotencyKey,
         inputs: body.inputs as object,
         twitterContext: body.twitterContext
-          ? (body.twitterContext as TwitterContext as Prisma.InputJsonValue)
+          ? (body.twitterContext as Prisma.InputJsonValue)
           : Prisma.JsonNull,
         publishStatus: body.publishStatus,
         status: "pending",

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -113,15 +113,35 @@ const inputsSchema = z
   })
   .strict();
 
+/**
+ * Twitter context for the optional ComposeReply pipeline stage.
+ *
+ * Trust boundary: this schema validates the *format* of `twitterHandle` and
+ * `tweetId`, but does NOT verify ownership — i.e. it doesn't check that the
+ * caller has the right to act as `@twitterHandle` or that `tweetId` was
+ * authored by them. That verification MUST happen at the caller (the twitter
+ * bot, which has access to the tweet author via the Twitter API). Passing
+ * an unverified twitterHandle would let an attacker produce a reply
+ * impersonating any handle, so the bot's pre-call check is load-bearing.
+ *
+ * This endpoint is also gated by `authOrAgentApiKeyAuth`, so only authorised
+ * server-side callers can reach it in the first place.
+ */
 const twitterContextSchema = z
   .object({
+    /** Twitter handle of the user who @mentioned the bot. Format-only check;
+     *  caller is responsible for verifying ownership against the tweet author. */
     twitterHandle: z.string().regex(/^@?[A-Za-z0-9_]{1,15}$/, {
       message:
         "twitterHandle must match /^@?[A-Za-z0-9_]{1,15}$/ (1-15 alphanumeric/underscore, optional @ prefix)",
     }),
+    /** ID of the tweet that triggered the request. Numeric string per Twitter's
+     *  snowflake format. Caller is responsible for matching this against the
+     *  authenticated request context. */
     tweetId: z.string().regex(/^\d+$/, {
       message: "tweetId must be a numeric string",
     }),
+    /** Optional override for the moderation/reply input. Defaults to inputs.text. */
     idea: z.string().optional(),
   })
   .strict();
@@ -387,18 +407,21 @@ async function streamUntilTerminal(args: {
 // Handler
 // ---------------------------------------------------------------------------
 
-/** Internal type for the idempotency dedupe lookup. Includes `source` so the
- *  body comparison can detect cross-source key reuse (e.g. same Idempotency-Key
- *  with source="twitter-bot" vs source="ios-app"). */
+/** Internal type for the idempotency dedupe lookup. Includes `source` and
+ *  `twitterContext` so the body comparison can detect cross-source or
+ *  cross-tweet key reuse (e.g. same Idempotency-Key with source="twitter-bot"
+ *  vs source="ios-app", or same key with different tweetIds). */
 interface DedupeRow extends GenerationRow {
   source: string;
   inputs: unknown;
+  twitterContext: unknown;
 }
 
 const dedupeSelect = {
   id: true,
   source: true,
   inputs: true,
+  twitterContext: true,
   status: true,
   templateId: true,
   reply: true,
@@ -407,12 +430,22 @@ const dedupeSelect = {
   updatedAt: true,
 } as const;
 
-/** Compare the full idempotent contract (source + inputs), not just inputs.
- *  Matches the docstring's "409 on body mismatch" promise. */
+/** Compare the full idempotent contract (source + inputs + twitterContext),
+ *  not just inputs. Matches the docstring's "409 on body mismatch" promise
+ *  and prevents two different tweets that happen to share idea text from
+ *  cross-linking under the same Idempotency-Key. */
 function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
   return bodiesMatch(
-    { source: existing.source, inputs: existing.inputs },
-    { source: body.source, inputs: body.inputs },
+    {
+      source: existing.source,
+      inputs: existing.inputs,
+      twitterContext: existing.twitterContext,
+    },
+    {
+      source: body.source,
+      inputs: body.inputs,
+      twitterContext: body.twitterContext ?? null,
+    },
   );
 }
 

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -23,7 +23,8 @@
  *   6. Idempotency-Key header present                           → 400
  *   7. Idempotency lookup → existing { source, inputs } match   → respondPerMode
  *   8.                  → existing different body              → 409
- *   9. Content moderation (universal)                           → 422
+ *   9. Content moderation (universal)                           → 422 (content)
+ *   9b. Twitter intent moderation (when twitterContext present)  → 422 (intent)
  *  10. Persist row + fire executor + respondPerMode
  *
  * Idempotent replays go through the SAME respondPerMode path as the original
@@ -36,10 +37,14 @@
  * Body size: 40 MB (route-specific middleware).
  */
 
+import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { executeGeneration } from "@/api/v2/agent-templates/services/generation-executor";
-import { checkContent } from "@/api/v2/agent-templates/services/moderation";
+import {
+  checkContent,
+  checkTwitterIntent,
+} from "@/api/v2/agent-templates/services/moderation";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { prisma } from "@/utils/prisma";
 
@@ -108,10 +113,26 @@ const inputsSchema = z
   })
   .strict();
 
+const twitterContextSchema = z
+  .object({
+    twitterHandle: z
+      .string()
+      .regex(/^@?[A-Za-z0-9_]{1,15}$/, {
+        message:
+          "twitterHandle must match /^@?[A-Za-z0-9_]{1,15}$/ (1-15 alphanumeric/underscore, optional @ prefix)",
+      }),
+    tweetId: z.string().regex(/^\d+$/, {
+      message: "tweetId must be a numeric string",
+    }),
+    idea: z.string().optional(),
+  })
+  .strict();
+
 const bodySchema = z
   .object({
     source: z.string().min(1, "source is required"),
     inputs: inputsSchema,
+    twitterContext: twitterContextSchema.optional(),
     publishStatus: z
       .enum(["draft", "unlisted", "published"])
       .optional()
@@ -121,6 +142,7 @@ const bodySchema = z
 
 type Body = z.infer<typeof bodySchema>;
 type Inputs = z.infer<typeof inputsSchema>;
+type TwitterContext = z.infer<typeof twitterContextSchema>;
 
 // ---------------------------------------------------------------------------
 // Coalescing — for length validation; also used in executor at runtime
@@ -210,6 +232,7 @@ interface GenerationRow {
   id: string;
   status: string;
   templateId: string | null;
+  reply: string | null;
   error: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -219,6 +242,7 @@ interface GenerationResponse {
   generationId: string;
   status: string;
   templateId?: string;
+  reply?: { text: string };
   error?: string;
   createdAt: string;
   updatedAt: string;
@@ -232,6 +256,7 @@ function toResponse(row: GenerationRow): GenerationResponse {
     updatedAt: row.updatedAt.toISOString(),
   };
   if (row.templateId) out.templateId = row.templateId;
+  if (row.reply) out.reply = { text: row.reply };
   if (row.error) out.error = row.error;
   return out;
 }
@@ -246,6 +271,7 @@ async function fetchOwnedGeneration(
       id: true,
       status: true,
       templateId: true,
+      reply: true,
       error: true,
       createdAt: true,
       updatedAt: true,
@@ -378,6 +404,7 @@ const dedupeSelect = {
   inputs: true,
   status: true,
   templateId: true,
+  reply: true,
   error: true,
   createdAt: true,
   updatedAt: true,
@@ -587,6 +614,28 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
+  // 9b. Twitter intent gate — only when twitterContext is present
+  if (body.twitterContext) {
+    const intentInput =
+      body.twitterContext.idea ??
+      (coalesced.kind === "text" ? coalesced.text : "");
+    if (!intentInput || intentInput.trim().length === 0) {
+      res.status(400).json({
+        error:
+          "twitterContext.idea or inputs.text required for twitter intent check",
+      });
+      return;
+    }
+    const intent = await checkTwitterIntent(intentInput);
+    if (!intent.allowed) {
+      res.status(422).json({
+        reason: intent.reason || "not_agent_request",
+        category: "intent",
+      });
+      return;
+    }
+  }
+
   // 10. Persist + fire executor
   let created: GenerationRow;
   try {
@@ -596,6 +645,9 @@ export async function generationsPostHandler(req: Request, res: Response) {
         source: body.source,
         idempotencyKey,
         inputs: body.inputs as object,
+        twitterContext: body.twitterContext
+          ? (body.twitterContext as TwitterContext as Prisma.InputJsonValue)
+          : Prisma.JsonNull,
         publishStatus: body.publishStatus,
         status: "pending",
       },
@@ -603,6 +655,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
         id: true,
         status: true,
         templateId: true,
+        reply: true,
         error: true,
         createdAt: true,
         updatedAt: true,

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -112,7 +112,9 @@ export function buildDeterministicFallback(input: ReplyInput): string {
 
   let sentence = firstSentence;
   if (sentence.length > availableForSentence) {
-    sentence = sentence.slice(0, Math.max(0, availableForSentence - 1)).trimEnd();
+    sentence = sentence
+      .slice(0, Math.max(0, availableForSentence - 1))
+      .trimEnd();
     const lastSpace = sentence.lastIndexOf(" ");
     if (lastSpace > 0) sentence = sentence.slice(0, lastSpace);
     sentence += "…";

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -1,0 +1,253 @@
+/**
+ * Twitter Reply Composition Service — composes tweet replies for
+ * agent templates built from Twitter @mention requests.
+ *
+ * Uses Claude Haiku via OpenRouter (same BUILDER_OPENROUTER_API_KEY as templateGen).
+ * Composes a tweet reply that:
+ *   - Starts with @{handle}
+ *   - Contains the template URL
+ *   - Does not exceed 270 characters
+ *   - Uses a deterministic fallback when LLM fails
+ *   - Uses a minimal fallback when agentName is unavailable
+ *
+ * Fallback hierarchy:
+ *   1. LLM-composed reply (must start with @handle, contain url, ≤ 270 chars)
+ *   2. Deterministic: "@{handle} Meet {agentName} — {firstSentence}. {url}"
+ *   3. Minimal: "@{handle} {url}" (when agentName is unavailable)
+ *
+ * Env vars:
+ *   BUILDER_OPENROUTER_API_KEY — required for LLM calls
+ *   TWITTER_REPLY_MODEL        — model override (default: anthropic/claude-3-5-haiku-20241022)
+ *   TEMPLATE_SITE_URL          — base URL for templates (default: https://convos.org/assistants)
+ *
+ * Test seam: __resetComposeReplyForTests(override | null).
+ */
+
+import logger from "@/utils/logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReplyInput {
+  /** Twitter handle of the user who @mentioned the bot (e.g. "@alice"). */
+  handle: string;
+  /** Name of the generated agent. */
+  agentName: string;
+  /** First sentence of the agent's description or prompt. */
+  firstSentence: string;
+  /** Slug of the persisted template. */
+  slug: string;
+}
+
+export interface ReplyResult {
+  replyText: string;
+}
+
+export type ReplyOverride = (input: ReplyInput) => Promise<ReplyResult>;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_REPLY_MODEL = "anthropic/claude-3-5-haiku-20241022";
+const DEFAULT_TEMPLATE_SITE_URL = "https://convos.org/assistants";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const REPLY_TIMEOUT_MS = 10_000;
+const MAX_REPLY_LENGTH = 270;
+
+// ---------------------------------------------------------------------------
+// Lazy env var access
+// ---------------------------------------------------------------------------
+
+function getApiKey(): string | null {
+  return process.env.BUILDER_OPENROUTER_API_KEY || null;
+}
+
+function getModel(): string {
+  return process.env.TWITTER_REPLY_MODEL || DEFAULT_REPLY_MODEL;
+}
+
+function getTemplateSiteUrl(): string {
+  return process.env.TEMPLATE_SITE_URL || DEFAULT_TEMPLATE_SITE_URL;
+}
+
+function templateUrlFor(slug: string): string {
+  return `${getTemplateSiteUrl()}/${slug}`;
+}
+
+function normalizeHandle(handle: string): string {
+  return handle.startsWith("@") ? handle : `@${handle}`;
+}
+
+// ---------------------------------------------------------------------------
+// Test seam
+// ---------------------------------------------------------------------------
+
+let _override: ReplyOverride | null = null;
+
+export function __resetComposeReplyForTests(
+  override: ReplyOverride | null,
+): void {
+  _override = override;
+}
+
+// ---------------------------------------------------------------------------
+// Fallback reply generation
+// ---------------------------------------------------------------------------
+
+/** Deterministic fallback: "@{handle} Meet {agentName} — {firstSentence}. {url}" */
+export function buildDeterministicFallback(input: ReplyInput): string {
+  const { handle, agentName, firstSentence, slug } = input;
+  const url = templateUrlFor(slug);
+  const normalizedHandle = normalizeHandle(handle);
+
+  const prefix = `${normalizedHandle} Meet ${agentName} — `;
+  const suffix = `. ${url}`;
+  const availableForSentence = MAX_REPLY_LENGTH - prefix.length - suffix.length;
+
+  if (availableForSentence <= 0) {
+    return buildMinimalFallback(input);
+  }
+
+  let sentence = firstSentence;
+  if (sentence.length > availableForSentence) {
+    sentence = sentence.slice(0, Math.max(0, availableForSentence - 1)).trimEnd();
+    const lastSpace = sentence.lastIndexOf(" ");
+    if (lastSpace > 0) sentence = sentence.slice(0, lastSpace);
+    sentence += "…";
+  }
+
+  return `${prefix}${sentence}${suffix}`;
+}
+
+/** Minimal fallback when even agentName is unavailable. */
+export function buildMinimalFallback(input: ReplyInput): string {
+  return `${normalizeHandle(input.handle)} ${templateUrlFor(input.slug)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+function buildReplyPrompt(input: ReplyInput): string {
+  const { handle, agentName, firstSentence, slug } = input;
+  const url = templateUrlFor(slug);
+
+  return `You are composing a tweet reply for an AI agent that was just built from a Twitter @mention request.
+
+Requirements:
+- Start with the user's handle: ${handle}
+- Mention the agent by name: ${agentName}
+- Include the template URL: ${url}
+- Keep it under ${MAX_REPLY_LENGTH} characters (well under Twitter's 280 limit)
+- Be friendly, enthusiastic, and concise
+- Do NOT use hashtags
+- Do NOT use emojis (the agent name may contain one)
+- The reply should feel natural and conversational
+
+Agent details:
+- Name: ${agentName}
+- Description: ${firstSentence}
+- URL: ${url}
+
+Write ONLY the tweet reply text. No quotes, no explanation, no labels. Just the reply text starting with ${handle}.`;
+}
+
+// ---------------------------------------------------------------------------
+// LLM reply validation
+// ---------------------------------------------------------------------------
+
+function validateLlmReply(
+  rawReply: string,
+  handle: string,
+  url: string,
+): string | null {
+  const trimmed = rawReply.trim();
+  if (!trimmed) return null;
+  const normalizedHandle = normalizeHandle(handle);
+  if (!trimmed.startsWith(normalizedHandle)) return null;
+  if (trimmed.length > MAX_REPLY_LENGTH) return null;
+  if (!trimmed.includes(url)) return null;
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function composeReply(input: ReplyInput): Promise<ReplyResult> {
+  if (_override) return _override(input);
+  return _composeReply(input);
+}
+
+async function _composeReply(input: ReplyInput): Promise<ReplyResult> {
+  const { handle, agentName, slug } = input;
+  const url = templateUrlFor(slug);
+
+  if (!agentName || agentName.trim() === "") {
+    return { replyText: buildMinimalFallback(input) };
+  }
+
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    logger.warn(
+      "[compose-reply] BUILDER_OPENROUTER_API_KEY not set, using deterministic fallback",
+    );
+    return { replyText: buildDeterministicFallback(input) };
+  }
+
+  const prompt = buildReplyPrompt(input);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, REPLY_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(OPENROUTER_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: getModel(),
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.7,
+        max_tokens: 100,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      logger.error(
+        { status: res.status, body: body.slice(0, 300) },
+        "[compose-reply] OpenRouter error",
+      );
+      return { replyText: buildDeterministicFallback(input) };
+    }
+
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) {
+      logger.warn("[compose-reply] Empty LLM response, using fallback");
+      return { replyText: buildDeterministicFallback(input) };
+    }
+
+    const validated = validateLlmReply(content, handle, url);
+    if (validated) return { replyText: validated };
+
+    return { replyText: buildDeterministicFallback(input) };
+  } catch (err: unknown) {
+    logger.error(
+      { err },
+      "[compose-reply] Error during reply composition, using fallback",
+    );
+    return { replyText: buildDeterministicFallback(input) };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -36,7 +36,11 @@ export interface ReplyInput {
   agentName: string;
   /** First sentence of the agent's description or prompt. */
   firstSentence: string;
-  /** Slug of the persisted template. */
+  /** **Canonical (hashed) public slug** — e.g. `"brewski.x4f9k"`, the value
+   *  produced by `buildSlug(baseSlug, templateId)`. Callers must NOT pass the
+   *  base slug stored on `AgentTemplate.slug` directly: the public URL
+   *  resolver (resolve-id-or-hashed-slug.ts) requires the `<base>.<hash>`
+   *  form, so passing the base alone would render a reply URL that 404s. */
   slug: string;
 }
 

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -135,11 +135,17 @@ export function buildMinimalFallback(input: ReplyInput): string {
 function buildReplyPrompt(input: ReplyInput): string {
   const { handle, agentName, firstSentence, slug } = input;
   const url = templateUrlFor(slug);
+  // Normalize once so the LLM is instructed to produce the same form that
+  // validateLlmReply() checks for. Otherwise a caller passing "alice" (no @)
+  // gets a prompt that says "start with: alice", LLM does exactly that,
+  // and validation rejects because it expects "@alice" — pushing every
+  // un-prefixed handle through the deterministic fallback unnecessarily.
+  const normalizedHandle = normalizeHandle(handle);
 
   return `You are composing a tweet reply for an AI agent that was just built from a Twitter @mention request.
 
 Requirements:
-- Start with the user's handle: ${handle}
+- Start with the user's handle: ${normalizedHandle}
 - Mention the agent by name: ${agentName}
 - Include the template URL: ${url}
 - Keep it under ${MAX_REPLY_LENGTH} characters (well under Twitter's 280 limit)
@@ -153,7 +159,7 @@ Agent details:
 - Description: ${firstSentence}
 - URL: ${url}
 
-Write ONLY the tweet reply text. No quotes, no explanation, no labels. Just the reply text starting with ${handle}.`;
+Write ONLY the tweet reply text. No quotes, no explanation, no labels. Just the reply text starting with ${normalizedHandle}.`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -23,6 +23,11 @@
  * Test seam: __resetComposeReplyForTests(override | null).
  */
 
+import {
+  BUILDER_OPENROUTER_API_KEY,
+  TEMPLATE_SITE_URL,
+  TWITTER_REPLY_MODEL,
+} from "@/config";
 import logger from "@/utils/logger";
 
 // ---------------------------------------------------------------------------
@@ -54,30 +59,20 @@ export type ReplyOverride = (input: ReplyInput) => Promise<ReplyResult>;
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_REPLY_MODEL = "anthropic/claude-3-5-haiku-20241022";
-const DEFAULT_TEMPLATE_SITE_URL = "https://convos.org/assistants";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const REPLY_TIMEOUT_MS = 10_000;
 const MAX_REPLY_LENGTH = 270;
 
-// ---------------------------------------------------------------------------
-// Lazy env var access
-// ---------------------------------------------------------------------------
-
 function getApiKey(): string | null {
-  return process.env.BUILDER_OPENROUTER_API_KEY || null;
+  return BUILDER_OPENROUTER_API_KEY || null;
 }
 
 function getModel(): string {
-  return process.env.TWITTER_REPLY_MODEL || DEFAULT_REPLY_MODEL;
-}
-
-function getTemplateSiteUrl(): string {
-  return process.env.TEMPLATE_SITE_URL || DEFAULT_TEMPLATE_SITE_URL;
+  return TWITTER_REPLY_MODEL;
 }
 
 function templateUrlFor(slug: string): string {
-  return `${getTemplateSiteUrl()}/${slug}`;
+  return `${TEMPLATE_SITE_URL}/${slug}`;
 }
 
 function normalizeHandle(handle: string): string {

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -513,7 +513,6 @@ async function _runPipeline(
     return;
   }
 
-
   capturePostHog({
     ...templateResult.metrics,
     requestId: generationId,

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -41,6 +41,7 @@ import {
 import { GENERATION_EXECUTOR_TIMEOUT_MS, GENERATION_TTL_HOURS } from "@/config";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
+import { buildSlug } from "@/utils/slug-hash";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -457,11 +458,17 @@ async function _runPipeline(
     const firstSentence = firstSentenceOf(
       templateResult.template.description || templateResult.template.prompt,
     );
+    // composeReply expects the canonical/hashed slug (e.g. "brewski.x4f9k")
+    // — that's the form the resolver in resolve-id-or-hashed-slug.ts matches
+    // against. `persisted.slug` is the BASE form ("brewski") because of the
+    // store-base-not-hashed convention from PR #199. Construct the public
+    // hashed slug here via buildSlug so the URL the reply contains
+    // (`${TEMPLATE_SITE_URL}/<hashed>`) actually resolves.
     const replyInput = {
       handle: twitterContext.twitterHandle,
       agentName: templateResult.template.agentName,
       firstSentence,
-      slug: persisted.slug,
+      slug: buildSlug(persisted.slug, persisted.id),
     };
     try {
       const reply = await composeReply(replyInput);

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -2,10 +2,14 @@
  * Generation Executor — runs the async pipeline for AgentTemplateGeneration.
  *
  * Pipeline:
- *   1. Atomic claim    — UPDATE WHERE status=pending → running. Bails if already claimed.
- *   2. Generate        — callGenerateTemplate(inputs) via OpenRouter
- *   3. Persist         — create AgentTemplate row, set generation.templateId
- *   4. Mark done       — status=done, expiresAt set (TTL window)
+ *   1. Atomic claim     — UPDATE WHERE status=pending → running. Bails if already claimed.
+ *   2. Generate         — callGenerateTemplate(inputs) via OpenRouter
+ *   3. Persist          — create AgentTemplate row, set generation.templateId
+ *   4. ComposeReply (opt) — only when twitterContext is present. composeReply()
+ *                          falls back to deterministic text on LLM failure, so this
+ *                          stage never fails the generation — failure just yields
+ *                          fallback reply text and we proceed to done.
+ *   5. Mark done        — status=done, reply (or null), expiresAt set (TTL window)
  *
  * On any stage failure: mark failed with stage-tagged error message,
  * still set expiresAt so the TTL sweep cleans up.
@@ -24,6 +28,10 @@ import {
   isSlugExhaustionError,
   pickCollisionFreeId,
 } from "@/api/v2/agent-templates/lib/pick-collision-free-id";
+import {
+  buildDeterministicFallback,
+  composeReply,
+} from "@/api/v2/agent-templates/services/compose-reply";
 import { capturePostHog } from "@/api/v2/agent-templates/services/posthog";
 import {
   callGenerateTemplate,
@@ -95,6 +103,12 @@ interface GenerationInputs {
   imageBase64?: string;
   mimeType?: string;
   filename?: string;
+}
+
+interface TwitterContext {
+  twitterHandle: string;
+  tweetId: string;
+  idea?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -250,12 +264,14 @@ async function tryClaim(generationId: string): Promise<boolean> {
 async function markDone(
   generationId: string,
   templateId: string,
+  reply: string | null,
 ): Promise<boolean> {
   const result = await prisma.agentTemplateGeneration.updateMany({
     where: { id: generationId, status: "running" },
     data: {
       status: "done",
       templateId,
+      reply,
       expiresAt: new Date(Date.now() + getTtlMs()),
     },
   });
@@ -432,7 +448,35 @@ async function _runPipeline(
     );
   }
 
-  // 5. Mark done (conditional on status=running). If markDone returns false,
+  // 5. ComposeReply stage — only when twitterContext is present.
+  //    composeReply has its own fallback on LLM failure, so this stage
+  //    never throws; worst case we get the deterministic fallback string.
+  let replyText: string | null = null;
+  const twitterContext = generation.twitterContext as TwitterContext | null;
+  if (twitterContext) {
+    const firstSentence = firstSentenceOf(
+      templateResult.template.description || templateResult.template.prompt,
+    );
+    const replyInput = {
+      handle: twitterContext.twitterHandle,
+      agentName: templateResult.template.agentName,
+      firstSentence,
+      slug: persisted.slug,
+    };
+    try {
+      const reply = await composeReply(replyInput);
+      replyText = reply.replyText;
+    } catch (err) {
+      // composeReply itself shouldn't throw — fallback is internal. Defensive log + fallback.
+      logger.warn(
+        { err, generationId },
+        "[generation-executor] composeReply threw; using deterministic fallback",
+      );
+      replyText = buildDeterministicFallback(replyInput);
+    }
+  }
+
+  // 6. Mark done (conditional on status='running'). If markDone returns false,
   // the pipeline lost the race against the per-generation timeout — markFailed
   // has already set status=failed. Skip the success PostHog event so metering
   // matches the row's terminal state, AND clean up the AgentTemplate we just
@@ -440,7 +484,7 @@ async function _runPipeline(
   // list. The template was created microseconds ago by this same execution and
   // nothing else can hold a reference yet (generation.templateId is still NULL
   // because markDone no-opped), so the delete is safe.
-  const claimed = await markDone(generationId, persisted.id);
+  const claimed = await markDone(generationId, persisted.id, replyText);
   if (!claimed) {
     try {
       await prisma.agentTemplate.delete({ where: { id: persisted.id } });
@@ -469,6 +513,7 @@ async function _runPipeline(
     return;
   }
 
+
   capturePostHog({
     ...templateResult.metrics,
     requestId: generationId,
@@ -478,7 +523,19 @@ async function _runPipeline(
     outcome: "done",
   });
   logger.info(
-    { generationId, templateId: persisted.id, slug: persisted.slug },
+    {
+      generationId,
+      templateId: persisted.id,
+      slug: persisted.slug,
+      hasReply: replyText !== null,
+    },
     "[generation-executor] Generation complete",
   );
+}
+
+/** First-sentence helper for compose-reply's deterministic fallback. */
+function firstSentenceOf(text: string | null | undefined): string {
+  if (!text) return "";
+  const match = text.match(/^[^.!?\n]+[.!?]?/);
+  return match ? match[0].trim() : text.slice(0, 120).trim();
 }

--- a/src/api/v2/agent-templates/services/moderation.ts
+++ b/src/api/v2/agent-templates/services/moderation.ts
@@ -311,12 +311,3 @@ async function _classify(opts: ClassifyOptions): Promise<ModerationResult> {
     clearTimeout(timeoutId);
   }
 }
-
-// ---------------------------------------------------------------------------
-// Internal — exported for PR #201 to extend with checkTwitterIntent.
-// PR #200 only ships checkContent.
-// ---------------------------------------------------------------------------
-
-export const __internal = {
-  classify: _classify,
-};

--- a/src/api/v2/agent-templates/services/moderation.ts
+++ b/src/api/v2/agent-templates/services/moderation.ts
@@ -18,10 +18,10 @@
  *
  * Exports:
  *   - checkContent(text) — universal content safety. Source-agnostic.
- *     Runs on every submission per the agent-templates refactor plan.
- *
- * (PR #201 will add checkTwitterIntent to this file for twitter-only
- * intent classification.)
+ *     Runs on every submission.
+ *   - checkTwitterIntent(text) — twitter-only intent classification.
+ *     Confirms input is an agent-build request vs. spam. Runs after
+ *     checkContent passes, only when twitterContext is present.
  */
 
 import { BUILDER_OPENROUTER_API_KEY, CONTENT_MODERATION_MODEL } from "@/config";
@@ -78,11 +78,16 @@ export function __setContentModelOverrideForTests(model: string | null): void {
   _contentModelOverride = model;
 }
 
+function getTwitterIntentModel(): string {
+  return process.env.TWITTER_MODERATION_MODEL || DEFAULT_MODERATION_MODEL;
+}
+
 // ---------------------------------------------------------------------------
 // Test seam — singleton override pattern
 // ---------------------------------------------------------------------------
 
 let _contentOverride: ModerationOverride | null = null;
+let _twitterIntentOverride: ModerationOverride | null = null;
 
 /**
  * Install a test override for `checkContent`.
@@ -94,9 +99,53 @@ export function __resetModerationForTests(
   _contentOverride = override;
 }
 
+/**
+ * Install a test override for `checkTwitterIntent`.
+ * Pass `null` to restore normal behaviour.
+ */
+export function __resetTwitterIntentForTests(
+  override: ModerationOverride | null,
+): void {
+  _twitterIntentOverride = override;
+}
+
 // ---------------------------------------------------------------------------
 // Prompts
 // ---------------------------------------------------------------------------
+
+function buildTwitterIntentPrompt(input: string): string {
+  return `You are an intent classifier for a Twitter bot that builds AI assistants when users @mention it with requests like "Build me a math tutor bot".
+
+The input below has already passed a separate content-safety check; you are ONLY judging whether the user is genuinely asking the bot to BUILD AN AGENT.
+
+Classify into exactly one of two categories:
+
+- "agent_request": The user is requesting an AI agent / assistant / bot to be built. Examples: "Build me a math tutor", "Create a recipe assistant", "Make me a travel planner bot", "I need a bot that helps with coding".
+
+- "not_agent_request": The content is something other than a build request. Examples: "follow me back", "retweet this", "hi", "good morning", "@bot what's up", "lol", generic greetings, requests for the bot to perform actions other than building agents.
+
+Respond with ONLY the classification label, nothing else. No quotes, no explanation, no extra text.
+
+Tweet text to classify:
+${input}`;
+}
+
+function mapTwitterIntentLabel(label: string): ModerationResult {
+  const trimmed = label.trim().toLowerCase();
+
+  if (trimmed === "agent_request") {
+    return { allowed: true };
+  }
+  if (trimmed === "not_agent_request") {
+    return { allowed: false, reason: "not_agent_request" };
+  }
+
+  logger.warn(
+    { label },
+    "[moderation:twitter-intent] Unexpected classification label, failing open",
+  );
+  return { allowed: true };
+}
 
 function buildContentPrompt(input: string): string {
   return `You are a content safety classifier for an AI assistant template generation service.
@@ -152,6 +201,20 @@ export async function checkContent(input: string): Promise<ModerationResult> {
   return _checkContent(input);
 }
 
+/**
+ * Twitter-only intent check. Runs after checkContent passes, only when
+ * twitterContext is present on the request. Confirms the input is an
+ * agent-build request vs. unrelated spam. Fails open on infrastructure errors.
+ */
+export async function checkTwitterIntent(
+  input: string,
+): Promise<ModerationResult> {
+  if (_twitterIntentOverride) {
+    return _twitterIntentOverride(input);
+  }
+  return _checkTwitterIntent(input);
+}
+
 // ---------------------------------------------------------------------------
 // Internal implementation
 // ---------------------------------------------------------------------------
@@ -163,6 +226,16 @@ async function _checkContent(input: string): Promise<ModerationResult> {
     labelMapper: mapContentLabel,
     model: getContentModel(),
     logTag: "[moderation:content]",
+  });
+}
+
+async function _checkTwitterIntent(input: string): Promise<ModerationResult> {
+  return _classify({
+    input,
+    promptBuilder: buildTwitterIntentPrompt,
+    labelMapper: mapTwitterIntentLabel,
+    model: getTwitterIntentModel(),
+    logTag: "[moderation:twitter-intent]",
   });
 }
 

--- a/src/api/v2/agent-templates/services/moderation.ts
+++ b/src/api/v2/agent-templates/services/moderation.ts
@@ -24,7 +24,11 @@
  *     checkContent passes, only when twitterContext is present.
  */
 
-import { BUILDER_OPENROUTER_API_KEY, CONTENT_MODERATION_MODEL } from "@/config";
+import {
+  BUILDER_OPENROUTER_API_KEY,
+  CONTENT_MODERATION_MODEL,
+  TWITTER_MODERATION_MODEL,
+} from "@/config";
 import logger from "@/utils/logger";
 
 // ---------------------------------------------------------------------------
@@ -79,7 +83,7 @@ export function __setContentModelOverrideForTests(model: string | null): void {
 }
 
 function getTwitterIntentModel(): string {
-  return process.env.TWITTER_MODERATION_MODEL || DEFAULT_MODERATION_MODEL;
+  return TWITTER_MODERATION_MODEL;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,19 @@ export const CONTENT_MODERATION_MODEL =
   "anthropic/claude-3-5-haiku-20241022";
 export const EXA_SERVICE_KEY = process.env.EXA_SERVICE_KEY?.trim() || "";
 
+// Twitter integration (optional — moderation/reply paths only fire when
+// twitterContext is present on a generation; defaults match the content
+// moderation model so a single env var change can pin everything to one
+// model if desired).
+export const TWITTER_MODERATION_MODEL =
+  process.env.TWITTER_MODERATION_MODEL?.trim() ||
+  "anthropic/claude-3-5-haiku-20241022";
+export const TWITTER_REPLY_MODEL =
+  process.env.TWITTER_REPLY_MODEL?.trim() ||
+  "anthropic/claude-3-5-haiku-20241022";
+export const TEMPLATE_SITE_URL =
+  process.env.TEMPLATE_SITE_URL?.trim() || "https://convos.org/assistants";
+
 // PostHog metering (optional — capture is no-op if either is unset).
 export const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY?.trim() || "";
 export const POSTHOG_HOST = process.env.POSTHOG_HOST?.trim() || "";

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for the twitter integration on POST /generations and GET /generations/:id.
+ *
+ * Covers:
+ *   - Body shape: twitterContext fields validated (handle regex, numeric tweetId)
+ *   - Twitter intent moderation gate → 422 with category=intent when blocked
+ *   - Twitter intent moderation gate passes → row persisted with twitterContext
+ *   - Generation pipeline runs ComposeReply when twitterContext is present
+ *   - GET response includes reply.text on terminal twitter generations
+ *   - Non-twitter generations: ComposeReply does NOT run; reply field absent
+ *   - composeReply LLM failure → deterministic fallback text still written
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import {
+  __resetComposeReplyForTests,
+  buildDeterministicFallback,
+} from "@/api/v2/agent-templates/services/compose-reply";
+import {
+  __resetGenerationExecutorForTests,
+  __setExecutorTimeoutMsForTests,
+} from "@/api/v2/agent-templates/services/generation-executor";
+import {
+  __resetModerationForTests,
+  __resetTwitterIntentForTests,
+} from "@/api/v2/agent-templates/services/moderation";
+import { __resetPostHogForTests } from "@/api/v2/agent-templates/services/posthog";
+import {
+  __resetGenerateTemplateForTests,
+  DEFAULT_TEST_METRICS,
+  type GeneratedTemplate,
+} from "@/api/v2/agent-templates/services/templateGen";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+
+const TEST_PORT = 4078;
+const TEST_SOURCE = "generations-twitter-test";
+
+const fakeTemplate: GeneratedTemplate = {
+  agentName: "Tweet Replier",
+  description: "Helps reply to tweets quickly.",
+  prompt: "You compose pithy tweet replies",
+  category: "Social",
+  emoji: "🐦",
+  tools: [],
+  connections: [],
+};
+
+const baseHeaders = () => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+});
+
+const withKey = (key: string) => ({ ...baseHeaders(), "Idempotency-Key": key });
+
+const twitterBody = (overrides: Record<string, unknown> = {}) => ({
+  source: TEST_SOURCE,
+  inputs: { text: "Build a SEC filings summarizer" },
+  twitterContext: {
+    twitterHandle: "@some_user",
+    tweetId: "1789432100123456789",
+    idea: "Build a SEC filings summarizer",
+  },
+  ...overrides,
+});
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+async function cleanup() {
+  await prisma.agentTemplateGeneration.deleteMany({
+    where: { ownerAccountId: ADMIN_ACCOUNT_ID, source: TEST_SOURCE },
+  });
+  await prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      agentName: fakeTemplate.agentName,
+    },
+  });
+}
+
+beforeAll(async () => {
+  process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+  __resetPostHogForTests(() => {});
+  __resetModerationForTests(() => Promise.resolve({ allowed: true }));
+  __resetTwitterIntentForTests(() => Promise.resolve({ allowed: true }));
+  __resetGenerateTemplateForTests(() =>
+    Promise.resolve({
+      template: fakeTemplate,
+      metrics: DEFAULT_TEST_METRICS,
+    }),
+  );
+
+  const server = await startAgentTemplatesServer(TEST_PORT);
+  baseURL = server.baseURL;
+  closeServer = server.close;
+});
+
+afterEach(async () => {
+  __resetModerationForTests(() => Promise.resolve({ allowed: true }));
+  __resetTwitterIntentForTests(() => Promise.resolve({ allowed: true }));
+  __resetComposeReplyForTests(null);
+  __setExecutorTimeoutMsForTests(null);
+  __resetGenerationExecutorForTests(null);
+  await cleanup();
+});
+
+afterAll(async () => {
+  __resetGenerateTemplateForTests(null);
+  __resetPostHogForTests(null);
+  __resetModerationForTests(null);
+  __resetTwitterIntentForTests(null);
+  __resetComposeReplyForTests(null);
+  await closeServer();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const post = (
+  body: unknown,
+  opts: { headers?: Record<string, string>; query?: string } = {},
+) =>
+  fetch(
+    `${baseURL}/api/v2/agent-templates/generations${opts.query ?? ""}`,
+    {
+      method: "POST",
+      headers: opts.headers ?? withKey(`tw-${Date.now()}-${Math.random()}`),
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+  );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /generations — twitterContext validation", () => {
+  test("invalid twitterHandle → 400", async () => {
+    const body = twitterBody({
+      twitterContext: {
+        twitterHandle: "not-a-handle-with-dashes",
+        tweetId: "123",
+      },
+    });
+    const res = await post(body, { headers: withKey("tw-bad-handle") });
+    expect(res.status).toBe(400);
+  });
+
+  test("non-numeric tweetId → 400", async () => {
+    const body = twitterBody({
+      twitterContext: {
+        twitterHandle: "@alice",
+        tweetId: "not-numeric",
+      },
+    });
+    const res = await post(body, { headers: withKey("tw-bad-tweet") });
+    expect(res.status).toBe(400);
+  });
+
+  test("missing twitterHandle → 400", async () => {
+    const body = twitterBody({
+      twitterContext: { tweetId: "123" },
+    });
+    const res = await post(body, { headers: withKey("tw-missing-handle") });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /generations — twitter intent moderation", () => {
+  test("intent blocked → 422 with category=intent (row not created)", async () => {
+    __resetTwitterIntentForTests(() =>
+      Promise.resolve({ allowed: false, reason: "not_agent_request" }),
+    );
+
+    const res = await post(twitterBody(), { headers: withKey("tw-intent-blocked") });
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { reason: string; category: string };
+    expect(body.reason).toBe("not_agent_request");
+    expect(body.category).toBe("intent");
+
+    const rows = await prisma.agentTemplateGeneration.findMany({
+      where: { source: TEST_SOURCE, ownerAccountId: ADMIN_ACCOUNT_ID },
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  test("content gate blocks before intent gate runs", async () => {
+    let intentCalls = 0;
+    __resetModerationForTests(() =>
+      Promise.resolve({ allowed: false, reason: "blocked" }),
+    );
+    __resetTwitterIntentForTests(() => {
+      intentCalls += 1;
+      return Promise.resolve({ allowed: true });
+    });
+
+    const res = await post(twitterBody(), { headers: withKey("tw-content-blocks") });
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { reason: string; category: string };
+    expect(body.category).toBe("content");
+    expect(intentCalls).toBe(0);
+  });
+});
+
+describe("POST /generations — twitter happy path", () => {
+  test("wait_ms inline poll → done with reply.text set", async () => {
+    const res = await post(twitterBody(), {
+      headers: withKey("tw-happy"),
+      query: "?wait_ms=10000",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      generationId: string;
+      status: string;
+      templateId?: string;
+      reply?: { text: string };
+    };
+    expect(body.status).toBe("done");
+    expect(typeof body.templateId).toBe("string");
+    expect(body.reply).toBeDefined();
+    expect(typeof body.reply?.text).toBe("string");
+    expect(body.reply?.text.length).toBeGreaterThan(0);
+    // Default deterministic fallback should at least include the handle
+    expect(body.reply?.text).toContain("@some_user");
+
+    // Verify the row stores both templateId and reply
+    const row = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: body.generationId },
+    });
+    expect(row?.templateId).toBe(body.templateId as string);
+    expect(row?.reply).toBe(body.reply?.text as string);
+    expect(row?.twitterContext).toMatchObject({
+      twitterHandle: "@some_user",
+      tweetId: "1789432100123456789",
+    });
+  });
+
+  test("LLM-composed reply is used when validator accepts it", async () => {
+    const llmReply = "@some_user Built it! Meet Tweet Replier — try it now https://convos.org/assistants/tweet-replier.abcde";
+    __resetComposeReplyForTests(() =>
+      Promise.resolve({ replyText: llmReply }),
+    );
+
+    const res = await post(twitterBody(), {
+      headers: withKey("tw-llm-reply"),
+      query: "?wait_ms=10000",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { reply?: { text: string } };
+    expect(body.reply?.text).toBe(llmReply);
+  });
+
+  test("composeReply throwing is caught and yields deterministic fallback", async () => {
+    __resetComposeReplyForTests(() => Promise.reject(new Error("boom")));
+
+    const res = await post(twitterBody(), {
+      headers: withKey("tw-fallback"),
+      query: "?wait_ms=10000",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      reply?: { text: string };
+    };
+    expect(body.status).toBe("done");
+    // Fallback always starts with the normalized handle
+    expect(body.reply?.text.startsWith("@some_user")).toBe(true);
+
+    // Sanity: the deterministic fallback is what we expect
+    const expected = buildDeterministicFallback({
+      handle: "@some_user",
+      agentName: fakeTemplate.agentName,
+      firstSentence: "Helps reply to tweets quickly",
+      slug: body.reply!.text.match(/[a-z0-9-]+\.[a-z0-9]+$/i)?.[0] ?? "",
+    });
+    // Match prefix, since slug is dynamic
+    expect(body.reply?.text.startsWith(expected.split(" — ")[0])).toBe(true);
+  });
+});
+
+describe("POST /generations — non-twitter generations do NOT run ComposeReply", () => {
+  test("no twitterContext → reply absent in response", async () => {
+    let composeCalls = 0;
+    __resetComposeReplyForTests(() => {
+      composeCalls += 1;
+      return Promise.resolve({ replyText: "should not appear" });
+    });
+
+    const res = await post(
+      {
+        source: TEST_SOURCE,
+        inputs: { text: "non-twitter input" },
+      },
+      {
+        headers: withKey("non-twitter"),
+        query: "?wait_ms=10000",
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      templateId?: string;
+      reply?: { text: string };
+    };
+    expect(body.status).toBe("done");
+    expect(body.templateId).toBeTruthy();
+    expect(body.reply).toBeUndefined();
+    expect(composeCalls).toBe(0);
+  });
+});

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -35,7 +35,6 @@ import { __resetPostHogForTests } from "@/api/v2/agent-templates/services/postho
 import {
   __resetGenerateTemplateForTests,
   DEFAULT_TEST_METRICS,
-  type GeneratedTemplate,
 } from "@/api/v2/agent-templates/services/templateGen";
 import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
@@ -44,19 +43,18 @@ import {
   startAgentTemplatesServer,
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
+import { makeFakeTemplate } from "./agent-templates.generation.helpers";
 
 const TEST_PORT = 4078;
 const TEST_SOURCE = "generations-twitter-test";
 
-const fakeTemplate: GeneratedTemplate = {
+const fakeTemplate = makeFakeTemplate({
   agentName: "Tweet Replier",
   description: "Helps reply to tweets quickly.",
   prompt: "You compose pithy tweet replies",
   category: "Social",
   emoji: "🐦",
-  tools: [],
-  connections: [],
-};
+});
 
 const baseHeaders = () => ({
   "Content-Type": "application/json",

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -133,14 +133,11 @@ const post = (
   body: unknown,
   opts: { headers?: Record<string, string>; query?: string } = {},
 ) =>
-  fetch(
-    `${baseURL}/api/v2/agent-templates/generations${opts.query ?? ""}`,
-    {
-      method: "POST",
-      headers: opts.headers ?? withKey(`tw-${Date.now()}-${Math.random()}`),
-      body: typeof body === "string" ? body : JSON.stringify(body),
-    },
-  );
+  fetch(`${baseURL}/api/v2/agent-templates/generations${opts.query ?? ""}`, {
+    method: "POST",
+    headers: opts.headers ?? withKey(`tw-${Date.now()}-${Math.random()}`),
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -184,7 +181,9 @@ describe("POST /generations — twitter intent moderation", () => {
       Promise.resolve({ allowed: false, reason: "not_agent_request" }),
     );
 
-    const res = await post(twitterBody(), { headers: withKey("tw-intent-blocked") });
+    const res = await post(twitterBody(), {
+      headers: withKey("tw-intent-blocked"),
+    });
     expect(res.status).toBe(422);
     const body = (await res.json()) as { reason: string; category: string };
     expect(body.reason).toBe("not_agent_request");
@@ -206,7 +205,9 @@ describe("POST /generations — twitter intent moderation", () => {
       return Promise.resolve({ allowed: true });
     });
 
-    const res = await post(twitterBody(), { headers: withKey("tw-content-blocks") });
+    const res = await post(twitterBody(), {
+      headers: withKey("tw-content-blocks"),
+    });
     expect(res.status).toBe(422);
     const body = (await res.json()) as { reason: string; category: string };
     expect(body.category).toBe("content");
@@ -248,10 +249,9 @@ describe("POST /generations — twitter happy path", () => {
   });
 
   test("LLM-composed reply is used when validator accepts it", async () => {
-    const llmReply = "@some_user Built it! Meet Tweet Replier — try it now https://convos.org/assistants/tweet-replier.abcde";
-    __resetComposeReplyForTests(() =>
-      Promise.resolve({ replyText: llmReply }),
-    );
+    const llmReply =
+      "@some_user Built it! Meet Tweet Replier — try it now https://convos.org/assistants/tweet-replier.abcde";
+    __resetComposeReplyForTests(() => Promise.resolve({ replyText: llmReply }));
 
     const res = await post(twitterBody(), {
       headers: withKey("tw-llm-reply"),

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -173,6 +173,27 @@ describe("POST /generations — twitterContext validation", () => {
     const res = await post(body, { headers: withKey("tw-missing-handle") });
     expect(res.status).toBe(400);
   });
+
+  test("twitterContext + binary-only inputs (no text, no idea) → 400", async () => {
+    // When the caller sends twitterContext but provides only a pdfBase64 or
+    // imageBase64 input AND no `twitterContext.idea`, there's no text for the
+    // intent moderation check to operate on. The handler should reject with
+    // 400 rather than send the placeholder "[binary input: ...]" string to
+    // the intent classifier.
+    const body = {
+      source: TEST_SOURCE,
+      inputs: { pdfBase64: "JVBERi0xLjQK" }, // minimal pdf base64 stub
+      twitterContext: {
+        twitterHandle: "@some_user",
+        tweetId: "1789432100123456789",
+        // no `idea`
+      },
+    };
+    const res = await post(body, { headers: withKey("tw-binary-no-idea") });
+    expect(res.status).toBe(400);
+    const errBody = (await res.json()) as { error: string };
+    expect(errBody.error.toLowerCase()).toContain("twittercontext.idea");
+  });
 });
 
 describe("POST /generations — twitter intent moderation", () => {
@@ -287,6 +308,42 @@ describe("POST /generations — twitter happy path", () => {
     });
     // Match prefix, since slug is dynamic
     expect(body.reply?.text.startsWith(expected.split(" — ")[0])).toBe(true);
+  });
+});
+
+describe("POST /generations — twitter idempotency", () => {
+  test("same key + same source + same inputs + different twitterContext → 409", async () => {
+    // Submit with twitter context A
+    const bodyA = twitterBody({
+      twitterContext: {
+        twitterHandle: "@alice",
+        tweetId: "1111111111111111111",
+        idea: "Build a SEC filings summarizer",
+      },
+    });
+    const firstRes = await post(bodyA, {
+      headers: withKey("tw-idem-cross-tweet"),
+      query: "?wait_ms=10000",
+    });
+    expect([200, 202]).toContain(firstRes.status);
+
+    // Submit with same source + same inputs but a DIFFERENT tweet under the
+    // same idempotency key. dedupeBodiesMatch now includes twitterContext,
+    // so this must 409 — without the fix, two unrelated tweets that share
+    // idea text would cross-link.
+    const bodyB = twitterBody({
+      twitterContext: {
+        twitterHandle: "@bob",
+        tweetId: "2222222222222222222",
+        idea: "Build a SEC filings summarizer",
+      },
+    });
+    const secondRes = await post(bodyB, {
+      headers: withKey("tw-idem-cross-tweet"),
+    });
+    expect(secondRes.status).toBe(409);
+    const errBody = (await secondRes.json()) as { error: string };
+    expect(errBody.error.toLowerCase()).toContain("idempotency-key");
   });
 });
 

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_TEST_METRICS,
   type GeneratedTemplate,
 } from "@/api/v2/agent-templates/services/templateGen";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import {
@@ -91,7 +92,7 @@ async function cleanup() {
 }
 
 beforeAll(async () => {
-  process.env.AGENT_ASSETS_API_KEY = validAgentAssetsApiKey;
+  __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
   __resetPostHogForTests(() => {});
   __resetModerationForTests(() => Promise.resolve({ allowed: true }));
   __resetTwitterIntentForTests(() => Promise.resolve({ allowed: true }));

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -256,6 +256,11 @@ describe("POST /generations — twitter happy path", () => {
     expect(body.reply?.text.length).toBeGreaterThan(0);
     // Default deterministic fallback should at least include the handle
     expect(body.reply?.text).toContain("@some_user");
+    // The reply URL must use the canonical hashed slug (`<base>.<hash5>`),
+    // not the bare base slug. Resolver in resolve-id-or-hashed-slug.ts
+    // requires the hash; passing the base would 404. Regression guard for
+    // the executor's buildSlug call.
+    expect(body.reply?.text).toMatch(/[a-z0-9-]+\.[0-9a-z]{5}/i);
 
     // Verify the row stores both templateId and reply
     const row = await prisma.agentTemplateGeneration.findUnique({


### PR DESCRIPTION
## Summary

Adds optional `twitterContext` + ComposeReply stage to the async generation pipeline introduced in #204. **Replaces PR #201**.

## Changes

- `AgentTemplateGeneration` gains `twitterContext` (JSONB) and `reply` (TEXT) columns. Migration purely additive.
- `POST /agent-templates/generations` accepts optional `twitterContext { twitterHandle, tweetId, idea? }`. Validated via zod (handle regex `/^@?[A-Za-z0-9_]{1,15}$/`, numeric tweetId).
- Twitter intent moderation gate (`checkTwitterIntent`) runs after the universal content gate, only when `twitterContext` is present. Returns 422 `{ reason, category: "intent" }` on block.
- Generation executor extends with optional ComposeReply stage that runs only when `twitterContext` is present.
- `composeReply` has three fallback tiers: LLM → deterministic → minimal.
- `GET /generations/:id` response includes `reply: { text }` when populated.
- `compose-reply` service ported from the old `/create-job` line of work.
- `moderation` service extended with `checkTwitterIntent` (same OpenRouter Haiku model).

## Test plan

- [x] 135 agent-templates tests passing locally (9 new twitter cases on top of #204's 126)
- [x] Migration applied locally (`20260512000110_add_generation_twitter_fields`)
- [x] Typecheck clean
- [ ] CI green
- [ ] Migration applied to staging via deploy pipeline

## Stack

Stacked on #204 (which replaces #200). #199 → #204 → this PR.

## Replaces #201

This PR supersedes #201 entirely. The old `/create-job` surface (handlers, executor, provisioning client) never lands. Once approved + merged, please close #201.

## Client migration (vs. the deployed #201 surface)

| Client | Today's `/create-job` shape | This PR's `/generations` shape |
|---|---|---|
| iOS / web | `POST /create-job { source: "app", text, joinUrl }`, polls `/create-job/:id` | `POST /generations { source: "ios-app", inputs: { text } }` + `Idempotency-Key`, polls `/generations/:id`. iOS/web call their own provisioning client with the returned `templateId`. |
| Twitter bot | `POST /create-job { source: "twitter", metadata: { idea, twitterHandle, tweetId } }` | `POST /generations { source: "twitter-bot", inputs: { text: idea }, twitterContext: { twitterHandle, tweetId } }` + `Idempotency-Key: tweet:${tweetId}`. Reads `reply.text` from terminal state. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Twitter integration and async generation pipeline to agent-templates surface
> - Adds `POST /api/v2/agent-templates/generations` and `GET /api/v2/agent-templates/generations/:id` endpoints supporting 202 JSON, optional long-poll via `?wait_ms=`, and SSE streaming with keep-alive frames
> - Introduces a generation executor pipeline: claim → generate → persist → optional Twitter reply composition → mark terminal, with per-run timeout and PostHog metering
> - Adds `twitterContext` (JSONB) and `reply` (TEXT) columns to `AgentTemplateGeneration` via migration; Twitter generations trigger `composeReply` and include `reply.text` in GET responses
> - Adds a TTL sweep service ([ttl-sweep.ts](https://github.com/ephemeraHQ/convos-backend/pull/205/files#diff-a02182dd600fe8ef1b364e213988d62f4635bc784ffb3c5d01573e35420ce725)) that marks stuck `running` rows as `failed` and sets `expiresAt` on terminal rows; sweep starts on server boot when `XMTP_ENV !== 'production'`
> - Adds content and Twitter intent moderation gates before enqueueing generation, with fail-open semantics when `BUILDER_OPENROUTER_API_KEY` is absent
> - Adds new config constants for OpenRouter, moderation models, Exa, Twitter, PostHog, and generation timing knobs (`GENERATION_TTL_HOURS`, `GENERATION_EXECUTOR_TIMEOUT_MS`, `GENERATION_STUCK_SWEEP_THRESHOLD_MS`)
> - Risk: importing `config.ts` now throws at startup if `GENERATION_STUCK_SWEEP_THRESHOLD_MS <= GENERATION_EXECUTOR_TIMEOUT_MS`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40314e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow submitting Twitter context with generation requests; system composes a tweet reply and persists/returns it when generation completes.
  * Idempotency now includes Twitter context so dedupe respects per-tweet differences.

* **Bug Fixes**
  * Added Twitter-intent moderation; deterministic fallback reply used on composer failures, timeouts, or blocked intent.

* **Tests**
  * New tests covering Twitter validation, moderation, reply composition, fallbacks, and idempotency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/205)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->