### PR TITLE
feat: make agent-template read + generation endpoints public [STACKED ON #205]

### DIFF
--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -28,17 +28,18 @@ agentTemplatesRouter.post(
 );
 
 // Async generation surface — must be mounted before /:idOrHashedSlug so the
-// wildcard doesn't capture "generations" as a slug-or-id.
+// wildcard doesn't capture "generations" as a slug-or-id. Both POST and GET
+// are public: anonymous submissions default to the ADMIN owner; the GET
+// status endpoint treats the generation ID itself as the capability token
+// (anyone with the UUID can poll).
 agentTemplatesRouter.post(
   "/generations",
-  authOrAgentApiKeyAuth,
-  requireAccount,
+  optionalAuthOrAgentApiKeyAuth,
   generationsPostHandler,
 );
 agentTemplatesRouter.get(
   "/generations/:generationId",
-  authOrAgentApiKeyAuth,
-  requireAccount,
+  optionalAuthOrAgentApiKeyAuth,
   generationsGetHandler,
 );
 

--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -1,5 +1,8 @@
 import { Router } from "express";
-import { authOrAgentApiKeyAuth } from "@/middleware/agentAuth";
+import {
+  authOrAgentApiKeyAuth,
+  optionalAuthOrAgentApiKeyAuth,
+} from "@/middleware/agentAuth";
 import { requireAccount } from "@/middleware/auth";
 import { createHandler } from "./handlers/create";
 import { deleteHandler } from "./handlers/delete";
@@ -12,12 +15,11 @@ import { publishHandler } from "./handlers/publish";
 
 export const agentTemplatesRouter = Router();
 
-agentTemplatesRouter.get(
-  "/",
-  authOrAgentApiKeyAuth,
-  requireAccount,
-  listHandler,
-);
+// Read endpoints (list, detail) are public. `optionalAuthOrAgentApiKeyAuth`
+// still sets res.locals.accountId when credentials are provided, so a
+// signed-in user can still see their own drafts; anonymous callers get
+// the published-only view.
+agentTemplatesRouter.get("/", optionalAuthOrAgentApiKeyAuth, listHandler);
 agentTemplatesRouter.post(
   "/",
   authOrAgentApiKeyAuth,
@@ -60,7 +62,6 @@ agentTemplatesRouter.post(
 );
 agentTemplatesRouter.get(
   "/:idOrHashedSlug",
-  authOrAgentApiKeyAuth,
-  requireAccount,
+  optionalAuthOrAgentApiKeyAuth,
   detailHandler,
 );

--- a/src/api/v2/agent-templates/handlers/detail.ts
+++ b/src/api/v2/agent-templates/handlers/detail.ts
@@ -58,12 +58,14 @@ export async function detailHandler(req: Request, res: Response) {
     });
 
     // If not found, check if it's a draft template accessible to the caller.
-    // accountId is guaranteed by the router (authOrAgentApiKeyAuth + requireAccount).
+    // The router uses `optionalAuthOrAgentApiKeyAuth`, so `accountId` may be
+    // undefined for anonymous callers — they never own a draft, so the
+    // ownership check below falls through and they get a 404.
     if (
       template === null &&
       uuidPattern.test(parsedParams.data.idOrHashedSlug)
     ) {
-      const accountId = res.locals.accountId as string;
+      const accountId = res.locals.accountId as string | undefined;
       const isApiKeyListener = res.locals.isApiKeyListener ?? false;
 
       const draftTemplate = await prisma.agentTemplate.findUnique({
@@ -71,8 +73,13 @@ export async function detailHandler(req: Request, res: Response) {
       });
 
       if (draftTemplate !== null && draftTemplate.status === "draft") {
-        // Draft is only visible to the owner or API key listener
-        if (draftTemplate.ownerAccountId === accountId || isApiKeyListener) {
+        // Draft is only visible to the owner or API key listener.
+        // `accountId === undefined` (anonymous) won't match the owner column.
+        if (
+          isApiKeyListener ||
+          (accountId !== undefined &&
+            draftTemplate.ownerAccountId === accountId)
+        ) {
           template = draftTemplate;
         }
         // If not authorized, template stays null → 404

--- a/src/api/v2/agent-templates/handlers/detail.ts
+++ b/src/api/v2/agent-templates/handlers/detail.ts
@@ -65,7 +65,7 @@ export async function detailHandler(req: Request, res: Response) {
       template === null &&
       uuidPattern.test(parsedParams.data.idOrHashedSlug)
     ) {
-      const accountId = res.locals.accountId as string | undefined;
+      const accountId: string | undefined = res.locals.accountId;
       const isApiKeyListener = res.locals.isApiKeyListener ?? false;
 
       const draftTemplate = await prisma.agentTemplate.findUnique({

--- a/src/api/v2/agent-templates/handlers/generations-get.ts
+++ b/src/api/v2/agent-templates/handlers/generations-get.ts
@@ -5,7 +5,9 @@
  * terminal via `?wait_ms=N` (capped at 45_000, polled every 500 ms).
  *
  * Visibility:
- *   - Cross-account access returns 404 (don't leak existence).
+ *   - The generation ID itself is the capability — anyone with the UUID
+ *     can read the row. (Anonymous submissions need this; once they have
+ *     the ID handed back from POST, no auth is required to poll status.)
  *   - Expired rows (expiresAt < NOW()) return 404.
  *
  * Response shape:
@@ -15,12 +17,12 @@
  *     createdAt, updatedAt
  *   }
  *
- * Auth: authOrAgentApiKeyAuth + requireAccount.
+ * Auth: optionalAuthOrAgentApiKeyAuth. Anonymous reads are permitted; the
+ * generation ID is treated as a bearer secret.
  * Production guard: XMTP_ENV !== "production" (in v2/index.ts).
  */
 
 import type { Request, Response } from "express";
-import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { prisma } from "@/utils/prisma";
 
 // ---------------------------------------------------------------------------
@@ -98,12 +100,9 @@ function toResponse(row: GenerationRow): GenerationResponse {
   return out;
 }
 
-async function fetchOwnedRow(
-  generationId: string,
-  ownerAccountId: string,
-): Promise<GenerationRow | null> {
-  return prisma.agentTemplateGeneration.findFirst({
-    where: { id: generationId, ownerAccountId },
+async function fetchRow(generationId: string): Promise<GenerationRow | null> {
+  return prisma.agentTemplateGeneration.findUnique({
+    where: { id: generationId },
     select: {
       id: true,
       status: true,
@@ -128,7 +127,6 @@ function parseWaitMs(raw: unknown): number {
 
 async function waitForTerminal(args: {
   generationId: string;
-  ownerAccountId: string;
   waitMs: number;
   /** Returns true once the client has hung up the request. The loop bails
    *  early in that case to avoid wasted DB queries when nobody is listening. */
@@ -138,7 +136,7 @@ async function waitForTerminal(args: {
   let attempt = 0;
   while (Date.now() < deadline) {
     if (args.isClosed()) return null;
-    const row = await fetchOwnedRow(args.generationId, args.ownerAccountId);
+    const row = await fetchRow(args.generationId);
     if (!row) return null;
     if (isExpired(row)) return null;
     if (isTerminal(row.status)) return row;
@@ -151,7 +149,7 @@ async function waitForTerminal(args: {
   }
   // Timeout — return current state, hide already-expired rows
   if (args.isClosed()) return null;
-  const final = await fetchOwnedRow(args.generationId, args.ownerAccountId);
+  const final = await fetchRow(args.generationId);
   if (final && isExpired(final)) return null;
   return final;
 }
@@ -180,24 +178,17 @@ export async function generationsGetHandler(req: Request, res: Response) {
     return;
   }
 
-  // 2. Auth → ownerAccountId
-  const ownerAccountId = getEffectiveOwnerId(res);
-  if (!ownerAccountId) {
-    res.status(403).json({ error: "Account required" });
-    return;
-  }
-
-  // 3. Fetch (with optional long-poll)
+  // 2. Fetch (with optional long-poll). No ownership check — the
+  //    generation ID is the capability.
   let row: GenerationRow | null;
   if (waitMs > 0) {
     row = await waitForTerminal({
       generationId,
-      ownerAccountId,
       waitMs,
       isClosed: () => closed,
     });
   } else {
-    row = await fetchOwnedRow(generationId, ownerAccountId);
+    row = await fetchRow(generationId);
     if (row && isExpired(row)) row = null;
   }
 
@@ -207,7 +198,7 @@ export async function generationsGetHandler(req: Request, res: Response) {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (closed || res.writableEnded) return;
 
-  // 4. Not found / expired / cross-account → 404
+  // 3. Not found / expired → 404
   if (!row) {
     res.status(404).json({ error: "Generation not found" });
     return;

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -61,6 +61,11 @@ const MAX_BODY_BYTES = 40 * 1024 * 1024;
 const MAX_WAIT_MS = 45_000;
 const DEFAULT_SSE_KEEPALIVE_MS = 15_000;
 
+// RFC 4122 UUID format. Version digit is any 1-5 (accepts v4 random,
+// v5 namespaced, etc.); variant nibble is 8/9/a/b.
+const IDEMPOTENCY_KEY_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 /**
  * Adaptive backoff for long-poll + SSE poll loops.
  *
@@ -617,10 +622,25 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 6. Idempotency-Key required
+  // 6. Idempotency-Key required and MUST be a UUID (any RFC 4122 version).
+  //    Both the agent API key path and anonymous submissions are owned by
+  //    `ADMIN_ACCOUNT_ID`, so they share an idempotency namespace; using
+  //    UUIDs (122 bits of entropy) keeps that shared namespace safe from
+  //    accidental and adversarial collisions — without UUIDs, an attacker
+  //    could pick a key they know another caller will use and read back
+  //    that caller's `generationId` (which is itself a bearer secret) via
+  //    the dedupe path. Callers needing stable retries can derive a
+  //    deterministic UUID from their external identifier (e.g. `uuidv5`
+  //    of the tweet ID in the twitter bot's case).
   const idempotencyKey = req.get("idempotency-key");
   if (!idempotencyKey || idempotencyKey.length === 0) {
     res.status(400).json({ error: "Idempotency-Key header required" });
+    return;
+  }
+  if (!IDEMPOTENCY_KEY_UUID_RE.test(idempotencyKey)) {
+    res.status(400).json({
+      error: "Idempotency-Key must be a UUID",
+    });
     return;
   }
 

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -19,7 +19,7 @@
  *   2. Content-Length > 40 MB                                   → 413
  *   3. Coalesced inputs present                                 → 400
  *   4. Input length limits (text ≤ 50k, base64 ≤ 35M)           → 400
- *   5. Auth + getEffectiveOwnerId                               → 403
+ *   5. Owner resolution (auth account or admin fallback)
  *   6. Idempotency-Key header present                           → 400
  *   7. Idempotency lookup → existing { source, inputs } match   → respondPerMode
  *   8.                  → existing different body              → 409
@@ -32,7 +32,9 @@
  * the requested mode (the previous behaviour was to immediately return JSON
  * regardless of how the replay was framed).
  *
- * Auth: authOrAgentApiKeyAuth + requireAccount.
+ * Auth: optionalAuthOrAgentApiKeyAuth. Anonymous submissions are accepted
+ * and owned by ADMIN_ACCOUNT_ID; authenticated submissions are owned by
+ * the JWT/API-key account.
  * Production guard: XMTP_ENV !== "production" (in v2/index.ts).
  * Body size: 40 MB (route-specific middleware).
  */
@@ -46,6 +48,7 @@ import {
   checkTwitterIntent,
 } from "@/api/v2/agent-templates/services/moderation";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 
 // ---------------------------------------------------------------------------
@@ -594,12 +597,10 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 5. Auth → ownerAccountId
-  const ownerAccountId = getEffectiveOwnerId(res);
-  if (!ownerAccountId) {
-    res.status(403).json({ error: "Account required" });
-    return;
-  }
+  // 5. Owner account. The route now uses optional auth so anonymous
+  //    submissions are allowed; those rows are owned by the admin seed
+  //    account (the closest thing we have to a system identity).
+  const ownerAccountId = getEffectiveOwnerId(res) ?? ADMIN_ACCOUNT_ID;
 
   // 6. Idempotency-Key required
   const idempotencyKey = req.get("idempotency-key");

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -127,8 +127,11 @@ const inputsSchema = z
  * an unverified twitterHandle would let an attacker produce a reply
  * impersonating any handle, so the bot's pre-call check is load-bearing.
  *
- * This endpoint is also gated by `authOrAgentApiKeyAuth`, so only authorised
- * server-side callers can reach it in the first place.
+ * The endpoint itself is reachable anonymously (optional auth), so
+ * `twitterContext` is gated separately: the handler rejects the field
+ * unless the caller authenticated with the agent API key
+ * (`isApiKeyListener`). That means only the twitter bot — the one party
+ * able to verify handle ownership — can attach this context.
  */
 const twitterContextSchema = z
   .object({
@@ -601,6 +604,18 @@ export async function generationsPostHandler(req: Request, res: Response) {
   //    submissions are allowed; those rows are owned by the admin seed
   //    account (the closest thing we have to a system identity).
   const ownerAccountId = getEffectiveOwnerId(res) ?? ADMIN_ACCOUNT_ID;
+  const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+
+  // 5b. twitterContext is privileged — it ends up attributed to a real
+  //     twitter handle. Only the bot (agent API key) is in a position to
+  //     verify handle ownership against the tweet author, so reject the
+  //     field for anonymous and JWT-only callers.
+  if (body.twitterContext && !isApiKeyListener) {
+    res.status(403).json({
+      error: "twitterContext requires agent API key authentication",
+    });
+    return;
+  }
 
   // 6. Idempotency-Key required
   const idempotencyKey = req.get("idempotency-key");

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -101,7 +101,7 @@ export async function listHandler(req: Request, res: Response) {
   // The router uses `optionalAuthOrAgentApiKeyAuth`, so `accountId` is set
   // when the caller presented valid credentials and `undefined` for
   // anonymous callers. Anonymous = published-only view.
-  const accountId = res.locals.accountId as string | undefined;
+  const accountId: string | undefined = res.locals.accountId;
   const isApiKeyListener = res.locals.isApiKeyListener ?? false;
 
   // Status filter handling. Express + qs can deliver `?status=draft` as a

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -98,10 +98,10 @@ const decodeCursor = (cursor: string | undefined) => {
 };
 
 export async function listHandler(req: Request, res: Response) {
-  // The router pins this route to authOrAgentApiKeyAuth + requireAccount, so
-  // accountId is always set by the time we get here. We don't expose the list
-  // surface to unauthenticated callers — there's no public discovery API.
-  const accountId = res.locals.accountId as string;
+  // The router uses `optionalAuthOrAgentApiKeyAuth`, so `accountId` is set
+  // when the caller presented valid credentials and `undefined` for
+  // anonymous callers. Anonymous = published-only view.
+  const accountId = res.locals.accountId as string | undefined;
   const isApiKeyListener = res.locals.isApiKeyListener ?? false;
 
   // Status filter handling. Express + qs can deliver `?status=draft` as a
@@ -147,14 +147,23 @@ export async function listHandler(req: Request, res: Response) {
     return;
   }
 
-  // Build the where clause based on caller type (regular user vs API key).
+  // Build the where clause based on caller type (anonymous vs regular user
+  // vs API key listener).
   const where: Prisma.AgentTemplateWhereInput = {};
 
   if (hasStatusFilter && statusFilter) {
     // API key listeners see all templates with that status (admin-like access);
-    // regular users see only their own templates with the requested status.
+    // regular users see only their own templates with the requested status;
+    // anonymous callers can only ask for `published` — any other status
+    // returns an empty result (no enumeration of drafts/unlisted/archived).
     if (isApiKeyListener) {
       where.status = statusFilter as Prisma.EnumPublishStatusFilter;
+    } else if (accountId === undefined) {
+      if (statusFilter !== "published") {
+        res.status(200).json({ data: [], hasMore: false, nextCursor: null });
+        return;
+      }
+      where.status = "published";
     } else {
       where.AND = [
         { status: statusFilter as Prisma.EnumPublishStatusFilter },
@@ -163,6 +172,9 @@ export async function listHandler(req: Request, res: Response) {
     }
   } else if (isApiKeyListener) {
     // API key listener sees everything (admin-like access). No filter needed.
+  } else if (accountId === undefined) {
+    // Anonymous caller with no status filter: published-only view.
+    where.status = "published";
   } else {
     // Regular authenticated user without status filter:
     // Published templates from any owner + own drafts/unlisted/archived.

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -128,10 +128,14 @@ export const optionalAuthOrAgentApiKeyAuth = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const providedAgentApiKey = req.header(AGENT_API_KEY_HEADER)?.trim();
-  const providedAuthToken = req.header("X-Convos-AuthToken")?.trim();
+  // Check presence on the RAW header, not on the trimmed value. A blank
+  // header (`X-Convos-AuthToken: "   "`) is still an attempt to
+  // authenticate — fall through to the strict auth path so it 401s,
+  // matching the "present but invalid → 401" contract documented below.
+  const providedAgentApiKey = req.header(AGENT_API_KEY_HEADER);
+  const providedAuthToken = req.header("X-Convos-AuthToken");
 
-  if (!providedAgentApiKey && !providedAuthToken) {
+  if (providedAgentApiKey === undefined && providedAuthToken === undefined) {
     next();
     return;
   }

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -103,3 +103,38 @@ export const authOrAgentApiKeyAuth = async (
   req.log.debug("Attempting JWT authentication");
   await authMiddleware(req, res, next);
 };
+
+/**
+ * Optional auth middleware for endpoints that should be reachable
+ * without credentials but still pick up account context when it's
+ * provided.
+ *
+ * Behaviour:
+ *   - Auth header (X-Agent-API-Key OR X-Convos-AuthToken) present →
+ *     delegate to `authOrAgentApiKeyAuth` (same shape as today, sets
+ *     `res.locals.accountId` and `res.locals.isApiKeyListener`).
+ *   - No auth header → skip auth entirely. `res.locals.accountId`
+ *     remains `undefined`; downstream handlers branch on that to
+ *     return the public/anonymous view.
+ *   - Auth header present but INVALID → 401. Presenting credentials
+ *     is opt-in; if you opt in, they have to be valid.
+ *
+ * Used by the agent-templates list/detail/generation-{post,status}
+ * endpoints. Write endpoints (POST /, PATCH, DELETE, /publish) stay
+ * on `authOrAgentApiKeyAuth + requireAccount`.
+ */
+export const optionalAuthOrAgentApiKeyAuth = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const providedAgentApiKey = req.header(AGENT_API_KEY_HEADER)?.trim();
+  const providedAuthToken = req.header("X-Convos-AuthToken")?.trim();
+
+  if (!providedAgentApiKey && !providedAuthToken) {
+    next();
+    return;
+  }
+
+  await authOrAgentApiKeyAuth(req, res, next);
+};

--- a/src/utils/auth-helpers.ts
+++ b/src/utils/auth-helpers.ts
@@ -6,12 +6,14 @@ import type { Response } from "express";
  * When API key auth is used, `res.locals.accountId` is set to
  * `ADMIN_ACCOUNT_ID` by `authOrAgentApiKeyAuth`. When JWT auth is used,
  * `res.locals.accountId` comes from the verified JWT payload via
- * `authMiddleware`.
+ * `authMiddleware`. On routes that use `optionalAuthOrAgentApiKeyAuth`
+ * and the caller did not present credentials, this returns `undefined`
+ * — handlers must decide whether to coalesce to a fallback or reject.
  *
  * Callers should use this instead of hardcoding `ADMIN_ACCOUNT_ID` so
  * that per-account ownership works when SIWE-authenticated users create
  * resources.
  */
-export function getEffectiveOwnerId(res: Response) {
+export function getEffectiveOwnerId(res: Response): string | undefined {
   return res.locals.accountId;
 }

--- a/tests/agent-templates.cross.e2e.test.ts
+++ b/tests/agent-templates.cross.e2e.test.ts
@@ -31,6 +31,7 @@ import {
   hashedSlugFor,
   listTemplates,
   publishTemplate,
+  stableUuid,
   startAgentTemplatesServer,
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
@@ -121,7 +122,7 @@ describe("Cross-area E2E: Generate → Create → Publish → List → Hashed-sl
         headers: {
           "Content-Type": "application/json",
           "X-Agent-API-Key": validAgentAssetsApiKey,
-          "Idempotency-Key": "cross-e2e-step1",
+          "Idempotency-Key": stableUuid("cross-e2e-step1"),
         },
         body: JSON.stringify({
           source: "cross-e2e",

--- a/tests/agent-templates.cross.helpers.ts
+++ b/tests/agent-templates.cross.helpers.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Server } from "node:http";
 import express from "express";
 import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.router";
@@ -7,6 +8,24 @@ import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { buildSlug } from "@/utils/slug-hash";
+
+/**
+ * Derive a deterministic UUIDv5-shaped string from a human-readable label
+ * so test fixtures can keep using mnemonic keys ("idem-1", "tw-happy")
+ * while still satisfying the handler's UUID validation. The same label
+ * always produces the same UUID, so two calls to `withKey("idem-1")`
+ * still dedupe correctly inside an idempotency test.
+ *
+ * Pure SHA-1 of `namespace:label`, sliced into the UUIDv5 layout and
+ * pinned to version=5/variant=10xx. Not cryptographically meaningful;
+ * this is purely a format-compliant identifier generator for tests.
+ */
+export const stableUuid = (label: string): string => {
+  const hex = createHash("sha1")
+    .update(`agent-templates-test:${label}`)
+    .digest("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+};
 
 export type TemplateBody = Record<string, unknown>;
 export type ListBody = {

--- a/tests/agent-templates.generations-get.test.ts
+++ b/tests/agent-templates.generations-get.test.ts
@@ -204,12 +204,18 @@ describe("GET /generations/:id", () => {
     expect(body.error).toContain("kaboom");
   });
 
-  test("cross-account access → 404 (no existence leak)", async () => {
+  test("cross-account access → 200 (generation ID is the capability)", async () => {
+    // The GET status endpoint is public — anyone with the UUID can read
+    // the row. This matches anonymous-submission semantics: callers get
+    // the ID handed back from POST and poll status without minting a
+    // token.
     const gen = await insertGeneration({ status: "pending" });
 
     const headers = await otherAccountHeaders();
     const res = await get(gen.id, { headers });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { generationId: string };
+    expect(body.generationId).toBe(gen.id);
   });
 
   test("expired row → 404", async () => {

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -36,6 +36,7 @@ import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import {
+  stableUuid,
   startAgentTemplatesServer,
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
@@ -55,7 +56,14 @@ const baseHeaders = () => ({
   "X-Agent-API-Key": validAgentAssetsApiKey,
 });
 
-const withKey = (key: string) => ({ ...baseHeaders(), "Idempotency-Key": key });
+// Tests pass mnemonic labels; `stableUuid` wraps them in a deterministic
+// UUIDv5 shape so the same label always yields the same key (required for
+// the idempotency replay tests) while still passing the handler's UUID
+// validation.
+const withKey = (key: string) => ({
+  ...baseHeaders(),
+  "Idempotency-Key": stableUuid(key),
+});
 
 const sampleBody = {
   source: TEST_SOURCE,
@@ -165,6 +173,20 @@ describe("POST /generations — validation", () => {
     expect(body.error).toBe("Idempotency-Key header required");
   });
 
+  test("non-UUID Idempotency-Key → 400", async () => {
+    // The agent API key path and anonymous submissions share one idempotency
+    // namespace (both owned by ADMIN_ACCOUNT_ID), so the handler requires
+    // every key to be a UUID — that's what keeps the shared namespace safe
+    // from accidental and adversarial collisions. Any non-UUID string here
+    // (a raw tweet ID, a slug, a counter, etc.) must be rejected.
+    const res = await post(sampleBody, {
+      headers: { ...baseHeaders(), "Idempotency-Key": "1789432100123456789" },
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Idempotency-Key must be a UUID");
+  });
+
   test("publishStatus 'archived' → 400 (zod enum gate)", async () => {
     const res = await post(
       { ...sampleBody, publishStatus: "archived" },
@@ -240,7 +262,7 @@ describe("POST /generations — happy path", () => {
     });
     expect(row).not.toBeNull();
     expect(row?.source).toBe(TEST_SOURCE);
-    expect(row?.idempotencyKey).toBe("happy-1");
+    expect(row?.idempotencyKey).toBe(stableUuid("happy-1"));
   });
 
   test("wait_ms long-polls inline → 200 with terminal state + templateId", async () => {

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -195,6 +195,33 @@ describe("POST /generations — twitterContext validation", () => {
   });
 });
 
+describe("POST /generations — twitterContext auth gate", () => {
+  // twitterContext is privileged: it is published as a reply attributed to a
+  // real twitter handle. Only the bot (agent API key) is in a position to
+  // verify handle ownership against the tweet author, so the handler rejects
+  // the field for anonymous and JWT-only callers. These tests are the safety
+  // net for that gate — without it, an anonymous attacker could impersonate
+  // any handle.
+  test("anonymous caller with twitterContext → 403", async () => {
+    const body = twitterBody();
+    const res = await post(body, {
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": "tw-anon-gate",
+      },
+    });
+    expect(res.status).toBe(403);
+    const errBody = (await res.json()) as { error: string };
+    expect(errBody.error.toLowerCase()).toContain("agent api key");
+
+    // No row was persisted.
+    const rows = await prisma.agentTemplateGeneration.findMany({
+      where: { idempotencyKey: "tw-anon-gate" },
+    });
+    expect(rows).toHaveLength(0);
+  });
+});
+
 describe("POST /generations — twitter intent moderation", () => {
   test("intent blocked → 422 with category=intent (row not created)", async () => {
     __resetTwitterIntentForTests(() =>

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -40,6 +40,7 @@ import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import {
+  stableUuid,
   startAgentTemplatesServer,
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
@@ -61,7 +62,13 @@ const baseHeaders = () => ({
   "X-Agent-API-Key": validAgentAssetsApiKey,
 });
 
-const withKey = (key: string) => ({ ...baseHeaders(), "Idempotency-Key": key });
+// Tests pass mnemonic labels; `stableUuid` wraps them in a deterministic
+// UUIDv5 shape so the handler's UUID-format requirement is satisfied while
+// retries against the same label still dedupe.
+const withKey = (key: string) => ({
+  ...baseHeaders(),
+  "Idempotency-Key": stableUuid(key),
+});
 
 const twitterBody = (overrides: Record<string, unknown> = {}) => ({
   source: TEST_SOURCE,
@@ -204,10 +211,11 @@ describe("POST /generations — twitterContext auth gate", () => {
   // any handle.
   test("anonymous caller with twitterContext → 403", async () => {
     const body = twitterBody();
+    const anonKey = stableUuid("tw-anon-gate");
     const res = await post(body, {
       headers: {
         "Content-Type": "application/json",
-        "Idempotency-Key": "tw-anon-gate",
+        "Idempotency-Key": anonKey,
       },
     });
     expect(res.status).toBe(403);
@@ -216,7 +224,7 @@ describe("POST /generations — twitterContext auth gate", () => {
 
     // No row was persisted.
     const rows = await prisma.agentTemplateGeneration.findMany({
-      where: { idempotencyKey: "tw-anon-gate" },
+      where: { idempotencyKey: anonKey },
     });
     expect(rows).toHaveLength(0);
   });

--- a/tests/agent-templates.generations.sse.test.ts
+++ b/tests/agent-templates.generations.sse.test.ts
@@ -36,6 +36,7 @@ import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import {
+  stableUuid,
   startAgentTemplatesServer,
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
@@ -95,10 +96,12 @@ afterAll(async () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// `stableUuid(label)` keeps the mnemonic-label style of the existing
+// tests while satisfying the handler's UUID-format requirement.
 const sseHeaders = (key: string) => ({
   "Content-Type": "application/json",
   "X-Agent-API-Key": validAgentAssetsApiKey,
-  "Idempotency-Key": key,
+  "Idempotency-Key": stableUuid(key),
   Accept: "text/event-stream",
 });
 

--- a/tests/agent-templates.guard.test.ts
+++ b/tests/agent-templates.guard.test.ts
@@ -123,30 +123,35 @@ describe("agent templates production guard", () => {
     expect(hasMountedRouter(localRouter, "/agent-templates")).toBe(true);
 
     await withServer(localRouter, async (baseURL) => {
-      // The agent-templates list/detail routes are auth-required, so an
-      // unauthenticated read returns 401 (not 200/404). 401 here means the
-      // router is mounted but auth gated; 404 in production above means the
-      // router isn't mounted at all.
-      const paths = [
-        "/api/v2/agent-templates",
-        "/api/v2/agent-templates/anything",
-        "/api/v2/agent-templates/generations/some-id",
-      ];
+      // The agent-templates read/generation routes are public now, so an
+      // anonymous caller doesn't 401 anymore. We still want to prove the
+      // router is mounted (i.e. the handler ran) instead of falling
+      // through to noRouteMiddleware's bare 404. The discriminator here
+      // is the response body: handlers return JSON envelopes; the
+      // unmounted-production path returns 404 with an *empty* body.
 
-      const responses = await Promise.all(
-        paths.map((path) => fetch(`${baseURL}${path}`)),
+      // GET /agent-templates → 200 with `data` envelope (handler ran).
+      const listResponse = await fetch(`${baseURL}/api/v2/agent-templates`);
+      expect(listResponse.status).toBe(200);
+      const listBody = (await listResponse.json()) as { data: unknown[] };
+      expect(Array.isArray(listBody.data)).toBe(true);
+
+      // GET /agent-templates/anything → 404 *with* a JSON `error` body from
+      // the detail handler (mounted), vs the bare 404 with empty body that
+      // noRouteMiddleware would return if the router weren't mounted.
+      const detailResponse = await fetch(
+        `${baseURL}/api/v2/agent-templates/anything`,
       );
+      expect(detailResponse.status).toBe(404);
+      const detailBody = (await detailResponse.json()) as { error: string };
+      expect(detailBody.error).toBe("Agent template not found");
 
-      expect(responses.map((response) => response.status)).toEqual([
-        401, 401, 401,
-      ]);
-
-      // POST /generations is also mounted and auth-gated.
+      // POST /generations without a body → 400 (handler's zod gate ran).
       const generationsPost = await fetch(
         `${baseURL}/api/v2/agent-templates/generations`,
         { method: "POST" },
       );
-      expect(generationsPost.status).toBe(401);
+      expect(generationsPost.status).toBe(400);
     });
   });
 });

--- a/tests/agent-templates.read-guard.test.ts
+++ b/tests/agent-templates.read-guard.test.ts
@@ -8,7 +8,6 @@ import { agentTemplatesRouter } from "@/api/v2/agent-templates/agent-templates.r
 import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
-import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
 
 type ListEnvelope = {
@@ -182,16 +181,8 @@ describe("Agent template read production guard", () => {
       slug: "read-guard-reachable",
     });
 
-    // Reader token — list requires auth now. Non-owner reader sees only
-    // published, which matches what this test creates.
-    const READER_ID = "00000000-0000-4000-8000-cccccccc0003";
-    const authToken = await createJwtToken({
-      deviceId: "test-device-agent-templates-read-guard",
-      accountId: READER_ID,
-    });
-    const authHeader: Record<string, string> = {
-      "X-Convos-AuthToken": authToken,
-    };
+    // List is public; anonymous callers get the published-only view, which
+    // matches what this test creates.
 
     const envCases = [
       { label: "dev", value: "dev" },
@@ -203,9 +194,7 @@ describe("Agent template read production guard", () => {
 
     for (const envCase of envCases) {
       await withGuardedServer(envCase.value, async (baseURL) => {
-        const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
-          headers: authHeader,
-        });
+        const response = await fetch(`${baseURL}/api/v2/agent-templates`);
         const body = (await response.json()) as ListEnvelope;
 
         expect(response.status).toBe(200);

--- a/tests/auth-cross.test.ts
+++ b/tests/auth-cross.test.ts
@@ -287,9 +287,9 @@ describe("Cross-area auth flows", () => {
     expect(bPublishResponse.status).toBe(403);
   });
 
-  // Unauthenticated callers are rejected from every
-  // agent-templates route — no public discovery surface.
-  test("Unauthenticated callers cannot list or detail any template", async () => {
+  // Anonymous callers can hit GET list/detail but only see published rows;
+  // draft templates 404 and `?status=draft` returns an empty envelope.
+  test("Anonymous callers see published-only and cannot reach drafts", async () => {
     // Seed a draft template so we have a concrete URL to attempt.
     const draftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
       method: "POST",
@@ -303,24 +303,39 @@ describe("Cross-area auth flows", () => {
     const draftBody = (await draftResponse.json()) as Record<string, unknown>;
     const draftId = draftBody.id as string;
 
-    // (1) Unauthenticated GET list — 401
+    // (1) Anonymous GET list — 200, draft is invisible (published-only view)
     const listResponse = await fetch(
       `${baseURL}/api/v2/agent-templates?limit=100`,
     );
-    expect(listResponse.status).toBe(401);
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as {
+      data: Array<{ id: string; status: string }>;
+    };
+    expect(listBody.data.some((row) => row.id === draftId)).toBe(false);
+    for (const row of listBody.data) {
+      expect(row.status).toBe("published");
+    }
 
-    // (2) Unauthenticated GET ?status=draft — 401 (auth check runs before
-    // query validation, so this is the same code path as #1)
+    // (2) Anonymous GET ?status=draft — 200 with an empty envelope
+    //     (no enumeration of non-public rows)
     const statusFilterResponse = await fetch(
       `${baseURL}/api/v2/agent-templates?status=draft`,
     );
-    expect(statusFilterResponse.status).toBe(401);
+    expect(statusFilterResponse.status).toBe(200);
+    const statusFilterBody = (await statusFilterResponse.json()) as {
+      data: unknown[];
+      hasMore: boolean;
+      nextCursor: string | null;
+    };
+    expect(statusFilterBody.data).toEqual([]);
+    expect(statusFilterBody.hasMore).toBe(false);
+    expect(statusFilterBody.nextCursor).toBeNull();
 
-    // (3) Unauthenticated GET detail — 401
+    // (3) Anonymous GET detail on the draft — 404 (drafts are not visible)
     const draftDetailResponse = await fetch(
       `${baseURL}/api/v2/agent-templates/${draftId}`,
     );
-    expect(draftDetailResponse.status).toBe(401);
+    expect(draftDetailResponse.status).toBe(404);
   });
 
   // JWT-only user (no accountId) is rejected from write routes with 403

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -240,8 +240,8 @@ describe("getEffectiveOwnerId utility", () => {
   });
 });
 
-describe("requireAccount chained on every agent-templates route", () => {
-  test("router source chains requireAccount on read and write routes", () => {
+describe("agent-templates router auth wiring", () => {
+  test("write routes require an account; read + generations routes use optional auth", () => {
     const source = readFileSync(
       new URL(
         "../src/api/v2/agent-templates/agent-templates.router.ts",
@@ -250,22 +250,36 @@ describe("requireAccount chained on every agent-templates route", () => {
       "utf8",
     );
 
-    // Check that requireAccount is imported
+    // Both middlewares are imported.
+    expect(source).toContain("authOrAgentApiKeyAuth");
+    expect(source).toContain("optionalAuthOrAgentApiKeyAuth");
     expect(source).toContain("requireAccount");
     expect(source).toContain('from "@/middleware/auth"');
 
-    // Every route on this router requires an account, so the chain is always
-    // `authOrAgentApiKeyAuth, requireAccount, handler`. No public discovery
-    // surface — there is no unauth list/detail branch.
+    // Write routes (POST /, PATCH /:id, DELETE /:id, POST /:id/publish)
+    // chain `authOrAgentApiKeyAuth + requireAccount`. That's 4 routes,
+    // and one import, for 5 occurrences of `requireAccount` total.
     const requireAccountCount = (source.match(/requireAccount/g) ?? []).length;
+    expect(requireAccountCount).toBe(5);
 
-    // 5 write routes (POST /, POST /generations, PATCH /:id, DELETE /:id,
-    // POST /:id/publish) + 3 read routes (GET /, GET /generations/:id,
-    // GET /:idOrHashedSlug) + 1 import = 9 occurrences.
-    expect(requireAccountCount).toBe(9);
+    expect(source).toContain("requireAccount,\n  createHandler");
+    expect(source).toContain("requireAccount,\n  patchHandler");
+    expect(source).toContain("requireAccount,\n  deleteHandler");
+    expect(source).toContain("requireAccount,\n  publishHandler");
 
-    // Read routes DO have requireAccount chained.
-    expect(source).toContain("requireAccount,\n  listHandler");
-    expect(source).toContain("requireAccount,\n  detailHandler");
+    // Public routes use the optional middleware: GET /, GET /:idOrHashedSlug,
+    // POST /generations, GET /generations/:generationId. The optional
+    // middleware MUST NOT be followed by requireAccount.
+    expect(source).toContain("optionalAuthOrAgentApiKeyAuth, listHandler");
+    expect(source).toContain("optionalAuthOrAgentApiKeyAuth,\n  detailHandler");
+    expect(source).toContain(
+      "optionalAuthOrAgentApiKeyAuth,\n  generationsPostHandler",
+    );
+    expect(source).toContain(
+      "optionalAuthOrAgentApiKeyAuth,\n  generationsGetHandler",
+    );
+    expect(source).not.toMatch(
+      /optionalAuthOrAgentApiKeyAuth,\s*requireAccount/,
+    );
   });
 });

--- a/tests/auth-visibility.test.ts
+++ b/tests/auth-visibility.test.ts
@@ -1,13 +1,14 @@
 /**
  * List/detail visibility rule tests
  *
- * The list and detail endpoints both require auth — there is no public
- * discovery surface. Unauthenticated callers always receive 401.
+ * The list and detail endpoints are public. Anonymous callers see only
+ * published templates; authenticated callers additionally see their own
+ * drafts/unlisted/archived rows.
  *
  * Tests that:
- *   - Unauthenticated GET /agent-templates returns 401
+ *   - Unauthenticated GET /agent-templates returns published-only
  *   - Authenticated GET /agent-templates returns published + own drafts/unlisted/archived
- *   - GET /agent-templates?status=draft returns 401 for unauthenticated users
+ *   - GET /agent-templates?status=draft returns empty result for anonymous callers
  *   - GET /agent-templates?status=draft returns caller's own drafts for authenticated users
  *   - GET /agent-templates/:id returns 404 for draft templates not owned by caller
  *   - GET /agent-templates/:id returns template for drafts owned by caller
@@ -115,12 +116,51 @@ describe("List/detail visibility rules", () => {
     await cleanupTestRows();
   });
 
-  // Unauthenticated GET returns 401
-  test("Unauthenticated GET /agent-templates returns 401", async () => {
+  // Unauthenticated GET returns 200 with the published-only view
+  test("Unauthenticated GET /agent-templates returns 200 with published-only view", async () => {
+    // Create one published and one draft template — the anonymous lister
+    // should see the published row but not the draft.
+    const pubResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Anon Pub",
+        prompt: "Published",
+        slug: "vis-test-anon-pub",
+      }),
+    });
+    const pubBody = (await pubResponse.json()) as Record<string, unknown>;
+    const pubId = pubBody.id as string;
+    await fetch(`${baseURL}/api/v2/agent-templates/${pubId}/publish`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+    });
+
+    const draftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Anon Draft",
+        prompt: "Draft",
+        slug: "vis-test-anon-draft",
+      }),
+    });
+    const draftBody = (await draftResponse.json()) as Record<string, unknown>;
+    const draftId = draftBody.id as string;
+
     const listResponse = await fetch(
       `${baseURL}/api/v2/agent-templates?limit=100`,
     );
-    expect(listResponse.status).toBe(401);
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as {
+      data: Record<string, unknown>[];
+    };
+
+    expect(listBody.data.some((t) => t.id === pubId)).toBe(true);
+    expect(listBody.data.some((t) => t.id === draftId)).toBe(false);
+    for (const t of listBody.data) {
+      expect(t.status).toBe("published");
+    }
   });
 
   // Authenticated GET returns published + own drafts/unlisted/archived
@@ -188,12 +228,32 @@ describe("List/detail visibility rules", () => {
     expect(bListBody.data.some((t) => t.id === aDraftId)).toBe(false);
   });
 
-  // GET ?status=draft returns 401 for unauthenticated users
-  test("GET ?status=draft returns 401 for unauthenticated users", async () => {
+  // GET ?status=draft returns empty result for anonymous callers
+  test("GET ?status=draft returns empty result for anonymous callers", async () => {
+    // Create a draft so the table is non-empty for this filter; anonymous
+    // callers still see nothing.
+    await fetch(`${baseURL}/api/v2/agent-templates`, {
+      method: "POST",
+      headers: await jwtHeadersFor(USER_A_ID),
+      body: JSON.stringify({
+        agentName: "Vis Test Anon Filter",
+        prompt: "Draft",
+        slug: "vis-test-anon-filter",
+      }),
+    });
+
     const response = await fetch(
       `${baseURL}/api/v2/agent-templates?status=draft`,
     );
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: Record<string, unknown>[];
+      hasMore: boolean;
+      nextCursor: string | null;
+    };
+    expect(body.data).toEqual([]);
+    expect(body.hasMore).toBe(false);
+    expect(body.nextCursor).toBeNull();
   });
 
   // GET ?status=draft returns caller's own drafts for authed users
@@ -271,27 +331,27 @@ describe("List/detail visibility rules", () => {
     expect(detailResponse.status).toBe(404);
   });
 
-  test("GET /:id returns 401 for unauthenticated users", async () => {
+  test("GET /:id returns 404 for anonymous callers on a draft template", async () => {
     // User A creates a draft
     const createResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
       method: "POST",
       headers: await jwtHeadersFor(USER_A_ID),
       body: JSON.stringify({
-        agentName: "Vis Test Detail Unauth",
+        agentName: "Vis Test Detail Anon",
         prompt: "Draft by A",
-        slug: "vis-test-detail-unauth",
+        slug: "vis-test-detail-anon",
       }),
     });
     const createBody = (await createResponse.json()) as Record<string, unknown>;
     const templateId = createBody.id as string;
 
-    // Unauthenticated user — should be rejected at the auth layer regardless
-    // of template status (draft or published). 401, not 404.
+    // Anonymous caller — drafts are not visible to anonymous callers,
+    // so the response is 404 (indistinguishable from a missing row).
     const detailResponse = await fetch(
       `${baseURL}/api/v2/agent-templates/${templateId}`,
     );
 
-    expect(detailResponse.status).toBe(401);
+    expect(detailResponse.status).toBe(404);
   });
 
   // Detail returns template for drafts owned by the caller
@@ -375,12 +435,14 @@ describe("List/detail visibility rules", () => {
     );
     expect(bDetailResponse.status).toBe(200);
 
-    // Unauthenticated callers are rejected at the auth layer — published
-    // templates are not publicly discoverable through this API.
+    // Anonymous callers can also see published rows (public discovery).
     const unauthResponse = await fetch(
       `${baseURL}/api/v2/agent-templates/${templateId}`,
     );
-    expect(unauthResponse.status).toBe(401);
+    expect(unauthResponse.status).toBe(200);
+    const unauthBody = (await unauthResponse.json()) as Record<string, unknown>;
+    expect(unauthBody.id).toBe(templateId);
+    expect(unauthBody.status).toBe("published");
   });
 
   // Status filter with unlisted/archived for authenticated users

--- a/tests/auth-visibility.test.ts
+++ b/tests/auth-visibility.test.ts
@@ -129,12 +129,18 @@ describe("List/detail visibility rules", () => {
         slug: "vis-test-anon-pub",
       }),
     });
+    expect(pubResponse.status).toBe(201);
     const pubBody = (await pubResponse.json()) as Record<string, unknown>;
     const pubId = pubBody.id as string;
-    await fetch(`${baseURL}/api/v2/agent-templates/${pubId}/publish`, {
-      method: "POST",
-      headers: await jwtHeadersFor(USER_A_ID),
-    });
+    expect(pubId).toBeDefined();
+    const publishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${pubId}/publish`,
+      {
+        method: "POST",
+        headers: await jwtHeadersFor(USER_A_ID),
+      },
+    );
+    expect(publishResponse.status).toBe(200);
 
     const draftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
       method: "POST",
@@ -145,8 +151,10 @@ describe("List/detail visibility rules", () => {
         slug: "vis-test-anon-draft",
       }),
     });
+    expect(draftResponse.status).toBe(201);
     const draftBody = (await draftResponse.json()) as Record<string, unknown>;
     const draftId = draftBody.id as string;
+    expect(draftId).toBeDefined();
 
     const listResponse = await fetch(
       `${baseURL}/api/v2/agent-templates?limit=100`,
@@ -163,6 +171,33 @@ describe("List/detail visibility rules", () => {
     }
   });
 
+  // Optional-auth: present-but-invalid credentials must still 401.
+  // "No header" → anonymous path; "header with garbage value" → strict
+  // auth path → 401. The middleware's contract is "opt-in: if you opt in,
+  // they have to be valid", so we verify that for both header shapes.
+  test("Invalid credentials on optional-auth routes still return 401", async () => {
+    const garbageJwt = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=10`,
+      { headers: { "X-Convos-AuthToken": "not-a-real-jwt" } },
+    );
+    expect(garbageJwt.status).toBe(401);
+
+    const garbageAgentKey = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=10`,
+      { headers: { "X-Agent-API-Key": "not-the-real-key-just-a-stub" } },
+    );
+    expect(garbageAgentKey.status).toBe(401);
+
+    // Whitespace-only token is *present* and therefore opt-in to auth —
+    // strict path runs and fails. This is what the trimmed-vs-raw header
+    // check in `optionalAuthOrAgentApiKeyAuth` enforces.
+    const whitespaceJwt = await fetch(
+      `${baseURL}/api/v2/agent-templates?limit=10`,
+      { headers: { "X-Convos-AuthToken": "   " } },
+    );
+    expect(whitespaceJwt.status).toBe(401);
+  });
+
   // Authenticated GET returns published + own drafts/unlisted/archived
   test("Authenticated GET returns published + own drafts/unlisted/archived", async () => {
     // Create a published template (owned by admin)
@@ -175,12 +210,18 @@ describe("List/detail visibility rules", () => {
         slug: "vis-test-pub-a",
       }),
     });
+    expect(pubResponse.status).toBe(201);
     const pubBody = (await pubResponse.json()) as Record<string, unknown>;
     const pubId = pubBody.id as string;
-    await fetch(`${baseURL}/api/v2/agent-templates/${pubId}/publish`, {
-      method: "POST",
-      headers: await jwtHeadersFor(USER_A_ID),
-    });
+    expect(pubId).toBeDefined();
+    const publishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${pubId}/publish`,
+      {
+        method: "POST",
+        headers: await jwtHeadersFor(USER_A_ID),
+      },
+    );
+    expect(publishResponse.status).toBe(200);
 
     // User B creates a draft
     const bDraftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
@@ -192,8 +233,10 @@ describe("List/detail visibility rules", () => {
         slug: "vis-test-draft-b",
       }),
     });
+    expect(bDraftResponse.status).toBe(201);
     const bDraftBody = (await bDraftResponse.json()) as Record<string, unknown>;
     const bDraftId = bDraftBody.id as string;
+    expect(bDraftId).toBeDefined();
 
     // User A creates a draft
     const aDraftResponse = await fetch(`${baseURL}/api/v2/agent-templates`, {
@@ -205,8 +248,10 @@ describe("List/detail visibility rules", () => {
         slug: "vis-test-draft-a",
       }),
     });
+    expect(aDraftResponse.status).toBe(201);
     const aDraftBody = (await aDraftResponse.json()) as Record<string, unknown>;
     const aDraftId = aDraftBody.id as string;
+    expect(aDraftId).toBeDefined();
 
     // User B lists — should see published + own draft, NOT User A's draft
     const bListResponse = await fetch(
@@ -420,13 +465,19 @@ describe("List/detail visibility rules", () => {
         slug: "vis-test-pub-detail",
       }),
     });
+    expect(createResponse.status).toBe(201);
     const createBody = (await createResponse.json()) as Record<string, unknown>;
     const templateId = createBody.id as string;
+    expect(templateId).toBeDefined();
 
-    await fetch(`${baseURL}/api/v2/agent-templates/${templateId}/publish`, {
-      method: "POST",
-      headers: await jwtHeadersFor(USER_A_ID),
-    });
+    const publishResponse = await fetch(
+      `${baseURL}/api/v2/agent-templates/${templateId}/publish`,
+      {
+        method: "POST",
+        headers: await jwtHeadersFor(USER_A_ID),
+      },
+    );
+    expect(publishResponse.status).toBe(200);
 
     // Any authenticated user can see it
     const bDetailResponse = await fetch(


### PR DESCRIPTION
## Summary

After discussion with @neekolas, the agent-template **read surface** (list + detail) and the **generation request/status endpoints** should be reachable without auth. Agents and the public template gallery both want to fetch templates and kick off generations without minting a token. Write endpoints stay locked down — only GET list, GET detail, POST /generations, and GET /generations/:id flip to optional auth.

Stacked on #205. Base will be retargeted to `otr-dev` once 199/204/205 land.

## What changes

**Middleware**
- Reintroduce `optionalAuthOrAgentApiKeyAuth`: skip auth when no credential headers are present, otherwise delegate to `authOrAgentApiKeyAuth`. Invalid creds still 401 — presenting them is opt-in.

**Routes** (router edits only — no schema changes)
- `GET  /agent-templates`              → optional auth
- `GET  /agent-templates/:idOrHashedSlug` → optional auth
- `POST /agent-templates/generations`    → optional auth
- `GET  /agent-templates/generations/:id` → optional auth
- All write endpoints (POST /, PATCH /:id, DELETE /:id, POST /:id/publish) unchanged — still `authOrAgentApiKeyAuth + requireAccount`.

**Handler semantics for anonymous callers**
- `listHandler`: no filter → published-only. `?status=draft|unlisted|archived` → 200 with empty data (no enumeration of non-public rows). `?status=published` → all published.
- `detailHandler`: published/unlisted/archived rows resolve normally; draft lookups 404 (the ownership branch fails because `undefined !== ownerAccountId`).
- `generationsPostHandler`: anonymous submissions default `ownerAccountId` to `ADMIN_ACCOUNT_ID`. Idempotency keying stays per `(ownerAccountId, idempotencyKey)`.
- `generationsGetHandler`: the generation UUID is treated as a bearer secret — anyone with the ID can poll status. Cross-account → 200 with the row.

**Tests**
- `auth-visibility.test.ts`: flip the 401 assertions to the new published-only / empty-result shape; add positive cases for anonymous list + anonymous published-detail.
- `agent-templates.read-guard.test.ts`: list route remains reachable in non-prod envs without auth.
- `agent-templates.generations-get.test.ts`: `cross-account access → 404` flipped to `cross-account → 200`, asserting capability-token semantics.

## No schema/migration changes

Confirmed: zero `prisma/migrations/*`, no `schema.prisma` edits, no SQL — purely handler/middleware/test code.

## Test plan
- [ ] `bun test tests/auth-visibility.test.ts` passes
- [ ] `bun test tests/agent-templates.read-guard.test.ts` passes
- [ ] `bun test tests/agent-templates.generations-get.test.ts` cross-account case asserts 200
- [ ] Manual: anonymous `curl /api/v2/agent-templates` returns only published rows
- [ ] Manual: anonymous `curl /api/v2/agent-templates?status=draft` returns `{ data: [], ... }`
- [ ] Manual: anonymous `curl -X POST /api/v2/agent-templates/generations` succeeds and the row is owned by `ADMIN_ACCOUNT_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make agent-template read and generation endpoints public with optional authentication
> - Adds a full CRUD + async generation API under `/api/v2/agent-templates` via a new [agent-templates.router.ts](https://github.com/ephemeraHQ/convos-backend/pull/207/files#diff-2faa4dc4ec7ffff7ca01b15362dd5ad613f5a8a7f932fbb54c2ec18738d348d9), including list, detail, create, patch, delete, publish, and generation start/poll endpoints.
> - Introduces `optionalAuthOrAgentApiKeyAuth` middleware so that list, detail, and generation endpoints are accessible without authentication while still enforcing auth when credentials are present.
> - Adds an async generation pipeline with idempotency, OpenRouter-backed template generation, content moderation, optional Twitter reply composition, SSE/long-poll response modes, and a TTL sweep service for stuck/expired jobs.
> - Adds new Prisma models `AgentTemplate` and `AgentTemplateGeneration` with supporting migrations, enums, and indexes.
> - Behavioral Change: importing `config.ts` now throws at startup if `GENERATION_STUCK_SWEEP_THRESHOLD_MS` ≤ `GENERATION_EXECUTOR_TIMEOUT_MS`; the TTL sweep also starts automatically on non-production server boot.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 75b407b. 26 files reviewed, 5 issues evaluated, 2 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/api/v2/agent-templates/handlers/publish.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 97](https://github.com/ephemeraHQ/convos-backend/blob/3d34e4c6f499ee137e6d55afbb77144ef709ae9f/src/api/v2/agent-templates/handlers/publish.ts#L97): The re-publish logic on lines 96-99 uses `template.status` which was fetched at line 42-44, but this value may be stale by the time we reach the re-publish branch. If another concurrent request (e.g., a PATCH) changes the template's status between the initial `findUnique` and the re-publish `updateMany`, the code will make decisions based on outdated data. For example: if the template was `"draft"` at fetch time but another request changed it to `"archived"` before the re-publish runs, `template.status === "draft"` would still be true, causing the code to set status to `"published"` instead of preserving `"archived"`. This contradicts the stated intent in the comment on lines 86-88 that "Status is normally preserved on re-publish." The check should be done atomically within the `updateMany` WHERE clause rather than using prefetched data. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/api/v2/agent-templates/services/generation-executor.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 144](https://github.com/ephemeraHQ/convos-backend/blob/3d34e4c6f499ee137e6d55afbb77144ef709ae9f/src/api/v2/agent-templates/services/generation-executor.ts#L144): `deriveBaseSlug` can return an empty string when `agentName` consists entirely of non-alphanumeric characters (e.g., emoji-only names like `"🤖"` or `"✨💫"`). After lowercasing, replacing non-alphanumeric chars with hyphens, and trimming leading/trailing hyphens, the result is `""`. This empty slug is then used in `persistTemplate` to create an `AgentTemplate` row with `slug: ""`, which could cause URL resolution issues or violate implicit non-empty expectations downstream. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Published agent templates are now publicly discoverable and readable without authentication
  * Generation status polling is accessible using only the generation ID, without requiring authentication
  * Anonymous users can submit generations to the system

* **Documentation**
  * Updated endpoint documentation to reflect public access behavior for published templates and capability-based polling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/207)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->