### PR TITLE
feat(agents): forward skipGreeting flag through /api/v2/agents/join

### DIFF
--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -5,6 +5,7 @@ import { AGENT_POOL_API_KEY, AGENT_POOL_URL, XMTP_ENV } from "@/config";
 const bodySchema = z.object({
   slug: z.string().min(1, "Slug is required").max(2048),
   instructions: z.string().max(4096, "Instructions too long").optional(),
+  skipGreeting: z.boolean().optional(),
 });
 
 const FORCE_ERROR_DELAY_MS = 5_000;
@@ -99,8 +100,8 @@ export async function joinHandler(req: Request, res: Response) {
     return;
   }
 
-  const { slug, instructions } = parsed.data;
-  req.log.info({ slug }, "Agent join request received");
+  const { slug, instructions, skipGreeting } = parsed.data;
+  req.log.info({ slug, skipGreeting }, "Agent join request received");
 
   try {
     const joinUrl = buildInviteUrl(slug);
@@ -117,6 +118,7 @@ export async function joinHandler(req: Request, res: Response) {
         agentName: "Assistant",
         instructions: instructions || "You are a helpful assistant.",
         joinUrl,
+        ...(skipGreeting !== undefined && { skipGreeting }),
       }),
     });
 


### PR DESCRIPTION
## Summary

- Accept optional `skipGreeting: boolean` on `POST /api/v2/agents/join`
- Forward it to the agent pool's `/api/pool/claim`, which threads it through to hermes `/convos/join`
- Default behavior unchanged — flag is only included in the upstream payload when caller sets it

Pairs with convos-agents [#1565](https://github.com/xmtplabs/convos-agents/pull/1565), which added `skipGreeting` to the pool/runtime/hermes chain so callers can opt out of the welcome message when provisioning a new agent.

## Test plan

- [ ] `POST /api/v2/agents/join` without `skipGreeting` → pool body has no `skipGreeting` (unchanged behavior)
- [ ] `POST /api/v2/agents/join` with `{ "skipGreeting": true }` → pool body includes `skipGreeting: true`, agent joins without a greeting
- [ ] `POST /api/v2/agents/join` with `{ "skipGreeting": "yes" }` → 400 INVALID_REQUEST

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `skipGreeting` flag through the `/api/v2/agents/join` endpoint
> Adds an optional boolean `skipGreeting` field to the request body schema in [join.ts](https://github.com/ephemeraHQ/convos-backend/pull/208/files#diff-56b3806a78b9509421cf23cd82891715d11c219bad27f45a5a9ff9665a18cd7c). When provided, the value is forwarded to the agent pool claim payload and included in request log metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0247e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `skipGreeting` parameter to the join request, allowing users to skip the greeting message when joining agent pools. The parameter only applies when explicitly provided and preserves existing pool defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/208)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->