### PR TITLE
feat(auth): bind deviceId into SIWE + DeviceRegistration.accountId

### DIFF
--- a/prisma/migrations/20260513154554_device_registration_account/migration.sql
+++ b/prisma/migrations/20260513154554_device_registration_account/migration.sql
@@ -1,5 +1,5 @@
 -- AlterTable
-ALTER TABLE "DeviceRegistration" ADD COLUMN     "accountId" UUID;
+ALTER TABLE "DeviceRegistration" ADD COLUMN "accountId" UUID;
 
 -- CreateIndex
 CREATE INDEX "DeviceRegistration_accountId_idx" ON "DeviceRegistration"("accountId");

--- a/prisma/migrations/20260513154554_device_registration_account/migration.sql
+++ b/prisma/migrations/20260513154554_device_registration_account/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "DeviceRegistration" ADD COLUMN     "accountId" UUID;
+
+-- CreateIndex
+CREATE INDEX "DeviceRegistration_accountId_idx" ON "DeviceRegistration"("accountId");
+
+-- AddForeignKey
+ALTER TABLE "DeviceRegistration" ADD CONSTRAINT "DeviceRegistration_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,11 +39,14 @@ model DeviceRegistration {
   updatedAt         DateTime           @updatedAt
   lastSentAt        DateTime?
   lastFailureAt     DateTime?
+  accountId         String?            @db.Uuid
+  account           Account?           @relation(fields: [accountId], references: [id], onDelete: SetNull)
   clientIdentifiers ClientIdentifier[]
 
   @@unique([pushTokenType, apnsEnv, pushToken])
   @@index([pushToken])
   @@index([disabled, pushFailures])
+  @@index([accountId])
 }
 
 model ClientIdentifier {
@@ -99,9 +102,10 @@ model Account {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  authMethods               AuthMethod[]
-  agentTemplates            AgentTemplate[]
-  agentTemplateGenerations  AgentTemplateGeneration[]
+  authMethods              AuthMethod[]
+  agentTemplates           AgentTemplate[]
+  agentTemplateGenerations AgentTemplateGeneration[]
+  devices                  DeviceRegistration[]
 }
 
 enum PublishStatus {

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -105,6 +105,35 @@ export async function generateToken(
       externalKey: address,
     });
     accountId = upserted.accountId;
+
+    // Best-effort backfill of DeviceRegistration.accountId.
+    // Runs OUTSIDE the upsert transaction so a transient DB issue here
+    // can't fail token mint. updateMany silently no-ops when the device
+    // row doesn't exist (legitimate case: client called /auth/token
+    // before /device/register). Self-heals on next mint after device
+    // registers. Last-write-wins on wallet switch by design.
+    try {
+      const { count } = await prisma.deviceRegistration.updateMany({
+        where: { deviceId: body.deviceId },
+        data: { accountId },
+      });
+      if (count > 0) {
+        req.log.info(
+          { deviceId: body.deviceId, accountId },
+          "auth.device.account_backfill",
+        );
+      } else {
+        req.log.info(
+          { deviceId: body.deviceId, accountId },
+          "auth.device.account_backfill_noop",
+        );
+      }
+    } catch (err) {
+      req.log.warn(
+        { err, deviceId: body.deviceId, accountId },
+        "auth.device.account_backfill_failed",
+      );
+    }
   }
 
   // 4. Mint JWT

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -107,11 +107,27 @@ export async function generateToken(
     accountId = upserted.accountId;
 
     // Best-effort backfill of DeviceRegistration.accountId.
+    //
     // Runs OUTSIDE the upsert transaction so a transient DB issue here
     // can't fail token mint. updateMany silently no-ops when the device
     // row doesn't exist (legitimate case: client called /auth/token
     // before /device/register). Self-heals on next mint after device
-    // registers. Last-write-wins on wallet switch by design.
+    // registers.
+    //
+    // Concurrency: Postgres serializes UPDATEs on the same row, but commit
+    // order does NOT track request arrival order — a slower older request
+    // can land its UPDATE after a faster newer request, leaving the column
+    // pointing at the older intent. For typical iOS UX this is bounded
+    // because /auth/token is single-flight per device (user taps sign-in,
+    // waits for response). Two concurrent SIWE upgrades on the same device
+    // require two wallet signatures essentially simultaneously, which is
+    // physically rare. Even when it hits, impact is brief and self-healing
+    // (next SIWE rewrites the column) and JWT integrity is unaffected.
+    // Promoting this to an atomic transaction with the account upsert is
+    // intentionally rejected — see spec § "Locked design decisions"
+    // (Transaction grouping: best-effort over atomic) and § Risks
+    // (wallet-switch race). Revisit (e.g. add an issuedAt-scoped WHERE
+    // clause) if/when account-scoped push routing makes the race visible.
     try {
       const { count } = await prisma.deviceRegistration.updateMany({
         where: { deviceId: body.deviceId },

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -108,30 +108,36 @@ export async function generateToken(
 
     // Best-effort backfill of DeviceRegistration.accountId.
     //
-    // Runs OUTSIDE the upsert transaction so a transient DB issue here
-    // can't fail token mint. updateMany silently no-ops when the device
-    // row doesn't exist (legitimate case: client called /auth/token
-    // before /device/register). Self-heals on next mint after device
-    // registers.
+    // Runs in its own small transaction, SEPARATE from the upsert
+    // transaction. A transient DB issue here cannot fail token mint
+    // (try/catch below). updateMany silently no-ops when the device row
+    // doesn't exist (legitimate case: client called /auth/token before
+    // /device/register). Self-heals on next mint after device registers.
     //
-    // Concurrency: Postgres serializes UPDATEs on the same row, but commit
-    // order does NOT track request arrival order — a slower older request
-    // can land its UPDATE after a faster newer request, leaving the column
-    // pointing at the older intent. For typical iOS UX this is bounded
-    // because /auth/token is single-flight per device (user taps sign-in,
-    // waits for response). Two concurrent SIWE upgrades on the same device
-    // require two wallet signatures essentially simultaneously, which is
-    // physically rare. Even when it hits, impact is brief and self-healing
-    // (next SIWE rewrites the column) and JWT integrity is unaffected.
-    // Promoting this to an atomic transaction with the account upsert is
-    // intentionally rejected — see spec § "Locked design decisions"
-    // (Transaction grouping: best-effort over atomic) and § Risks
-    // (wallet-switch race). Revisit (e.g. add an issuedAt-scoped WHERE
-    // clause) if/when account-scoped push routing makes the race visible.
+    // Concurrency: a `SELECT ... FOR UPDATE` on the device row serializes
+    // concurrent backfills targeting the same deviceId. Without the lock,
+    // commit order can diverge from request-arrival order, so a slower
+    // older request can overwrite a faster newer one. With the lock, the
+    // second request blocks until the first commits, so the request that
+    // acquires the lock last is also the one whose value ends up in the
+    // column — restoring "later request wins" semantics for the sequential
+    // wallet-switch case. Truly simultaneous arrivals resolve to lock
+    // acquisition order (non-deterministic, but final state is still a
+    // valid one of the two — no torn writes).
     try {
-      const { count } = await prisma.deviceRegistration.updateMany({
-        where: { deviceId: body.deviceId },
-        data: { accountId },
+      const count = await prisma.$transaction(async (tx) => {
+        // Acquire row-level lock; no-op if device row doesn't exist
+        // (returns 0 rows, no lock taken, subsequent updateMany also 0).
+        await tx.$queryRaw`
+          SELECT 1 FROM "DeviceRegistration"
+          WHERE "deviceId" = ${body.deviceId}
+          FOR UPDATE
+        `;
+        const result = await tx.deviceRegistration.updateMany({
+          where: { deviceId: body.deviceId },
+          data: { accountId },
+        });
+        return result.count;
       });
       if (count > 0) {
         req.log.info(

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -86,6 +86,7 @@ export async function generateToken(
         message: body.siwe.message,
         signature: body.siwe.signature,
         expectedNonce: nonce,
+        expectedDeviceId: body.deviceId,
         now: new Date(),
       });
       address = result.address;

--- a/src/api/v2/auth/handlers/siwe.ts
+++ b/src/api/v2/auth/handlers/siwe.ts
@@ -3,6 +3,7 @@ import { SIWE_ALLOWED_CHAIN_IDS, SIWE_DOMAIN, SIWE_URI } from "@/config";
 
 const ISSUED_AT_SKEW_MS = 5 * 60 * 1000;
 const MAX_EXPIRATION_FUTURE_MS = 10 * 60 * 1000;
+const DEVICE_URI_PREFIX = "convos://device/";
 
 export class InvalidSiweError extends Error {
   constructor(public readonly reason: string) {
@@ -60,6 +61,24 @@ export async function verifySiwe(args: {
     if (!Number.isNaN(nbf) && nbf > args.now.getTime()) {
       throw new InvalidSiweError("notBefore");
     }
+  }
+
+  // Cryptographic device binding via Resources URI.
+  // Checked before msg.verify() so tampered messages fail fast without
+  // paying ecrecover cost.
+  const resources = msg.resources ?? [];
+  const deviceResources = resources.filter((r) =>
+    r.startsWith(DEVICE_URI_PREFIX),
+  );
+  if (deviceResources.length === 0) {
+    throw new InvalidSiweError("device_resource_missing");
+  }
+  if (deviceResources.length > 1) {
+    throw new InvalidSiweError("device_resource_duplicate");
+  }
+  const signedDeviceId = deviceResources[0].slice(DEVICE_URI_PREFIX.length);
+  if (signedDeviceId !== args.expectedDeviceId) {
+    throw new InvalidSiweError("device_mismatch");
   }
 
   let result;

--- a/src/api/v2/auth/handlers/siwe.ts
+++ b/src/api/v2/auth/handlers/siwe.ts
@@ -15,6 +15,7 @@ export async function verifySiwe(args: {
   message: string;
   signature: string;
   expectedNonce: string;
+  expectedDeviceId: string;
   now: Date;
 }): Promise<{ address: string }> {
   let msg: SiweMessage;

--- a/tests/auth-end-to-end.test.ts
+++ b/tests/auth-end-to-end.test.ts
@@ -1,14 +1,13 @@
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import cookieParser from "cookie-parser";
-import { Wallet } from "ethers";
 import express from "express";
-import { SiweMessage } from "siwe";
 import request from "supertest";
 import { authRouter } from "@/api/v2/auth/auth.router";
 import { authMiddleware, requireAccount } from "@/middleware/auth";
 import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
+import { buildSiweMessage } from "./helpers/siwe";
 
 function makeApp() {
   const app = express();
@@ -50,20 +49,11 @@ describe("auth end-to-end", () => {
     const nonce = cookie.split(".").pop()!;
 
     // 2. Sign SIWE
-    const wallet = new Wallet("0x" + "5".repeat(64));
-    const msg = new SiweMessage({
-      domain: "convos.app",
-      address: wallet.address,
-      statement: "Sign in to Convos",
-      uri: "https://convos.app",
-      version: "1",
-      chainId: 1,
+    const { messageStr, signature } = await buildSiweMessage({
+      deviceId: "dev-e2e",
       nonce,
-      issuedAt: new Date().toISOString(),
-      expirationTime: new Date(Date.now() + 5 * 60_000).toISOString(),
+      signerKey: "0x" + "5".repeat(64),
     });
-    const messageStr = msg.prepareMessage();
-    const signature = await wallet.signMessage(messageStr);
 
     // 3. Token
     const tokenRes = await request(app)

--- a/tests/auth-end-to-end.test.ts
+++ b/tests/auth-end-to-end.test.ts
@@ -26,6 +26,7 @@ async function reset() {
   // Preserve the admin account seeded by migration; only wipe test-created rows.
   await prisma.account.deleteMany({ where: { id: { not: ADMIN_ACCOUNT_ID } } });
   await prisma.authNonce.deleteMany();
+  await prisma.deviceRegistration.deleteMany();
 }
 
 describe("auth end-to-end", () => {
@@ -34,6 +35,11 @@ describe("auth end-to-end", () => {
 
   test("nonce → SIWE → token → gated route", async () => {
     const app = makeApp();
+
+    // Pre-create device row for assertion later.
+    await prisma.deviceRegistration.create({
+      data: { deviceId: "dev-e2e" },
+    });
 
     // 1. Get nonce
     const nonceRes = await request(app)
@@ -79,6 +85,14 @@ describe("auth end-to-end", () => {
     expect(gatedBody.accountId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
+
+    // Backfill check: DeviceRegistration row for dev-e2e should have
+    // accountId equal to the minted account in the JWT.
+    const deviceRow = await prisma.deviceRegistration.findUnique({
+      where: { deviceId: "dev-e2e" },
+    });
+    expect(deviceRow).toBeTruthy();
+    expect(deviceRow!.accountId).toBe(gatedBody.accountId);
   });
 
   test("legacy device-only token cannot reach gated route", async () => {

--- a/tests/auth-siwe.test.ts
+++ b/tests/auth-siwe.test.ts
@@ -196,4 +196,118 @@ describe("verifySiwe", () => {
       now: NOW,
     });
   });
+
+  test("rejects when Resources field is empty", async () => {
+    const { messageStr, signature } = await buildMessage({ resources: [] });
+    await expectInvalidSiwe(
+      {
+        message: messageStr,
+        signature,
+        expectedNonce: NONCE,
+        expectedDeviceId: TEST_DEVICE_ID,
+        now: NOW,
+      },
+      "device_resource_missing",
+    );
+  });
+
+  test("rejects when Resources lacks a convos://device/ entry", async () => {
+    const { messageStr, signature } = await buildMessage({
+      resources: ["https://example.com/something"],
+    });
+    await expectInvalidSiwe(
+      {
+        message: messageStr,
+        signature,
+        expectedNonce: NONCE,
+        expectedDeviceId: TEST_DEVICE_ID,
+        now: NOW,
+      },
+      "device_resource_missing",
+    );
+  });
+
+  test("rejects when Resources contains two convos://device/ entries", async () => {
+    const { messageStr, signature } = await buildMessage({
+      resources: [
+        `convos://device/${TEST_DEVICE_ID}`,
+        `convos://device/${TEST_DEVICE_ID}-2`,
+      ],
+    });
+    await expectInvalidSiwe(
+      {
+        message: messageStr,
+        signature,
+        expectedNonce: NONCE,
+        expectedDeviceId: TEST_DEVICE_ID,
+        now: NOW,
+      },
+      "device_resource_duplicate",
+    );
+  });
+
+  test("rejects when signed deviceId differs from expectedDeviceId", async () => {
+    const { messageStr, signature } = await buildMessage({
+      resources: ["convos://device/some-other-device"],
+    });
+    await expectInvalidSiwe(
+      {
+        message: messageStr,
+        signature,
+        expectedNonce: NONCE,
+        expectedDeviceId: TEST_DEVICE_ID,
+        now: NOW,
+      },
+      "device_mismatch",
+    );
+  });
+
+  test("rejects case-different deviceId (opaque, exact match)", async () => {
+    const { messageStr, signature } = await buildMessage({
+      resources: [`convos://device/${TEST_DEVICE_ID.toUpperCase()}`],
+    });
+    await expectInvalidSiwe(
+      {
+        message: messageStr,
+        signature,
+        expectedNonce: NONCE,
+        expectedDeviceId: TEST_DEVICE_ID,
+        now: NOW,
+      },
+      "device_mismatch",
+    );
+  });
+
+  test("accepts when an extra non-device Resources entry is present", async () => {
+    const { messageStr, signature, address } = await buildMessage({
+      resources: [
+        "https://example.com/unrelated",
+        `convos://device/${TEST_DEVICE_ID}`,
+      ],
+    });
+    const result = await verifySiwe({
+      message: messageStr,
+      signature,
+      expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
+      now: NOW,
+    });
+    expect(result.address).toBe(address);
+  });
+
+  test("device check runs before msg.verify (tampered signature with valid URI still throws signature)", async () => {
+    const { messageStr } = await buildMessage();
+    // Replace the signature with a syntactically valid but wrong one.
+    const badSignature = "0x" + "00".repeat(65);
+    await expectInvalidSiwe(
+      {
+        message: messageStr,
+        signature: badSignature,
+        expectedNonce: NONCE,
+        expectedDeviceId: TEST_DEVICE_ID,
+        now: NOW,
+      },
+      "signature",
+    );
+  });
 });

--- a/tests/auth-siwe.test.ts
+++ b/tests/auth-siwe.test.ts
@@ -44,6 +44,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
     expect(result.address).toBe(address);
@@ -57,6 +58,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -67,6 +69,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: "00".repeat(32),
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -77,6 +80,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -89,6 +93,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -107,6 +112,7 @@ describe("verifySiwe", () => {
         message: tampered,
         signature,
         expectedNonce: NONCE,
+        expectedDeviceId: TEST_DEVICE_ID,
         now: NOW,
       },
       "parse",
@@ -121,6 +127,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -133,6 +140,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -145,6 +153,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -157,6 +166,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -169,6 +179,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });
@@ -181,6 +192,7 @@ describe("verifySiwe", () => {
       message: messageStr,
       signature: badSig,
       expectedNonce: NONCE,
+      expectedDeviceId: TEST_DEVICE_ID,
       now: NOW,
     });
   });

--- a/tests/auth-siwe.test.ts
+++ b/tests/auth-siwe.test.ts
@@ -1,31 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { Wallet } from "ethers";
-import { SiweMessage } from "siwe";
+import type { SiweMessage } from "siwe";
 import { InvalidSiweError, verifySiwe } from "@/api/v2/auth/handlers/siwe";
+import { buildSiweMessage } from "./helpers/siwe";
 
 const NONCE = "abcdef".padEnd(64, "0");
 const NOW = new Date("2026-05-08T12:00:00Z");
+const TEST_DEVICE_ID = "test-device-id";
 
 async function buildMessage(
   overrides: Partial<SiweMessage> = {},
   signerKey?: string,
 ) {
-  const wallet = new Wallet(signerKey ?? "0x" + "1".repeat(64));
-  const base: ConstructorParameters<typeof SiweMessage>[0] = {
-    domain: "convos.app",
-    address: wallet.address,
-    statement: "Sign in to Convos",
-    uri: "https://convos.app",
-    version: "1",
-    chainId: 1,
+  return buildSiweMessage({
+    deviceId: TEST_DEVICE_ID,
     nonce: NONCE,
-    issuedAt: NOW.toISOString(),
-    expirationTime: new Date(NOW.getTime() + 5 * 60_000).toISOString(),
-  };
-  const msg = new SiweMessage({ ...base, ...overrides });
-  const messageStr = msg.prepareMessage();
-  const signature = await wallet.signMessage(messageStr);
-  return { messageStr, signature, address: wallet.address.toLowerCase() };
+    signerKey,
+    now: NOW,
+    overrides,
+  });
 }
 
 async function expectInvalidSiwe(

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -221,4 +221,168 @@ describe("POST /auth/token (legacy + SIWE)", () => {
     const row = await prisma.authNonce.findUnique({ where: { nonce } });
     expect(row).toBeNull();
   });
+
+  test("first SIWE on registered device sets DeviceRegistration.accountId", async () => {
+    const deviceId = "dev-backfill-1";
+    await prisma.deviceRegistration.create({ data: { deviceId } });
+
+    const nonce = await issueNonce();
+    const cookieValue = signNonce(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, deviceId);
+
+    const res = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookieValue}`)
+      .send({ deviceId, siwe: { message: messageStr, signature } });
+
+    expect(res.status).toBe(200);
+
+    const dr = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+    expect(dr?.accountId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("second SIWE same wallet same device: column unchanged (idempotent)", async () => {
+    const deviceId = "dev-backfill-2";
+    await prisma.deviceRegistration.create({ data: { deviceId } });
+
+    const nonce1 = await issueNonce();
+    const cookie1 = signNonce(nonce1);
+    const built1 = await buildSiwe(nonce1, deviceId);
+    const res1 = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookie1}`)
+      .send({
+        deviceId,
+        siwe: { message: built1.messageStr, signature: built1.signature },
+      });
+    expect(res1.status).toBe(200);
+    const after1 = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+
+    const nonce2 = await issueNonce();
+    const cookie2 = signNonce(nonce2);
+    const built2 = await buildSiwe(nonce2, deviceId);
+    const res2 = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookie2}`)
+      .send({
+        deviceId,
+        siwe: { message: built2.messageStr, signature: built2.signature },
+      });
+    expect(res2.status).toBe(200);
+    const after2 = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+
+    expect(after2?.accountId ?? null).toBe(after1?.accountId ?? null);
+  });
+
+  test("different wallet on same device flips column (last-write-wins)", async () => {
+    const deviceId = "dev-backfill-3";
+    await prisma.deviceRegistration.create({ data: { deviceId } });
+
+    // First wallet — uses default signerKey (helper default)
+    const nonce1 = await issueNonce();
+    const cookie1 = signNonce(nonce1);
+    const built1 = await buildSiwe(nonce1, deviceId);
+    const res1 = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookie1}`)
+      .send({
+        deviceId,
+        siwe: { message: built1.messageStr, signature: built1.signature },
+      });
+    expect(res1.status).toBe(200);
+    const after1 = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+    const firstAccountId = after1?.accountId;
+    expect(firstAccountId).toBeTruthy();
+
+    // Second wallet — distinct private key produces different address → different account
+    const nonce2 = await issueNonce();
+    const cookie2 = signNonce(nonce2);
+    const built2 = await buildSiweMessage({
+      deviceId,
+      nonce: nonce2,
+      signerKey: "0x" + "2".repeat(64),
+    });
+    const res2 = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookie2}`)
+      .send({
+        deviceId,
+        siwe: { message: built2.messageStr, signature: built2.signature },
+      });
+    expect(res2.status).toBe(200);
+    const after2 = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+
+    expect(after2?.accountId).toBeTruthy();
+    expect(after2?.accountId).not.toBe(firstAccountId);
+  });
+
+  test("SIWE on never-registered device: token still 200, no row to update", async () => {
+    const deviceId = "dev-backfill-noop";
+    // Intentionally do NOT pre-create DeviceRegistration row.
+
+    const nonce = await issueNonce();
+    const cookieValue = signNonce(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, deviceId);
+
+    const res = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookieValue}`)
+      .send({ deviceId, siwe: { message: messageStr, signature } });
+
+    expect(res.status).toBe(200);
+
+    const dr = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+    expect(dr).toBeNull();
+  });
+
+  test("legacy /auth/token (no siwe) preserves existing accountId column", async () => {
+    const deviceId = "dev-backfill-legacy";
+    await prisma.deviceRegistration.create({ data: { deviceId } });
+
+    // Seed column via SIWE upgrade
+    const nonce = await issueNonce();
+    const cookieValue = signNonce(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, deviceId);
+    await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookieValue}`)
+      .send({ deviceId, siwe: { message: messageStr, signature } });
+    const seeded = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+    expect(seeded?.accountId).toBeTruthy();
+
+    // Legacy mint — no siwe in body
+    const legacyRes = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .send({ deviceId });
+    expect(legacyRes.status).toBe(200);
+
+    const after = await prisma.deviceRegistration.findUnique({
+      where: { deviceId },
+    });
+    expect(after?.accountId ?? null).toBe(seeded?.accountId ?? null);
+  });
 });

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import cookieParser from "cookie-parser";
 import { Wallet } from "ethers";
 import express from "express";
-import { SiweMessage } from "siwe";
 import request from "supertest";
 import { issueNonce } from "@/api/v2/auth/auth-nonce.repository";
 import { authRouter } from "@/api/v2/auth/auth.router";
@@ -11,6 +10,7 @@ import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { verifyJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { buildSiweMessage } from "./helpers/siwe";
 
 function makeApp() {
   const app = express();
@@ -23,22 +23,12 @@ function makeApp() {
 
 const APPCHECK = ["X-Firebase-AppCheck", "valid-app-check-token"] as const;
 
-async function buildSiwe(nonce: string) {
-  const wallet = new Wallet("0x" + "1".repeat(64));
-  const msg = new SiweMessage({
-    domain: "convos.app",
-    address: wallet.address,
-    statement: "Sign in to Convos",
-    uri: "https://convos.app",
-    version: "1",
-    chainId: 1,
+async function buildSiwe(nonce: string, deviceId = "test-device-id") {
+  const { messageStr, signature, address } = await buildSiweMessage({
+    deviceId,
     nonce,
-    issuedAt: new Date().toISOString(),
-    expirationTime: new Date(Date.now() + 5 * 60_000).toISOString(),
   });
-  const messageStr = msg.prepareMessage();
-  const signature = await wallet.signMessage(messageStr);
-  return { messageStr, signature, address: wallet.address.toLowerCase() };
+  return { messageStr, signature, address };
 }
 
 async function reset() {
@@ -69,7 +59,10 @@ describe("POST /auth/token (legacy + SIWE)", () => {
   test("siwe happy path → upserts account, JWT carries accountId, clears cookie", async () => {
     const nonce = await issueNonce();
     const cookieValue = signNonce(nonce);
-    const { messageStr, signature, address } = await buildSiwe(nonce);
+    const { messageStr, signature, address } = await buildSiwe(
+      nonce,
+      "dev-siwe",
+    );
 
     const res = await request(makeApp())
       .post("/auth/token")
@@ -104,7 +97,7 @@ describe("POST /auth/token (legacy + SIWE)", () => {
   test("replay: same nonce twice → 401 on second attempt", async () => {
     const nonce = await issueNonce();
     const cookieValue = signNonce(nonce);
-    const { messageStr, signature } = await buildSiwe(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, "dev-replay");
 
     const first = await request(makeApp())
       .post("/auth/token")
@@ -129,7 +122,7 @@ describe("POST /auth/token (legacy + SIWE)", () => {
 
   test("siwe present but no cookie → 401", async () => {
     const nonce = "00".repeat(32);
-    const { messageStr, signature } = await buildSiwe(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, "dev");
     const res = await request(makeApp())
       .post("/auth/token")
       .set(...APPCHECK)
@@ -139,7 +132,7 @@ describe("POST /auth/token (legacy + SIWE)", () => {
 
   test("JSON-prefixed nonce cookie (cookie-parser parses to object) → 401, not 500", async () => {
     const nonce = "00".repeat(32);
-    const { messageStr, signature } = await buildSiwe(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, "dev");
     // cookie-parser parses values prefixed with `j:` as JSON. The cookie
     // value below decodes to {x:1}, a plain object. Without a string-type
     // guard the handler would crash; the contract is "treat as missing → 401".
@@ -156,7 +149,7 @@ describe("POST /auth/token (legacy + SIWE)", () => {
     const nonce = await issueNonce();
     const valid = signNonce(nonce);
     const tampered = "AAAA" + valid.slice(4);
-    const { messageStr, signature } = await buildSiwe(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, "dev");
     const res = await request(makeApp())
       .post("/auth/token")
       .set(...APPCHECK)
@@ -182,7 +175,7 @@ describe("POST /auth/token (legacy + SIWE)", () => {
 
     const nonce = await issueNonce();
     const cookieValue = signNonce(nonce);
-    const { messageStr, signature } = await buildSiwe(nonce);
+    const { messageStr, signature } = await buildSiwe(nonce, "dev-disabled");
 
     const res = await request(makeApp())
       .post("/auth/token")
@@ -207,7 +200,7 @@ describe("POST /auth/token (legacy + SIWE)", () => {
   test("valid HMAC + bad SIWE signature → 401 AND nonce is consumed (locks in atomic-consume-before-verify ordering)", async () => {
     const nonce = await issueNonce();
     const cookieValue = signNonce(nonce);
-    const { messageStr } = await buildSiwe(nonce);
+    const { messageStr } = await buildSiwe(nonce, "dev-bad-sig");
 
     // Sign the same message with a different wallet so signature fails verifySiwe
     const otherWallet = new Wallet("0x" + "9".repeat(64));

--- a/tests/helpers/siwe.ts
+++ b/tests/helpers/siwe.ts
@@ -1,0 +1,48 @@
+import { Wallet } from "ethers";
+import { SiweMessage } from "siwe";
+
+export const DEFAULT_TEST_PRIVATE_KEY = "0x" + "1".repeat(64);
+
+export interface BuildSiweArgs {
+  deviceId: string;
+  nonce: string;
+  signerKey?: string;
+  now?: Date;
+  /** Override any SiweMessage field. Pass `resources: []` to omit the device URI. */
+  overrides?: Partial<SiweMessage>;
+}
+
+export interface BuiltSiwe {
+  messageStr: string;
+  signature: string;
+  address: string;
+  deviceId: string;
+}
+
+export async function buildSiweMessage(
+  args: BuildSiweArgs,
+): Promise<BuiltSiwe> {
+  const wallet = new Wallet(args.signerKey ?? DEFAULT_TEST_PRIVATE_KEY);
+  const now = args.now ?? new Date();
+  const base: Partial<SiweMessage> = {
+    domain: "convos.app",
+    address: wallet.address,
+    statement: "Sign in to Convos",
+    uri: "https://convos.app",
+    version: "1",
+    chainId: 1,
+    nonce: args.nonce,
+    issuedAt: now.toISOString(),
+    expirationTime: new Date(now.getTime() + 5 * 60_000).toISOString(),
+    resources: [`convos://device/${args.deviceId}`],
+  };
+  const msg = new SiweMessage({ ...base, ...(args.overrides ?? {}) });
+  const messageStr = msg.prepareMessage();
+  const signature = await wallet.signMessage(messageStr);
+  return {
+    messageStr,
+    signature,
+    address: wallet.address.toLowerCase(),
+    deviceId: args.deviceId,
+  };
+}


### PR DESCRIPTION
Summary
--

  - Cryptographically bind `deviceId` into every SIWE message via `Resources: ["convos://device/<deviceId>"]`. `verifySiwe` now rejects mismatched, missing, or
  duplicate device URIs.
  - Persist `(deviceId → accountId)` on `DeviceRegistration` via best-effort backfill after successful SIWE upgrade in `/auth/token`. Last-write-wins on wallet switch;
   legacy path preserves the column.
  - New nullable `DeviceRegistration.accountId` column with FK to `Account` (`onDelete: SetNull`) and supporting index. Foundation for future account-level features
  (push routing, revocation, sensitive-op re-auth).

  No new env vars. No new routes. No new dependencies. Pure additive schema + handler changes.

  ## iOS coordination required before merge

  iOS SIWE builder MUST include `Resources: ["convos://device/<identifierForVendor>"]`. Post-merge, any SIWE flow without the URI returns 401
  `device_resource_missing`. Case-sensitive exact match against `body.deviceId`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind deviceId into SIWE verification and backfill `DeviceRegistration.accountId` on token mint
> - `verifySiwe` now requires exactly one `convos://device/{id}` resource in the SIWE message matching the request's `deviceId`; messages with missing, duplicate, or mismatched device resources are rejected with specific `InvalidSiweError` reasons.
> - After a successful SIWE verification in [`generate-token.ts`](https://github.com/ephemeraHQ/convos-backend/pull/209/files#diff-efae9276d245e77d478e0961baa0a511ec789b80927164138b3523f31781fb70), the handler backfills `DeviceRegistration.accountId` for the device using a row-level `SELECT ... FOR UPDATE` lock to serialize concurrent updates (last-writer-wins).
> - A new optional `accountId` column and foreign key are added to `DeviceRegistration` via a Prisma migration, with `ON DELETE SET NULL` semantics.
> - Backfill errors are caught and logged but do not fail the token mint. Legacy token mints (no SIWE) leave `accountId` unchanged.
> - Risk: existing SIWE clients must include a valid `convos://device/{id}` resource or authentication will be rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d67f504.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device registrations can be linked to user accounts; sign-in now binds device IDs to accounts and backfills registrations.
  * SIWE authentication enforces cryptographic device binding (requires a matching device resource) for stronger security.

* **Tests**
  * Expanded SIWE/device test coverage and added a shared SIWE test helper to validate persistence and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/209)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->