### PR TITLE
fix: copy data/ into Docker image so generation prompt loads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN mkdir -p /temp/prod/prisma
 COPY prisma /temp/prod/prisma
 RUN mkdir -p /temp/prod/proto
 COPY proto /temp/prod/proto
+RUN mkdir -p /temp/prod/data
+COPY data /temp/prod/data
 
 # Install all dependencies (including devDependencies needed for code generation)
 RUN cd /temp/prod && bun install --frozen-lockfile


### PR DESCRIPTION
## Problem

Agent-template generation fails in deployed environments with:

```
Generate stage failed: Template generator system prompt not loaded
```

Found while smoke-testing the generation endpoint on OTR dev.

## Root cause

`src/api/v2/agent-templates/lib/system-prompt.ts` reads `data/template-generator-prompt.txt` at module load. The file exists in the repo (added in #204), but the `Dockerfile` only copies `src`, `prisma`, `proto`, and root config files — **not `data/`**. In the container, `readFileSync` throws, `SYSTEM_PROMPT` stays `null`, and every generation bails at the generate stage.

## Fix

Add a `COPY data /temp/prod/data` alongside the existing `src`/`prisma`/`proto` copies. It propagates to the release image via the existing `COPY --from=install /temp/prod .`.

## Test plan

- [ ] After merge + deploy, re-run the generation smoke test against OTR dev and confirm it reaches a `done` status instead of failing at the generate stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Copy `data/` directory into Docker image so generation prompt loads
> The [Dockerfile](https://github.com/ephemeraHQ/convos-backend/pull/211/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) install stage now creates `/temp/prod/data` and copies the local `data/` directory into it, which is then included when `/temp/prod` is copied into the release stage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4fc49f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->