### PR TITLE
feat(agent-templates): revalidate assistants-dashboard cache on writes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,11 @@ BUILDER_SITE_URL=https://dev.convos.org
 BUILDER_OPENROUTER_API_KEY=
 BUILDER_MODEL=
 BUILDER_EXA_SERVICE_KEY=
+# Shared bearer for the assistants-dashboard revalidate webhook
+# (POST BUILDER_SITE_URL/api/revalidate). Must match the dashboard's
+# BUILDER_REVALIDATE_SECRET. Unset → no-op (dashboard's 60s Data Cache TTL
+# is the fallback).
+BUILDER_REVALIDATE_SECRET=
 POSTHOG_PROJECT_TOKEN=
 POSTHOG_HOST=
 # Content moderation model override (default: google/gemini-3.1-flash-lite)

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { pickCollisionFreeId } from "@/api/v2/agent-templates/lib/pick-collision-free-id";
 import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
+import { revalidateTemplate } from "@/api/v2/agent-templates/services/revalidate-dashboard";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
@@ -182,6 +183,13 @@ export async function createHandler(req: Request, res: Response) {
       slug: validation.slug,
       ownerAccountId,
     });
+
+    void revalidateTemplate({
+      id: template.id,
+      slug: template.slug,
+      log: req.log,
+    });
+
     res.status(201).json(serializeAgentTemplate(template));
   } catch (error) {
     // Race: a referenced row (ownerAccountId → Account, or forkedFromId →

--- a/src/api/v2/agent-templates/handlers/delete.ts
+++ b/src/api/v2/agent-templates/handlers/delete.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { revalidateTemplate } from "@/api/v2/agent-templates/services/revalidate-dashboard";
 import { prisma } from "@/utils/prisma";
 
 const paramsSchema = z.object({
@@ -19,7 +20,7 @@ export async function deleteHandler(req: Request, res: Response) {
   try {
     const template = await prisma.agentTemplate.findUnique({
       where: { id: parsedParams.data.id },
-      select: { id: true, ownerAccountId: true },
+      select: { id: true, slug: true, ownerAccountId: true },
     });
 
     if (template === null) {
@@ -58,6 +59,12 @@ export async function deleteHandler(req: Request, res: Response) {
       res.status(404).json({ error: "Agent template not found" });
       return;
     }
+
+    void revalidateTemplate({
+      id: template.id,
+      slug: template.slug,
+      log: req.log,
+    });
 
     res.status(200).json({
       object: "agent_template",

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -2,6 +2,7 @@ import type { Prisma, PublishStatus } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
+import { revalidateTemplate } from "@/api/v2/agent-templates/services/revalidate-dashboard";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
 
@@ -243,6 +244,12 @@ export async function patchHandler(req: Request, res: Response) {
 
     const updated = await prisma.agentTemplate.findUniqueOrThrow({
       where: { id: template.id },
+    });
+
+    void revalidateTemplate({
+      id: updated.id,
+      slug: updated.slug,
+      log: req.log,
     });
 
     res.status(200).json(serializeAgentTemplate(updated));

--- a/src/api/v2/agent-templates/handlers/publish.ts
+++ b/src/api/v2/agent-templates/handlers/publish.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
+import { revalidateTemplate } from "@/api/v2/agent-templates/services/revalidate-dashboard";
 import { prisma } from "@/utils/prisma";
 
 const paramsSchema = z.object({
@@ -113,6 +114,12 @@ export async function publishHandler(req: Request, res: Response) {
 
     const updated = await prisma.agentTemplate.findUniqueOrThrow({
       where: { id: template.id },
+    });
+
+    void revalidateTemplate({
+      id: updated.id,
+      slug: updated.slug,
+      log: req.log,
     });
 
     res.status(200).json(serializeAgentTemplate(updated));

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -34,6 +34,7 @@ import {
   resolveActor,
   type PostHogCaptureProperties,
 } from "@/api/v2/agent-templates/services/posthog";
+import { revalidateTemplate } from "@/api/v2/agent-templates/services/revalidate-dashboard";
 import {
   callGenerateTemplate,
   getModel,
@@ -630,6 +631,13 @@ async function _runPipeline(
     ...base,
     outcome: "done",
   });
+
+  // Only fire revalidation when the new row is actually visible on the
+  // dashboard. Drafts aren't surfaced, so the cache has nothing to drop.
+  if (generation.publishStatus !== "draft") {
+    void revalidateTemplate({ id: persisted.id, slug: persisted.slug });
+  }
+
   logger.info(
     {
       generationId,

--- a/src/api/v2/agent-templates/services/revalidate-dashboard.ts
+++ b/src/api/v2/agent-templates/services/revalidate-dashboard.ts
@@ -1,0 +1,146 @@
+/**
+ * Fire-and-forget revalidation of the assistants-dashboard Next.js cache.
+ *
+ * The dashboard (assistants.convos.org) reads agent-templates from
+ * `/api/v2/agent-templates*` via Next.js Data Cache with a 60s TTL,
+ * tagged `templates` and `template:<idOrHashedSlug>`. It exposes
+ * `POST /api/revalidate` (auth: `Authorization: Bearer <secret>`,
+ * body: `{ tags: string[] }`) so callers can drop tagged entries on
+ * demand.
+ *
+ * Configuration:
+ *   - BUILDER_SITE_URL              — dashboard base URL (reused; same env
+ *                                     var the builder uses for share links)
+ *   - BUILDER_REVALIDATE_SECRET  — shared bearer; service no-ops when unset
+ *
+ * Contract:
+ *   - Best-effort: never throws. Errors are logged at warn and swallowed.
+ *   - 3-second hard timeout via AbortController so a slow dashboard cannot
+ *     stall an HTTP handler that fires this from its hot path.
+ *   - The dashboard's 60s TTL is the fallback when this call drops.
+ */
+
+import { BUILDER_REVALIDATE_SECRET, BUILDER_SITE_URL } from "@/config";
+import logger from "@/utils/logger";
+import { buildUrlSlug } from "@/utils/url-slug";
+
+const REVALIDATE_TIMEOUT_MS = 3_000;
+
+// Test seams — let the test suite stub fetch + override the secret/base URL
+// without monkey-patching globalThis or reloading the config module.
+type FetchLike = typeof fetch;
+let _fetchOverride: FetchLike | null = null;
+let _secretOverride: string | null | undefined = undefined;
+let _baseUrlOverride: string | null | undefined = undefined;
+
+export function __setFetchForTests(fn: FetchLike | null): void {
+  _fetchOverride = fn;
+}
+
+/** Pass a string to override, `null` to simulate "unset", `undefined` to
+ *  clear and fall back to BUILDER_REVALIDATE_SECRET from config. */
+export function __setSecretForTests(value: string | null | undefined): void {
+  _secretOverride = value;
+}
+
+/** Pass a string to override, `null` to simulate "unset", `undefined` to
+ *  clear and fall back to BUILDER_SITE_URL from config. */
+export function __setBaseUrlForTests(value: string | null | undefined): void {
+  _baseUrlOverride = value;
+}
+
+function currentFetch(): FetchLike {
+  return _fetchOverride ?? fetch;
+}
+
+function currentSecret(): string {
+  if (_secretOverride !== undefined) return _secretOverride ?? "";
+  return BUILDER_REVALIDATE_SECRET;
+}
+
+function currentBaseUrl(): string {
+  if (_baseUrlOverride !== undefined) return _baseUrlOverride ?? "";
+  return BUILDER_SITE_URL;
+}
+
+/**
+ * Fire a tag revalidation against the dashboard. Resolves once the request
+ * completes (or has been swallowed). Caller may `void` the returned promise
+ * to keep the request path off the critical path.
+ */
+export async function revalidateDashboardTags(args: {
+  tags: readonly string[];
+  log?: Pick<typeof logger, "warn" | "info">;
+}): Promise<void> {
+  const log = args.log ?? logger;
+
+  if (args.tags.length === 0) return;
+
+  const secret = currentSecret();
+  if (!secret) {
+    // Unset secret means revalidation is intentionally disabled (local dev,
+    // tests). Stay quiet: this fires from every template mutation and the
+    // 60s TTL covers the gap.
+    return;
+  }
+
+  const baseUrl = currentBaseUrl();
+  if (!baseUrl) return;
+
+  const url = `${baseUrl.replace(/\/+$/, "")}/api/revalidate`;
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => {
+    controller.abort();
+  }, REVALIDATE_TIMEOUT_MS);
+
+  try {
+    const response = await currentFetch()(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${secret}`,
+      },
+      body: JSON.stringify({ tags: args.tags }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      log.warn(
+        {
+          status: response.status,
+          tags: args.tags,
+          url,
+        },
+        "[revalidate-dashboard] non-2xx response",
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { err, tags: args.tags, url },
+      "[revalidate-dashboard] request failed",
+    );
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+/**
+ * Convenience wrapper: fire the tag set the dashboard uses for a single
+ * template — `templates` (list/featured surface), `template:<id>`, and
+ * `template:<base>.<hash>` (the url-slug form the dashboard's
+ * `/a/[urlSlug]` page tags by). `args.slug` is the BASE slug; the url slug
+ * is derived with the same `buildUrlSlug` that serializes `publishedUrl`,
+ * so the tag matches what the dashboard keyed its fetch on.
+ */
+export function revalidateTemplate(args: {
+  id: string;
+  slug: string;
+  log?: Pick<typeof logger, "warn" | "info">;
+}): Promise<void> {
+  const tags = [
+    "templates",
+    `template:${args.id}`,
+    `template:${buildUrlSlug(args.slug, args.id)}`,
+  ];
+  return revalidateDashboardTags({ tags, log: args.log });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,6 +147,13 @@ if (!builderSiteUrl) {
 }
 export const BUILDER_SITE_URL = builderSiteUrl;
 
+// Shared bearer for the assistants-dashboard /api/revalidate webhook. When
+// unset, the revalidate service no-ops (relies on the dashboard's 60s TTL
+// fallback). Reuses BUILDER_SITE_URL as the dashboard base — see
+// services/revalidate-dashboard.ts.
+export const BUILDER_REVALIDATE_SECRET =
+  process.env.BUILDER_REVALIDATE_SECRET?.trim() || "";
+
 // PostHog metering (optional — capture is no-op if the token is unset).
 // Host defaults to PostHog Cloud US so setting only the token Just Works.
 export const POSTHOG_PROJECT_TOKEN =

--- a/tests/revalidate-dashboard.service.test.ts
+++ b/tests/revalidate-dashboard.service.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the assistants-dashboard revalidate service.
+ *
+ * Covers:
+ *   - no-op when secret is unset
+ *   - posts the expected URL/body/bearer when configured
+ *   - swallows network errors (best-effort contract)
+ *   - revalidateTemplate emits templates + template:<id> + template:<urlSlug>
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __setBaseUrlForTests,
+  __setFetchForTests,
+  __setSecretForTests,
+  revalidateDashboardTags,
+  revalidateTemplate,
+} from "@/api/v2/agent-templates/services/revalidate-dashboard";
+import { buildUrlSlug } from "@/utils/url-slug";
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+let captured: CapturedRequest[] = [];
+let fetchImpl: (url: string, init: RequestInit) => Promise<Response> = () =>
+  Promise.resolve(new Response(null, { status: 200 }));
+
+const installFetch = () => {
+  // Cast through `unknown` because the in-tree `typeof fetch` is Bun's
+  // flavoured signature (BunFetchRequestInit); we only need the standard
+  // shape to drive these tests.
+  const stub = ((input: unknown, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const method = init?.method ?? "GET";
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [k, v] of Object.entries(
+        init.headers as Record<string, string>,
+      )) {
+        headers[k.toLowerCase()] = v;
+      }
+    }
+    let body: unknown;
+    if (init?.body) {
+      try {
+        body = JSON.parse(init.body as string);
+      } catch {
+        body = init.body;
+      }
+    }
+    captured.push({ url, method, headers, body });
+    return fetchImpl(url, init ?? {});
+  }) as unknown as typeof fetch;
+  __setFetchForTests(stub);
+};
+
+// Silent log shim so the warn path doesn't spam test output.
+const silentLog = { warn: () => undefined, info: () => undefined };
+
+beforeEach(() => {
+  captured = [];
+  fetchImpl = () => Promise.resolve(new Response(null, { status: 200 }));
+  installFetch();
+  __setSecretForTests("test-secret");
+  __setBaseUrlForTests("https://dash.test.example");
+});
+
+afterEach(() => {
+  __setFetchForTests(null);
+  __setSecretForTests(undefined);
+  __setBaseUrlForTests(undefined);
+});
+
+describe("revalidateDashboardTags", () => {
+  test("no-ops when no tags provided", async () => {
+    await revalidateDashboardTags({ tags: [], log: silentLog });
+    expect(captured).toHaveLength(0);
+  });
+
+  test("no-ops when secret is unset", async () => {
+    __setSecretForTests(null);
+    await revalidateDashboardTags({ tags: ["templates"], log: silentLog });
+    expect(captured).toHaveLength(0);
+  });
+
+  test("posts tags + bearer to <base>/api/revalidate", async () => {
+    await revalidateDashboardTags({
+      tags: ["templates", "template:abc"],
+      log: silentLog,
+    });
+    expect(captured).toHaveLength(1);
+    const request = captured[0];
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe("https://dash.test.example/api/revalidate");
+    expect(request.headers.authorization).toBe("Bearer test-secret");
+    expect(request.headers["content-type"]).toBe("application/json");
+    expect(request.body).toEqual({ tags: ["templates", "template:abc"] });
+  });
+
+  test("strips trailing slashes from the base URL", async () => {
+    __setBaseUrlForTests("https://dash.test.example///");
+    await revalidateDashboardTags({ tags: ["templates"], log: silentLog });
+    expect(captured[0]?.url).toBe("https://dash.test.example/api/revalidate");
+  });
+
+  test("swallows non-2xx response without throwing", async () => {
+    fetchImpl = () => Promise.resolve(new Response("nope", { status: 500 }));
+    await revalidateDashboardTags({ tags: ["templates"], log: silentLog });
+    // Reaching this line is the assertion; the call must not throw.
+    expect(captured).toHaveLength(1);
+  });
+
+  test("swallows network errors without throwing", async () => {
+    fetchImpl = () => Promise.reject(new Error("ECONNREFUSED"));
+    await revalidateDashboardTags({ tags: ["templates"], log: silentLog });
+    expect(captured).toHaveLength(1);
+  });
+});
+
+describe("revalidateTemplate", () => {
+  test("emits templates + template:<id> + template:<urlSlug>", async () => {
+    const id = "11111111-2222-4333-8444-555555555555";
+    const slug = "brewski";
+    const urlSlug = buildUrlSlug(slug, id);
+
+    await revalidateTemplate({ id, slug, log: silentLog });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.body).toEqual({
+      tags: ["templates", `template:${id}`, `template:${urlSlug}`],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #213. **Paired with convos-assistants #1723** (the dashboard side of the webhook).

The assistants dashboard reads `/api/v2/agent-templates*` through Next.js Data Cache (60s TTL, tagged `templates` and `template:<idOrUrlSlug>`). Previously nothing drove the dashboard's `POST /api/revalidate` webhook, so template edits took up to 60s to surface.

This wires convos-backend to fire that webhook fire-and-forget on every mutating write.

- New service `src/api/v2/agent-templates/services/revalidate-dashboard.ts`
  - `revalidateDashboardTags({ tags })` — POSTs `{ tags }` with `Authorization: Bearer ${BUILDER_REVALIDATE_SECRET}` to `${BUILDER_SITE_URL}/api/revalidate`
  - `revalidateTemplate({ id, slug })` — convenience wrapper emitting `["templates", "template:<id>", "template:<base>.<hash>"]`. The url-slug form is built with the same `buildUrlSlug` that serializes `publishedUrl`, so the tag matches the slug the dashboard keyed its fetch on.
  - 3s AbortController timeout; non-2xx and network errors are logged at warn and swallowed
  - No-op when `BUILDER_REVALIDATE_SECRET` is unset (60s TTL is the fallback)
- Wiring: `handlers/create.ts`, `handlers/patch.ts`, `handlers/publish.ts`, `handlers/delete.ts`, and `services/generation-executor.ts` (only when `publishStatus !== "draft"`)
- Adds `BUILDER_REVALIDATE_SECRET` to `config.ts` + `.env.example`; reuses the existing required `BUILDER_SITE_URL` as the dashboard base.

### Secret alignment

`BUILDER_REVALIDATE_SECRET` must be set to the **same value** on both services. The dashboard's `/api/revalidate` previously authenticated against `POOL_API_KEY`, which is now orphaned (the pool is retired and convos-backend is the source of truth) — convos-assistants #1723 switches that check to `BUILDER_REVALIDATE_SECRET` to match this caller.

## Rebase / alignment notes

- Rebased onto latest `otr-dev` and squashed the prettier/eslint fixup commits into one.
- `otr-dev` renamed `src/utils/slug-hash.ts` → `src/utils/url-slug.ts` (`buildSlug` → `buildUrlSlug`); the service + test now import from there.

## Test plan

- [x] `bun test tests/revalidate-dashboard.service.test.ts` — 7 pass (no-op on unset secret / empty tags, URL/bearer/body shape, trailing-slash trim, non-2xx swallowed, network error swallowed, template tag set)
- [x] `eslint` clean on changed files; `prettier --check` clean
- [ ] Manual smoke against staging dashboard: create/publish/patch a template and confirm the dashboard reflects the change inside the 3s timeout window (not after 60s TTL) — requires `BUILDER_REVALIDATE_SECRET` set to the same value on both deploys
- [ ] Confirm unset `BUILDER_REVALIDATE_SECRET` in local/dev does not introduce any errors on the write path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template create/update/delete/publish now trigger automatic dashboard revalidation so the assistants dashboard reflects changes faster.

* **Configuration**
  * Added optional BUILDER_SITE_URL and BUILDER_REVALIDATE_SECRET environment variables to enable and authenticate dashboard revalidation (no-op when unset).

* **Tests**
  * Added tests validating revalidation requests, payload/tag composition, error handling, and base URL normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revalidate assistants-dashboard cache on agent template writes
> - Adds a new `revalidateTemplate` service in [`revalidate-dashboard.ts`](https://github.com/ephemeraHQ/convos-backend/pull/216/files#diff-0c5b0ba9f8e8e56e2c5efaa7797cdbaba9b500c722e26cf74b3e8565af61d5de) that fires a fire-and-forget POST to `<BUILDER_SITE_URL>/api/revalidate` with a bearer token, invalidating tags for the affected template.
> - Calls `revalidateTemplate` after create, patch, delete, publish, and (non-draft) generation pipeline operations on agent templates.
> - Revalidation is a no-op when `BUILDER_REVALIDATE_SECRET` or `BUILDER_SITE_URL` is unset, and swallows all errors with a 3-second timeout.
> - Adds `BUILDER_REVALIDATE_SECRET` to [`config.ts`](https://github.com/ephemeraHQ/convos-backend/pull/216/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012) and [`.env.example`](https://github.com/ephemeraHQ/convos-backend/pull/216/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acb0160.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->