### PR TITLE
fix(posthog): flush on SIGTERM and log async capture errors

### DIFF
--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -15,6 +15,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
 
 import { POSTHOG_HOST, POSTHOG_PROJECT_TOKEN } from "@/config";
+import logger from "@/utils/logger";
 import type { GenerationMetrics } from "./templateGen";
 
 // ---------------------------------------------------------------------------
@@ -73,6 +74,16 @@ function getPostHogClient(): any {
     PostHog: new (apiKey: string, opts: { host: string }) => any;
   };
   _posthogClient = new PostHog(POSTHOG_PROJECT_TOKEN, { host: POSTHOG_HOST });
+  // Surface async capture failures (auth 401s on a wrong token, wrong host,
+  // network errors). capture() is fire-and-forget so these are otherwise
+  // invisible — the request that triggered it has already returned. Subscribe
+  // once at client creation; client is cached for the lifetime of the process.
+  _posthogClient.on("error", (err: unknown) => {
+    logger.error(
+      { err: err instanceof Error ? err.message : err },
+      "[posthog] async capture error",
+    );
+  });
   return _posthogClient;
 }
 
@@ -129,9 +140,36 @@ export function capturePostHog(properties: PostHogCaptureProperties): void {
       properties,
     });
   } catch (err) {
-    console.error(
-      "[posthog] capture failed:",
-      err instanceof Error ? err.message : err,
+    logger.error(
+      { err: err instanceof Error ? err.message : err },
+      "[posthog] capture failed",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown
+// ---------------------------------------------------------------------------
+
+/**
+ * Flush any buffered events and tear down the PostHog client. Call once
+ * during SIGTERM so events captured in the last `flushInterval` window
+ * (default 10s in posthog-node v5) aren't lost when the process exits.
+ *
+ * No-op when the client was never created (env vars unset, or test
+ * override installed). Errors are caught and logged — never propagate
+ * to the caller so shutdown can continue.
+ */
+export async function shutdownPostHog(timeoutMs = 5000): Promise<void> {
+  const client = _posthogClient;
+  if (!client) return;
+  _posthogClient = null;
+  try {
+    await client.shutdown(timeoutMs);
+  } catch (err) {
+    logger.error(
+      { err: err instanceof Error ? err.message : err },
+      "[posthog] shutdown failed",
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { shutdownPostHog } from "@/api/v2/agent-templates/services/posthog";
 import {
   startTtlSweep as startGenerationTtlSweep,
   stopTtlSweep as stopGenerationTtlSweep,
@@ -89,12 +90,17 @@ validateJWTKeys()
       }
     });
 
-    process.on("SIGTERM", () => {
+    process.on("SIGTERM", async () => {
       logger.info("SIGTERM signal received: closing Convos API service");
       // Stop the generation TTL sweep so its setInterval doesn't keep
       // dispatching DB queries against a closing pool during the drain
       // window. No-op if the sweep was never started (production gate).
       stopGenerationTtlSweep();
+      // Flush buffered PostHog events before the process exits. The SDK
+      // buffers up to flushAt (default 20) or flushInterval (default 10s)
+      // — without an explicit shutdown, low-volume captures get dropped on
+      // every redeploy. Catches its own errors; never throws.
+      await shutdownPostHog();
       server.close(() => {
         logger.info("Convos API service closed");
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,20 +90,26 @@ validateJWTKeys()
       }
     });
 
-    process.on("SIGTERM", async () => {
-      logger.info("SIGTERM signal received: closing Convos API service");
-      // Stop the generation TTL sweep so its setInterval doesn't keep
-      // dispatching DB queries against a closing pool during the drain
-      // window. No-op if the sweep was never started (production gate).
-      stopGenerationTtlSweep();
-      // Flush buffered PostHog events before the process exits. The SDK
-      // buffers up to flushAt (default 20) or flushInterval (default 10s)
-      // — without an explicit shutdown, low-volume captures get dropped on
-      // every redeploy. Catches its own errors; never throws.
-      await shutdownPostHog();
-      server.close(() => {
-        logger.info("Convos API service closed");
-      });
+    // Wrap the async drain steps in a void-IIFE so the SIGTERM listener
+    // itself returns void (Node ignores the listener's return value, and
+    // an `async` listener would trip @typescript-eslint/no-misused-promises).
+    // `shutdownPostHog()` catches its own errors, so the IIFE never rejects.
+    process.on("SIGTERM", () => {
+      void (async () => {
+        logger.info("SIGTERM signal received: closing Convos API service");
+        // Stop the generation TTL sweep so its setInterval doesn't keep
+        // dispatching DB queries against a closing pool during the drain
+        // window. No-op if the sweep was never started (production gate).
+        stopGenerationTtlSweep();
+        // Flush buffered PostHog events before the process exits. The SDK
+        // buffers up to flushAt (default 20) or flushInterval (default 10s)
+        // — without an explicit shutdown, low-volume captures get dropped
+        // on every redeploy. Catches its own errors; never throws.
+        await shutdownPostHog();
+        server.close(() => {
+          logger.info("Convos API service closed");
+        });
+      })();
     });
   })
   .catch((error: unknown) => {


### PR DESCRIPTION
## Summary

Two leaks in the `posthog-node` integration that together make the
`builder.generation.completed` metering event effectively invisible:

1. **No flush on SIGTERM.** `posthog-node` buffers events (default
   `flushAt: 20`, `flushInterval: 10s`) and the SIGTERM handler only
   stopped the TTL sweep and called `server.close()` — buffered events
   were dropped on every redeploy. With low generation volume, that
   means most events are still in the buffer when the process exits.
   Adds `shutdownPostHog()` and awaits it in the SIGTERM handler.

2. **Async capture errors were invisible.** `capture()` is fire-and-forget;
   a wrong API key (401), wrong host URL, or network failure surfaces
   on the SDK's `error` event — but nothing was subscribed. The existing
   try/catch only catches synchronous errors (e.g. `require()` failures,
   serialization). Subscribes to `client.on("error", …)` and logs
   through the project's pino logger.

Also moves the sync-error log off `console.error` onto the pino logger
for consistency with the rest of the codebase.

## Why this is showing up now

Zero `builder.generation.completed` events have been received in PostHog,
despite the code being merged. After this change, either (a) events
land, or (b) the new error log surfaces the actual misconfiguration —
either way the operator gets feedback instead of silence.

## Risk

Low. `shutdownPostHog()` no-ops when the client was never created
(env vars unset or test override installed via `__resetPostHogForTests`).
The existing test seam is untouched — the override short-circuits
`capturePostHog()` before any PostHog client is constructed, so the
error listener is never wired in tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Flush PostHog events on SIGTERM and log async capture errors
> - Adds a `shutdownPostHog` function in [posthog.ts](https://github.com/ephemeraHQ/convos-backend/pull/217/files#diff-542f2fa8706fd2fc425fdfbf7c593fbab3b52265f4ec6025fa64cb3661637d81) that flushes buffered events and tears down the client, swallowing errors so callers are unaffected. Default timeout is 5000ms.
> - Hooks `shutdownPostHog` into the SIGTERM handler in [index.ts](https://github.com/ephemeraHQ/convos-backend/pull/217/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), awaiting it before `server.close()`.
> - Replaces `console.error` calls with structured `logger.error` logging, and subscribes to the PostHog client's `error` event to capture async SDK errors.
> - Behavioral Change: SIGTERM shutdown now waits up to 5s for PostHog to flush before closing the HTTP server.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #217 opened
>
> - Refactored the `SIGTERM` handler in the index bootstrap to use a non-async listener that immediately invokes a void-wrapped async IIFE, which logs shutdown start, stops the generation TTL sweep, awaits `shutdownPostHog()`, and calls `server.close()` with completion logging, including explanatory comments about Node ignoring listener return values and linting concerns [06fe9e3]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 156f6c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->