### PR TITLE
feat(posthog): per-actor distinctId via clientDeviceId / twitterHandle ladder

### DIFF
--- a/prisma/migrations/20260516000000_add_generation_client_device_id/migration.sql
+++ b/prisma/migrations/20260516000000_add_generation_client_device_id/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "AgentTemplateGeneration"
+  ADD COLUMN "clientDeviceId" TEXT;

--- a/prisma/migrations/20260516000000_add_generation_client_device_id/migration.sql
+++ b/prisma/migrations/20260516000000_add_generation_client_device_id/migration.sql
@@ -1,3 +1,5 @@
 -- AlterTable
+-- VARCHAR(128) mirrors the zod cap on the API body so the DB enforces
+-- the same contract for any non-handler write path (admin, seed, etc.).
 ALTER TABLE "AgentTemplateGeneration"
-  ADD COLUMN "clientDeviceId" TEXT;
+  ADD COLUMN "clientDeviceId" VARCHAR(128);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,7 +163,7 @@ model AgentTemplateGeneration {
   idempotencyKey  String
   inputs          Json
   twitterContext  Json?
-  clientDeviceId  String?
+  clientDeviceId  String?          @db.VarChar(128)
   templateId      String?          @db.Uuid
   publishStatus   PublishStatus    @default(draft)
   reply           String?          @db.Text

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,6 +163,7 @@ model AgentTemplateGeneration {
   idempotencyKey  String
   inputs          Json
   twitterContext  Json?
+  clientDeviceId  String?
   templateId      String?          @db.Uuid
   publishStatus   PublishStatus    @default(draft)
   reply           String?          @db.Text

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -162,6 +162,14 @@ const bodySchema = z
     source: z.string().min(1, "source is required"),
     inputs: inputsSchema,
     twitterContext: twitterContextSchema.optional(),
+    /** Stable per-client identifier used as the PostHog distinctId fallback
+     *  when the request isn't authenticated (anonymous web/iOS, or the
+     *  twitter-bot path before we wire Twitter user IDs). Web should pass
+     *  posthog-js's `$device_id`. Capped at 128 chars to bound storage and
+     *  prevent abuse — posthog-js generates a UUIDv7 (~36 chars). Excluded
+     *  from the idempotency dedupe body comparison (`dedupeBodiesMatch`)
+     *  so a retry with a rotated device ID still matches the original row. */
+    clientDeviceId: z.string().min(1).max(128).optional(),
     publishStatus: z
       .enum(["draft", "unlisted", "published"])
       .optional()
@@ -714,6 +722,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
         twitterContext: body.twitterContext
           ? (body.twitterContext as Prisma.InputJsonValue)
           : Prisma.JsonNull,
+        clientDeviceId: body.clientDeviceId ?? null,
         publishStatus: body.publishStatus,
         status: "pending",
       },

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -169,7 +169,7 @@ const bodySchema = z
      *  prevent abuse — posthog-js generates a UUIDv7 (~36 chars). Excluded
      *  from the idempotency dedupe body comparison (`dedupeBodiesMatch`)
      *  so a retry with a rotated device ID still matches the original row. */
-    clientDeviceId: z.string().min(1).max(128).optional(),
+    clientDeviceId: z.string().trim().min(1).max(128).optional(),
     publishStatus: z
       .enum(["draft", "unlisted", "published"])
       .optional()

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -28,13 +28,17 @@ import {
   buildDeterministicFallback,
   composeReply,
 } from "@/api/v2/agent-templates/services/compose-reply";
-import { capturePostHog } from "@/api/v2/agent-templates/services/posthog";
+import {
+  capturePostHog,
+  type PostHogCaptureProperties,
+} from "@/api/v2/agent-templates/services/posthog";
 import {
   callGenerateTemplate,
   getModel,
   type GenerateTemplateInput,
 } from "@/api/v2/agent-templates/services/templateGen";
 import { GENERATION_EXECUTOR_TIMEOUT_MS, GENERATION_TTL_HOURS } from "@/config";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
@@ -107,6 +111,64 @@ interface TwitterContext {
   twitterHandle: string;
   tweetId: string;
   idea?: string;
+}
+
+// ---------------------------------------------------------------------------
+// PostHog actor-attribution fields — shared across every capture site
+// ---------------------------------------------------------------------------
+
+/** Generation row shape consumed by `postHogBase` — the actor-attribution
+ *  inputs only. Declared as a structural subset of the Prisma row so this
+ *  helper is decoupled from the full schema. */
+interface PostHogActorSource {
+  ownerAccountId: string;
+  source: string;
+  twitterContext: unknown;
+  clientDeviceId: string | null;
+}
+
+/**
+ * Build the actor-attribution + always-on fields shared across every
+ * PostHog capture site in this pipeline. Centralised so the four sites
+ * (generate-fail, persist-fail, timeout-race-fail, success) stay in sync —
+ * adding a new actor signal only needs one edit here.
+ *
+ * `isAnonymous` is derived from the admin-account sentinel: anonymous
+ * submissions are owned by `ADMIN_ACCOUNT_ID` so the row has a valid
+ * owner FK, but the value is a system identity, not a real user.
+ * `resolveDistinctId` in posthog.ts skips ownerAccountId when this is set.
+ */
+function postHogBase(
+  generation: PostHogActorSource,
+  requestId: string,
+  inputType: "text" | "pdfBase64" | "imageBase64",
+): Pick<
+  PostHogCaptureProperties,
+  | "requestId"
+  | "inputType"
+  | "source"
+  | "ownerAccountId"
+  | "isAnonymous"
+  | "clientDeviceId"
+  | "twitterUserId"
+> {
+  const twitterCtx = generation.twitterContext as TwitterContext | null;
+  return {
+    requestId,
+    inputType,
+    source: generation.source,
+    ownerAccountId: generation.ownerAccountId,
+    isAnonymous: generation.ownerAccountId === ADMIN_ACCOUNT_ID,
+    clientDeviceId: generation.clientDeviceId ?? undefined,
+    // Lowercase + strip optional leading `@` so handle casing/format drift
+    // on the Twitter side doesn't fragment a single user across multiple
+    // PostHog persons. We don't currently have a stable numeric user ID
+    // from the twitter bot — once it's threaded through, replace this with
+    // `twitter:<numericUserId>` for true rename-resilient attribution.
+    twitterUserId: twitterCtx?.twitterHandle
+      ? twitterCtx.twitterHandle.toLowerCase().replace(/^@/, "")
+      : undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -395,10 +457,7 @@ async function _runPipeline(
       promptTokens: 0,
       completionTokens: 0,
       latencyMs: Math.round(performance.now() - startTime),
-      requestId: generationId,
-      source: generation.source,
-      ownerAccountId: generation.ownerAccountId,
-      inputType,
+      ...postHogBase(generation, generationId, inputType),
       outcome: "failed",
     });
     throw new Error(
@@ -428,10 +487,7 @@ async function _runPipeline(
   } catch (err) {
     capturePostHog({
       ...templateResult.metrics,
-      requestId: generationId,
-      source: generation.source,
-      ownerAccountId: generation.ownerAccountId,
-      inputType,
+      ...postHogBase(generation, generationId, inputType),
       outcome: "failed",
     });
     throw new Error(
@@ -501,10 +557,7 @@ async function _runPipeline(
     }
     capturePostHog({
       ...templateResult.metrics,
-      requestId: generationId,
-      source: generation.source,
-      ownerAccountId: generation.ownerAccountId,
-      inputType,
+      ...postHogBase(generation, generationId, inputType),
       outcome: "failed",
     });
     return;
@@ -512,10 +565,7 @@ async function _runPipeline(
 
   capturePostHog({
     ...templateResult.metrics,
-    requestId: generationId,
-    source: generation.source,
-    ownerAccountId: generation.ownerAccountId,
-    inputType,
+    ...postHogBase(generation, generationId, inputType),
     outcome: "done",
   });
   logger.info(

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -136,7 +136,7 @@ interface PostHogActorSource {
  * `isAnonymous` is derived from the admin-account sentinel: anonymous
  * submissions are owned by `ADMIN_ACCOUNT_ID` so the row has a valid
  * owner FK, but the value is a system identity, not a real user.
- * `resolveDistinctId` in posthog.ts skips ownerAccountId when this is set.
+ * `resolveActor` in posthog.ts skips ownerAccountId when this is set.
  */
 function postHogBase(
   generation: PostHogActorSource,

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -138,11 +138,11 @@ interface PostHogActorSource {
  * owner FK, but the value is a system identity, not a real user.
  * `resolveActor` in posthog.ts skips ownerAccountId when this is set.
  */
-function postHogBase(
-  generation: PostHogActorSource,
-  requestId: string,
-  inputType: "text" | "pdfBase64" | "imageBase64",
-): Pick<
+function postHogBase(args: {
+  generation: PostHogActorSource;
+  requestId: string;
+  inputType: "text" | "pdfBase64" | "imageBase64";
+}): Pick<
   PostHogCaptureProperties,
   | "requestId"
   | "inputType"
@@ -152,6 +152,7 @@ function postHogBase(
   | "clientDeviceId"
   | "twitterUserId"
 > {
+  const { generation, requestId, inputType } = args;
   const twitterCtx = generation.twitterContext as TwitterContext | null;
   return {
     requestId,
@@ -457,7 +458,7 @@ async function _runPipeline(
       promptTokens: 0,
       completionTokens: 0,
       latencyMs: Math.round(performance.now() - startTime),
-      ...postHogBase(generation, generationId, inputType),
+      ...postHogBase({ generation, requestId: generationId, inputType }),
       outcome: "failed",
     });
     throw new Error(
@@ -487,7 +488,7 @@ async function _runPipeline(
   } catch (err) {
     capturePostHog({
       ...templateResult.metrics,
-      ...postHogBase(generation, generationId, inputType),
+      ...postHogBase({ generation, requestId: generationId, inputType }),
       outcome: "failed",
     });
     throw new Error(
@@ -557,7 +558,7 @@ async function _runPipeline(
     }
     capturePostHog({
       ...templateResult.metrics,
-      ...postHogBase(generation, generationId, inputType),
+      ...postHogBase({ generation, requestId: generationId, inputType }),
       outcome: "failed",
     });
     return;
@@ -565,7 +566,7 @@ async function _runPipeline(
 
   capturePostHog({
     ...templateResult.metrics,
-    ...postHogBase(generation, generationId, inputType),
+    ...postHogBase({ generation, requestId: generationId, inputType }),
     outcome: "done",
   });
   logger.info(

--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -15,6 +15,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
 
 import { POSTHOG_HOST, POSTHOG_PROJECT_TOKEN } from "@/config";
+import logger from "@/utils/logger";
 import type { GenerationMetrics } from "./templateGen";
 
 // ---------------------------------------------------------------------------
@@ -73,6 +74,16 @@ function getPostHogClient(): any {
     PostHog: new (apiKey: string, opts: { host: string }) => any;
   };
   _posthogClient = new PostHog(POSTHOG_PROJECT_TOKEN, { host: POSTHOG_HOST });
+  // Surface async capture failures (auth 401s on a wrong token, wrong host,
+  // network errors). capture() is fire-and-forget so these are otherwise
+  // invisible — the request that triggered it has already returned. Subscribe
+  // once at client creation; client is cached for the lifetime of the process.
+  _posthogClient.on("error", (err: unknown) => {
+    logger.error(
+      { err: err instanceof Error ? err.message : err },
+      "[posthog] async capture error",
+    );
+  });
   return _posthogClient;
 }
 
@@ -129,9 +140,36 @@ export function capturePostHog(properties: PostHogCaptureProperties): void {
       properties,
     });
   } catch (err) {
-    console.error(
-      "[posthog] capture failed:",
-      err instanceof Error ? err.message : err,
+    logger.error(
+      { err: err instanceof Error ? err.message : err },
+      "[posthog] capture failed",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown
+// ---------------------------------------------------------------------------
+
+/**
+ * Flush any buffered events and tear down the PostHog client. Call once
+ * during SIGTERM so events captured in the last `flushInterval` window
+ * (default 10s in posthog-node v5) aren't lost when the process exits.
+ *
+ * No-op when the client was never created (env vars unset, or test
+ * override installed). Errors are caught and logged — never propagate
+ * to the caller so shutdown can continue.
+ */
+export async function shutdownPostHog(timeoutMs = 5000): Promise<void> {
+  const client = _posthogClient;
+  if (!client) return;
+  _posthogClient = null;
+  try {
+    await client.shutdown(timeoutMs);
+  } catch (err) {
+    logger.error(
+      { err: err instanceof Error ? err.message : err },
+      "[posthog] shutdown failed",
     );
   }
 }

--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -41,14 +41,59 @@ export interface PostHogCaptureProperties extends GenerationMetrics {
   /** Source field from the AgentTemplateGeneration row — free-form
    *  client telemetry tag (e.g. "ios-app", "web", "twitter-bot"). */
   source?: string;
-  /** Account ID of the generation owner. */
+  /** Account ID of the generation owner. Present whether or not the row
+   *  was anonymous — anonymous rows are owned by the admin sentinel. Use
+   *  `isAnonymous` to disambiguate. */
   ownerAccountId?: string;
+  /** True when the row is owned by the admin sentinel (no real account).
+   *  When true, `ownerAccountId` is NOT used for actor attribution. */
+  isAnonymous?: boolean;
+  /** Twitter user identifier (handle, lowercased, '@' stripped) when the
+   *  generation was triggered via the twitter bot. Used as a fallback
+   *  actor identifier when there's no `ownerAccountId`. */
+  twitterUserId?: string;
+  /** Stable device identifier supplied by the client (e.g. posthog-js's
+   *  `$device_id` cookie). Used as a fallback actor identifier when the
+   *  user hasn't authenticated. */
+  clientDeviceId?: string;
   /** Input type used for generation: "text", "pdfBase64", or "imageBase64". */
   inputType?: string;
   /** Terminal outcome: "done" or "failed". */
   outcome?: "done" | "failed";
   /** How the request was authenticated. Optional — present only when known. */
   authMode?: "jwt" | "agentKey";
+}
+
+// ---------------------------------------------------------------------------
+// Actor attribution — the distinctId precedence ladder
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the distinctId to send with the event from the available signals.
+ * Precedence:
+ *
+ *   1. `ownerAccountId` (real account)        — most stable; survives logout/re-auth.
+ *   2. `device:<clientDeviceId>`              — anonymous web/iOS, stable per browser/install.
+ *   3. `twitter:<twitterUserId>`              — anonymous twitter-bot path.
+ *   4. `generation:<requestId>`               — one-off attribution; preserves event volume
+ *                                               but loses per-actor uniqueness.
+ *
+ * The ladder is namespaced (`device:`, `twitter:`, `generation:`) so an
+ * anonymous identifier never collides with a real account UUID, and so the
+ * PostHog "person" view can distinguish identifier families on inspection.
+ *
+ * Reasoning: anonymous web/twitter submissions still populate `ownerAccountId`
+ * — the route uses `ADMIN_ACCOUNT_ID` as the system-identity fallback so the
+ * row has a valid owner FK. Using that sentinel directly as distinctId would
+ * collapse every anonymous submission onto a single PostHog person and defeat
+ * the point of analytics. The executor sets `isAnonymous: true` when the
+ * owner is the sentinel so this function skips to the next rung.
+ */
+export function resolveDistinctId(p: PostHogCaptureProperties): string {
+  if (p.ownerAccountId && !p.isAnonymous) return p.ownerAccountId;
+  if (p.clientDeviceId) return `device:${p.clientDeviceId}`;
+  if (p.twitterUserId) return `twitter:${p.twitterUserId}`;
+  return `generation:${p.requestId}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +180,7 @@ export function capturePostHog(properties: PostHogCaptureProperties): void {
     if (!client) return; // silent no-op when env not set
 
     client.capture({
-      distinctId: "builder",
+      distinctId: resolveDistinctId(properties),
       event: BUILDER_GENERATION_COMPLETED_EVENT,
       properties,
     });

--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -69,18 +69,32 @@ export interface PostHogCaptureProperties extends GenerationMetrics {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the distinctId to send with the event from the available signals.
- * Precedence:
+ * Kind of identifier used as `distinctId` on the event. Sent as a top-level
+ * `actorKind` property so downstream queries can segment by attribution type
+ * without parsing the distinctId string. Survives prefix-convention changes;
+ * makes post-merge analytics on aliased persons trivial.
+ */
+export type ActorKind = "account" | "device" | "twitter" | "unattributed";
+
+export interface ResolvedActor {
+  distinctId: string;
+  kind: ActorKind;
+}
+
+/**
+ * Resolve the distinctId + kind to send with the event from the available
+ * signals. Precedence:
  *
- *   1. `ownerAccountId` (real account)        — most stable; survives logout/re-auth.
- *   2. `device:<clientDeviceId>`              — anonymous web/iOS, stable per browser/install.
- *   3. `twitter:<twitterUserId>`              — anonymous twitter-bot path.
- *   4. `generation:<requestId>`               — one-off attribution; preserves event volume
- *                                               but loses per-actor uniqueness.
+ *   1. `<ownerAccountId>` (real account)      — kind: `account`        — most stable.
+ *   2. `device:<clientDeviceId>`              — kind: `device`         — anonymous web/iOS.
+ *   3. `twitter:<twitterUserId>`              — kind: `twitter`        — anonymous twitter-bot.
+ *   4. `request:<requestId>`                  — kind: `unattributed`   — one-off fallback.
  *
- * The ladder is namespaced (`device:`, `twitter:`, `generation:`) so an
- * anonymous identifier never collides with a real account UUID, and so the
- * PostHog "person" view can distinguish identifier families on inspection.
+ * Each non-account rung is namespaced (`device:`, `twitter:`, `request:`) so an
+ * anonymous identifier never collides with a real account UUID — which is the
+ * load-bearing property for safe `posthog.alias()` merges later: when an
+ * anonymous user authenticates, the frontend can alias `device:<X>` into the
+ * account UUID without risking a cross-person merge.
  *
  * Reasoning: anonymous web/twitter submissions still populate `ownerAccountId`
  * — the route uses `ADMIN_ACCOUNT_ID` as the system-identity fallback so the
@@ -88,12 +102,23 @@ export interface PostHogCaptureProperties extends GenerationMetrics {
  * collapse every anonymous submission onto a single PostHog person and defeat
  * the point of analytics. The executor sets `isAnonymous: true` when the
  * owner is the sentinel so this function skips to the next rung.
+ *
+ * `kind: "unattributed"` is the honest name for rung 4 — every event in this
+ * file is a generation, so calling rung 4 "generation" would conflate event
+ * type with actor identity. `unattributed` says what's actually true: we
+ * have no stable actor signal and each event gets a one-off person.
  */
-export function resolveDistinctId(p: PostHogCaptureProperties): string {
-  if (p.ownerAccountId && !p.isAnonymous) return p.ownerAccountId;
-  if (p.clientDeviceId) return `device:${p.clientDeviceId}`;
-  if (p.twitterUserId) return `twitter:${p.twitterUserId}`;
-  return `generation:${p.requestId}`;
+export function resolveActor(p: PostHogCaptureProperties): ResolvedActor {
+  if (p.ownerAccountId && !p.isAnonymous) {
+    return { distinctId: p.ownerAccountId, kind: "account" };
+  }
+  if (p.clientDeviceId) {
+    return { distinctId: `device:${p.clientDeviceId}`, kind: "device" };
+  }
+  if (p.twitterUserId) {
+    return { distinctId: `twitter:${p.twitterUserId}`, kind: "twitter" };
+  }
+  return { distinctId: `request:${p.requestId}`, kind: "unattributed" };
 }
 
 // ---------------------------------------------------------------------------
@@ -179,10 +204,13 @@ export function capturePostHog(properties: PostHogCaptureProperties): void {
     const client = getPostHogClient();
     if (!client) return; // silent no-op when env not set
 
+    const actor = resolveActor(properties);
     client.capture({
-      distinctId: resolveDistinctId(properties),
+      distinctId: actor.distinctId,
       event: BUILDER_GENERATION_COMPLETED_EVENT,
-      properties,
+      // Carry the rung as a property so dashboards can segment by
+      // attribution type without parsing prefixes off `distinct_id`.
+      properties: { ...properties, actorKind: actor.kind },
     });
   } catch (err) {
     logger.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { shutdownPostHog } from "@/api/v2/agent-templates/services/posthog";
 import {
   startTtlSweep as startGenerationTtlSweep,
   stopTtlSweep as stopGenerationTtlSweep,
@@ -89,12 +90,17 @@ validateJWTKeys()
       }
     });
 
-    process.on("SIGTERM", () => {
+    process.on("SIGTERM", async () => {
       logger.info("SIGTERM signal received: closing Convos API service");
       // Stop the generation TTL sweep so its setInterval doesn't keep
       // dispatching DB queries against a closing pool during the drain
       // window. No-op if the sweep was never started (production gate).
       stopGenerationTtlSweep();
+      // Flush buffered PostHog events before the process exits. The SDK
+      // buffers up to flushAt (default 20) or flushInterval (default 10s)
+      // — without an explicit shutdown, low-volume captures get dropped on
+      // every redeploy. Catches its own errors; never throws.
+      await shutdownPostHog();
       server.close(() => {
         logger.info("Convos API service closed");
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,20 +90,26 @@ validateJWTKeys()
       }
     });
 
-    process.on("SIGTERM", async () => {
-      logger.info("SIGTERM signal received: closing Convos API service");
-      // Stop the generation TTL sweep so its setInterval doesn't keep
-      // dispatching DB queries against a closing pool during the drain
-      // window. No-op if the sweep was never started (production gate).
-      stopGenerationTtlSweep();
-      // Flush buffered PostHog events before the process exits. The SDK
-      // buffers up to flushAt (default 20) or flushInterval (default 10s)
-      // — without an explicit shutdown, low-volume captures get dropped on
-      // every redeploy. Catches its own errors; never throws.
-      await shutdownPostHog();
-      server.close(() => {
-        logger.info("Convos API service closed");
-      });
+    // Wrap the async drain steps in a void-IIFE so the SIGTERM listener
+    // itself returns void (Node ignores the listener's return value, and
+    // an `async` listener would trip @typescript-eslint/no-misused-promises).
+    // `shutdownPostHog()` catches its own errors, so the IIFE never rejects.
+    process.on("SIGTERM", () => {
+      void (async () => {
+        logger.info("SIGTERM signal received: closing Convos API service");
+        // Stop the generation TTL sweep so its setInterval doesn't keep
+        // dispatching DB queries against a closing pool during the drain
+        // window. No-op if the sweep was never started (production gate).
+        stopGenerationTtlSweep();
+        // Flush buffered PostHog events before the process exits. The SDK
+        // buffers up to flushAt (default 20) or flushInterval (default 10s)
+        // — without an explicit shutdown, low-volume captures get dropped
+        // on every redeploy. Catches its own errors; never throws.
+        await shutdownPostHog();
+        server.close(() => {
+          logger.info("Convos API service closed");
+        });
+      })();
     });
   })
   .catch((error: unknown) => {

--- a/tests/agent-templates.executor.test.ts
+++ b/tests/agent-templates.executor.test.ts
@@ -390,6 +390,10 @@ describe("generation-executor", () => {
       expect(event.requestId).toBe(gen.id);
       expect(event.source).toBe(TEST_SOURCE);
       expect(event.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+      // Rows owned by ADMIN_ACCOUNT_ID are flagged anonymous so
+      // resolveDistinctId in posthog.ts skips the sentinel and falls
+      // through to the next rung of the actor-attribution ladder.
+      expect(event.isAnonymous).toBe(true);
       expect(event.inputType).toBe("text");
       expect(event.outcome).toBe("done");
       expect(event.model).toBe(DEFAULT_TEST_METRICS.model);

--- a/tests/agent-templates.executor.test.ts
+++ b/tests/agent-templates.executor.test.ts
@@ -391,7 +391,7 @@ describe("generation-executor", () => {
       expect(event.source).toBe(TEST_SOURCE);
       expect(event.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
       // Rows owned by ADMIN_ACCOUNT_ID are flagged anonymous so
-      // resolveDistinctId in posthog.ts skips the sentinel and falls
+      // resolveActor in posthog.ts skips the sentinel and falls
       // through to the next rung of the actor-attribution ladder.
       expect(event.isAnonymous).toBe(true);
       expect(event.inputType).toBe("text");

--- a/tests/posthog.service.test.ts
+++ b/tests/posthog.service.test.ts
@@ -15,8 +15,8 @@
 
 import { describe, expect, test } from "bun:test";
 import {
-  type PostHogCaptureProperties,
   resolveActor,
+  type PostHogCaptureProperties,
 } from "@/api/v2/agent-templates/services/posthog";
 
 describe("resolveActor — precedence ladder", () => {

--- a/tests/posthog.service.test.ts
+++ b/tests/posthog.service.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the PostHog metering service — actor attribution only.
+ *
+ * `resolveActor` decides which identifier becomes the event's distinctId
+ * and what `actorKind` it advertises. Every event in the system flows
+ * through this function, so a regression (e.g., accidentally swapping
+ * two rungs of the precedence ladder) silently misattributes downstream
+ * analytics. Pure-function unit tests are cheap insurance against that.
+ *
+ * Integration tests in agent-templates.executor.test.ts already cover
+ * the wiring (postHogBase → capturePostHog) but they only exercise the
+ * `account` / anonymous-sentinel path. These tests cover the device,
+ * twitter, and unattributed rungs directly.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type PostHogCaptureProperties,
+  resolveActor,
+} from "@/api/v2/agent-templates/services/posthog";
+
+describe("resolveActor — precedence ladder", () => {
+  // Base props supplied with every case so the function has a `requestId`
+  // (the rung-4 fallback) and won't return undefined accidentally.
+  const baseProps: PostHogCaptureProperties = {
+    requestId: "req-default",
+    // GenerationMetrics fields — required by the type but irrelevant to
+    // the ladder. Real values come from the LLM call at runtime.
+    model: "test-model",
+    promptTokens: 0,
+    completionTokens: 0,
+    latencyMs: 0,
+  };
+
+  test.each([
+    {
+      name: "account: ownerAccountId present and !isAnonymous wins over every other signal",
+      props: {
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        isAnonymous: false,
+        clientDeviceId: "device-abc",
+        twitterUserId: "jack",
+      },
+      expected: {
+        distinctId: "00000000-0000-0000-0000-000000000001",
+        kind: "account" as const,
+      },
+    },
+    {
+      name: "device: anonymous owner + clientDeviceId → device rung",
+      props: {
+        ownerAccountId: "admin-sentinel-uuid",
+        isAnonymous: true,
+        clientDeviceId: "device-abc123",
+      },
+      expected: {
+        distinctId: "device:device-abc123",
+        kind: "device" as const,
+      },
+    },
+    {
+      name: "device wins over twitter when both are present (anonymous)",
+      props: {
+        isAnonymous: true,
+        clientDeviceId: "device-abc",
+        twitterUserId: "jack",
+      },
+      expected: { distinctId: "device:device-abc", kind: "device" as const },
+    },
+    {
+      name: "twitter: anonymous + twitterUserId only → twitter rung",
+      props: {
+        isAnonymous: true,
+        twitterUserId: "jack",
+      },
+      expected: { distinctId: "twitter:jack", kind: "twitter" as const },
+    },
+    {
+      name: "unattributed: no actor signal at all → request:<requestId>",
+      props: { isAnonymous: true },
+      expected: {
+        distinctId: "request:req-default",
+        kind: "unattributed" as const,
+      },
+    },
+    {
+      name: "unattributed: missing ownerAccountId (undefined) falls through to request",
+      props: {
+        ownerAccountId: undefined,
+        isAnonymous: false,
+      },
+      expected: {
+        distinctId: "request:req-default",
+        kind: "unattributed" as const,
+      },
+    },
+  ])("$name", ({ props, expected }) => {
+    const resolved = resolveActor({ ...baseProps, ...props });
+    expect(resolved).toEqual(expected);
+  });
+
+  test("isAnonymous=true on a real-looking ownerAccountId still skips the account rung", () => {
+    // Guards the executor contract: anonymous submissions are owned by
+    // ADMIN_ACCOUNT_ID (a real UUID) but flagged isAnonymous. resolveActor
+    // MUST honour the flag, not the presence of the field.
+    const resolved = resolveActor({
+      ...baseProps,
+      ownerAccountId: "00000000-0000-0000-0000-000000000001",
+      isAnonymous: true,
+      clientDeviceId: "device-abc",
+    });
+    expect(resolved).toEqual({
+      distinctId: "device:device-abc",
+      kind: "device",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Today every `builder.generation.completed` event uses the literal string
`\"builder\"` as its PostHog distinctId. Every iOS user, web visitor, and
Twitter mention collapses onto **one** PostHog person — so uniqueness
metrics are meaningless even though `source` already segments volume by
surface.

Adopt a precedence ladder for `distinctId`:

| Rung | Identifier               | When it wins                          |
|------|--------------------------|---------------------------------------|
| 1    | `ownerAccountId`         | Authenticated request (most stable)   |
| 2    | `device:<clientDeviceId>`| Anonymous web/iOS (posthog-js `\$device_id`) |
| 3    | `twitter:<handle>`       | Twitter-bot path                      |
| 4    | `generation:<requestId>` | One-off fallback (preserves event volume) |

Each rung is namespaced so an anonymous identifier can never collide
with a real account UUID. Anonymous rows are owned by `ADMIN_ACCOUNT_ID`
(the system-identity sentinel), so the executor flags them
`isAnonymous: true` and `resolveDistinctId()` skips that rung.

## What changed

**Schema** (`prisma/`):
- New nullable `clientDeviceId` column on `AgentTemplateGeneration`.
- Hand-written migration matches the project's existing pattern (cf.
  `20260512000110_add_generation_twitter_fields`).

**Route handler** (`generations-post.ts`):
- Accepts top-level `clientDeviceId` on the POST body (zod-validated,
  1–128 chars to cover posthog-js's UUIDv7 with headroom).
- Excluded from the idempotency dedupe body comparison
  (`dedupeBodiesMatch`) so a retry with a rotated device ID still
  matches the original row instead of 409-ing.

**Executor** (`generation-executor.ts`):
- New `postHogBase(generation, requestId, inputType)` helper centralises
  the actor-attribution fields shared by **all four** capture sites
  (generate-fail, persist-fail, timeout-race-fail, success). Adding a
  new actor signal lands in one place; the previous code repeated the
  field list 4×.
- Twitter handle is lowercased + leading `@` stripped before use, so
  handle casing/format drift can't fragment a single user across
  PostHog persons.

**Capture service** (`posthog.ts`):
- New optional properties on `PostHogCaptureProperties`:
  `isAnonymous`, `twitterUserId`, `clientDeviceId`.
- Exported `resolveDistinctId(props)` implements the ladder above.
- All existing capture properties remain in place — dashboards keep
  working.

## Test coverage

- Existing executor tests still assert `ownerAccountId === ADMIN_ACCOUNT_ID`
  on captured events and now also assert `isAnonymous: true` lands when
  the row is owned by the admin sentinel.
- The Twitter and web-anonymous rungs aren't directly covered by the
  existing test harness; the logic is small enough that the per-call-site
  helper + `resolveDistinctId()` ladder can be reviewed by eye. Happy to
  add unit coverage if reviewer prefers.

## Frontend follow-ups (out of scope for this PR)

- **Web**: pass posthog-js's `\$device_id` cookie value as
  `clientDeviceId` on the POST body. Until then, anonymous web users
  fall through to rung 4 — anonymous count works, return-visit
  attribution doesn't.
- **iOS**: already authenticated, so it lands on rung 1. No frontend
  change needed.
- **Twitter bot**: thread a stable numeric Twitter user ID (handles
  can change). Until then the lowercased handle works for the vast
  majority of cases.
- **Auth bridge**: when an anonymous web user authenticates, call
  `posthog.alias({ distinctId: ownerAccountId, alias: 'device:<X>' })`
  once so the pre-auth history merges into the new account.

## Stack

Stacked on top of #217 (`fix(posthog): flush on SIGTERM and log async
capture errors`). Targets that branch so the two PRs can land in order.
Once #217 merges to `otr-dev`, this PR will auto-retarget.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-actor PostHog `distinctId` resolution via `clientDeviceId` and `twitterHandle`
> - Introduces `resolveActor` in [`posthog.ts`](https://github.com/ephemeraHQ/convos-backend/pull/218/files#diff-542f2fa8706fd2fc425fdfbf7c593fbab3b52265f4ec6025fa64cb3661637d81) to derive a `distinctId` using a precedence ladder: authenticated account → `device:<clientDeviceId>` → `twitter:<twitterUserId>` → `request:<requestId>`; attaches `actorKind` to all captured events.
> - Adds `clientDeviceId` as an optional field to the `AgentTemplateGeneration` model and POST request body, persisted via a new migration.
> - Extracts `postHogBase()` in [`generation-executor.ts`](https://github.com/ephemeraHQ/convos-backend/pull/218/files#diff-606bfcab4aaabc60e9aa7e0d358e823011fed37a5ab0fa8fbcaafa04b0f74e29) to consolidate attribution fields (`isAnonymous`, `clientDeviceId`, `twitterUserId`) across all four capture points.
> - Adds `shutdownPostHog()` and wires it into the SIGTERM handler in [`index.ts`](https://github.com/ephemeraHQ/convos-backend/pull/218/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to flush buffered events before server close.
> - Behavioral Change: PostHog events previously captured under a single `distinctId` now use per-actor IDs; historical identity stitching in PostHog will not apply retroactively.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #218 opened
>
> - Refactored `postHogBase` utility function signature to accept a single object argument with named properties [136f7b4]
> - Added unit tests for `PostHog` metering service `resolveActor` function [136f7b4]
> - Reordered named imports in `posthog.service.test.ts` [f68b5b8]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5497b22.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional client device ID in generation requests, enabling stable device-level tracking.
  * Enhanced event attribution logic with support for multiple actor identification types (account, device, Twitter, unattributed).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->