### PR TITLE
feat(credits): daily refill cron + free-tier /me/credits surface

### DIFF
--- a/src/api/v2/accounts/handlers/credits-get.ts
+++ b/src/api/v2/accounts/handlers/credits-get.ts
@@ -1,5 +1,8 @@
 import { LedgerReason } from "@prisma/client";
 import type { Request, Response } from "express";
+import { getBalance } from "@/payments";
+import { config } from "@/payments/credits/config";
+import { startOfNextUtcDay } from "@/payments/daily-refill/utc";
 import { findCurrentByAccountId } from "@/subscriptions/repository";
 import { isEntitledSubscription } from "@/subscriptions/status";
 import { tierGrant } from "@/subscriptions/tier-config";
@@ -10,9 +13,6 @@ const MONTH_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   timeZone: "UTC",
 });
-
-const startOfNextMonth = (now: Date): Date =>
-  new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
 
 const sumPeriodConsumes = async (
   accountId: string,
@@ -39,18 +39,19 @@ const sumPeriodConsumes = async (
  * `{ balance, monthlyGrant, monthlyGrantUsed, nextRefreshAt, periodLabel }`.
  *
  * Derivation:
- *   - With an active Subscription: `monthlyGrant` comes from the tier × period
+ *   - With an entitled Subscription: `monthlyGrant` comes from the tier × period
  *     config; `monthlyGrantUsed` is the sum of consume-ledger deltas since
  *     `currentPeriodStart`; `balance = monthlyGrant - monthlyGrantUsed`;
  *     `nextRefreshAt = currentPeriodEnd`.
- *   - Without a Subscription: all credit fields are 0, `nextRefreshAt` is the
- *     start of next calendar month, `periodLabel` is the current month.
- *     iOS will render this as "no plan / paywall".
+ *   - Without an entitled Subscription (free tier): balance is the daily-refill
+ *     ledger value, `monthlyGrant` is the free-tier daily cap, `monthlyGrantUsed`
+ *     is the cap minus the current balance, `nextRefreshAt` is the start of the
+ *     next UTC day, `periodLabel` is "Daily".
  *
- * Note for v1: additive grants (NUX trial, top-ups, manual ops) are NOT
- * folded into the balance display yet. The iOS `CreditBalance` model doesn't
- * yet expose a separate "bonus credits" field. When that surface ships,
- * widen this handler to include them.
+ * Note for v1: additive grants (NUX trial, top-ups, manual ops) outside the
+ * daily-refill ledger are NOT folded into the balance display yet. The iOS
+ * `CreditBalance` model doesn't yet expose a separate "bonus credits" field.
+ * When that surface ships, widen this handler to include them.
  */
 export async function creditsGetHandler(req: Request, res: Response) {
   const accountId = res.locals.accountId as string;
@@ -59,13 +60,17 @@ export async function creditsGetHandler(req: Request, res: Response) {
     const subscription = await findCurrentByAccountId(accountId);
 
     if (!subscription || !isEntitledSubscription(subscription)) {
+      const balance = await getBalance(accountId);
+      const cap = config.freeTierDailyCapCredits;
+      const positiveBalance = balance < 0n ? 0n : balance;
+      const used = Math.max(0, cap - Number(positiveBalance));
       const now = new Date();
       res.status(200).json({
-        balance: 0,
-        monthlyGrant: 0,
-        monthlyGrantUsed: 0,
-        nextRefreshAt: startOfNextMonth(now).toISOString(),
-        periodLabel: MONTH_LABEL_FORMATTER.format(now),
+        balance: Number(positiveBalance),
+        monthlyGrant: cap,
+        monthlyGrantUsed: used,
+        nextRefreshAt: startOfNextUtcDay(now).toISOString(),
+        periodLabel: "Daily",
       });
       return;
     }

--- a/src/api/v2/accounts/handlers/credits-get.ts
+++ b/src/api/v2/accounts/handlers/credits-get.ts
@@ -39,19 +39,20 @@ const sumPeriodConsumes = async (
  * `{ balance, monthlyGrant, monthlyGrantUsed, nextRefreshAt, periodLabel }`.
  *
  * Derivation:
- *   - With an entitled Subscription: `monthlyGrant` comes from the tier × period
- *     config; `monthlyGrantUsed` is the sum of consume-ledger deltas since
+ *   - With an entitled Subscription (effective status in trial/active/grace/
+ *     billingRetry per `isEntitledSubscription`): `monthlyGrant` from tier ×
+ *     period config; `monthlyGrantUsed` = sum of consume-ledger deltas since
  *     `currentPeriodStart`; `balance = monthlyGrant - monthlyGrantUsed`;
  *     `nextRefreshAt = currentPeriodEnd`.
- *   - Without an entitled Subscription (free tier): balance is the daily-refill
- *     ledger value, `monthlyGrant` is the free-tier daily cap, `monthlyGrantUsed`
- *     is the cap minus the current balance, `nextRefreshAt` is the start of the
- *     next UTC day, `periodLabel` is "Daily".
+ *   - Without an entitled Subscription (no row, expired, revoked, or grace
+ *     past end): free-tier daily-refill semantics. `balance` = live ledger
+ *     balance clamped to 0; `monthlyGrant` = `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS`;
+ *     `monthlyGrantUsed` = `max(0, cap - balance)`; `nextRefreshAt` = start
+ *     of next UTC day; `periodLabel` = "Daily".
  *
- * Note for v1: additive grants (NUX trial, top-ups, manual ops) outside the
- * daily-refill ledger are NOT folded into the balance display yet. The iOS
- * `CreditBalance` model doesn't yet expose a separate "bonus credits" field.
- * When that surface ships, widen this handler to include them.
+ * Note for v1: field names reuse `monthlyGrant`/`monthlyGrantUsed` for the
+ * daily cap so iOS doesn't need a client-side change. Proper `dailyCap` /
+ * `dailyUsed` fields are a follow-up requiring iOS coordination.
  */
 export async function creditsGetHandler(req: Request, res: Response) {
   const accountId = res.locals.accountId as string;

--- a/src/api/v2/credits/credits.router.ts
+++ b/src/api/v2/credits/credits.router.ts
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { agentApiKeyAuth } from "@/middleware/agentAuth";
+import { requireCronApiKey } from "./middleware/cron-api-key";
 import { check } from "./handlers/check";
 import { consume } from "./handlers/consume";
+import { dailyRefill } from "./handlers/daily-refill";
 import { grant } from "./handlers/grant";
 
 const creditsRouter = Router();
@@ -12,5 +14,8 @@ const creditsRouter = Router();
 creditsRouter.post("/check", agentApiKeyAuth, check);
 creditsRouter.post("/consume", agentApiKeyAuth, consume);
 creditsRouter.post("/grant", agentApiKeyAuth, grant);
+
+// Cron-only — separate gate (PAYMENTS_CRON_API_KEY), not agent key.
+creditsRouter.post("/daily", requireCronApiKey, dailyRefill);
 
 export { creditsRouter };

--- a/src/api/v2/credits/credits.router.ts
+++ b/src/api/v2/credits/credits.router.ts
@@ -1,10 +1,10 @@
 import { Router } from "express";
 import { agentApiKeyAuth } from "@/middleware/agentAuth";
-import { requireCronApiKey } from "./middleware/cron-api-key";
 import { check } from "./handlers/check";
 import { consume } from "./handlers/consume";
 import { dailyRefill } from "./handlers/daily-refill";
 import { grant } from "./handlers/grant";
+import { requireCronApiKey } from "./middleware/cron-api-key";
 
 const creditsRouter = Router();
 

--- a/src/api/v2/credits/handlers/consume.ts
+++ b/src/api/v2/credits/handlers/consume.ts
@@ -1,6 +1,6 @@
 import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
-import { consume as consumeCredits, getBalance } from "@/payments";
+import { consume as consumeCredits } from "@/payments";
 import {
   IdempotencyMismatchError,
   InsufficientBalanceError,
@@ -20,17 +20,13 @@ export async function consume(req: Request, res: Response): Promise<void> {
       requestId,
       model,
     });
-    // `balance` is advisory: read after the consume commit, so concurrent
-    // consumes on the same account may make this value reflect a later state.
-    // Hermes uses it only as a UI signal, not for accounting.
-    const balance = await getBalance(accountId);
     req.log.info(
       { accountId, spent: result.spent, replayed: result.replayed, requestId },
       result.replayed ? "credits.consume.replayed" : "credits.consume.accepted",
     );
     res.status(200).json({
       spent: result.spent,
-      balance: balance.toString(),
+      balance: result.newBalance.toString(),
       replayed: result.replayed,
     });
   } catch (err) {

--- a/src/api/v2/credits/handlers/daily-refill.ts
+++ b/src/api/v2/credits/handlers/daily-refill.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from "express";
+import { runDailyRefill } from "@/payments/daily-refill/service";
+
+export async function dailyRefill(req: Request, res: Response): Promise<void> {
+  const summary = await runDailyRefill();
+  req.log.info(
+    {
+      skipped: summary.skipped,
+      reason: summary.reason,
+      refilled: summary.refilled.length,
+      noOp: summary.noOp,
+      errors: summary.errors.length,
+    },
+    "credits.daily_refill.completed",
+  );
+  if (summary.skipped) {
+    res.status(200).json({
+      skipped: true,
+      reason: summary.reason,
+      lastRunAt: summary.lastRunAt?.toISOString(),
+    });
+    return;
+  }
+  res.status(200).json({
+    skipped: false,
+    refilled: summary.refilled.length,
+    noOp: summary.noOp,
+    errors: summary.errors.length,
+    runAt: summary.runAt?.toISOString(),
+  });
+}

--- a/src/api/v2/credits/handlers/grant.ts
+++ b/src/api/v2/credits/handlers/grant.ts
@@ -1,6 +1,6 @@
 import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
-import { getBalance, grant as grantCredits } from "@/payments";
+import { grant as grantCredits } from "@/payments";
 import { IdempotencyMismatchError } from "@/payments/errors";
 import { isAccountIdFkViolation } from "../fk-violation";
 import { grantRequestSchema } from "../schemas";
@@ -17,10 +17,6 @@ export async function grant(req: Request, res: Response): Promise<void> {
       idempotencyKey,
       note,
     });
-    // `balance` is advisory: read after the grant commit, not isolated with the
-    // grant transaction. Concurrent grants could make this value reflect a
-    // later state.
-    const balance = await getBalance(accountId);
     req.log.info(
       {
         accountId,
@@ -32,7 +28,7 @@ export async function grant(req: Request, res: Response): Promise<void> {
     );
     res.status(200).json({
       granted: result.granted,
-      balance: balance.toString(),
+      balance: result.newBalance.toString(),
       replayed: result.replayed,
     });
   } catch (err) {

--- a/src/api/v2/credits/middleware/cron-api-key.ts
+++ b/src/api/v2/credits/middleware/cron-api-key.ts
@@ -1,0 +1,70 @@
+import { createHash, timingSafeEqual } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+
+const MIN_CRON_API_KEY_LENGTH = 32;
+
+let _cronApiKeyOverride: string | null | undefined = undefined;
+
+function getCronApiKey(): string {
+  if (_cronApiKeyOverride !== undefined) {
+    return (_cronApiKeyOverride ?? "").trim();
+  }
+  return (process.env.PAYMENTS_CRON_API_KEY ?? "").trim();
+}
+
+/** Override `PAYMENTS_CRON_API_KEY` for tests.
+ *  - Pass a string to override.
+ *  - Pass `null` to simulate "key unset" (forces 503).
+ *  - Pass `undefined` to clear the override and fall back to env. */
+export function __setCronApiKeyOverrideForTests(
+  key: string | null | undefined,
+): void {
+  _cronApiKeyOverride = key;
+}
+
+function constantTimeSecretCompare(
+  provided: string,
+  expected: string,
+): boolean {
+  const a = createHash("sha256").update(provided, "utf8").digest();
+  const b = createHash("sha256").update(expected, "utf8").digest();
+  return timingSafeEqual(a, b);
+}
+
+function maskKeyPrefix(key: string): string {
+  if (key.length === 0) return "(empty)";
+  return `${key.slice(0, 4)}... (len=${key.length})`;
+}
+
+export const requireCronApiKey = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const expectedKey = getCronApiKey();
+
+  if (!expectedKey) {
+    res.status(503).json({ error: "Cron API key not configured" });
+    return;
+  }
+  if (expectedKey.length < MIN_CRON_API_KEY_LENGTH) {
+    req.log.error(
+      { keyLength: expectedKey.length },
+      "cron_api_key.config_invalid",
+    );
+    res.status(503).json({ error: "Cron API key misconfigured" });
+    return;
+  }
+
+  const provided = (req.headers["x-cron-api-key"] as string | undefined) ?? "";
+  if (!provided || !constantTimeSecretCompare(provided, expectedKey)) {
+    req.log.warn(
+      { providedPrefix: maskKeyPrefix(provided) },
+      "cron_api_key.unauthorized",
+    );
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+
+  next();
+};

--- a/src/api/v2/notifications/fcm-push.service.ts
+++ b/src/api/v2/notifications/fcm-push.service.ts
@@ -33,10 +33,14 @@ export function buildFcmWirePayload(args: {
 } {
   const { notification, isSilent } = args;
   const data: Record<string, string> = {
-    apiJWT: notification.apiJWT,
     notificationType: notification.notificationType,
     notificationData: JSON.stringify(notification.notificationData),
   };
+  // apiJWT is only present on user-routed payloads (Protocol, InviteJoinRequest).
+  // Backend-originated payloads (e.g. CreditsRefilled) don't carry one.
+  if ("apiJWT" in notification && notification.apiJWT) {
+    data.apiJWT = notification.apiJWT;
+  }
   // Add clientId or inboxId
   if ("clientId" in notification && notification.clientId) {
     data.clientId = notification.clientId;

--- a/src/api/v2/notifications/types.ts
+++ b/src/api/v2/notifications/types.ts
@@ -1,4 +1,7 @@
-export type NotificationType = "Protocol" | "InviteJoinRequest";
+export type NotificationType =
+  | "Protocol"
+  | "InviteJoinRequest"
+  | "CreditsRefilled";
 
 export type ProtocolNotificationData = {
   contentTopic: string;
@@ -30,10 +33,18 @@ export type InviteJoinRequestNotificationData = {
   autoApprove: boolean;
 };
 
+export type CreditsRefilledNotificationData = {
+  creditsAdded: number;
+  newBalance: string;       // bigint serialized
+  refilledAt: string;       // ISO UTC
+  nextRefreshAt: string;    // ISO UTC, start of next UTC day
+};
+
 // Mapping from NotificationType to its payload shape
 export type NotificationTypeToData = {
   Protocol: ProtocolNotificationData;
   InviteJoinRequest: InviteJoinRequestNotificationData;
+  CreditsRefilled: CreditsRefilledNotificationData;
 };
 
 // Base notification payload with XOR semantics for v1/v2 transition
@@ -67,7 +78,16 @@ export type V2NotificationPayload = {
   notificationData: ProtocolNotificationData;
 };
 
+// Backend-originated push — no user JWT, no inboxId. Added so push services
+// (APNS/FCM) can accept payloads that don't carry an apiJWT.
+export type CreditsRefilledPayload = {
+  clientId: string;                            // deviceId, for v2-shaped routing
+  notificationType: "CreditsRefilled";
+  notificationData: CreditsRefilledNotificationData;
+};
+
 // Union type for push services that can handle both v1 and v2
 export type AnyNotificationPayloadWithJWT =
   | NotificationPayloadWithJWTToken
-  | V2NotificationPayload;
+  | V2NotificationPayload
+  | CreditsRefilledPayload;

--- a/src/api/v2/notifications/types.ts
+++ b/src/api/v2/notifications/types.ts
@@ -35,9 +35,9 @@ export type InviteJoinRequestNotificationData = {
 
 export type CreditsRefilledNotificationData = {
   creditsAdded: number;
-  newBalance: string;       // bigint serialized
-  refilledAt: string;       // ISO UTC
-  nextRefreshAt: string;    // ISO UTC, start of next UTC day
+  newBalance: string; // bigint serialized
+  refilledAt: string; // ISO UTC
+  nextRefreshAt: string; // ISO UTC, start of next UTC day
 };
 
 // Mapping from NotificationType to its payload shape
@@ -81,7 +81,7 @@ export type V2NotificationPayload = {
 // Backend-originated push — no user JWT, no inboxId. Added so push services
 // (APNS/FCM) can accept payloads that don't carry an apiJWT.
 export type CreditsRefilledPayload = {
-  clientId: string;                            // deviceId, for v2-shaped routing
+  clientId: string; // deviceId, for v2-shaped routing
   notificationType: "CreditsRefilled";
   notificationData: CreditsRefilledNotificationData;
 };

--- a/src/payments/credits/config.ts
+++ b/src/payments/credits/config.ts
@@ -6,6 +6,7 @@ export interface PaymentsConfig {
   creditsPerDollar: bigint;
   reservedMaxTurnCredits: bigint;
   minBalance: bigint;
+  freeTierDailyCapCredits: number;
 }
 
 const requireFloat = (key: string, raw: string | undefined): number => {
@@ -110,11 +111,37 @@ const loadMinBalanceCredits = (): bigint => {
   return min;
 };
 
+// PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS
+//   Daily top-up-to-cap amount applied by the /credits/daily cron to
+//   SIWE-verified non-subscriber accounts. Must be a positive integer.
+export const loadFreeTierDailyCapCredits = (): number => {
+  const raw = process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS;
+  if (raw === undefined || raw.trim() === "") {
+    throw new ValidationError(
+      "PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS not configured",
+    );
+  }
+  const trimmed = raw.trim();
+  if (!/^-?\d+$/.test(trimmed)) {
+    throw new ValidationError(
+      `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS must be an integer: ${raw}`,
+    );
+  }
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n) || n <= 0) {
+    throw new ValidationError(
+      `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS must be > 0, got: ${n}`,
+    );
+  }
+  return n;
+};
+
 export const loadConfig = (): PaymentsConfig => ({
   ...loadMarkupRate(),
   creditsPerDollar: loadCreditsPerUsd(),
   reservedMaxTurnCredits: loadReservedMaxTurnCredits(),
   minBalance: loadMinBalanceCredits(),
+  freeTierDailyCapCredits: loadFreeTierDailyCapCredits(),
 });
 
 export const config: PaymentsConfig = loadConfig();

--- a/src/payments/credits/config.ts
+++ b/src/payments/credits/config.ts
@@ -115,25 +115,16 @@ const loadMinBalanceCredits = (): bigint => {
 //   Daily top-up-to-cap amount applied by the /credits/daily cron to
 //   SIWE-verified non-subscriber accounts. Must be a positive integer.
 export const loadFreeTierDailyCapCredits = (): number => {
-  const raw = process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS;
-  if (raw === undefined || raw.trim() === "") {
+  const big = requireBigInt(
+    "PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS",
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS,
+  );
+  if (big <= 0n || big > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new ValidationError(
-      "PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS not configured",
+      `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS must be a positive safe integer, got: ${big}`,
     );
   }
-  const trimmed = raw.trim();
-  if (!/^-?\d+$/.test(trimmed)) {
-    throw new ValidationError(
-      `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS must be an integer: ${raw}`,
-    );
-  }
-  const n = Number(trimmed);
-  if (!Number.isSafeInteger(n) || n <= 0) {
-    throw new ValidationError(
-      `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS must be > 0, got: ${n}`,
-    );
-  }
-  return n;
+  return Number(big);
 };
 
 export const loadConfig = (): PaymentsConfig => ({

--- a/src/payments/daily-refill/notify.ts
+++ b/src/payments/daily-refill/notify.ts
@@ -1,7 +1,7 @@
-import logger from "@/utils/logger";
 import { createApnsService } from "@/api/v2/notifications/apns-push.service";
 import { createFcmService } from "@/api/v2/notifications/fcm-push.service";
 import type { CreditsRefilledPayload } from "@/api/v2/notifications/types";
+import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 
 export type RefilledEntry = {
@@ -66,77 +66,83 @@ export async function fanOutCreditsRefilled(
   const fcm = createFcmService();
 
   await Promise.all(
-    [...devicesByAccount.entries()].flatMap(([accountId, accountDevices]) => {
-      const entry = refilledByAccount.get(accountId);
-      if (!entry) return [];
+    [...devicesByAccount.entries()]
+      .flatMap(([accountId, accountDevices]) => {
+        const entry = refilledByAccount.get(accountId);
+        if (!entry) return [];
 
-      const payload: CreditsRefilledPayload = {
-        clientId: accountId,
-        notificationType: "CreditsRefilled",
-        notificationData: {
-          creditsAdded: entry.creditsAdded,
-          newBalance: entry.newBalance.toString(),
-          refilledAt: now.toISOString(),
-          nextRefreshAt: nextRefreshAt.toISOString(),
-        },
-      };
+        return accountDevices.map((device) => async () => {
+          // Adapt DeviceRegistration → ApnsDevice / FcmDevice (id field)
+          const adapted = { ...device, id: device.deviceId };
 
-      return accountDevices.map((device) => async () => {
-        // Adapt DeviceRegistration → ApnsDevice / FcmDevice (id field)
-        const adapted = { ...device, id: device.deviceId };
+          // Per-device clientId matches v2 routing semantics (see types.ts).
+          const payload: CreditsRefilledPayload = {
+            clientId: device.deviceId,
+            notificationType: "CreditsRefilled",
+            notificationData: {
+              creditsAdded: entry.creditsAdded,
+              newBalance: entry.newBalance.toString(),
+              refilledAt: now.toISOString(),
+              nextRefreshAt: nextRefreshAt.toISOString(),
+            },
+          };
 
-        try {
-          if (device.pushTokenType === "apns") {
-            if (!apns) {
+          try {
+            if (device.pushTokenType === "apns") {
+              if (!apns) {
+                logger.warn(
+                  { deviceId: device.deviceId, accountId },
+                  "daily_refill.notify.apns_unavailable",
+                );
+                return;
+              }
+              const result = await apns.sendPushNotification({
+                device: adapted,
+                notification: payload,
+                isSilent: true,
+              });
+              if (!result.success) {
+                logger.warn(
+                  { deviceId: device.deviceId, accountId, error: result.error },
+                  "daily_refill.notify.apns_send_failed",
+                );
+              }
+            } else if (device.pushTokenType === "fcm") {
+              if (!fcm) {
+                logger.warn(
+                  { deviceId: device.deviceId, accountId },
+                  "daily_refill.notify.fcm_unavailable",
+                );
+                return;
+              }
+              const result = await fcm.sendPushNotification({
+                device: adapted,
+                notification: payload,
+                isSilent: true,
+              });
+              if (!result.success) {
+                logger.warn(
+                  { deviceId: device.deviceId, accountId, error: result.error },
+                  "daily_refill.notify.fcm_send_failed",
+                );
+              }
+            } else {
               logger.warn(
-                { deviceId: device.deviceId, accountId },
-                "daily_refill.notify.apns_unavailable",
-              );
-              return;
-            }
-            const result = await apns.sendPushNotification({
-              device: adapted,
-              notification: payload,
-              isSilent: true,
-            });
-            if (!result.success) {
-              logger.warn(
-                { deviceId: device.deviceId, accountId, error: result.error },
-                "daily_refill.notify.apns_send_failed",
+                {
+                  deviceId: device.deviceId,
+                  pushTokenType: device.pushTokenType,
+                },
+                "daily_refill.notify.unknown_token_type",
               );
             }
-          } else if (device.pushTokenType === "fcm") {
-            if (!fcm) {
-              logger.warn(
-                { deviceId: device.deviceId, accountId },
-                "daily_refill.notify.fcm_unavailable",
-              );
-              return;
-            }
-            const result = await fcm.sendPushNotification({
-              device: adapted,
-              notification: payload,
-              isSilent: true,
-            });
-            if (!result.success) {
-              logger.warn(
-                { deviceId: device.deviceId, accountId, error: result.error },
-                "daily_refill.notify.fcm_send_failed",
-              );
-            }
-          } else {
+          } catch (err) {
             logger.warn(
-              { deviceId: device.deviceId, pushTokenType: device.pushTokenType },
-              "daily_refill.notify.unknown_token_type",
+              { err, deviceId: device.deviceId, accountId },
+              "daily_refill.notify.send_error",
             );
           }
-        } catch (err) {
-          logger.warn(
-            { err, deviceId: device.deviceId, accountId },
-            "daily_refill.notify.send_error",
-          );
-        }
-      });
-    }).map((fn) => fn()),
+        });
+      })
+      .map((fn) => fn()),
   );
 }

--- a/src/payments/daily-refill/notify.ts
+++ b/src/payments/daily-refill/notify.ts
@@ -1,0 +1,142 @@
+import logger from "@/utils/logger";
+import { createApnsService } from "@/api/v2/notifications/apns-push.service";
+import { createFcmService } from "@/api/v2/notifications/fcm-push.service";
+import type { CreditsRefilledPayload } from "@/api/v2/notifications/types";
+import { prisma } from "@/utils/prisma";
+
+export type RefilledEntry = {
+  accountId: string;
+  creditsAdded: number;
+  newBalance: bigint;
+};
+
+/**
+ * Fire-and-forget push fan-out for accounts that were refilled.
+ *
+ * - Queries non-disabled DeviceRegistrations for the refilled account IDs.
+ * - Groups by accountId, then fans out one push per device.
+ * - Each device send is individually try/caught — rejections cannot escape.
+ * - Returns void; callers use `void fanOutCreditsRefilled(...).catch(...)`.
+ */
+export async function fanOutCreditsRefilled(
+  refilled: RefilledEntry[],
+  now: Date,
+): Promise<void> {
+  if (refilled.length === 0) return;
+
+  const accountIds = refilled.map((r) => r.accountId);
+
+  const devices = await prisma.deviceRegistration.findMany({
+    where: {
+      accountId: { in: accountIds },
+      disabled: false,
+      pushToken: { not: null },
+    },
+    select: {
+      deviceId: true,
+      accountId: true,
+      pushToken: true,
+      pushTokenType: true,
+      apnsEnv: true,
+    },
+  });
+
+  if (devices.length === 0) return;
+
+  // Build lookup: accountId → RefilledEntry
+  const refilledByAccount = new Map<string, RefilledEntry>(
+    refilled.map((r) => [r.accountId, r]),
+  );
+
+  // Group devices by accountId
+  const devicesByAccount = new Map<string, typeof devices>();
+  for (const device of devices) {
+    if (!device.accountId) continue;
+    const list = devicesByAccount.get(device.accountId) ?? [];
+    list.push(device);
+    devicesByAccount.set(device.accountId, list);
+  }
+
+  // Compute next UTC day midnight for nextRefreshAt
+  const nextRefreshAt = new Date(now);
+  nextRefreshAt.setUTCHours(0, 0, 0, 0);
+  nextRefreshAt.setUTCDate(nextRefreshAt.getUTCDate() + 1);
+
+  const apns = createApnsService();
+  const fcm = createFcmService();
+
+  await Promise.all(
+    [...devicesByAccount.entries()].flatMap(([accountId, accountDevices]) => {
+      const entry = refilledByAccount.get(accountId);
+      if (!entry) return [];
+
+      const payload: CreditsRefilledPayload = {
+        clientId: accountId,
+        notificationType: "CreditsRefilled",
+        notificationData: {
+          creditsAdded: entry.creditsAdded,
+          newBalance: entry.newBalance.toString(),
+          refilledAt: now.toISOString(),
+          nextRefreshAt: nextRefreshAt.toISOString(),
+        },
+      };
+
+      return accountDevices.map((device) => async () => {
+        // Adapt DeviceRegistration → ApnsDevice / FcmDevice (id field)
+        const adapted = { ...device, id: device.deviceId };
+
+        try {
+          if (device.pushTokenType === "apns") {
+            if (!apns) {
+              logger.warn(
+                { deviceId: device.deviceId, accountId },
+                "daily_refill.notify.apns_unavailable",
+              );
+              return;
+            }
+            const result = await apns.sendPushNotification({
+              device: adapted,
+              notification: payload,
+              isSilent: true,
+            });
+            if (!result.success) {
+              logger.warn(
+                { deviceId: device.deviceId, accountId, error: result.error },
+                "daily_refill.notify.apns_send_failed",
+              );
+            }
+          } else if (device.pushTokenType === "fcm") {
+            if (!fcm) {
+              logger.warn(
+                { deviceId: device.deviceId, accountId },
+                "daily_refill.notify.fcm_unavailable",
+              );
+              return;
+            }
+            const result = await fcm.sendPushNotification({
+              device: adapted,
+              notification: payload,
+              isSilent: true,
+            });
+            if (!result.success) {
+              logger.warn(
+                { deviceId: device.deviceId, accountId, error: result.error },
+                "daily_refill.notify.fcm_send_failed",
+              );
+            }
+          } else {
+            logger.warn(
+              { deviceId: device.deviceId, pushTokenType: device.pushTokenType },
+              "daily_refill.notify.unknown_token_type",
+            );
+          }
+        } catch (err) {
+          logger.warn(
+            { err, deviceId: device.deviceId, accountId },
+            "daily_refill.notify.send_error",
+          );
+        }
+      });
+    }).map((fn) => fn()),
+  );
+}

--- a/src/payments/daily-refill/notify.ts
+++ b/src/payments/daily-refill/notify.ts
@@ -3,6 +3,7 @@ import { createFcmService } from "@/api/v2/notifications/fcm-push.service";
 import type { CreditsRefilledPayload } from "@/api/v2/notifications/types";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
+import { startOfNextUtcDay } from "./utc";
 
 export type RefilledEntry = {
   accountId: string;
@@ -57,10 +58,7 @@ export async function fanOutCreditsRefilled(
     devicesByAccount.set(device.accountId, list);
   }
 
-  // Compute next UTC day midnight for nextRefreshAt
-  const nextRefreshAt = new Date(now);
-  nextRefreshAt.setUTCHours(0, 0, 0, 0);
-  nextRefreshAt.setUTCDate(nextRefreshAt.getUTCDate() + 1);
+  const nextRefreshAt = startOfNextUtcDay(now);
 
   const apns = createApnsService();
   const fcm = createFcmService();
@@ -107,7 +105,9 @@ export async function fanOutCreditsRefilled(
                   "daily_refill.notify.apns_send_failed",
                 );
               }
-            } else if (device.pushTokenType === "fcm") {
+            } else {
+              // pushTokenType narrows to "fcm" — the PushTokenType enum has
+              // only "apns" | "fcm" per prisma/schema.prisma.
               if (!fcm) {
                 logger.warn(
                   { deviceId: device.deviceId, accountId },
@@ -126,14 +126,6 @@ export async function fanOutCreditsRefilled(
                   "daily_refill.notify.fcm_send_failed",
                 );
               }
-            } else {
-              logger.warn(
-                {
-                  deviceId: device.deviceId,
-                  pushTokenType: device.pushTokenType,
-                },
-                "daily_refill.notify.unknown_token_type",
-              );
             }
           } catch (err) {
             logger.warn(

--- a/src/payments/daily-refill/service.ts
+++ b/src/payments/daily-refill/service.ts
@@ -1,0 +1,125 @@
+import logger from "@/utils/logger";
+import { getBalance, grant } from "@/payments";
+import { config } from "@/payments/credits/config";
+import { prisma } from "@/utils/prisma";
+import { startOfTodayUtc, ymdUtc } from "./utc";
+
+export type DailyRefillSummary = {
+  skipped: boolean;
+  reason?: "already_ran_today";
+  lastRunAt?: Date;
+  runAt?: Date;
+  refilled: Array<{
+    accountId: string;
+    creditsAdded: number;
+    newBalance: bigint;
+  }>;
+  noOp: number;
+  errors: Array<{ accountId: string; error: string }>;
+};
+
+export async function lastRefillDateUTC(): Promise<Date | null> {
+  const row = await prisma.creditLedger.findFirst({
+    where: { grantKindId: "daily_refill" },
+    orderBy: { createdAt: "desc" },
+    select: { createdAt: true },
+  });
+  return row?.createdAt ?? null;
+}
+
+export async function runDailyRefill(opts?: {
+  now?: Date;
+}): Promise<DailyRefillSummary> {
+  const now = opts?.now ?? new Date();
+  const cap = config.freeTierDailyCapCredits;
+
+  // 1. Self-rate-limit
+  const lastRun = await lastRefillDateUTC();
+  const startOfToday = startOfTodayUtc(now);
+  if (lastRun && lastRun >= startOfToday) {
+    logger.warn(
+      { lastRunAt: lastRun.toISOString(), runAt: now.toISOString() },
+      "daily_refill.skipped.already_ran_today",
+    );
+    return {
+      skipped: true,
+      reason: "already_ran_today",
+      lastRunAt: lastRun,
+      refilled: [],
+      noOp: 0,
+      errors: [],
+    };
+  }
+
+  // 2. Eligibility — SIWE-verified non-subscribers.
+  //    Active subscription = status IN (trial, active, grace, billingRetry)
+  //    per src/subscriptions/repository.ts on louis/iap-credits-backend.
+  const eligible = await prisma.$queryRaw<Array<{ account_id: string }>>`
+    SELECT a.id AS account_id
+    FROM "Account" a
+    WHERE EXISTS (
+      SELECT 1 FROM "AuthMethod" am WHERE am."accountId" = a.id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM "Subscription" s
+      WHERE s."accountId" = a.id
+        AND s.status IN ('trial', 'active', 'grace', 'billingRetry')
+    )
+  `;
+
+  const summary: DailyRefillSummary = {
+    skipped: false,
+    runAt: now,
+    refilled: [],
+    noOp: 0,
+    errors: [],
+  };
+  const dayKey = ymdUtc(now);
+
+  // 3. Per-account loop
+  for (const { account_id: accountId } of eligible) {
+    try {
+      const balance = await getBalance(accountId);
+      const positiveBalance = balance < 0n ? 0n : balance;
+      const headroom = BigInt(cap) - positiveBalance;
+      if (headroom <= 0n) {
+        summary.noOp++;
+        continue;
+      }
+      // headroom > 0n and cap is safe int, so headroom fits in Number
+      const delta = Number(headroom);
+
+      const result = await grant({
+        accountId,
+        credits: delta,
+        kind: "daily_refill",
+        idempotencyKey: `daily_refill:${accountId}:${dayKey}`,
+        note: `Daily refill to cap ${cap}`,
+      });
+      summary.refilled.push({
+        accountId,
+        creditsAdded: result.granted,
+        newBalance: balance + BigInt(result.granted),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        { err, accountId, op: "daily_refill" },
+        "daily_refill.grant.failed",
+      );
+      summary.errors.push({ accountId, error: message });
+    }
+  }
+
+  logger.info(
+    {
+      refilled: summary.refilled.length,
+      noOp: summary.noOp,
+      errors: summary.errors.length,
+      runAt: now.toISOString(),
+    },
+    "daily_refill.completed",
+  );
+
+  return summary;
+}

--- a/src/payments/daily-refill/service.ts
+++ b/src/payments/daily-refill/service.ts
@@ -59,7 +59,9 @@ export async function runDailyRefill(opts?: {
     SELECT a.id AS account_id
     FROM "Account" a
     WHERE EXISTS (
-      SELECT 1 FROM "AuthMethod" am WHERE am."accountId" = a.id
+      SELECT 1 FROM "AuthMethod" am
+      WHERE am."accountId" = a.id
+        AND am.type = 'SIWE'
     )
     AND NOT EXISTS (
       SELECT 1 FROM "Subscription" s

--- a/src/payments/daily-refill/service.ts
+++ b/src/payments/daily-refill/service.ts
@@ -102,7 +102,7 @@ export async function runDailyRefill(opts?: {
       summary.refilled.push({
         accountId,
         creditsAdded: result.granted,
-        newBalance: balance + BigInt(result.granted),
+        newBalance: result.newBalance,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/payments/daily-refill/service.ts
+++ b/src/payments/daily-refill/service.ts
@@ -126,7 +126,7 @@ export async function runDailyRefill(opts?: {
 
   // Fire-and-forget — never block the response on push delivery.
   if (summary.refilled.length > 0) {
-    void fanOutCreditsRefilled(summary.refilled, now).catch((err) => {
+    void fanOutCreditsRefilled(summary.refilled, now).catch((err: unknown) => {
       logger.error(
         { err, op: "daily_refill_notify" },
         "daily_refill.notify.fanout_failed",

--- a/src/payments/daily-refill/service.ts
+++ b/src/payments/daily-refill/service.ts
@@ -1,9 +1,9 @@
-import logger from "@/utils/logger";
 import { getBalance, grant } from "@/payments";
 import { config } from "@/payments/credits/config";
+import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
-import { startOfTodayUtc, ymdUtc } from "./utc";
 import { fanOutCreditsRefilled } from "./notify";
+import { startOfTodayUtc, ymdUtc } from "./utc";
 
 export type DailyRefillSummary = {
   skipped: boolean;

--- a/src/payments/daily-refill/service.ts
+++ b/src/payments/daily-refill/service.ts
@@ -3,6 +3,7 @@ import { getBalance, grant } from "@/payments";
 import { config } from "@/payments/credits/config";
 import { prisma } from "@/utils/prisma";
 import { startOfTodayUtc, ymdUtc } from "./utc";
+import { fanOutCreditsRefilled } from "./notify";
 
 export type DailyRefillSummary = {
   skipped: boolean;
@@ -120,6 +121,16 @@ export async function runDailyRefill(opts?: {
     },
     "daily_refill.completed",
   );
+
+  // Fire-and-forget — never block the response on push delivery.
+  if (summary.refilled.length > 0) {
+    void fanOutCreditsRefilled(summary.refilled, now).catch((err) => {
+      logger.error(
+        { err, op: "daily_refill_notify" },
+        "daily_refill.notify.fanout_failed",
+      );
+    });
+  }
 
   return summary;
 }

--- a/src/payments/daily-refill/utc.ts
+++ b/src/payments/daily-refill/utc.ts
@@ -1,0 +1,16 @@
+export const startOfTodayUtc = (now: Date): Date =>
+  new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+
+export const startOfNextUtcDay = (now: Date): Date =>
+  new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+  );
+
+export const ymdUtc = (now: Date): string => {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(now.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};

--- a/src/payments/daily-refill/utc.ts
+++ b/src/payments/daily-refill/utc.ts
@@ -1,7 +1,5 @@
 export const startOfTodayUtc = (now: Date): Date =>
-  new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
+  new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 
 export const startOfNextUtcDay = (now: Date): Date =>
   new Date(

--- a/src/payments/index.ts
+++ b/src/payments/index.ts
@@ -45,7 +45,7 @@ export const consume = async (args: {
 }): Promise<ConsumeResult> => {
   const credits = usdToCredits(args.usdCostMicros);
   try {
-    const { replayed } = await applyDelta({
+    const { replayed, newBalance } = await applyDelta({
       accountId: args.accountId,
       delta: BigInt(-credits),
       reason: LedgerReason.consume,
@@ -57,7 +57,7 @@ export const consume = async (args: {
       requestId: args.requestId,
       floorCheck: { minBalance: config.minBalance },
     });
-    return { spent: credits, replayed };
+    return { spent: credits, replayed, newBalance };
   } catch (err) {
     if (err instanceof LedgerFloorBreachError) {
       throw new InsufficientBalanceError(
@@ -116,12 +116,13 @@ export const grant = async (args: {
   );
   if (prior) {
     validateReplayPayload(prior, ledgerInput);
-    return { granted: args.credits, replayed: true };
+    const newBalance = await ledgerGetBalance(args.accountId);
+    return { granted: args.credits, replayed: true, newBalance };
   }
 
   // 2. Active-kind check only applies on first grant, not on replay.
   try {
-    await prisma.$transaction(async (tx) => {
+    const txResult = await prisma.$transaction(async (tx) => {
       const kindRow = await tx.grantKind.findUnique({
         where: { id: parsedKind },
         select: { id: true, active: true },
@@ -131,7 +132,11 @@ export const grant = async (args: {
       }
       return applyDeltaWithTx(tx, ledgerInput);
     });
-    return { granted: args.credits, replayed: false };
+    return {
+      granted: args.credits,
+      replayed: false,
+      newBalance: txResult.newBalance,
+    };
   } catch (err) {
     if (
       err instanceof Prisma.PrismaClientKnownRequestError &&
@@ -145,7 +150,8 @@ export const grant = async (args: {
       );
       if (racePrior) {
         validateReplayPayload(racePrior, ledgerInput);
-        return { granted: args.credits, replayed: true };
+        const newBalance = await ledgerGetBalance(args.accountId);
+        return { granted: args.credits, replayed: true, newBalance };
       }
     }
     throw err;
@@ -174,7 +180,7 @@ export const adjust = async (args: {
   const opts =
     args.delta < 0 ? { floorCheck: { minBalance: config.minBalance } } : {};
   try {
-    const { replayed } = await applyDelta({
+    const { replayed, newBalance } = await applyDelta({
       accountId: args.accountId,
       delta: BigInt(args.delta),
       reason: LedgerReason.adjust,
@@ -182,7 +188,7 @@ export const adjust = async (args: {
       note: args.note,
       ...opts,
     });
-    return { applied: true, replayed };
+    return { applied: true, replayed, newBalance };
   } catch (err) {
     if (err instanceof LedgerFloorBreachError) {
       throw new InsufficientBalanceError(

--- a/src/payments/ledger/repository.ts
+++ b/src/payments/ledger/repository.ts
@@ -21,6 +21,7 @@ interface ApplyDeltaInput {
 export interface ApplyDeltaResult {
   ledgerId: string;
   replayed: boolean;
+  newBalance: bigint;
 }
 
 interface RawBalanceRow {
@@ -189,7 +190,7 @@ export const applyDeltaWithTx = async (
     },
   });
 
-  return { ledgerId: created.id, replayed: false };
+  return { ledgerId: created.id, replayed: false, newBalance: after };
 };
 
 export const applyDelta = async (
@@ -208,7 +209,11 @@ export const applyDelta = async (
       );
       if (prior) {
         validateReplayPayload(prior, input);
-        return { ledgerId: prior.id, replayed: true };
+        // Replay path: read current balance post-fact. Not the lock-window
+        // exact value, but accurate at read time — same race window as any
+        // independent getBalance call.
+        const newBalance = await getBalance(input.accountId);
+        return { ledgerId: prior.id, replayed: true, newBalance };
       }
     }
     throw err;

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -9,6 +9,18 @@ export type GrantKindId = z.infer<typeof GrantKindIdSchema>;
 
 export type HistoryCursor = { createdAt: Date; id: string };
 
-export type ConsumeResult = { spent: number; replayed: boolean };
-export type GrantResult = { granted: number; replayed: boolean };
-export type AdjustResult = { applied: true; replayed: boolean };
+export type ConsumeResult = {
+  spent: number;
+  replayed: boolean;
+  newBalance: bigint;
+};
+export type GrantResult = {
+  granted: number;
+  replayed: boolean;
+  newBalance: bigint;
+};
+export type AdjustResult = {
+  applied: true;
+  replayed: boolean;
+  newBalance: bigint;
+};

--- a/tests/credits/cron-api-key.unit.test.ts
+++ b/tests/credits/cron-api-key.unit.test.ts
@@ -1,12 +1,11 @@
-import { describe, expect, test, afterEach } from "bun:test";
-import type { Request, Response, NextFunction } from "express";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { NextFunction, Request, Response } from "express";
 import {
-  requireCronApiKey,
   __setCronApiKeyOverrideForTests,
+  requireCronApiKey,
 } from "@/api/v2/credits/middleware/cron-api-key";
 
-const TEST_KEY =
-  "test-cron-api-key-that-is-at-least-32-characters-long";
+const TEST_KEY = "test-cron-api-key-that-is-at-least-32-characters-long";
 
 function mockRes() {
   const headers: Record<string, unknown> = {};

--- a/tests/credits/cron-api-key.unit.test.ts
+++ b/tests/credits/cron-api-key.unit.test.ts
@@ -36,7 +36,9 @@ function mockReq(headerVal?: string) {
   } as unknown as Request;
 }
 
-afterEach(() => __setCronApiKeyOverrideForTests(undefined));
+afterEach(() => {
+  __setCronApiKeyOverrideForTests(undefined);
+});
 
 describe("requireCronApiKey", () => {
   test("missing header → 401", () => {

--- a/tests/credits/cron-api-key.unit.test.ts
+++ b/tests/credits/cron-api-key.unit.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import type { Request, Response, NextFunction } from "express";
+import {
+  requireCronApiKey,
+  __setCronApiKeyOverrideForTests,
+} from "@/api/v2/credits/middleware/cron-api-key";
+
+const TEST_KEY =
+  "test-cron-api-key-that-is-at-least-32-characters-long";
+
+function mockRes() {
+  const headers: Record<string, unknown> = {};
+  const body: { json?: unknown; status?: number } = {};
+  const res = {
+    status(code: number) {
+      body.status = code;
+      return this;
+    },
+    json(obj: unknown) {
+      body.json = obj;
+      return this;
+    },
+    headers,
+    body,
+  } as unknown as Response & { body: typeof body };
+  return res;
+}
+
+function mockReq(headerVal?: string) {
+  return {
+    headers: headerVal ? { "x-cron-api-key": headerVal } : {},
+    log: {
+      info() {},
+      warn() {},
+      error() {},
+    },
+  } as unknown as Request;
+}
+
+afterEach(() => __setCronApiKeyOverrideForTests(undefined));
+
+describe("requireCronApiKey", () => {
+  test("missing header → 401", () => {
+    __setCronApiKeyOverrideForTests(TEST_KEY);
+    const req = mockReq();
+    const res = mockRes();
+    let nextCalled = false;
+    requireCronApiKey(req, res, (() => {
+      nextCalled = true;
+    }) as NextFunction);
+    expect(nextCalled).toBe(false);
+    expect(res.body.status).toBe(401);
+  });
+
+  test("wrong header → 401", () => {
+    __setCronApiKeyOverrideForTests(TEST_KEY);
+    const req = mockReq("wrong-key");
+    const res = mockRes();
+    let nextCalled = false;
+    requireCronApiKey(req, res, (() => {
+      nextCalled = true;
+    }) as NextFunction);
+    expect(nextCalled).toBe(false);
+    expect(res.body.status).toBe(401);
+  });
+
+  test("correct header → next()", () => {
+    __setCronApiKeyOverrideForTests(TEST_KEY);
+    const req = mockReq(TEST_KEY);
+    const res = mockRes();
+    let nextCalled = false;
+    requireCronApiKey(req, res, (() => {
+      nextCalled = true;
+    }) as NextFunction);
+    expect(nextCalled).toBe(true);
+  });
+
+  test("unset cron key → 503", () => {
+    __setCronApiKeyOverrideForTests(null);
+    const req = mockReq("anything");
+    const res = mockRes();
+    requireCronApiKey(req, res, (() => {}) as NextFunction);
+    expect(res.body.status).toBe(503);
+  });
+});

--- a/tests/credits/daily-refill.integration.test.ts
+++ b/tests/credits/daily-refill.integration.test.ts
@@ -9,11 +9,7 @@ import {
 } from "bun:test";
 import { __setCronApiKeyOverrideForTests } from "@/api/v2/credits/middleware/cron-api-key";
 import { prisma } from "@/utils/prisma";
-import {
-  buildCreditsApp,
-  cleanupAccounts,
-  seedAccount,
-} from "./helpers";
+import { buildCreditsApp, cleanupAccounts, seedAccount } from "./helpers";
 
 const TEST_CRON_KEY = "test-cron-api-key-that-is-at-least-32-characters-long";
 

--- a/tests/credits/daily-refill.integration.test.ts
+++ b/tests/credits/daily-refill.integration.test.ts
@@ -1,0 +1,127 @@
+import type { Server } from "node:http";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { __setCronApiKeyOverrideForTests } from "@/api/v2/credits/middleware/cron-api-key";
+import { prisma } from "@/utils/prisma";
+import {
+  buildCreditsApp,
+  cleanupAccounts,
+  seedAccount,
+} from "./helpers";
+
+const TEST_CRON_KEY = "test-cron-api-key-that-is-at-least-32-characters-long";
+
+let BASE = "";
+let server: Server;
+const tracker: string[] = [];
+
+beforeAll(async () => {
+  __setCronApiKeyOverrideForTests(TEST_CRON_KEY);
+  const app = buildCreditsApp();
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("Failed to resolve test server address");
+      }
+      BASE = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  // Delete AuthMethod rows first (FK child of Account) so cleanupAccounts can delete Account
+  if (tracker.length > 0) {
+    await prisma.authMethod.deleteMany({
+      where: { accountId: { in: tracker } },
+    });
+  }
+  await cleanupAccounts(tracker);
+  tracker.length = 0;
+});
+
+afterAll(async () => {
+  __setCronApiKeyOverrideForTests(undefined);
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+});
+
+const post = (path: string, hdrs: Record<string, string> = {}) =>
+  fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...hdrs },
+  });
+
+describe("POST /api/v2/credits/daily", () => {
+  test("missing X-Cron-API-Key → 401", async () => {
+    const res = await post("/api/v2/credits/daily");
+    expect(res.status).toBe(401);
+  });
+
+  test("wrong X-Cron-API-Key → 401", async () => {
+    const res = await post("/api/v2/credits/daily", {
+      "X-Cron-API-Key": "wrong-key-that-is-also-at-least-32-characters-long",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("correct key + fresh accounts → 200 with counts", async () => {
+    // Seed an account with an auth method so it appears in eligible query
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    // Add a SIWE auth method so the account is eligible
+    await prisma.authMethod.create({
+      data: {
+        accountId,
+        type: "SIWE",
+        externalKey: `0xtest-daily-refill-${accountId}`,
+      },
+    });
+
+    const res = await post("/api/v2/credits/daily", {
+      "X-Cron-API-Key": TEST_CRON_KEY,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.skipped).toBe(false);
+    expect(typeof body.refilled).toBe("number");
+    expect(typeof body.noOp).toBe("number");
+    expect(typeof body.errors).toBe("number");
+    expect(typeof body.runAt).toBe("string");
+    // Our seeded account has no balance, so it should be refilled
+    expect(body.refilled as number).toBeGreaterThanOrEqual(1);
+  });
+
+  test("second call same UTC day → 200 skipped:true", async () => {
+    // First call
+    const res1 = await post("/api/v2/credits/daily", {
+      "X-Cron-API-Key": TEST_CRON_KEY,
+    });
+    expect(res1.status).toBe(200);
+    const body1 = (await res1.json()) as Record<string, unknown>;
+    // May have been skipped from a prior test's run — either way, do a second call
+    if (body1.skipped) {
+      // Already skipped from prior run — second call must also skip
+    }
+
+    // Second call — must be skipped (already_ran_today guard)
+    const res2 = await post("/api/v2/credits/daily", {
+      "X-Cron-API-Key": TEST_CRON_KEY,
+    });
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as Record<string, unknown>;
+    expect(body2.skipped).toBe(true);
+    expect(body2.reason).toBe("already_ran_today");
+    expect(typeof body2.lastRunAt).toBe("string");
+  });
+});

--- a/tests/credits/daily-refill.integration.test.ts
+++ b/tests/credits/daily-refill.integration.test.ts
@@ -45,6 +45,11 @@ afterEach(async () => {
   }
   await cleanupAccounts(tracker);
   tracker.length = 0;
+  // Wipe any daily_refill ledger rows from other test files in the same
+  // suite run so the rate-limit anchor doesn't leak across tests.
+  await prisma.creditLedger.deleteMany({
+    where: { grantKindId: "daily_refill" },
+  });
 });
 
 afterAll(async () => {
@@ -103,18 +108,26 @@ describe("POST /api/v2/credits/daily", () => {
   });
 
   test("second call same UTC day → 200 skipped:true", async () => {
-    // First call
+    // Seed an eligible account so the first call writes a real rate-limit anchor.
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await prisma.authMethod.create({
+      data: {
+        accountId,
+        type: "SIWE",
+        externalKey: `0xtest-second-call-${accountId}`,
+      },
+    });
+
+    // First call refills the account and writes the rate-limit anchor.
     const res1 = await post("/api/v2/credits/daily", {
       "X-Cron-API-Key": TEST_CRON_KEY,
     });
     expect(res1.status).toBe(200);
     const body1 = (await res1.json()) as Record<string, unknown>;
-    // May have been skipped from a prior test's run — either way, do a second call
-    if (body1.skipped) {
-      // Already skipped from prior run — second call must also skip
-    }
+    expect(body1.skipped).toBe(false);
 
-    // Second call — must be skipped (already_ran_today guard)
+    // Second call must be skipped (already_ran_today guard).
     const res2 = await post("/api/v2/credits/daily", {
       "X-Cron-API-Key": TEST_CRON_KEY,
     });

--- a/tests/payments/daily-refill-config.unit.test.ts
+++ b/tests/payments/daily-refill-config.unit.test.ts
@@ -32,7 +32,9 @@ describe("PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS", () => {
     const { loadFreeTierDailyCapCredits } = await import(
       "@/payments/credits/config"
     );
-    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be > 0/);
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(
+      /must be a positive safe integer/,
+    );
   });
 
   test("rejects negative", async () => {
@@ -40,11 +42,21 @@ describe("PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS", () => {
     const { loadFreeTierDailyCapCredits } = await import(
       "@/payments/credits/config"
     );
-    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be > 0/);
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(
+      /must be a positive safe integer/,
+    );
   });
 
   test("rejects non-integer", async () => {
     process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "1.5";
+    const { loadFreeTierDailyCapCredits } = await import(
+      "@/payments/credits/config"
+    );
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be an integer/);
+  });
+
+  test("rejects alpha string", async () => {
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "abc";
     const { loadFreeTierDailyCapCredits } = await import(
       "@/payments/credits/config"
     );

--- a/tests/payments/daily-refill-config.unit.test.ts
+++ b/tests/payments/daily-refill-config.unit.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+describe("PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS", () => {
+  const original = process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS;
+    } else {
+      process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = original;
+    }
+  });
+
+  test("loads positive int", async () => {
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "100";
+    const { loadFreeTierDailyCapCredits } = await import(
+      "@/payments/credits/config"
+    );
+    expect(loadFreeTierDailyCapCredits()).toBe(100);
+  });
+
+  test("rejects missing", async () => {
+    delete process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS;
+    const { loadFreeTierDailyCapCredits } = await import(
+      "@/payments/credits/config"
+    );
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(/not configured/);
+  });
+
+  test("rejects zero", async () => {
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "0";
+    const { loadFreeTierDailyCapCredits } = await import(
+      "@/payments/credits/config"
+    );
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be > 0/);
+  });
+
+  test("rejects negative", async () => {
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "-5";
+    const { loadFreeTierDailyCapCredits } = await import(
+      "@/payments/credits/config"
+    );
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be > 0/);
+  });
+
+  test("rejects non-integer", async () => {
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "1.5";
+    const { loadFreeTierDailyCapCredits } = await import(
+      "@/payments/credits/config"
+    );
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be an integer/);
+  });
+});

--- a/tests/payments/daily-refill/notify.unit.test.ts
+++ b/tests/payments/daily-refill/notify.unit.test.ts
@@ -1,11 +1,5 @@
 import { randomUUID } from "node:crypto";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { fanOutCreditsRefilled } from "@/payments/daily-refill/notify";
 import { prisma } from "@/utils/prisma";
 

--- a/tests/payments/daily-refill/notify.unit.test.ts
+++ b/tests/payments/daily-refill/notify.unit.test.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { fanOutCreditsRefilled } from "@/payments/daily-refill/notify";
+import { prisma } from "@/utils/prisma";
+
+const tracker: string[] = [];
+const deviceTracker: string[] = [];
+
+afterEach(async () => {
+  for (const deviceId of deviceTracker) {
+    await prisma.deviceRegistration.deleteMany({ where: { deviceId } });
+  }
+  for (const accountId of tracker) {
+    await prisma.account.deleteMany({ where: { id: accountId } });
+  }
+  tracker.length = 0;
+  deviceTracker.length = 0;
+});
+
+describe("fanOutCreditsRefilled", () => {
+  test("no refilled accounts → no DB query, returns immediately", async () => {
+    await fanOutCreditsRefilled([], new Date());
+    expect(true).toBe(true);
+  });
+
+  test("refilled account with no devices → returns without sending", async () => {
+    const acct = await prisma.account.create({ data: {} });
+    tracker.push(acct.id);
+    await fanOutCreditsRefilled(
+      [{ accountId: acct.id, creditsAdded: 50, newBalance: 100n }],
+      new Date(),
+    );
+    expect(true).toBe(true);
+  });
+
+  test("refilled account with disabled device → device filtered out", async () => {
+    const acct = await prisma.account.create({ data: {} });
+    tracker.push(acct.id);
+    const deviceId = randomUUID();
+    await prisma.deviceRegistration.create({
+      data: {
+        deviceId,
+        accountId: acct.id,
+        pushToken: "tok",
+        pushTokenType: "apns",
+        apnsEnv: "sandbox",
+        disabled: true,
+      },
+    });
+    deviceTracker.push(deviceId);
+    await fanOutCreditsRefilled(
+      [{ accountId: acct.id, creditsAdded: 50, newBalance: 100n }],
+      new Date(),
+    );
+    expect(true).toBe(true);
+  });
+});

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -323,3 +323,46 @@ describe("runDailyRefill — idempotency", () => {
     expect(await balanceOf(accountId)).toBe(40n);
   });
 });
+
+describe("runDailyRefill — failure isolation", () => {
+  test("pre-seeded idempotency-key collision with mismatched payload → error for that account, others succeed", async () => {
+    const goodAccountId = await seedAccount();
+    const collidingAccountId = await seedAccount();
+
+    // Pre-insert a ledger row using the same idempotency key the service
+    // will generate for `collidingAccountId` today, but with a different
+    // delta. The grant() call inside the service will see the prior row
+    // and throw IdempotencyMismatchError.
+    //
+    // IMPORTANT: createdAt is set to yesterday so the global rate-limit
+    // query (MAX createdAt WHERE grantKindId='daily_refill' >= startOfTodayUtc(NOW))
+    // does NOT short-circuit the batch. The date-keyed idempotency key
+    // ('daily_refill:<accountId>:2026-05-15') still collides with what the
+    // service generates for today, triggering the mismatch error.
+    const dayKey = ymdUtc(NOW);
+    const collidingKey = `daily_refill:${collidingAccountId}:${dayKey}`;
+    await prisma.creditLedger.create({
+      data: {
+        accountId: collidingAccountId,
+        delta: 99n,
+        reason: LedgerReason.grant,
+        idempotencyKey: collidingKey,
+        grantKindId: "daily_refill",
+        createdAt: new Date(NOW.getTime() - 24 * 60 * 60 * 1000),
+      },
+    });
+    // Also reflect the delta in UserCredits so balance is internally consistent
+    await prisma.userCredits.create({
+      data: { accountId: collidingAccountId, balance: 99n },
+    });
+
+    const summary = await runDailyRefill({ now: NOW });
+
+    expect(summary.refilled.map((r) => r.accountId)).toContain(goodAccountId);
+    expect(summary.errors.map((e) => e.accountId)).toContain(collidingAccountId);
+    const collidingError = summary.errors.find(
+      (e) => e.accountId === collidingAccountId,
+    );
+    expect(collidingError?.error).toMatch(/idempotency|replay|mismatch/i);
+  });
+});

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { afterEach, describe, expect, test } from "bun:test";
 import { LedgerReason } from "@prisma/client";
+import { afterEach, describe, expect, test } from "bun:test";
 import { getBalance } from "@/payments";
 import { runDailyRefill } from "@/payments/daily-refill/service";
 import { ymdUtc } from "@/payments/daily-refill/utc";
@@ -20,7 +20,9 @@ afterEach(async () => {
   tracker.length = 0;
 });
 
-async function seedAccount(opts?: { withAuthMethod?: boolean }): Promise<string> {
+async function seedAccount(opts?: {
+  withAuthMethod?: boolean;
+}): Promise<string> {
   const acct = await prisma.account.create({ data: {} });
   tracker.push(acct.id);
   if (opts?.withAuthMethod ?? true) {
@@ -318,7 +320,9 @@ describe("runDailyRefill — idempotency", () => {
     expect(summarySecond.skipped).toBe(false);
 
     // Account must NOT appear in refilled — the error path fires instead.
-    expect(summarySecond.refilled.map((r) => r.accountId)).not.toContain(accountId);
+    expect(summarySecond.refilled.map((r) => r.accountId)).not.toContain(
+      accountId,
+    );
     // Balance must remain at 40n — no double-credit.
     expect(await balanceOf(accountId)).toBe(40n);
   });
@@ -359,7 +363,9 @@ describe("runDailyRefill — failure isolation", () => {
     const summary = await runDailyRefill({ now: NOW });
 
     expect(summary.refilled.map((r) => r.accountId)).toContain(goodAccountId);
-    expect(summary.errors.map((e) => e.accountId)).toContain(collidingAccountId);
+    expect(summary.errors.map((e) => e.accountId)).toContain(
+      collidingAccountId,
+    );
     const collidingError = summary.errors.find(
       (e) => e.accountId === collidingAccountId,
     );

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { LedgerReason } from "@prisma/client";
+import { getBalance } from "@/payments";
 import { runDailyRefill } from "@/payments/daily-refill/service";
+import { ymdUtc } from "@/payments/daily-refill/utc";
+import { applyDelta } from "@/payments/ledger/repository";
 import { prisma } from "@/utils/prisma";
 
 const tracker: string[] = [];
@@ -29,6 +33,10 @@ async function seedAccount(opts?: { withAuthMethod?: boolean }): Promise<string>
     });
   }
   return acct.id;
+}
+
+async function balanceOf(accountId: string): Promise<bigint> {
+  return getBalance(accountId);
 }
 
 async function seedActiveSubscription(accountId: string): Promise<void> {
@@ -102,5 +110,151 @@ describe("runDailyRefill — eligibility", () => {
     });
     const summary = await runDailyRefill({ now: NOW });
     expect(summary.refilled.map((r) => r.accountId)).toContain(accountId);
+  });
+});
+
+describe("runDailyRefill — top-up math", () => {
+  test("zero balance → grant equal to cap (100)", async () => {
+    const accountId = await seedAccount();
+    // No UserCredits row → balance is 0n by default
+    const summary = await runDailyRefill({ now: NOW });
+    const entry = summary.refilled.find((r) => r.accountId === accountId);
+    expect(entry).toBeDefined();
+    expect(entry!.creditsAdded).toBe(100);
+    expect(await balanceOf(accountId)).toBe(100n);
+  });
+
+  test("balance below cap (40) → grant 60 to reach cap", async () => {
+    const accountId = await seedAccount();
+    // Seed 40 credits via applyDelta (direct ledger write, no grant kind needed)
+    await applyDelta({
+      accountId,
+      delta: 40n,
+      idempotencyKey: `seed-40:${accountId}`,
+      reason: LedgerReason.adjust,
+    });
+    const summary = await runDailyRefill({ now: NOW });
+    const entry = summary.refilled.find((r) => r.accountId === accountId);
+    expect(entry).toBeDefined();
+    expect(entry!.creditsAdded).toBe(60);
+    expect(await balanceOf(accountId)).toBe(100n);
+  });
+
+  test("balance at cap → noOp (no ledger row added)", async () => {
+    const accountId = await seedAccount();
+    await applyDelta({
+      accountId,
+      delta: 100n,
+      idempotencyKey: `seed-100:${accountId}`,
+      reason: LedgerReason.adjust,
+    });
+    const before = await balanceOf(accountId);
+    const summary = await runDailyRefill({ now: NOW });
+    expect(summary.refilled.map((r) => r.accountId)).not.toContain(accountId);
+    expect(summary.noOp).toBeGreaterThanOrEqual(1);
+    expect(await balanceOf(accountId)).toBe(before);
+  });
+
+  test("balance above cap (150) → noOp (headroom <= 0)", async () => {
+    const accountId = await seedAccount();
+    await applyDelta({
+      accountId,
+      delta: 150n,
+      idempotencyKey: `seed-150:${accountId}`,
+      reason: LedgerReason.adjust,
+    });
+    const before = await balanceOf(accountId);
+    const summary = await runDailyRefill({ now: NOW });
+    expect(summary.refilled.map((r) => r.accountId)).not.toContain(accountId);
+    expect(await balanceOf(accountId)).toBe(before);
+  });
+
+  test("negative balance → grant exactly cap (positiveBalance clamped to 0)", async () => {
+    const accountId = await seedAccount();
+    // Drive balance negative via two applyDelta calls:
+    // First create the row with a positive seed, then subtract more than seeded.
+    await applyDelta({
+      accountId,
+      delta: 10n,
+      idempotencyKey: `seed-pos:${accountId}`,
+      reason: LedgerReason.adjust,
+    });
+    await applyDelta({
+      accountId,
+      delta: -50n,
+      idempotencyKey: `seed-neg:${accountId}`,
+      reason: LedgerReason.adjust,
+    });
+    // balance is now -40n; positiveBalance clamps to 0n; headroom = cap = 100
+    const summary = await runDailyRefill({ now: NOW });
+    const entry = summary.refilled.find((r) => r.accountId === accountId);
+    expect(entry).toBeDefined();
+    expect(entry!.creditsAdded).toBe(100);
+    expect(await balanceOf(accountId)).toBe(60n); // -40 + 100 = 60
+  });
+});
+
+describe("runDailyRefill — idempotency", () => {
+  test("global rate-limit: second run on same UTC day returns skipped:true (no double-credit)", async () => {
+    const accountId = await seedAccount();
+
+    // First run — inserts a daily_refill ledger row, setting the global anchor.
+    const summaryFirst = await runDailyRefill({ now: NOW });
+    expect(summaryFirst.skipped).toBe(false);
+    expect(summaryFirst.refilled.map((r) => r.accountId)).toContain(accountId);
+    const balanceAfterFirst = await balanceOf(accountId);
+    expect(balanceAfterFirst).toBe(100n);
+
+    // Second run on the SAME UTC day — global rate-limit sees MAX(createdAt) >= startOfToday
+    // and short-circuits immediately. No per-account grant() calls are made.
+    const summarySecond = await runDailyRefill({ now: NOW });
+    expect(summarySecond.skipped).toBe(true);
+    expect(summarySecond.reason).toBe("already_ran_today");
+
+    // Balance must be unchanged — no double-credit.
+    expect(await balanceOf(accountId)).toBe(balanceAfterFirst);
+  });
+
+  test("per-account idempotency key replay: balance unchanged even when global rate-limit bypassed", async () => {
+    const accountId = await seedAccount();
+
+    // First run — inserts the per-account daily_refill ledger row (delta=100)
+    // and sets balance to 100n.
+    await runDailyRefill({ now: NOW });
+    const balanceAfterFirst = await balanceOf(accountId);
+    expect(balanceAfterFirst).toBe(100n);
+
+    // Drain 60 credits so balance is 40n and headroom would be 60 on next run.
+    await applyDelta({
+      accountId,
+      delta: -60n,
+      idempotencyKey: `drain:${accountId}`,
+      reason: LedgerReason.adjust,
+    });
+    expect(await balanceOf(accountId)).toBe(40n);
+
+    // Backdate the daily_refill ledger row to yesterday so the global rate-limit
+    // anchor (MAX createdAt WHERE grantKindId='daily_refill') falls before
+    // startOfTodayUtc(NOW) → self-rate-limit check passes for second run.
+    const yesterday = new Date(NOW.getTime() - 24 * 60 * 60 * 1000);
+    await prisma.creditLedger.updateMany({
+      where: { accountId, grantKindId: "daily_refill" },
+      data: { createdAt: yesterday },
+    });
+
+    // Second run: sees balance=40n, headroom=60, calls
+    //   grant({ credits: 60, idempotencyKey: "daily_refill:<accountId>:2026-05-15" })
+    // The stored row has delta=100 (from the first run). The mismatch between
+    // requested delta (60) and stored delta (100) triggers IdempotencyMismatchError,
+    // which the service catches and logs in errors[]. Balance stays at 40n.
+    // This is the correct defense: the same-day key blocks re-crediting even if
+    // the headroom calculation changed mid-day (e.g., due to consumption).
+    const summarySecond = await runDailyRefill({ now: NOW });
+    expect(summarySecond.skipped).toBe(false);
+
+    // Account must NOT appear in refilled — the error path fires instead.
+    expect(summarySecond.refilled.map((r) => r.accountId)).not.toContain(accountId);
+    // Balance must remain at 40n — no double-credit.
+    expect(await balanceOf(accountId)).toBe(40n);
   });
 });

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -7,6 +7,7 @@ const tracker: string[] = [];
 
 afterEach(async () => {
   for (const accountId of tracker) {
+    await prisma.subscription.deleteMany({ where: { accountId } });
     await prisma.creditLedger.deleteMany({ where: { accountId } });
     await prisma.userCredits.deleteMany({ where: { accountId } });
     await prisma.authMethod.deleteMany({ where: { accountId } });
@@ -14,6 +15,41 @@ afterEach(async () => {
   }
   tracker.length = 0;
 });
+
+async function seedAccount(opts?: { withAuthMethod?: boolean }): Promise<string> {
+  const acct = await prisma.account.create({ data: {} });
+  tracker.push(acct.id);
+  if (opts?.withAuthMethod ?? true) {
+    await prisma.authMethod.create({
+      data: {
+        accountId: acct.id,
+        type: "SIWE",
+        externalKey: `0x${randomUUID().replace(/-/g, "")}`,
+      },
+    });
+  }
+  return acct.id;
+}
+
+async function seedActiveSubscription(accountId: string): Promise<void> {
+  await prisma.subscription.create({
+    data: {
+      accountId,
+      productId: "com.example.builder.monthly",
+      tier: "builder",
+      period: "monthly",
+      status: "active",
+      originalTransactionId: `otx-${randomUUID()}`,
+      appAccountToken: randomUUID(),
+      startedAt: new Date("2026-05-01"),
+      currentPeriodStart: new Date("2026-05-01"),
+      currentPeriodEnd: new Date("2026-06-01"),
+      environment: "production",
+    },
+  });
+}
+
+const NOW = new Date(Date.UTC(2026, 4, 15, 12, 0, 0));
 
 describe("runDailyRefill — empty DB", () => {
   test("no eligible accounts → empty summary", async () => {
@@ -24,5 +60,47 @@ describe("runDailyRefill — empty DB", () => {
     expect(summary.refilled).toEqual([]);
     expect(summary.noOp).toBe(0);
     expect(summary.errors).toEqual([]);
+  });
+});
+
+describe("runDailyRefill — eligibility", () => {
+  test("includes SIWE-verified non-subscriber", async () => {
+    const accountId = await seedAccount();
+    const summary = await runDailyRefill({ now: NOW });
+    expect(summary.refilled.map((r) => r.accountId)).toContain(accountId);
+  });
+
+  test("excludes account without AuthMethod (anonymous device-only)", async () => {
+    const accountId = await seedAccount({ withAuthMethod: false });
+    const summary = await runDailyRefill({ now: NOW });
+    expect(summary.refilled.map((r) => r.accountId)).not.toContain(accountId);
+  });
+
+  test("excludes account with active subscription", async () => {
+    const accountId = await seedAccount();
+    await seedActiveSubscription(accountId);
+    const summary = await runDailyRefill({ now: NOW });
+    expect(summary.refilled.map((r) => r.accountId)).not.toContain(accountId);
+  });
+
+  test("includes account whose subscription is revoked (non-active status)", async () => {
+    const accountId = await seedAccount();
+    await prisma.subscription.create({
+      data: {
+        accountId,
+        productId: "com.example.builder.monthly",
+        tier: "builder",
+        period: "monthly",
+        status: "revoked",
+        originalTransactionId: `otx-${randomUUID()}`,
+        appAccountToken: randomUUID(),
+        startedAt: new Date("2026-04-01"),
+        currentPeriodStart: new Date("2026-04-01"),
+        currentPeriodEnd: new Date("2026-05-01"),
+        environment: "production",
+      },
+    });
+    const summary = await runDailyRefill({ now: NOW });
+    expect(summary.refilled.map((r) => r.accountId)).toContain(accountId);
   });
 });

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { runDailyRefill } from "@/payments/daily-refill/service";
+import { prisma } from "@/utils/prisma";
+
+const tracker: string[] = [];
+
+afterEach(async () => {
+  for (const accountId of tracker) {
+    await prisma.creditLedger.deleteMany({ where: { accountId } });
+    await prisma.userCredits.deleteMany({ where: { accountId } });
+    await prisma.authMethod.deleteMany({ where: { accountId } });
+    await prisma.account.deleteMany({ where: { id: accountId } });
+  }
+  tracker.length = 0;
+});
+
+describe("runDailyRefill — empty DB", () => {
+  test("no eligible accounts → empty summary", async () => {
+    const summary = await runDailyRefill({
+      now: new Date(Date.UTC(2026, 4, 15, 12, 0, 0)),
+    });
+    expect(summary.skipped).toBe(false);
+    expect(summary.refilled).toEqual([]);
+    expect(summary.noOp).toBe(0);
+    expect(summary.errors).toEqual([]);
+  });
+});

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -59,6 +59,33 @@ async function seedActiveSubscription(accountId: string): Promise<void> {
 
 const NOW = new Date(Date.UTC(2026, 4, 15, 12, 0, 0));
 
+// Helper: write a rate-limit anchor row directly with controlled createdAt.
+// CRITICAL: do NOT rely on runDailyRefill to write the first anchor — its
+// CreditLedger row uses server clock (`@default(now())`) which may not
+// match the injected `now`. The mismatch causes date-dependent flakes
+// when the suite runs near a UTC day boundary.
+async function seedRateLimitAnchor(
+  accountId: string,
+  createdAt: Date,
+): Promise<void> {
+  await prisma.creditLedger.create({
+    data: {
+      accountId,
+      delta: 100n,
+      reason: LedgerReason.grant,
+      idempotencyKey: `daily_refill:${accountId}:${ymdUtc(createdAt)}-seed`,
+      grantKindId: "daily_refill",
+      createdAt,
+    },
+  });
+  // Mirror in UserCredits so balance is consistent with the anchor
+  await prisma.userCredits.upsert({
+    where: { accountId },
+    update: { balance: { increment: 100n } },
+    create: { accountId, balance: 100n },
+  });
+}
+
 describe("runDailyRefill — empty DB", () => {
   test("no eligible accounts → empty summary", async () => {
     const summary = await runDailyRefill({
@@ -191,6 +218,44 @@ describe("runDailyRefill — top-up math", () => {
     expect(entry).toBeDefined();
     expect(entry!.creditsAdded).toBe(100);
     expect(await balanceOf(accountId)).toBe(60n); // -40 + 100 = 60
+  });
+});
+
+describe("runDailyRefill — rate limit", () => {
+  test("anchor row from today → service skips with already_ran_today", async () => {
+    const accountId = await seedAccount();
+    await seedRateLimitAnchor(accountId, NOW);
+
+    const result = await runDailyRefill({ now: NOW });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("already_ran_today");
+    expect(result.refilled).toEqual([]);
+  });
+
+  test("anchor row from yesterday → service runs, refills today", async () => {
+    const accountId = await seedAccount();
+    const yesterday = new Date(NOW.getTime() - 24 * 60 * 60 * 1000);
+    await seedRateLimitAnchor(accountId, yesterday);
+    // Drain so today's refill has work to do
+    await prisma.userCredits.update({
+      where: { accountId },
+      data: { balance: 30n },
+    });
+
+    const result = await runDailyRefill({ now: NOW });
+    expect(result.skipped).toBe(false);
+    expect(result.refilled.map((r) => r.accountId)).toContain(accountId);
+    expect(await balanceOf(accountId)).toBe(100n);
+  });
+
+  test("anchor row from today 00:01 UTC, run at today 23:59 UTC → still skipped", async () => {
+    const accountId = await seedAccount();
+    const earlyToday = new Date(Date.UTC(2026, 4, 15, 0, 1, 0));
+    const lateToday = new Date(Date.UTC(2026, 4, 15, 23, 59, 0));
+    await seedRateLimitAnchor(accountId, earlyToday);
+
+    const result = await runDailyRefill({ now: lateToday });
+    expect(result.skipped).toBe(true);
   });
 });
 

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -151,6 +151,7 @@ describe("runDailyRefill — top-up math", () => {
     expect(entry).toBeDefined();
     expect(entry!.creditsAdded).toBe(100);
     expect(await balanceOf(accountId)).toBe(100n);
+    expect(entry!.newBalance).toBe(100n);
   });
 
   test("balance below cap (40) → grant 60 to reach cap", async () => {
@@ -167,6 +168,7 @@ describe("runDailyRefill — top-up math", () => {
     expect(entry).toBeDefined();
     expect(entry!.creditsAdded).toBe(60);
     expect(await balanceOf(accountId)).toBe(100n);
+    expect(entry!.newBalance).toBe(100n);
   });
 
   test("balance at cap → noOp (no ledger row added)", async () => {
@@ -220,6 +222,7 @@ describe("runDailyRefill — top-up math", () => {
     expect(entry).toBeDefined();
     expect(entry!.creditsAdded).toBe(100);
     expect(await balanceOf(accountId)).toBe(60n); // -40 + 100 = 60
+    expect(entry!.newBalance).toBe(60n);
   });
 });
 

--- a/tests/payments/daily-refill/utc.unit.test.ts
+++ b/tests/payments/daily-refill/utc.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
-  startOfTodayUtc,
   startOfNextUtcDay,
+  startOfTodayUtc,
   ymdUtc,
 } from "@/payments/daily-refill/utc";
 

--- a/tests/payments/daily-refill/utc.unit.test.ts
+++ b/tests/payments/daily-refill/utc.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+  startOfTodayUtc,
+  startOfNextUtcDay,
+  ymdUtc,
+} from "@/payments/daily-refill/utc";
+
+describe("startOfTodayUtc", () => {
+  test("midday UTC → midnight UTC same day", () => {
+    const now = new Date(Date.UTC(2026, 4, 15, 13, 30, 0));
+    expect(startOfTodayUtc(now).toISOString()).toBe("2026-05-15T00:00:00.000Z");
+  });
+
+  test("midnight UTC → itself", () => {
+    const now = new Date(Date.UTC(2026, 4, 15, 0, 0, 0));
+    expect(startOfTodayUtc(now).toISOString()).toBe("2026-05-15T00:00:00.000Z");
+  });
+
+  test("23:59:59.999 UTC → midnight that day", () => {
+    const now = new Date(Date.UTC(2026, 4, 15, 23, 59, 59, 999));
+    expect(startOfTodayUtc(now).toISOString()).toBe("2026-05-15T00:00:00.000Z");
+  });
+});
+
+describe("startOfNextUtcDay", () => {
+  test("midday UTC → midnight next day", () => {
+    const now = new Date(Date.UTC(2026, 4, 15, 13, 30, 0));
+    expect(startOfNextUtcDay(now).toISOString()).toBe(
+      "2026-05-16T00:00:00.000Z",
+    );
+  });
+
+  test("last second of month → midnight first of next month", () => {
+    const now = new Date(Date.UTC(2026, 4, 31, 23, 59, 59));
+    expect(startOfNextUtcDay(now).toISOString()).toBe(
+      "2026-06-01T00:00:00.000Z",
+    );
+  });
+
+  test("last second of year → first of next year", () => {
+    const now = new Date(Date.UTC(2026, 11, 31, 23, 59, 59));
+    expect(startOfNextUtcDay(now).toISOString()).toBe(
+      "2027-01-01T00:00:00.000Z",
+    );
+  });
+});
+
+describe("ymdUtc", () => {
+  test("formats as YYYY-MM-DD", () => {
+    expect(ymdUtc(new Date(Date.UTC(2026, 4, 15, 13, 30)))).toBe("2026-05-15");
+  });
+
+  test("zero-pads single-digit month/day", () => {
+    expect(ymdUtc(new Date(Date.UTC(2026, 0, 5, 0, 0)))).toBe("2026-01-05");
+  });
+});

--- a/tests/payments/ledger.integration.test.ts
+++ b/tests/payments/ledger.integration.test.ts
@@ -137,6 +137,55 @@ describe("payments/ledger/repository", () => {
     expect(await getBalance(accountId)).toBe(50n);
   });
 
+  test("applyDelta first-write returns post-tx newBalance", async () => {
+    const accountId = await seedAccount();
+    cleanupAccounts.push(accountId);
+
+    const result = await applyDelta({
+      accountId,
+      delta: 100n,
+      reason: LedgerReason.grant,
+      idempotencyKey: "nb-1",
+      grantKindId: "manual",
+    });
+
+    expect(result.newBalance).toBe(100n);
+    expect(result.newBalance).toBe(await getBalance(accountId));
+  });
+
+  test("applyDelta replay returns current newBalance, not stale grant-time value", async () => {
+    const accountId = await seedAccount();
+    cleanupAccounts.push(accountId);
+
+    await applyDelta({
+      accountId,
+      delta: 100n,
+      reason: LedgerReason.grant,
+      idempotencyKey: "nb-orig",
+      grantKindId: "manual",
+    });
+    // Intervening consume after original grant — replay must report current
+    // balance (70n), not the post-original-grant balance (100n).
+    await applyDelta({
+      accountId,
+      delta: -30n,
+      reason: LedgerReason.consume,
+      idempotencyKey: "nb-burn",
+    });
+
+    const replay = await applyDelta({
+      accountId,
+      delta: 100n,
+      reason: LedgerReason.grant,
+      idempotencyKey: "nb-orig",
+      grantKindId: "manual",
+    });
+
+    expect(replay.replayed).toBe(true);
+    expect(replay.newBalance).toBe(70n);
+    expect(replay.newBalance).toBe(await getBalance(accountId));
+  });
+
   test("invariant: balance == SUM(delta) after mixed sequence", async () => {
     const accountId = await seedAccount();
     cleanupAccounts.push(accountId);

--- a/tests/payments/payments.integration.test.ts
+++ b/tests/payments/payments.integration.test.ts
@@ -48,6 +48,52 @@ describe("payments/index — composed service", () => {
     expect(rows[0].reason).toBe("grant");
   });
 
+  test("grant returns post-tx newBalance on first call", async () => {
+    const accountId = await seedAccount();
+    cleanupAccounts.push(accountId);
+
+    const r = await grant({
+      accountId,
+      credits: 100,
+      idempotencyKey: "nb-grant-1",
+      kind: "signup_bonus",
+    });
+
+    expect(r.newBalance).toBe(100n);
+    expect(r.newBalance).toBe(await getBalance(accountId));
+  });
+
+  test("grant replay returns current newBalance, not stale grant-time value", async () => {
+    const accountId = await seedAccount();
+    cleanupAccounts.push(accountId);
+
+    await grant({
+      accountId,
+      credits: 100,
+      idempotencyKey: "nb-grant-replay",
+      kind: "signup_bonus",
+    });
+    // Simulate concurrent burn after grant — replay must report current
+    // balance (70n), not the post-grant balance (100n).
+    await consume({
+      accountId,
+      usdCostMicros: 15000n, // 15000 micros × markup 2 × 1000 cpd / 1e6 = 30 credits
+      idempotencyKey: "nb-grant-burn",
+      requestId: "req-burn",
+    });
+
+    const replay = await grant({
+      accountId,
+      credits: 100,
+      idempotencyKey: "nb-grant-replay",
+      kind: "signup_bonus",
+    });
+
+    expect(replay.replayed).toBe(true);
+    expect(replay.newBalance).toBe(70n);
+    expect(replay.newBalance).toBe(await getBalance(accountId));
+  });
+
   test("grant rejects unknown kind", async () => {
     const accountId = await seedAccount();
     cleanupAccounts.push(accountId);

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -49,6 +49,10 @@ process.env.PAYMENTS_MARKUP_RATE = "2.0";
 process.env.PAYMENTS_CREDITS_PER_USD = "1000";
 process.env.PAYMENTS_RESERVED_MAX_TURN_CREDITS = "1";
 process.env.PAYMENTS_MIN_BALANCE_CREDITS = "-1000";
+process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "100";
+process.env.PAYMENTS_CRON_API_KEY =
+  process.env.PAYMENTS_CRON_API_KEY ||
+  "test-cron-api-key-that-is-at-least-32-characters-long";
 
 // Subscription tier credit allotments — placeholder values for tests.
 // Final numbers are set by ops via env in each deploy environment.

--- a/tests/subscriptions/account-credits.test.ts
+++ b/tests/subscriptions/account-credits.test.ts
@@ -122,7 +122,7 @@ describe("GET /v2/accounts/me/credits", () => {
     expect(res.status).toBe(403);
   });
 
-  test("no subscription: returns zero-state shape with nextRefreshAt + periodLabel", async () => {
+  test("no subscription: returns free-tier daily shape (balance:0, cap:100, periodLabel:Daily)", async () => {
     const accountId = await newAccount();
     const token = await tokenFor(accountId);
     const res = await request(makeApp())
@@ -131,10 +131,9 @@ describe("GET /v2/accounts/me/credits", () => {
     expect(res.status).toBe(200);
     const body = res.body as BalanceBody;
     expect(body.balance).toBe(0);
-    expect(body.monthlyGrant).toBe(0);
-    expect(body.monthlyGrantUsed).toBe(0);
-    expect(typeof body.periodLabel).toBe("string");
-    expect(body.periodLabel.length).toBeGreaterThan(0);
+    expect(body.monthlyGrant).toBe(100);
+    expect(body.monthlyGrantUsed).toBe(100);
+    expect(body.periodLabel).toBe("Daily");
     expect(new Date(body.nextRefreshAt).getTime()).toBeGreaterThan(Date.now());
   });
 
@@ -303,5 +302,84 @@ describe("GET /v2/accounts/me/credits", () => {
     expect(body.monthlyGrant).toBe(10000 * 12);
     expect(body.balance).toBe(10000 * 12);
     expect(body.nextRefreshAt).toBe("2027-05-01T00:00:00.000Z");
+  });
+});
+
+describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
+  test("zero balance → balance:0, monthlyGrant: cap, monthlyGrantUsed: cap, periodLabel: Daily", async () => {
+    const accountId = await newAccount();
+    const token = await tokenFor(accountId);
+    const res = await request(makeApp())
+      .get("/v2/accounts/me/credits")
+      .set("X-Convos-AuthToken", token);
+    expect(res.status).toBe(200);
+    expect(res.body.balance).toBe(0);
+    expect(res.body.monthlyGrant).toBe(100);
+    expect(res.body.monthlyGrantUsed).toBe(100);
+    expect(res.body.periodLabel).toBe("Daily");
+    expect(typeof res.body.nextRefreshAt).toBe("string");
+  });
+
+  test("partial balance (60) → balance:60, monthlyGrantUsed:40", async () => {
+    const accountId = await newAccount();
+    const token = await tokenFor(accountId);
+    await prisma.userCredits.create({ data: { accountId, balance: 60n } });
+    const res = await request(makeApp())
+      .get("/v2/accounts/me/credits")
+      .set("X-Convos-AuthToken", token);
+    expect(res.body.balance).toBe(60);
+    expect(res.body.monthlyGrant).toBe(100);
+    expect(res.body.monthlyGrantUsed).toBe(40);
+  });
+
+  test("balance above cap (150) → balance:150, monthlyGrantUsed:0", async () => {
+    const accountId = await newAccount();
+    const token = await tokenFor(accountId);
+    await prisma.userCredits.create({ data: { accountId, balance: 150n } });
+    const res = await request(makeApp())
+      .get("/v2/accounts/me/credits")
+      .set("X-Convos-AuthToken", token);
+    expect(res.body.balance).toBe(150);
+    expect(res.body.monthlyGrant).toBe(100);
+    expect(res.body.monthlyGrantUsed).toBe(0);
+  });
+
+  test("negative balance → balance:0 (clamped), monthlyGrantUsed:cap", async () => {
+    const accountId = await newAccount();
+    const token = await tokenFor(accountId);
+    await prisma.userCredits.create({ data: { accountId, balance: -50n } });
+    const res = await request(makeApp())
+      .get("/v2/accounts/me/credits")
+      .set("X-Convos-AuthToken", token);
+    expect(res.body.balance).toBe(0);
+    expect(res.body.monthlyGrant).toBe(100);
+    expect(res.body.monthlyGrantUsed).toBe(100);
+  });
+
+  test("expired subscription → takes free-tier branch (NOT stale tierGrant)", async () => {
+    const accountId = await newAccount();
+    const token = await tokenFor(accountId);
+    const { randomUUID } = await import("node:crypto");
+    await prisma.subscription.create({
+      data: {
+        accountId,
+        productId: "app.convos.subs.builder.monthly",
+        tier: SubscriptionTier.builder,
+        period: SubscriptionPeriod.monthly,
+        status: SubscriptionStatus.expired,
+        originalTransactionId: `otx-expired-${accountId}`,
+        appAccountToken: randomUUID(),
+        startedAt: new Date("2026-04-01"),
+        currentPeriodStart: new Date("2026-04-01"),
+        currentPeriodEnd: new Date("2026-05-01"),
+        environment: AppleEnv.sandbox,
+      },
+    });
+    const res = await request(makeApp())
+      .get("/v2/accounts/me/credits")
+      .set("X-Convos-AuthToken", token);
+    expect(res.status).toBe(200);
+    expect(res.body.periodLabel).toBe("Daily");
+    expect(res.body.monthlyGrant).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary

- Stacks on `louis/iap-credits-backend`. Adds a daily credit-refill cron + extends `/v2/accounts/me/credits` so free-tier accounts see live ledger balance.
- `POST /v2/credits/daily` — batch top-up-to-cap (env `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS`) for SIWE-verified non-subscribers (`status NOT IN trial/active/grace/billingRetry`). Self-rate-limited by UTC day via `MAX(CreditLedger.createdAt WHERE grantKindId='daily_refill')`. Auth: dedicated `PAYMENTS_CRON_API_KEY` header gate (separate from `X-Agent-API-Key`).
- Per-account idempotency keys `daily_refill:<accountId>:<YYYY-MM-DD>` — defense in depth + mid-loop failure isolation (one bad row never aborts the batch).
- Silent push fan-out on success via existing APNS/FCM services, fire-and-forget. New `CreditsRefilled` `NotificationType` variant + FCM `apiJWT` narrowing so the union widens safely.
- `/v2/accounts/me/credits` extended: `ACTIVE_STATUSES` gate before the WITH-sub branch closes a latent bug where expired/revoked subs would have shown stale `tierGrant` numbers. Free-tier path surfaces `{ balance, monthlyGrant: cap, monthlyGrantUsed: cap - balance, nextRefreshAt: startOfNextUtcDay, periodLabel: "Daily" }`.

## Test plan

- [ ] Branch-relevant suite green: `bun test tests/payments/daily-refill/ tests/credits/ tests/subscriptions/account-credits.test.ts` — currently 65/65 pass.
- [ ] `bun run tsc --noEmit` — only the 2 pre-existing protobuf errors (`@/gen/invite/v2/invite_pb`, `@/gen/notifications/v1/service_pb`); no new errors introduced.
- [ ] Confirm sibling Terraform PR sets `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS` and `PAYMENTS_CRON_API_KEY` before any deploy.
- [ ] External scheduler (Cloud Scheduler / k8s CronJob / equivalent) configured to hit `POST /v2/credits/daily` once per UTC day with the `X-Cron-API-Key` header.
- [ ] iOS smoke: free-tier account sees non-zero balance + `periodLabel: "Daily"` on `/me/credits` after first daily cron run. Subscribed accounts unchanged.
- [ ] Push smoke: confirm at least one device receives the silent `CreditsRefilled` payload and refreshes balance UI on receipt.

## Follow-ups (not in this PR)

1. Push-payload test seam (`__setApnsServiceForTests` / `__setFcmServiceForTests`) so fan-out tests can assert exact payload shape, not just no-throw.
2. Proper `dailyCap` / `dailyUsed` field names on `/me/credits` (requires iOS coordination — current PR reuses `monthlyGrant` for free-tier cap to ship standalone).
3. Per-instance cron API key rotation (backlog #3 direction).
4. Distributed-lock (`pg_advisory_xact_lock`) on the MAX-query → first-grant race window if multi-pod cron becomes operationally relevant.
5. Partial-batch crash semantics — if loop crashes after N of M accounts, MAX-query anchor blocks the remaining M-N from refill until tomorrow's tick (per-account date-scoped keys ensure exactly-once when they do refill, so no double-grant). Documented in spec §H; revisit if scale demands it.
6. `recordPushFailure` shared helper to centralize `BadDeviceToken` / 410 handling across notification call sites.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily credits refill for free-tier accounts with visible next-refresh (next UTC day) and a cron-protected POST /daily endpoint.
  * Silent push notifications for credits refilled showing credits added, new balance, and refill timestamps.

* **Bug Fixes**
  * Free-tier grant semantics corrected to daily refill; negative balances clamped to zero.

* **Config**
  * New configurable free-tier daily cap via environment variable.

* **Tests**
  * Extensive unit and integration tests for refill workflow, cron auth, config loader, notifications, and UTC helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add daily credits refill cron endpoint and free-tier balance view for non-entitled accounts
> - Adds `runDailyRefill` service ([service.ts](https://github.com/ephemeraHQ/convos-backend/pull/219/files#diff-8679ceae2d84b5f2aa35c463964294c46686a1bd13f295d85b31e27ffcfb2f77)) that tops up eligible accounts (SIWE auth, no entitled subscription) to `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS` once per UTC day, with per-account error isolation and idempotency via date-scoped keys.
> - Exposes `POST /api/v2/credits/daily` ([credits.router.ts](https://github.com/ephemeraHQ/convos-backend/pull/219/files#diff-2b1295473246cd74486e3fadf04a43881ceb5285c6f456e5cbaea0a4d7cc4305)) gated by a new `requireCronApiKey` middleware that validates `x-cron-api-key` using constant-time comparison; returns 503 for misconfigured key, 401 for invalid.
> - Updates `GET /v2/accounts/me/credits` to return daily-based semantics for non-entitled users: live ledger balance (clamped to 0), daily cap as `monthlyGrant`, `nextRefreshAt` at start of next UTC day, and `periodLabel` "Daily".
> - After a successful refill, fans out silent push notifications (APNS/FCM) to registered devices via `fanOutCreditsRefilled` ([notify.ts](https://github.com/ephemeraHQ/convos-backend/pull/219/files#diff-8327e44cd0237930d555bcb458b3654848daa37d51392ba92c4c1e3880e1d32d)).
> - `ConsumeResult`, `GrantResult`, and `AdjustResult` now include `newBalance` from the transaction, removing post-commit reads.
> - Risk: `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS` and `PAYMENTS_CRON_API_KEY` must be set at startup or the process throws a `ValidationError` / returns 503.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdfb7e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->