### PR TITLE
fix(docs): make TypeScript code blocks parseable by sort-imports plugin

### DIFF
--- a/docs/plans/agent-invite-endpoint-plan.md
+++ b/docs/plans/agent-invite-endpoint-plan.md
@@ -63,20 +63,18 @@ POST /api/v2/agents/join
 Request validation (zod):
 
 ```typescript
-{
+const requestBody = z.object({
   slug: z.string().min(1).max(2048),
   instructions: z.string().optional(),
-}
+});
 ```
 
 Response shape:
 
 ```typescript
-// Success
-{ success: true, joined: boolean }
-
-// Error
-{ success: false, error: string, message: string }
+type Response =
+  | { success: true; joined: boolean }
+  | { success: false; error: string; message: string };
 ```
 
 Invite URL construction based on `XMTP_ENV`:


### PR DESCRIPTION
## Summary

Two code blocks in `docs/plans/agent-invite-endpoint-plan.md` were bare top-level object literals. `prettier-plugin-sort-imports` parses every ` ```typescript ` block as a TS module to sort imports, and babel rejects these particular blocks as "labeled statement followed by comma" — surfacing as two recurring `import sorting aborted due to babel parsing error` warnings in `prettier --check` across CI for any PR touching this tree (noticed on #219 and the IAP branches).

Wrapping the snippets in declarations (`const … = z.object({…})` and `type Response = …`) makes them valid TS, drops the warnings, and keeps the docs readable.

## Test plan

- [x] `bun format:check` → no more babel parsing errors
- [x] CI green on this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TypeScript code blocks in agent invite endpoint plan to be parseable by sort-imports plugin
> Updates TypeScript snippets in [agent-invite-endpoint-plan.md](https://github.com/ephemeraHQ/convos-backend/pull/220/files#diff-86a3c54cc33bd4f6dc4dbf185c9a9543b78125334bd51916fb6bd14ad8320570) to use valid, parseable syntax. The request validation example is rewritten as an explicit Zod schema, and the response shape is expressed as a TypeScript union type instead of comment-based object examples.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99223e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent invite endpoint documentation with clarified request validation and response structure specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->