### PR TITLE
fix(posthog): default POSTHOG_HOST to PostHog Cloud US

### DIFF
--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -4,8 +4,9 @@
  * Fires a single `builder.generation.completed` event per generation
  * pipeline invocation that reaches the LLM call (both success and error
  * paths). Capture is fire-and-forget — no blocking await on `capture()` or
- * `flush()`. Missing `POSTHOG_PROJECT_TOKEN`/`POSTHOG_HOST` env vars are
- * a silent no-op (the SDK never initialises, no outbound requests).
+ * `flush()`. A missing `POSTHOG_PROJECT_TOKEN` is a silent no-op (the SDK
+ * never initialises, no outbound requests). `POSTHOG_HOST` defaults to
+ * PostHog Cloud US in `config.ts`, so setting only the token Just Works.
  *
  * Test seam: `__resetPostHogForTests(override)` mirrors the
  * `__resetComposioServiceForTests` / `__resetGenerateTemplateForTests`
@@ -184,7 +185,7 @@ export function __resetPostHogForTests(
  * Fire a `builder.template.generated` PostHog event.
  *
  * - When a test override is installed, delegates to the override.
- * - When `POSTHOG_PROJECT_TOKEN`/`POSTHOG_HOST` are unset, returns immediately (no-op).
+ * - When `POSTHOG_PROJECT_TOKEN` is unset, returns immediately (no-op).
  * - Otherwise, calls `posthog.capture()` which is buffered/async internally —
  *   we do NOT await it, keeping the route response fast.
  */

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,10 +112,12 @@ export const TWITTER_REPLY_MODEL =
 export const BUILDER_SITE_URL =
   process.env.BUILDER_SITE_URL?.trim() || "https://convos.org/assistants";
 
-// PostHog metering (optional — capture is no-op if either is unset).
+// PostHog metering (optional — capture is no-op if the token is unset).
+// Host defaults to PostHog Cloud US so setting only the token Just Works.
 export const POSTHOG_PROJECT_TOKEN =
   process.env.POSTHOG_PROJECT_TOKEN?.trim() || "";
-export const POSTHOG_HOST = process.env.POSTHOG_HOST?.trim() || "";
+export const POSTHOG_HOST =
+  process.env.POSTHOG_HOST?.trim() || "https://us.i.posthog.com";
 
 // Generation pipeline timing knobs (override via env in tests / staging).
 const parsePositiveInt = (


### PR DESCRIPTION
## Summary

- Default `POSTHOG_HOST` to `https://us.i.posthog.com` instead of `""`, so setting only `POSTHOG_PROJECT_TOKEN` is enough to start sending template-generation events.
- Update related docstrings in `posthog.ts` to reflect the new "token-only" no-op rule.

## Why

`getPostHogClient()` returns `null` (silent no-op) when **either** env var is empty. Datadog (`env:convos-otr-dev service:api`) shows 0 `[posthog]` log lines over 7d despite generations completing — strong signal that the host isn't being set in the deployed env, even though a token may be. Giving host a sane default removes that footgun: an operator who sets just the token gets working capture against PostHog Cloud US.

The host check in `getPostHogClient()` is kept as defensive code (explicit `POSTHOG_HOST=""` override still disables).

## Test plan

- [ ] Confirm `POSTHOG_PROJECT_TOKEN` is set on the `convos-otr-dev` task definition before deploying — that's the remaining requirement for events to flow.
- [ ] After deploy, verify a builder.generation.completed event lands in PostHog within ~10s of a template generation.
- [ ] `bun test tests/builder-deps-env.test.ts tests/posthog.service.test.ts` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `POSTHOG_HOST` to PostHog Cloud US when env var is unset
> Changes the default value of `POSTHOG_HOST` in [config.ts](https://github.com/ephemeraHQ/convos-backend/pull/223/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012) from an empty string to `'https://us.i.posthog.com'`. Comments in the PostHog capture service are updated to reflect that only `POSTHOG_PROJECT_TOKEN` controls the no-op behavior. Behavioral Change: environments without `POSTHOG_HOST` set will now send events to PostHog Cloud US instead of failing silently due to an empty host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d11eeaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified PostHog metering behavior when the project token is not configured.

* **Chores**
  * PostHog host now defaults to the US Cloud endpoint, simplifying configuration setup by requiring only the project token to be manually set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->