### PR TITLE
refactor(agent-templates): public agent URLs under /a/ + "url slug" naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ AGENT_ASSETS_API_KEY=
 COMPOSIO_API_KEY=
 COMPOSIO_CONNECTION_CALLBACK_URL=convos://connections/callback
 
+# Public Playroom origin for agent template URLs (required — backend refuses to
+# start without it). Env-specific: https://dev.convos.org / https://convos.org.
+BUILDER_SITE_URL=https://dev.convos.org
+
 # Builder/template generation (optional)
 BUILDER_OPENROUTER_API_KEY=
 BUILDER_MODEL=

--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -27,7 +27,7 @@ agentTemplatesRouter.post(
   createHandler,
 );
 
-// Async generation surface — must be mounted before /:idOrHashedSlug so the
+// Async generation surface — must be mounted before /:idOrUrlSlug so the
 // wildcard doesn't capture "generations" as a slug-or-id. Both POST and GET
 // are public: anonymous submissions default to the ADMIN owner; the GET
 // status endpoint treats the generation ID itself as the capability token
@@ -62,7 +62,7 @@ agentTemplatesRouter.post(
   publishHandler,
 );
 agentTemplatesRouter.get(
-  "/:idOrHashedSlug",
+  "/:idOrUrlSlug",
   optionalAuthOrAgentApiKeyAuth,
   detailHandler,
 );

--- a/src/api/v2/agent-templates/handlers/detail.ts
+++ b/src/api/v2/agent-templates/handlers/detail.ts
@@ -1,12 +1,12 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
-import { resolveAgentTemplateByIdOrHashedSlug } from "../lib/resolve-id-or-hashed-slug";
+import { resolveAgentTemplateByIdOrUrlSlug } from "../lib/resolve-id-or-url-slug";
 import { serializeAgentTemplate } from "../lib/serialize-agent-template";
 
 const paramsSchema = z
   .object({
-    idOrHashedSlug: z.string().min(1),
+    idOrUrlSlug: z.string().min(1),
   })
   .strict();
 
@@ -53,23 +53,20 @@ export async function detailHandler(req: Request, res: Response) {
 
   try {
     // First try to resolve via the standard path (published/unlisted/archived only)
-    let template = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: parsedParams.data.idOrHashedSlug,
+    let template = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: parsedParams.data.idOrUrlSlug,
     });
 
     // If not found, check if it's a draft template accessible to the caller.
     // The router uses `optionalAuthOrAgentApiKeyAuth`, so `accountId` may be
     // undefined for anonymous callers — they never own a draft, so the
     // ownership check below falls through and they get a 404.
-    if (
-      template === null &&
-      uuidPattern.test(parsedParams.data.idOrHashedSlug)
-    ) {
+    if (template === null && uuidPattern.test(parsedParams.data.idOrUrlSlug)) {
       const accountId: string | undefined = res.locals.accountId;
       const isApiKeyListener = res.locals.isApiKeyListener ?? false;
 
       const draftTemplate = await prisma.agentTemplate.findUnique({
-        where: { id: parsedParams.data.idOrHashedSlug },
+        where: { id: parsedParams.data.idOrUrlSlug },
       });
 
       if (draftTemplate !== null && draftTemplate.status === "draft") {

--- a/src/api/v2/agent-templates/lib/pick-collision-free-id.ts
+++ b/src/api/v2/agent-templates/lib/pick-collision-free-id.ts
@@ -25,12 +25,12 @@
 
 import { randomUUID } from "node:crypto";
 import { prisma } from "@/utils/prisma";
-import { buildUniqueSlug, slugHash } from "@/utils/slug-hash";
+import { buildUniqueUrlSlug, slugHash } from "@/utils/slug-hash";
 
 export async function pickCollisionFreeId(args: {
   baseSlug: string;
 }): Promise<string> {
-  const { id } = await buildUniqueSlug({
+  const { id } = await buildUniqueUrlSlug({
     baseSlug: args.baseSlug,
     idFactory: () => randomUUID(),
     isTaken: async (candidate) => {

--- a/src/api/v2/agent-templates/lib/pick-collision-free-id.ts
+++ b/src/api/v2/agent-templates/lib/pick-collision-free-id.ts
@@ -1,5 +1,5 @@
 /**
- * Pick a row id whose `slugHash(id)` doesn't collide with any existing
+ * Pick a row id whose `hashId(id)` doesn't collide with any existing
  * AgentTemplate row sharing the given `baseSlug` — ACROSS owners.
  *
  * Context: AgentTemplate slugs are NOT unique — there is no DB constraint,
@@ -25,7 +25,7 @@
 
 import { randomUUID } from "node:crypto";
 import { prisma } from "@/utils/prisma";
-import { buildUniqueUrlSlug, slugHash } from "@/utils/slug-hash";
+import { buildUniqueUrlSlug, hashId } from "@/utils/url-slug";
 
 export async function pickCollisionFreeId(args: {
   baseSlug: string;
@@ -41,7 +41,7 @@ export async function pickCollisionFreeId(args: {
         where: { slug: base },
         select: { id: true },
       });
-      return rows.some((row) => slugHash(row.id) === hash);
+      return rows.some((row) => hashId(row.id) === hash);
     },
   });
   return id;

--- a/src/api/v2/agent-templates/lib/resolve-id-or-url-slug.ts
+++ b/src/api/v2/agent-templates/lib/resolve-id-or-url-slug.ts
@@ -1,7 +1,7 @@
 import type { PublishStatus } from "@prisma/client";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
-import { slugHash } from "@/utils/slug-hash";
+import { hashId } from "@/utils/url-slug";
 
 const visibleStatuses = [
   "published",
@@ -16,9 +16,9 @@ const uuidPattern =
 
 export async function resolveAgentTemplateByIdOrUrlSlug(args: {
   idOrUrlSlug: string;
-  slugHasher?: (id: string) => string;
+  hasher?: (id: string) => string;
 }) {
-  const slugHasher = args.slugHasher ?? slugHash;
+  const hasher = args.hasher ?? hashId;
 
   if (uuidPattern.test(args.idOrUrlSlug)) {
     return prisma.agentTemplate.findFirst({
@@ -48,7 +48,7 @@ export async function resolveAgentTemplateByIdOrUrlSlug(args: {
     },
   });
   const matches = candidates.filter(
-    (candidate) => slugHasher(candidate.id) === hash,
+    (candidate) => hasher(candidate.id) === hash,
   );
 
   if (matches.length > 1) {

--- a/src/api/v2/agent-templates/lib/resolve-id-or-url-slug.ts
+++ b/src/api/v2/agent-templates/lib/resolve-id-or-url-slug.ts
@@ -14,28 +14,28 @@ const hashPattern = /^[0-9a-z]{5}$/;
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export async function resolveAgentTemplateByIdOrHashedSlug(args: {
-  idOrHashedSlug: string;
+export async function resolveAgentTemplateByIdOrUrlSlug(args: {
+  idOrUrlSlug: string;
   slugHasher?: (id: string) => string;
 }) {
   const slugHasher = args.slugHasher ?? slugHash;
 
-  if (uuidPattern.test(args.idOrHashedSlug)) {
+  if (uuidPattern.test(args.idOrUrlSlug)) {
     return prisma.agentTemplate.findFirst({
       where: {
-        id: args.idOrHashedSlug,
+        id: args.idOrUrlSlug,
         status: { in: visibleStatuses },
       },
     });
   }
 
-  const lastDotIndex = args.idOrHashedSlug.lastIndexOf(".");
+  const lastDotIndex = args.idOrUrlSlug.lastIndexOf(".");
   if (lastDotIndex <= 0) {
     return null;
   }
 
-  const baseSlug = args.idOrHashedSlug.slice(0, lastDotIndex);
-  const hash = args.idOrHashedSlug.slice(lastDotIndex + 1);
+  const baseSlug = args.idOrUrlSlug.slice(0, lastDotIndex);
+  const hash = args.idOrUrlSlug.slice(lastDotIndex + 1);
 
   if (!hashPattern.test(hash)) {
     return null;
@@ -62,7 +62,7 @@ export async function resolveAgentTemplateByIdOrHashedSlug(args: {
         hash,
         matchedIds: matches.map((match) => match.id),
       },
-      "[resolve-agent-template] hashed-slug collision: multiple rows match base slug + hash",
+      "[resolve-agent-template] url-slug collision: multiple rows match base slug + hash",
     );
     return null;
   }

--- a/src/api/v2/agent-templates/lib/serialize-agent-template.ts
+++ b/src/api/v2/agent-templates/lib/serialize-agent-template.ts
@@ -1,6 +1,5 @@
 import type { Account, AgentTemplate } from "@prisma/client";
-import { BUILDER_SITE_URL } from "@/config";
-import { buildSlug } from "@/utils/slug-hash";
+import { templatePublicUrl } from "./template-url";
 
 export const serializeAccount = (account: Account) => ({
   object: "account",
@@ -15,7 +14,7 @@ export const serializeAccount = (account: Account) => ({
 // rather than rebuilding the URL from `slug`. `null` for drafts.
 const publishedUrlFor = (template: AgentTemplate): string | null => {
   if (template.status === "draft") return null;
-  return `${BUILDER_SITE_URL}/${buildSlug(template.slug, template.id)}`;
+  return templatePublicUrl(template.slug, template.id);
 };
 
 /**

--- a/src/api/v2/agent-templates/lib/serialize-agent-template.ts
+++ b/src/api/v2/agent-templates/lib/serialize-agent-template.ts
@@ -9,7 +9,7 @@ export const serializeAccount = (account: Account) => ({
 
 // `template.slug` is the BASE slug ("brewski"); public URLs use the HASHED
 // form ("brewski.x4f9k") that the resolver in
-// `lib/resolve-id-or-hashed-slug.ts` matches against. Single server-side
+// `lib/resolve-id-or-url-slug.ts` matches against. Single server-side
 // source for URL format — clients (iOS, runtime, web) read this field
 // rather than rebuilding the URL from `slug`. `null` for drafts.
 const publishedUrlFor = (template: AgentTemplate): string | null => {

--- a/src/api/v2/agent-templates/lib/template-url.ts
+++ b/src/api/v2/agent-templates/lib/template-url.ts
@@ -1,5 +1,5 @@
 import { BUILDER_SITE_URL } from "@/config";
-import { buildSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/slug-hash";
 
 /**
  * Single source of truth for an agent template's public Playroom URL.
@@ -8,15 +8,16 @@ import { buildSlug } from "@/utils/slug-hash";
  * convos.org). The trailing slash is stripped so a configured value with
  * or without one yields the same result (no `//` in the path). Agent pages
  * live under the `/a/` segment; the final path component is the canonical
- * `<base>.<hash>` hashed slug that resolve-id-or-hashed-slug.ts matches.
+ * `<base>.<hash>` url slug that resolve-id-or-url-slug.ts matches. (The hash
+ * is of the template id, not of the slug — the base slug is left intact.)
  */
 
-/** origin + an already-hashed `<base>.<hash>` slug → full public URL */
-export function templateUrlFromHashedSlug(hashedSlug: string): string {
-  return `${BUILDER_SITE_URL.replace(/\/+$/, "")}/a/${hashedSlug}`;
+/** origin + an already-built `<base>.<hash>` url slug → full public URL */
+export function templateUrlFromUrlSlug(urlSlug: string): string {
+  return `${BUILDER_SITE_URL.replace(/\/+$/, "")}/a/${urlSlug}`;
 }
 
 /** template row (base slug + id) → full public URL */
 export function templatePublicUrl(baseSlug: string, id: string): string {
-  return templateUrlFromHashedSlug(buildSlug(baseSlug, id));
+  return templateUrlFromUrlSlug(buildUrlSlug(baseSlug, id));
 }

--- a/src/api/v2/agent-templates/lib/template-url.ts
+++ b/src/api/v2/agent-templates/lib/template-url.ts
@@ -6,14 +6,14 @@ import { buildSlug } from "@/utils/slug-hash";
  *
  * BUILDER_SITE_URL is the env-specific Playroom origin (dev.convos.org /
  * convos.org). The trailing slash is stripped so a configured value with
- * or without one yields the same result (no `//` in the path). The path
- * component is always the canonical `<base>.<hash>` slug that
- * resolve-id-or-hashed-slug.ts matches.
+ * or without one yields the same result (no `//` in the path). Agent pages
+ * live under the `/a/` segment; the final path component is the canonical
+ * `<base>.<hash>` hashed slug that resolve-id-or-hashed-slug.ts matches.
  */
 
 /** origin + an already-hashed `<base>.<hash>` slug → full public URL */
 export function templateUrlFromHashedSlug(hashedSlug: string): string {
-  return `${BUILDER_SITE_URL.replace(/\/+$/, "")}/${hashedSlug}`;
+  return `${BUILDER_SITE_URL.replace(/\/+$/, "")}/a/${hashedSlug}`;
 }
 
 /** template row (base slug + id) → full public URL */

--- a/src/api/v2/agent-templates/lib/template-url.ts
+++ b/src/api/v2/agent-templates/lib/template-url.ts
@@ -1,5 +1,5 @@
 import { BUILDER_SITE_URL } from "@/config";
-import { buildUrlSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/url-slug";
 
 /**
  * Single source of truth for an agent template's public Playroom URL.

--- a/src/api/v2/agent-templates/lib/template-url.ts
+++ b/src/api/v2/agent-templates/lib/template-url.ts
@@ -1,0 +1,22 @@
+import { BUILDER_SITE_URL } from "@/config";
+import { buildSlug } from "@/utils/slug-hash";
+
+/**
+ * Single source of truth for an agent template's public Playroom URL.
+ *
+ * BUILDER_SITE_URL is the env-specific Playroom origin (dev.convos.org /
+ * convos.org). The trailing slash is stripped so a configured value with
+ * or without one yields the same result (no `//` in the path). The path
+ * component is always the canonical `<base>.<hash>` slug that
+ * resolve-id-or-hashed-slug.ts matches.
+ */
+
+/** origin + an already-hashed `<base>.<hash>` slug → full public URL */
+export function templateUrlFromHashedSlug(hashedSlug: string): string {
+  return `${BUILDER_SITE_URL.replace(/\/+$/, "")}/${hashedSlug}`;
+}
+
+/** template row (base slug + id) → full public URL */
+export function templatePublicUrl(baseSlug: string, id: string): string {
+  return templateUrlFromHashedSlug(buildSlug(baseSlug, id));
+}

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -25,7 +25,7 @@
 
 import { BUILDER_OPENROUTER_API_KEY, TWITTER_REPLY_MODEL } from "@/config";
 import logger from "@/utils/logger";
-import { templateUrlFromHashedSlug } from "../lib/template-url";
+import { templateUrlFromUrlSlug } from "../lib/template-url";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,12 +38,13 @@ export interface ReplyInput {
   agentName: string;
   /** First sentence of the agent's description or prompt. */
   firstSentence: string;
-  /** **Canonical (hashed) public slug** — e.g. `"brewski.x4f9k"`, the value
-   *  produced by `buildSlug(baseSlug, templateId)`. Callers must NOT pass the
-   *  base slug stored on `AgentTemplate.slug` directly: the public URL
-   *  resolver (resolve-id-or-hashed-slug.ts) requires the `<base>.<hash>`
-   *  form, so passing the base alone would render a reply URL that 404s. */
-  slug: string;
+  /** **Canonical url slug** — e.g. `"brewski.x4f9k"`, the value produced by
+   *  `buildUrlSlug(baseSlug, templateId)` (base slug + a hash of the template
+   *  id). Callers must NOT pass the base slug stored on `AgentTemplate.slug`
+   *  directly: the public URL resolver (resolve-id-or-url-slug.ts) requires the
+   *  `<base>.<hash>` form, so passing the base alone would render a reply URL
+   *  that 404s. */
+  urlSlug: string;
 }
 
 export interface ReplyResult {
@@ -68,8 +69,8 @@ function getModel(): string {
   return TWITTER_REPLY_MODEL;
 }
 
-function templateUrlFor(slug: string): string {
-  return templateUrlFromHashedSlug(slug);
+function templateUrlFor(urlSlug: string): string {
+  return templateUrlFromUrlSlug(urlSlug);
 }
 
 function normalizeHandle(handle: string): string {
@@ -94,8 +95,8 @@ export function __resetComposeReplyForTests(
 
 /** Deterministic fallback: "@{handle} Meet {agentName} — {firstSentence}. {url}" */
 export function buildDeterministicFallback(input: ReplyInput): string {
-  const { handle, agentName, firstSentence, slug } = input;
-  const url = templateUrlFor(slug);
+  const { handle, agentName, firstSentence, urlSlug } = input;
+  const url = templateUrlFor(urlSlug);
   const normalizedHandle = normalizeHandle(handle);
 
   const prefix = `${normalizedHandle} Meet ${agentName} — `;
@@ -121,7 +122,7 @@ export function buildDeterministicFallback(input: ReplyInput): string {
 
 /** Minimal fallback when even agentName is unavailable. */
 export function buildMinimalFallback(input: ReplyInput): string {
-  return `${normalizeHandle(input.handle)} ${templateUrlFor(input.slug)}`;
+  return `${normalizeHandle(input.handle)} ${templateUrlFor(input.urlSlug)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -129,8 +130,8 @@ export function buildMinimalFallback(input: ReplyInput): string {
 // ---------------------------------------------------------------------------
 
 function buildReplyPrompt(input: ReplyInput): string {
-  const { handle, agentName, firstSentence, slug } = input;
-  const url = templateUrlFor(slug);
+  const { handle, agentName, firstSentence, urlSlug } = input;
+  const url = templateUrlFor(urlSlug);
   // Normalize once so the LLM is instructed to produce the same form that
   // validateLlmReply() checks for. Otherwise a caller passing "alice" (no @)
   // gets a prompt that says "start with: alice", LLM does exactly that,
@@ -186,8 +187,8 @@ export async function composeReply(input: ReplyInput): Promise<ReplyResult> {
 }
 
 async function _composeReply(input: ReplyInput): Promise<ReplyResult> {
-  const { handle, agentName, slug } = input;
-  const url = templateUrlFor(slug);
+  const { handle, agentName, urlSlug } = input;
+  const url = templateUrlFor(urlSlug);
 
   if (!agentName || agentName.trim() === "") {
     return { replyText: buildMinimalFallback(input) };

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -23,12 +23,9 @@
  * Test seam: __resetComposeReplyForTests(override | null).
  */
 
-import {
-  BUILDER_OPENROUTER_API_KEY,
-  BUILDER_SITE_URL,
-  TWITTER_REPLY_MODEL,
-} from "@/config";
+import { BUILDER_OPENROUTER_API_KEY, TWITTER_REPLY_MODEL } from "@/config";
 import logger from "@/utils/logger";
+import { templateUrlFromHashedSlug } from "../lib/template-url";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -72,7 +69,7 @@ function getModel(): string {
 }
 
 function templateUrlFor(slug: string): string {
-  return `${BUILDER_SITE_URL}/${slug}`;
+  return templateUrlFromHashedSlug(slug);
 }
 
 function normalizeHandle(handle: string): string {

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -18,7 +18,7 @@
  * Env vars:
  *   BUILDER_OPENROUTER_API_KEY — required for LLM calls
  *   TWITTER_REPLY_MODEL        — model override (default: anthropic/claude-3-5-haiku-20241022)
- *   BUILDER_SITE_URL           — base URL for builder (default: https://convos.org/assistants)
+ *   BUILDER_SITE_URL           — base URL for builder (default: https://dev.convos.org)
  *
  * Test seam: __resetComposeReplyForTests(override | null).
  */

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -42,7 +42,7 @@ import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
-import { buildSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/slug-hash";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -270,8 +270,8 @@ function deriveTemplateSlug(agentName: string): string {
  *
  *  Slug policy mirrors the CRUD handler (handlers/create.ts):
  *  - Stores the **base slug** (e.g. "brewski"). The public hashed-slug URL
- *    is reconstructed by callers via `buildSlug(row.slug, row.id)` and the
- *    resolver in `resolve-id-or-hashed-slug.ts` queries `where: { slug: baseSlug }`.
+ *    is reconstructed by callers via `buildUrlSlug(row.slug, row.id)` and the
+ *    resolver in `resolve-id-or-url-slug.ts` queries `where: { slug: baseSlug }`.
  *    Storing the hashed form would make these rows unreachable via the resolver.
  *  - The slug is derived from agentName and run through `validateSlug`,
  *    falling back to `FALLBACK_SLUG` when the derivation is empty/reserved/
@@ -540,11 +540,11 @@ async function _runPipeline(
       templateToPersist.description || templateToPersist.prompt,
     );
     // composeReply expects the canonical/hashed slug (e.g. "brewski.x4f9k")
-    // — that's the form the resolver in resolve-id-or-hashed-slug.ts matches
+    // — that's the form the resolver in resolve-id-or-url-slug.ts matches
     // against. `persisted.slug` is the BASE form ("brewski") because of the
-    // store-base-not-hashed convention from PR #199. Construct the public
-    // hashed slug here via buildSlug so the URL the reply contains
-    // (`${BUILDER_SITE_URL}/<hashed>`) actually resolves.
+    // store-base-not-hashed convention. Construct the public url slug here
+    // via buildUrlSlug so the URL the reply contains
+    // (`${BUILDER_SITE_URL}/a/<url-slug>`) actually resolves.
     //
     // Use `templateToPersist` (which has identity constraints applied)
     // rather than `templateResult.template` so the reply mirrors what
@@ -553,7 +553,7 @@ async function _runPipeline(
       handle: twitterContext.twitterHandle,
       agentName: templateToPersist.agentName,
       firstSentence,
-      slug: buildSlug(persisted.slug, persisted.id),
+      urlSlug: buildUrlSlug(persisted.slug, persisted.id),
     };
     try {
       const reply = await composeReply(replyInput);

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -42,7 +42,7 @@ import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
-import { buildUrlSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/url-slug";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -278,7 +278,7 @@ function deriveTemplateSlug(agentName: string): string {
  *    malformed (see `deriveTemplateSlug`).
  *  - Slugs are NOT unique (no DB constraint). Any number of rows can share a
  *    base slug; the row `id` is pre-picked via `pickCollisionFreeId` so its
- *    `slugHash(id)` doesn't collide with any existing row sharing `baseSlug`,
+ *    `hashId(id)` doesn't collide with any existing row sharing `baseSlug`,
  *    which is what keeps the public `<base>.<hash>` URL unambiguous. */
 async function persistTemplate(
   template: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,7 +144,7 @@ export const TWITTER_REPLY_MODEL =
   process.env.TWITTER_REPLY_MODEL?.trim() ||
   "anthropic/claude-3-5-haiku-20241022";
 export const BUILDER_SITE_URL =
-  process.env.BUILDER_SITE_URL?.trim() || "https://convos.org/assistants";
+  process.env.BUILDER_SITE_URL?.trim() || "https://dev.convos.org";
 
 // PostHog metering (optional — capture is no-op if the token is unset).
 // Host defaults to PostHog Cloud US so setting only the token Just Works.

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,8 +143,14 @@ export const TWITTER_MODERATION_MODEL =
 export const TWITTER_REPLY_MODEL =
   process.env.TWITTER_REPLY_MODEL?.trim() ||
   "anthropic/claude-3-5-haiku-20241022";
-export const BUILDER_SITE_URL =
-  process.env.BUILDER_SITE_URL?.trim() || "https://dev.convos.org";
+// Required — public template URLs (`<origin>/a/<slug>`) are user-facing, so a
+// missing value must fail the deploy rather than silently misroute to a wrong
+// origin. Tests seed it via tests/preload.ts.
+const builderSiteUrl = process.env.BUILDER_SITE_URL?.trim();
+if (!builderSiteUrl) {
+  throw new Error("BUILDER_SITE_URL is not configured");
+}
+export const BUILDER_SITE_URL = builderSiteUrl;
 
 // PostHog metering (optional — capture is no-op if the token is unset).
 // Host defaults to PostHog Cloud US so setting only the token Just Works.

--- a/src/utils/slug-hash.ts
+++ b/src/utils/slug-hash.ts
@@ -20,17 +20,17 @@ export function slugHash(id: string): string {
 }
 
 /** Combine a base slug with the hash suffix derived from `id`. */
-export function buildSlug(baseSlug: string, id: string): string {
+export function buildUrlSlug(baseSlug: string, id: string): string {
   return `${baseSlug}.${slugHash(id)}`;
 }
 
 /** True when the slug already has the `.hash` suffix. */
-export function isHashedSlug(slug: string): boolean {
+export function isUrlSlug(slug: string): boolean {
   return HASHED_SLUG_RE.test(slug);
 }
 
 /**
- * Reserve a unique hashed slug for a record. Generates a fresh ID per attempt
+ * Reserve a unique url slug for a record. Generates a fresh ID per attempt
  * so a hash collision picks a new suffix instead of clobbering an existing
  * row. Returns the chosen `{ id, slug }` so the caller persists both.
  *
@@ -38,7 +38,7 @@ export function isHashedSlug(slug: string): boolean {
  * arbiter — `isTaken` and the eventual insert race, and the constraint is
  * what keeps that race correct.
  */
-export async function buildUniqueSlug(args: {
+export async function buildUniqueUrlSlug(args: {
   baseSlug: string;
   idFactory: () => string;
   isTaken: (slug: string) => Promise<boolean>;
@@ -46,7 +46,7 @@ export async function buildUniqueSlug(args: {
   const { baseSlug, idFactory, isTaken } = args;
   for (let i = 0; i < MAX_SLUG_ATTEMPTS; i++) {
     const id = idFactory();
-    const slug = buildSlug(baseSlug, id);
+    const slug = buildUrlSlug(baseSlug, id);
     if (!(await isTaken(slug))) {
       return { id, slug };
     }

--- a/src/utils/url-slug.ts
+++ b/src/utils/url-slug.ts
@@ -13,7 +13,7 @@ const MAX_SLUG_ATTEMPTS = 8;
  * slug (`brewski.x4f9k`) so two skills with the same name don't collide on
  * URL, and so published pages aren't trivially guessable from the agent name.
  */
-export function slugHash(id: string): string {
+export function hashId(id: string): string {
   const sha = crypto.createHash("sha1").update(id).digest("hex");
   const n = parseInt(sha.slice(0, 8), 16);
   return n.toString(36).padStart(HASH_LEN, "0").slice(-HASH_LEN);
@@ -21,7 +21,7 @@ export function slugHash(id: string): string {
 
 /** Combine a base slug with the hash suffix derived from `id`. */
 export function buildUrlSlug(baseSlug: string, id: string): string {
-  return `${baseSlug}.${slugHash(id)}`;
+  return `${baseSlug}.${hashId(id)}`;
 }
 
 /** True when the slug already has the `.hash` suffix. */

--- a/tests/agent-templates.cross.e2e.test.ts
+++ b/tests/agent-templates.cross.e2e.test.ts
@@ -28,11 +28,11 @@ import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import {
   getTemplate,
-  hashedSlugFor,
   listTemplates,
   publishTemplate,
   stableUuid,
   startAgentTemplatesServer,
+  urlSlugFor,
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
 import { makeFakeTemplate } from "./agent-templates.generation.helpers";
@@ -198,13 +198,13 @@ describe("Cross-area E2E: Generate → Create → Publish → List → Hashed-sl
     expect(listIds).toContain(persistedId);
 
     // --- Step 5: Public hashed-slug GET (M2 reads, no auth) ---
-    const hashedSlug = hashedSlugFor({
+    const urlSlug = urlSlugFor({
       id: persistedId,
       slug: persistedSlug,
     });
     const { body: detailBody, response: detailResponse } = await getTemplate({
       baseURL,
-      path: hashedSlug,
+      path: urlSlug,
     });
 
     expect(detailResponse.status).toBe(200);

--- a/tests/agent-templates.cross.helpers.ts
+++ b/tests/agent-templates.cross.helpers.ts
@@ -7,7 +7,7 @@ import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
-import { buildSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/slug-hash";
 
 /**
  * Derive a deterministic UUIDv5-shaped string from a human-readable label
@@ -203,5 +203,5 @@ export const getTemplate = async (args: {
   return { body, response };
 };
 
-export const hashedSlugFor = (template: TemplateBody) =>
-  buildSlug(template.slug as string, template.id as string);
+export const urlSlugFor = (template: TemplateBody) =>
+  buildUrlSlug(template.slug as string, template.id as string);

--- a/tests/agent-templates.cross.helpers.ts
+++ b/tests/agent-templates.cross.helpers.ts
@@ -7,7 +7,7 @@ import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
-import { buildUrlSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/url-slug";
 
 /**
  * Derive a deterministic UUIDv5-shaped string from a human-readable label

--- a/tests/agent-templates.cross.lifecycle.test.ts
+++ b/tests/agent-templates.cross.lifecycle.test.ts
@@ -12,11 +12,11 @@ import {
   createTemplate,
   deleteTemplate,
   getTemplate,
-  hashedSlugFor,
   listTemplates,
   patchTemplate,
   publishTemplate,
   startAgentTemplatesServer,
+  urlSlugFor,
   type TemplateBody,
 } from "./agent-templates.cross.helpers";
 
@@ -95,7 +95,7 @@ describe("Agent template cross lifecycle flow", () => {
 
     const direct = await getTemplate({
       baseURL,
-      path: hashedSlugFor(created.body),
+      path: urlSlugFor(created.body),
     });
 
     expect(direct.response.status).toBe(200);

--- a/tests/agent-templates.cross.slug.test.ts
+++ b/tests/agent-templates.cross.slug.test.ts
@@ -11,10 +11,10 @@ import { prisma } from "@/utils/prisma";
 import {
   createTemplate,
   getTemplate,
-  hashedSlugFor,
   patchTemplate,
   publishTemplate,
   startAgentTemplatesServer,
+  urlSlugFor,
 } from "./agent-templates.cross.helpers";
 
 let baseURL: string;
@@ -95,11 +95,11 @@ describe("Agent template cross slug flow", () => {
 
     const firstDirect = await getTemplate({
       baseURL,
-      path: hashedSlugFor(first.body),
+      path: urlSlugFor(first.body),
     });
     const secondDirect = await getTemplate({
       baseURL,
-      path: hashedSlugFor(second.body),
+      path: urlSlugFor(second.body),
     });
 
     // Each `brewski.<hash>` URL resolves to its own row — the shared base

--- a/tests/agent-templates.cross.visibility.test.ts
+++ b/tests/agent-templates.cross.visibility.test.ts
@@ -11,11 +11,11 @@ import { prisma } from "@/utils/prisma";
 import {
   createTemplate,
   getTemplate,
-  hashedSlugFor,
   listTemplates,
   patchTemplate,
   publishTemplate,
   startAgentTemplatesServer,
+  urlSlugFor,
 } from "./agent-templates.cross.helpers";
 
 let baseURL: string;
@@ -66,13 +66,13 @@ describe("Agent template cross visibility flow", () => {
       },
     });
     const id = created.body.id as string;
-    const hashedSlug = hashedSlugFor(created.body);
+    const urlSlug = urlSlugFor(created.body);
 
     expect(created.response.status).toBe(201);
     expect(created.body.status).toBe("draft");
     expect(await listContains(id)).toBe(false);
     expect(
-      (await getTemplate({ baseURL, path: hashedSlug })).response.status,
+      (await getTemplate({ baseURL, path: urlSlug })).response.status,
     ).toBe(404);
 
     const published = await publishTemplate({ baseURL, id });
@@ -81,7 +81,7 @@ describe("Agent template cross visibility flow", () => {
     expect(published.body.firstPublishedAt).toEqual(expect.any(String));
     expect(await listContains(id)).toBe(true);
 
-    const publishedDetail = await getTemplate({ baseURL, path: hashedSlug });
+    const publishedDetail = await getTemplate({ baseURL, path: urlSlug });
     expect(publishedDetail.response.status).toBe(200);
     expect(publishedDetail.body.status).toBe("published");
 
@@ -94,7 +94,7 @@ describe("Agent template cross visibility flow", () => {
     expect(archived.body.status).toBe("archived");
     expect(await listContains(id)).toBe(false);
 
-    const archivedDetail = await getTemplate({ baseURL, path: hashedSlug });
+    const archivedDetail = await getTemplate({ baseURL, path: urlSlug });
     expect(archivedDetail.response.status).toBe(200);
     expect(archivedDetail.body.status).toBe("archived");
   });

--- a/tests/agent-templates.detail.test.ts
+++ b/tests/agent-templates.detail.test.ts
@@ -12,7 +12,7 @@ import {
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
-import { slugHash } from "@/utils/slug-hash";
+import { hashId } from "@/utils/url-slug";
 import { buildAgentTemplatesApp } from "./agent-templates.cross.helpers";
 
 type DetailBody = Record<string, unknown>;
@@ -156,7 +156,7 @@ describe("Agent template detail endpoint", () => {
       slug: "brewski",
     });
 
-    const hash = slugHash(tmpl.id);
+    const hash = hashId(tmpl.id);
     const hashed = await readDetail({
       path: `/api/v2/agent-templates/brewski.${hash}`,
     });
@@ -198,7 +198,7 @@ describe("Agent template detail endpoint", () => {
     const headers = await readerAuthHeaders();
     for (const path of [
       `/api/v2/agent-templates/${draft.id}`,
-      `/api/v2/agent-templates/detail-draft.${slugHash(draft.id)}`,
+      `/api/v2/agent-templates/detail-draft.${hashId(draft.id)}`,
     ]) {
       const response = await fetch(`${baseURL}${path}`, { headers });
       expect(response.status).toBe(404);
@@ -215,7 +215,7 @@ describe("Agent template detail endpoint", () => {
       expect(byId.body?.status).toBe(fixture.status);
 
       const byHash = await readDetail({
-        path: `/api/v2/agent-templates/${fixture.slug}.${slugHash(fixture.tmpl.id)}`,
+        path: `/api/v2/agent-templates/${fixture.slug}.${hashId(fixture.tmpl.id)}`,
       });
       expect(byHash.response.status).toBe(200);
       expect(byHash.body?.status).toBe(fixture.status);

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -291,9 +291,9 @@ describe("POST /generations — twitter happy path", () => {
     // Default deterministic fallback should at least include the handle
     expect(body.reply?.text).toContain("@some_user");
     // The reply URL must use the canonical hashed slug (`<base>.<hash5>`),
-    // not the bare base slug. Resolver in resolve-id-or-hashed-slug.ts
+    // not the bare base slug. Resolver in resolve-id-or-url-slug.ts
     // requires the hash; passing the base would 404. Regression guard for
-    // the executor's buildSlug call.
+    // the executor's buildUrlSlug call.
     expect(body.reply?.text).toMatch(/[a-z0-9-]+\.[0-9a-z]{5}/i);
 
     // Verify the row stores both templateId and reply
@@ -364,7 +364,7 @@ describe("POST /generations — twitter happy path", () => {
       handle: "@some_user",
       agentName: fakeTemplate.agentName,
       firstSentence: "Helps reply to tweets quickly",
-      slug: body.reply!.text.match(/[a-z0-9-]+\.[a-z0-9]+$/i)?.[0] ?? "",
+      urlSlug: body.reply!.text.match(/[a-z0-9-]+\.[a-z0-9]+$/i)?.[0] ?? "",
     });
     // Match prefix, since slug is dynamic
     expect(body.reply?.text.startsWith(expected.split(" — ")[0])).toBe(true);

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -310,7 +310,7 @@ describe("POST /generations — twitter happy path", () => {
 
   test("LLM-composed reply is used when validator accepts it", async () => {
     const llmReply =
-      "@some_user Built it! Meet Tweet Replier — try it now https://convos.org/assistants/tweet-replier.abcde";
+      "@some_user Built it! Meet Tweet Replier — try it now https://dev.convos.org/a/tweet-replier.abcde";
     __resetComposeReplyForTests(() => Promise.resolve({ replyText: llmReply }));
 
     const res = await post(twitterBody(), {

--- a/tests/agent-templates.resolver.test.ts
+++ b/tests/agent-templates.resolver.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Prisma } from "@prisma/client";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
-import { resolveAgentTemplateByIdOrHashedSlug } from "@/api/v2/agent-templates/lib/resolve-id-or-hashed-slug";
+import { resolveAgentTemplateByIdOrUrlSlug } from "@/api/v2/agent-templates/lib/resolve-id-or-url-slug";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import { slugHash } from "@/utils/slug-hash";
@@ -74,13 +74,13 @@ describe("agent template id-or-hashed-slug resolver", () => {
     const tmplId = await createTemplate({ slug: "unrelated" });
     await createTemplate({ slug: "brewski" });
 
-    const byId = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: tmplId.id,
+    const byId = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: tmplId.id,
     });
     expect(byId?.id).toBe(tmplId.id);
 
-    const bareSlug = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: "brewski",
+    const bareSlug = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: "brewski",
     });
     expect(bareSlug).toBeNull();
   });
@@ -89,13 +89,13 @@ describe("agent template id-or-hashed-slug resolver", () => {
     const tmpl = await createTemplate({ slug: "my-thing" });
 
     const correctHash = slugHash(tmpl.id);
-    const valid = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `my-thing.${correctHash}`,
+    const valid = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `my-thing.${correctHash}`,
     });
     expect(valid?.id).toBe(tmpl.id);
 
-    const extraBaseDot = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `extra.my-thing.${correctHash}`,
+    const extraBaseDot = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `extra.my-thing.${correctHash}`,
     });
     expect(extraBaseDot).toBeNull();
 
@@ -106,8 +106,8 @@ describe("agent template id-or-hashed-slug resolver", () => {
       "!@#$%",
       "",
     ]) {
-      const invalid = await resolveAgentTemplateByIdOrHashedSlug({
-        idOrHashedSlug: `my-thing.${suffix}`,
+      const invalid = await resolveAgentTemplateByIdOrUrlSlug({
+        idOrUrlSlug: `my-thing.${suffix}`,
       });
       expect(invalid).toBeNull();
     }
@@ -129,23 +129,23 @@ describe("agent template id-or-hashed-slug resolver", () => {
     const hashA = slugHash(tmplA.id);
     const hashB = slugHash(tmplB.id);
 
-    const rowA = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `shared.${hashA}`,
+    const rowA = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `shared.${hashA}`,
     });
     expect(rowA?.id).toBe(tmplA.id);
 
-    const rowB = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `shared.${hashB}`,
+    const rowB = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `shared.${hashB}`,
     });
     expect(rowB?.id).toBe(tmplB.id);
 
-    const wrongHash = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `shared.${slugHash(randomUUID())}`,
+    const wrongHash = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `shared.${slugHash(randomUUID())}`,
     });
     expect(wrongHash).toBeNull();
 
-    const collision = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: "shared.zzzzz",
+    const collision = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: "shared.zzzzz",
       slugHasher: () => "zzzzz",
     });
     expect(collision).toBeNull();
@@ -166,13 +166,13 @@ describe("agent template id-or-hashed-slug resolver", () => {
       status: "archived",
     });
 
-    const draftById = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: draft.id,
+    const draftById = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: draft.id,
     });
     expect(draftById).toBeNull();
 
-    const draftByHash = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `resolver-draft.${slugHash(draft.id)}`,
+    const draftByHash = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `resolver-draft.${slugHash(draft.id)}`,
     });
     expect(draftByHash).toBeNull();
 
@@ -182,13 +182,13 @@ describe("agent template id-or-hashed-slug resolver", () => {
     ] as const;
 
     for (const fixture of visibleFixtures) {
-      const byId = await resolveAgentTemplateByIdOrHashedSlug({
-        idOrHashedSlug: fixture.tmpl.id,
+      const byId = await resolveAgentTemplateByIdOrUrlSlug({
+        idOrUrlSlug: fixture.tmpl.id,
       });
       expect(byId?.status).toBe(fixture.status);
 
-      const byHash = await resolveAgentTemplateByIdOrHashedSlug({
-        idOrHashedSlug: `${fixture.slug}.${slugHash(fixture.tmpl.id)}`,
+      const byHash = await resolveAgentTemplateByIdOrUrlSlug({
+        idOrUrlSlug: `${fixture.slug}.${slugHash(fixture.tmpl.id)}`,
       });
       expect(byHash?.status).toBe(fixture.status);
     }
@@ -206,26 +206,26 @@ describe("agent template id-or-hashed-slug resolver", () => {
     });
 
     // Hashed slug with matching id resolves correctly
-    const prefixedSlug = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `something-inside.${slugHash(tmplPrefixedSlug.id)}`,
+    const prefixedSlug = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `something-inside.${slugHash(tmplPrefixedSlug.id)}`,
     });
     expect(prefixedSlug?.id).toBe(tmplPrefixedSlug.id);
 
     // Direct UUID lookup still works
-    const prefixedId = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: tmplPrefixedSlug.id,
+    const prefixedId = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: tmplPrefixedSlug.id,
     });
     expect(prefixedId?.id).toBe(tmplPrefixedSlug.id);
 
     // Hash from tmplHashA on slug "bbb" (which belongs to tmplHashB) → null
-    const hashAOnB = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `bbb.${slugHash(tmplHashA.id)}`,
+    const hashAOnB = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `bbb.${slugHash(tmplHashA.id)}`,
     });
     expect(hashAOnB).toBeNull();
 
     // Hash from tmplHashB on slug "aaa" (which belongs to tmplHashA) → null
-    const hashBOnA = await resolveAgentTemplateByIdOrHashedSlug({
-      idOrHashedSlug: `aaa.${slugHash(tmplHashB.id)}`,
+    const hashBOnA = await resolveAgentTemplateByIdOrUrlSlug({
+      idOrUrlSlug: `aaa.${slugHash(tmplHashB.id)}`,
     });
     expect(hashBOnA).toBeNull();
   });

--- a/tests/agent-templates.resolver.test.ts
+++ b/tests/agent-templates.resolver.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { resolveAgentTemplateByIdOrUrlSlug } from "@/api/v2/agent-templates/lib/resolve-id-or-url-slug";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
-import { slugHash } from "@/utils/slug-hash";
+import { hashId } from "@/utils/url-slug";
 
 const OTHER_OWNER_ID = "bbbbbbbb-cccc-4ddd-eeee-ffffffff0002";
 
@@ -88,7 +88,7 @@ describe("agent template id-or-hashed-slug resolver", () => {
   test("splits hashed slugs on the last dot and validates hash syntax exactly", async () => {
     const tmpl = await createTemplate({ slug: "my-thing" });
 
-    const correctHash = slugHash(tmpl.id);
+    const correctHash = hashId(tmpl.id);
     const valid = await resolveAgentTemplateByIdOrUrlSlug({
       idOrUrlSlug: `my-thing.${correctHash}`,
     });
@@ -126,8 +126,8 @@ describe("agent template id-or-hashed-slug resolver", () => {
       }),
     ]);
 
-    const hashA = slugHash(tmplA.id);
-    const hashB = slugHash(tmplB.id);
+    const hashA = hashId(tmplA.id);
+    const hashB = hashId(tmplB.id);
 
     const rowA = await resolveAgentTemplateByIdOrUrlSlug({
       idOrUrlSlug: `shared.${hashA}`,
@@ -140,13 +140,13 @@ describe("agent template id-or-hashed-slug resolver", () => {
     expect(rowB?.id).toBe(tmplB.id);
 
     const wrongHash = await resolveAgentTemplateByIdOrUrlSlug({
-      idOrUrlSlug: `shared.${slugHash(randomUUID())}`,
+      idOrUrlSlug: `shared.${hashId(randomUUID())}`,
     });
     expect(wrongHash).toBeNull();
 
     const collision = await resolveAgentTemplateByIdOrUrlSlug({
       idOrUrlSlug: "shared.zzzzz",
-      slugHasher: () => "zzzzz",
+      hasher: () => "zzzzz",
     });
     expect(collision).toBeNull();
   });
@@ -172,7 +172,7 @@ describe("agent template id-or-hashed-slug resolver", () => {
     expect(draftById).toBeNull();
 
     const draftByHash = await resolveAgentTemplateByIdOrUrlSlug({
-      idOrUrlSlug: `resolver-draft.${slugHash(draft.id)}`,
+      idOrUrlSlug: `resolver-draft.${hashId(draft.id)}`,
     });
     expect(draftByHash).toBeNull();
 
@@ -188,7 +188,7 @@ describe("agent template id-or-hashed-slug resolver", () => {
       expect(byId?.status).toBe(fixture.status);
 
       const byHash = await resolveAgentTemplateByIdOrUrlSlug({
-        idOrUrlSlug: `${fixture.slug}.${slugHash(fixture.tmpl.id)}`,
+        idOrUrlSlug: `${fixture.slug}.${hashId(fixture.tmpl.id)}`,
       });
       expect(byHash?.status).toBe(fixture.status);
     }
@@ -207,7 +207,7 @@ describe("agent template id-or-hashed-slug resolver", () => {
 
     // Hashed slug with matching id resolves correctly
     const prefixedSlug = await resolveAgentTemplateByIdOrUrlSlug({
-      idOrUrlSlug: `something-inside.${slugHash(tmplPrefixedSlug.id)}`,
+      idOrUrlSlug: `something-inside.${hashId(tmplPrefixedSlug.id)}`,
     });
     expect(prefixedSlug?.id).toBe(tmplPrefixedSlug.id);
 
@@ -219,13 +219,13 @@ describe("agent template id-or-hashed-slug resolver", () => {
 
     // Hash from tmplHashA on slug "bbb" (which belongs to tmplHashB) → null
     const hashAOnB = await resolveAgentTemplateByIdOrUrlSlug({
-      idOrUrlSlug: `bbb.${slugHash(tmplHashA.id)}`,
+      idOrUrlSlug: `bbb.${hashId(tmplHashA.id)}`,
     });
     expect(hashAOnB).toBeNull();
 
     // Hash from tmplHashB on slug "aaa" (which belongs to tmplHashA) → null
     const hashBOnA = await resolveAgentTemplateByIdOrUrlSlug({
-      idOrUrlSlug: `aaa.${slugHash(tmplHashB.id)}`,
+      idOrUrlSlug: `aaa.${hashId(tmplHashB.id)}`,
     });
     expect(hashBOnA).toBeNull();
   });

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -267,7 +267,7 @@ describe("agent-templates router auth wiring", () => {
     expect(source).toContain("requireAccount,\n  deleteHandler");
     expect(source).toContain("requireAccount,\n  publishHandler");
 
-    // Public routes use the optional middleware: GET /, GET /:idOrHashedSlug,
+    // Public routes use the optional middleware: GET /, GET /:idOrUrlSlug,
     // POST /generations, GET /generations/:generationId. The optional
     // middleware MUST NOT be followed by requireAccount.
     expect(source).toContain("optionalAuthOrAgentApiKeyAuth, listHandler");

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -24,6 +24,10 @@ process.env.ASSISTANT_JOIN_WAIT_BUDGET_MS =
 process.env.ASSISTANT_JOIN_POLL_INTERVAL_MS =
   process.env.ASSISTANT_JOIN_POLL_INTERVAL_MS || "20";
 
+// Public template URL origin (required by config.ts; no prod default).
+process.env.BUILDER_SITE_URL =
+  process.env.BUILDER_SITE_URL || "https://dev.convos.org";
+
 process.env.SIWE_DOMAIN = process.env.SIWE_DOMAIN || "convos.app";
 process.env.SIWE_URI = process.env.SIWE_URI || "https://convos.app";
 process.env.SIWE_ALLOWED_CHAIN_IDS = process.env.SIWE_ALLOWED_CHAIN_IDS || "1";

--- a/tests/slug-hash.test.ts
+++ b/tests/slug-hash.test.ts
@@ -1,10 +1,10 @@
 import crypto from "node:crypto";
 import { describe, expect, test } from "bun:test";
 import {
-  buildSlug,
-  buildUniqueSlug,
+  buildUniqueUrlSlug,
+  buildUrlSlug,
   HASH_LEN,
-  isHashedSlug,
+  isUrlSlug,
   MAX_SLUG_ATTEMPTS,
   slugHash,
 } from "@/utils/slug-hash";
@@ -50,32 +50,32 @@ describe("slug-hash utilities", () => {
     }
   });
 
-  test("buildSlug concatenates base slug and hash with one dot", () => {
-    const built = buildSlug("brewski", "tmpl_abc123");
+  test("buildUrlSlug concatenates base slug and hash with one dot", () => {
+    const built = buildUrlSlug("brewski", "tmpl_abc123");
 
     expect(built).toBe(`brewski.${slugHash("tmpl_abc123")}`);
     expect(built).toMatch(/^brewski\.[0-9a-z]{5}$/);
     expect(built.split(".")).toHaveLength(2);
   });
 
-  test("isHashedSlug accepts a valid lowercase base36 tail", () => {
-    expect(isHashedSlug("brewski.x4f9k")).toBe(true);
-    expect(isHashedSlug("foo.bar.baz12")).toBe(true);
+  test("isUrlSlug accepts a valid lowercase base36 tail", () => {
+    expect(isUrlSlug("brewski.x4f9k")).toBe(true);
+    expect(isUrlSlug("foo.bar.baz12")).toBe(true);
   });
 
-  test("isHashedSlug rejects missing or invalid hash tails", () => {
-    expect(isHashedSlug("brewski")).toBe(false);
-    expect(isHashedSlug("brewski.")).toBe(false);
-    expect(isHashedSlug("brewski.toolong")).toBe(false);
-    expect(isHashedSlug("brewski.UPPER")).toBe(false);
+  test("isUrlSlug rejects missing or invalid hash tails", () => {
+    expect(isUrlSlug("brewski")).toBe(false);
+    expect(isUrlSlug("brewski.")).toBe(false);
+    expect(isUrlSlug("brewski.toolong")).toBe(false);
+    expect(isUrlSlug("brewski.UPPER")).toBe(false);
   });
 });
 
-describe("buildUniqueSlug", () => {
+describe("buildUniqueUrlSlug", () => {
   test("returns the first generated slug when nothing is taken", async () => {
     const ids = ["tmpl_first", "tmpl_second"];
     let calls = 0;
-    const result = await buildUniqueSlug({
+    const result = await buildUniqueUrlSlug({
       baseSlug: "brewski",
       idFactory: () => ids[calls++],
       isTaken: () => Promise.resolve(false),
@@ -83,18 +83,18 @@ describe("buildUniqueSlug", () => {
 
     expect(calls).toBe(1);
     expect(result.id).toBe("tmpl_first");
-    expect(result.slug).toBe(buildSlug("brewski", "tmpl_first"));
+    expect(result.slug).toBe(buildUrlSlug("brewski", "tmpl_first"));
   });
 
   test("retries with a fresh id when the slug is taken", async () => {
     const ids = ["tmpl_first", "tmpl_second", "tmpl_third"];
     let calls = 0;
     const taken = new Set([
-      buildSlug("brewski", "tmpl_first"),
-      buildSlug("brewski", "tmpl_second"),
+      buildUrlSlug("brewski", "tmpl_first"),
+      buildUrlSlug("brewski", "tmpl_second"),
     ]);
 
-    const result = await buildUniqueSlug({
+    const result = await buildUniqueUrlSlug({
       baseSlug: "brewski",
       idFactory: () => ids[calls++],
       isTaken: (slug) => Promise.resolve(taken.has(slug)),
@@ -102,14 +102,14 @@ describe("buildUniqueSlug", () => {
 
     expect(calls).toBe(3);
     expect(result.id).toBe("tmpl_third");
-    expect(result.slug).toBe(buildSlug("brewski", "tmpl_third"));
+    expect(result.slug).toBe(buildUrlSlug("brewski", "tmpl_third"));
   });
 
   test("throws after MAX_SLUG_ATTEMPTS when every candidate is taken", async () => {
     let calls = 0;
     let caught: unknown;
     try {
-      await buildUniqueSlug({
+      await buildUniqueUrlSlug({
         baseSlug: "brewski",
         idFactory: () => `tmpl_${calls++}`,
         isTaken: () => Promise.resolve(true),

--- a/tests/template-url.test.ts
+++ b/tests/template-url.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
   templatePublicUrl,
-  templateUrlFromHashedSlug,
+  templateUrlFromUrlSlug,
 } from "@/api/v2/agent-templates/lib/template-url";
 import { BUILDER_SITE_URL } from "@/config";
-import { buildSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/slug-hash";
 
 describe("template public URL helpers", () => {
   // BUILDER_SITE_URL default ("https://convos.org/assistants") carries no
   // trailing slash; agent pages live under the `/a/` segment.
-  test("templateUrlFromHashedSlug joins origin + /a/ + already-hashed slug", () => {
-    expect(templateUrlFromHashedSlug("brewski.x4f9k")).toBe(
+  test("templateUrlFromUrlSlug joins origin + /a/ + already-hashed slug", () => {
+    expect(templateUrlFromUrlSlug("brewski.x4f9k")).toBe(
       `${BUILDER_SITE_URL}/a/brewski.x4f9k`,
     );
   });
@@ -18,7 +18,7 @@ describe("template public URL helpers", () => {
   test("templatePublicUrl builds origin + /a/ + canonical <base>.<hash>", () => {
     const url = templatePublicUrl("brewski", "tmpl_abc123");
     expect(url).toBe(
-      `${BUILDER_SITE_URL}/a/${buildSlug("brewski", "tmpl_abc123")}`,
+      `${BUILDER_SITE_URL}/a/${buildUrlSlug("brewski", "tmpl_abc123")}`,
     );
     expect(url).toMatch(/\/a\/brewski\.[0-9a-z]{5}$/);
   });

--- a/tests/template-url.test.ts
+++ b/tests/template-url.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+  templatePublicUrl,
+  templateUrlFromHashedSlug,
+} from "@/api/v2/agent-templates/lib/template-url";
+import { BUILDER_SITE_URL } from "@/config";
+import { buildSlug } from "@/utils/slug-hash";
+
+describe("template public URL helpers", () => {
+  // BUILDER_SITE_URL default ("https://convos.org/assistants") carries no
+  // trailing slash, so the join here is a plain `${origin}/${slug}`.
+  test("templateUrlFromHashedSlug joins origin + already-hashed slug", () => {
+    expect(templateUrlFromHashedSlug("brewski.x4f9k")).toBe(
+      `${BUILDER_SITE_URL}/brewski.x4f9k`,
+    );
+  });
+
+  test("templatePublicUrl builds origin + canonical <base>.<hash>", () => {
+    const url = templatePublicUrl("brewski", "tmpl_abc123");
+    expect(url).toBe(
+      `${BUILDER_SITE_URL}/${buildSlug("brewski", "tmpl_abc123")}`,
+    );
+    expect(url).toMatch(/\/brewski\.[0-9a-z]{5}$/);
+  });
+});

--- a/tests/template-url.test.ts
+++ b/tests/template-url.test.ts
@@ -7,8 +7,8 @@ import { BUILDER_SITE_URL } from "@/config";
 import { buildUrlSlug } from "@/utils/url-slug";
 
 describe("template public URL helpers", () => {
-  // BUILDER_SITE_URL default ("https://convos.org/assistants") carries no
-  // trailing slash; agent pages live under the `/a/` segment.
+  // BUILDER_SITE_URL default ("https://dev.convos.org") carries no trailing
+  // slash; agent pages live under the `/a/` segment.
   test("templateUrlFromUrlSlug joins origin + /a/ + already-hashed slug", () => {
     expect(templateUrlFromUrlSlug("brewski.x4f9k")).toBe(
       `${BUILDER_SITE_URL}/a/brewski.x4f9k`,

--- a/tests/template-url.test.ts
+++ b/tests/template-url.test.ts
@@ -4,7 +4,7 @@ import {
   templateUrlFromUrlSlug,
 } from "@/api/v2/agent-templates/lib/template-url";
 import { BUILDER_SITE_URL } from "@/config";
-import { buildUrlSlug } from "@/utils/slug-hash";
+import { buildUrlSlug } from "@/utils/url-slug";
 
 describe("template public URL helpers", () => {
   // BUILDER_SITE_URL default ("https://convos.org/assistants") carries no

--- a/tests/template-url.test.ts
+++ b/tests/template-url.test.ts
@@ -8,18 +8,18 @@ import { buildSlug } from "@/utils/slug-hash";
 
 describe("template public URL helpers", () => {
   // BUILDER_SITE_URL default ("https://convos.org/assistants") carries no
-  // trailing slash, so the join here is a plain `${origin}/${slug}`.
-  test("templateUrlFromHashedSlug joins origin + already-hashed slug", () => {
+  // trailing slash; agent pages live under the `/a/` segment.
+  test("templateUrlFromHashedSlug joins origin + /a/ + already-hashed slug", () => {
     expect(templateUrlFromHashedSlug("brewski.x4f9k")).toBe(
-      `${BUILDER_SITE_URL}/brewski.x4f9k`,
+      `${BUILDER_SITE_URL}/a/brewski.x4f9k`,
     );
   });
 
-  test("templatePublicUrl builds origin + canonical <base>.<hash>", () => {
+  test("templatePublicUrl builds origin + /a/ + canonical <base>.<hash>", () => {
     const url = templatePublicUrl("brewski", "tmpl_abc123");
     expect(url).toBe(
-      `${BUILDER_SITE_URL}/${buildSlug("brewski", "tmpl_abc123")}`,
+      `${BUILDER_SITE_URL}/a/${buildSlug("brewski", "tmpl_abc123")}`,
     );
-    expect(url).toMatch(/\/brewski\.[0-9a-z]{5}$/);
+    expect(url).toMatch(/\/a\/brewski\.[0-9a-z]{5}$/);
   });
 });

--- a/tests/url-slug.test.ts
+++ b/tests/url-slug.test.ts
@@ -4,10 +4,10 @@ import {
   buildUniqueUrlSlug,
   buildUrlSlug,
   HASH_LEN,
+  hashId,
   isUrlSlug,
   MAX_SLUG_ATTEMPTS,
-  slugHash,
-} from "@/utils/slug-hash";
+} from "@/utils/url-slug";
 
 function referenceSlugHash(id: string) {
   const sha = crypto.createHash("sha1").update(id).digest("hex");
@@ -20,7 +20,7 @@ describe("slug-hash utilities", () => {
     expect(typeof HASH_LEN).toBe("number");
   });
 
-  test("slugHash returns exactly five lowercase base36 chars", () => {
+  test("hashId returns exactly five lowercase base36 chars", () => {
     const inputs = [
       "",
       "a",
@@ -30,30 +30,30 @@ describe("slug-hash utilities", () => {
     ];
 
     for (const input of inputs) {
-      const hash = slugHash(input);
+      const hash = hashId(input);
       expect(hash).toHaveLength(HASH_LEN);
       expect(hash).toMatch(/^[0-9a-z]{5}$/);
     }
   });
 
-  test("slugHash matches the pool reference algorithm", () => {
+  test("hashId matches the pool reference algorithm", () => {
     for (const id of ["a", "tmpl_abc123_extra_long_456", ""]) {
-      expect(slugHash(id)).toBe(referenceSlugHash(id));
+      expect(hashId(id)).toBe(referenceSlugHash(id));
     }
   });
 
-  test("slugHash is deterministic across repeated calls", () => {
-    const first = slugHash("tmpl_abc123");
+  test("hashId is deterministic across repeated calls", () => {
+    const first = hashId("tmpl_abc123");
 
     for (let i = 0; i < 100; i++) {
-      expect(slugHash("tmpl_abc123")).toBe(first);
+      expect(hashId("tmpl_abc123")).toBe(first);
     }
   });
 
   test("buildUrlSlug concatenates base slug and hash with one dot", () => {
     const built = buildUrlSlug("brewski", "tmpl_abc123");
 
-    expect(built).toBe(`brewski.${slugHash("tmpl_abc123")}`);
+    expect(built).toBe(`brewski.${hashId("tmpl_abc123")}`);
     expect(built).toMatch(/^brewski\.[0-9a-z]{5}$/);
     expect(built.split(".")).toHaveLength(2);
   });


### PR DESCRIPTION
## Summary

Stacked on #226. Shapes the public agent URL and aligns the vocabulary around it. (`publishedUrl` itself landed in #221; this refactors how it's built and named.)

- **Single source for the public URL** — new `lib/template-url.ts` (`templateUrlFromUrlSlug` / `templatePublicUrl`). Both the serializer's `publishedUrl` and the Twitter reply link build through it (was duplicated in two spots), and it strips a trailing slash on `BUILDER_SITE_URL` so a configured value with/without one can't yield `//`.
- **Agent pages live under `/a/`** — the public URL is now `${origin}/a/<base>.<hash>`, matching the Playroom serving the route at `/a/[urlSlug]` (#1688).
- **Naming: "url slug", not "hashed slug"** — the `<base>.<hash>` value is a *url slug*; the base slug is **not** hashed (the `<hash>` is a hash of the template **id**). Renamed:
  - `buildSlug → buildUrlSlug`, `buildUniqueSlug → buildUniqueUrlSlug`, `isHashedSlug → isUrlSlug`
  - `slugHash → hashId` (it hashes the id); `src/utils/slug-hash.ts → url-slug.ts`
  - `resolveAgentTemplateByIdOrHashedSlug → …ByIdOrUrlSlug`, `idOrHashedSlug → idOrUrlSlug`, file → `resolve-id-or-url-slug.ts`
  - `ReplyInput.slug → ReplyInput.urlSlug`; resolver test seam `slugHasher → hasher`
  - `AgentTemplate.slug` (the bare base slug) is unchanged.

## Why

One definition of an agent's public URL; accurate, consistent naming; and the trailing-slash fix lands before `BUILDER_SITE_URL` is repointed to convos.org / dev.convos.org.

## Notes

- Pairs with website PR #1688 (serves `/a/[urlSlug]`). `publishedUrl` is consumed by iOS/runtime, so deploy the website `/a/` route at/with this.
- CI green (682 pass / 0 fail).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename agent template public URLs to use `/a/<urlSlug>` path format
> - Renames `slug-hash.ts` to [url-slug.ts](https://github.com/ephemeraHQ/convos-backend/pull/225/files#diff-bbef0fe7af95ae2b8200be94ed1991299eec4193b9bd53496f647f19e9979275) and updates exported function names (`slugHash`→`hashId`, `buildSlug`→`buildUrlSlug`, etc.) with no algorithmic changes.
> - Introduces [template-url.ts](https://github.com/ephemeraHQ/convos-backend/pull/225/files#diff-bbc620af279c759de0db09842bdcffb598233a82b5596776f075c91144ce481a) with `templatePublicUrl` and `templateUrlFromUrlSlug` helpers that build canonical URLs as `<BUILDER_SITE_URL>/a/<urlSlug>`.
> - Updates `compose-reply` and `generation-executor` to pass `urlSlug` instead of `slug`, so generated tweet reply URLs now use the `/a/` path.
> - Renames the detail route parameter from `:idOrHashedSlug` to `:idOrUrlSlug` and the resolver to `resolveAgentTemplateByIdOrUrlSlug`.
> - Risk: `BUILDER_SITE_URL` is now required at startup — the application throws if unset, removing the previous default fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 019c4ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent template public URLs now use a canonical URL-slug format and resolution, and template detail endpoints accept the new id-or-URL-slug path.
  * URL-slug utilities renamed/reorganized for clarity.

* **Configuration**
  * BUILDER_SITE_URL is now required and documented as the public origin for template URLs.

* **Tests**
  * Added and updated tests to cover the new URL-slug helpers and resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->