### PR TITLE
fix(tests): align notifications-payload-guard with test suite

### DIFF
--- a/tests/notifications-payload-guard.test.ts
+++ b/tests/notifications-payload-guard.test.ts
@@ -1,6 +1,7 @@
 import type { ClientIdentifier, DeviceRegistration } from "@prisma/client";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Request } from "express";
+import { prisma } from "@/utils/prisma";
 
 // ---- Mocks (must be installed BEFORE importing the SUT) ----
 
@@ -114,29 +115,11 @@ void mock.module("@/api/v2/notifications/fcm-push.service", () => {
   };
 });
 
-const deviceUpdateMock = mock(() =>
-  Promise.resolve({ pushFailures: 0, lastFailureAt: null }),
-);
-const deviceTxMock = mock(() =>
-  Promise.resolve({ pushFailures: 1, lastFailureAt: new Date() }),
-);
-const clientDeleteMock = mock(() => Promise.resolve());
-const txMock = mock(async (fn: (tx: unknown) => Promise<unknown>) =>
-  fn({
-    deviceRegistration: {
-      update: deviceTxMock,
-      updateMany: mock(() => Promise.resolve()),
-    },
-  }),
-);
-
-void mock.module("@/utils/prisma", () => ({
-  prisma: {
-    deviceRegistration: { update: deviceUpdateMock },
-    clientIdentifier: { delete: clientDeleteMock },
-    $transaction: txMock,
-  },
-}));
+// NOTE: prisma is NOT module-mocked here. A global `mock.module("@/utils/prisma")`
+// leaks across the whole `bun test` process (bun hoists module mocks and never
+// restores them), replacing the real client for every test file that loads after
+// this one — which is what poisoned the suite. This file now follows the repo's
+// real-DB integration pattern: seed/clean real rows in beforeEach/afterAll.
 
 void mock.module("@/notifications/client", () => ({
   createNotificationClient: () => ({
@@ -147,14 +130,9 @@ void mock.module("@/notifications/client", () => ({
   },
 }));
 
-void mock.module("@/utils/jwt", () => ({
-  createJwtToken: () =>
-    Promise.resolve(
-      "eyJhbGciOiJFUzI1NiIsImtpZCI6InRlc3Qta2lkLTAxIiwidHlwIjoiSldUIn0." +
-        "x".repeat(280) +
-        ".sig-placeholder",
-    ),
-}));
+// jwt is NOT mocked either — the same leak would replace `@/utils/jwt` (dropping
+// verifyJwtToken etc.) for downstream test files. The handler uses the real
+// createJwtToken (signing keys come from tests/preload.ts).
 
 const { handleV2Notification } = await import(
   "@/api/v2/notifications/handlers/webhook"
@@ -234,11 +212,38 @@ function makeWebhook(args: {
   };
 }
 
-beforeEach(() => {
+// Match the ids makeClient() puts on the in-memory client passed to the handler,
+// so the handler's success/failure bookkeeping (keyed by deviceId / client id)
+// lands on these real rows.
+const TEST_DEVICE_ID = "dev-1";
+const TEST_CLIENT_ID = "client-1";
+
+beforeEach(async () => {
   apnsSendMock.mockClear();
   fcmSendMock.mockClear();
-  deviceUpdateMock.mockClear();
-  deviceTxMock.mockClear();
+  // Real-DB seed scoped to this file's ids (won't disturb other suites).
+  await prisma.clientIdentifier.deleteMany({ where: { id: TEST_CLIENT_ID } });
+  await prisma.deviceRegistration.deleteMany({
+    where: { deviceId: TEST_DEVICE_ID },
+  });
+  await prisma.deviceRegistration.create({
+    data: {
+      deviceId: TEST_DEVICE_ID,
+      pushToken: `seed-${TEST_DEVICE_ID}`,
+      pushTokenType: "apns",
+      apnsEnv: "sandbox",
+    },
+  });
+  await prisma.clientIdentifier.create({
+    data: { id: TEST_CLIENT_ID, deviceId: TEST_DEVICE_ID },
+  });
+});
+
+afterAll(async () => {
+  await prisma.clientIdentifier.deleteMany({ where: { id: TEST_CLIENT_ID } });
+  await prisma.deviceRegistration.deleteMany({
+    where: { deviceId: TEST_DEVICE_ID },
+  });
 });
 
 // ---- Tests ----
@@ -407,7 +412,12 @@ describe("handleV2Notification – reactive PayloadTooLarge retry", () => {
     expect(second.notificationData.encryptedMessage).toBeUndefined();
 
     // pushFailures NOT bumped (retry succeeded; also PayloadTooLarge wouldn't bump anyway)
-    expect(deviceTxMock).not.toHaveBeenCalled();
+    // PayloadTooLarge never bumps pushFailures — the failure transaction must
+    // not have run, so the seeded row stays at 0.
+    const deviceRow = await prisma.deviceRegistration.findUnique({
+      where: { deviceId: TEST_DEVICE_ID },
+    });
+    expect(deviceRow?.pushFailures).toBe(0);
 
     const retryLog = req.capturedLogs.find((l) =>
       l.msg.includes(
@@ -431,7 +441,12 @@ describe("handleV2Notification – reactive PayloadTooLarge retry", () => {
     await handleV2Notification({ notification: webhook, client, req });
 
     expect(apnsSendMock).toHaveBeenCalledTimes(1);
-    expect(deviceTxMock).not.toHaveBeenCalled();
+    // PayloadTooLarge never bumps pushFailures — the failure transaction must
+    // not have run, so the seeded row stays at 0.
+    const deviceRow = await prisma.deviceRegistration.findUnique({
+      where: { deviceId: TEST_DEVICE_ID },
+    });
+    expect(deviceRow?.pushFailures).toBe(0);
 
     const errorLog = req.capturedLogs.find((l) =>
       l.msg.includes("PayloadTooLarge on already-stripped payload"),
@@ -457,7 +472,12 @@ describe("handleV2Notification – reactive PayloadTooLarge retry", () => {
 
     // Welcome path already stripped, so PayloadTooLarge → no retry
     expect(apnsSendMock).toHaveBeenCalledTimes(1);
-    expect(deviceTxMock).not.toHaveBeenCalled();
+    // PayloadTooLarge never bumps pushFailures — the failure transaction must
+    // not have run, so the seeded row stays at 0.
+    const deviceRow = await prisma.deviceRegistration.findUnique({
+      where: { deviceId: TEST_DEVICE_ID },
+    });
+    expect(deviceRow?.pushFailures).toBe(0);
 
     const errorLog = req.capturedLogs.find((l) =>
       l.msg.includes("PayloadTooLarge on already-stripped payload"),
@@ -481,7 +501,12 @@ describe("handleV2Notification – reactive PayloadTooLarge retry", () => {
     await handleV2Notification({ notification: webhook, client, req });
 
     expect(apnsSendMock).toHaveBeenCalledTimes(2);
-    expect(deviceTxMock).not.toHaveBeenCalled();
+    // PayloadTooLarge never bumps pushFailures — the failure transaction must
+    // not have run, so the seeded row stays at 0.
+    const deviceRow = await prisma.deviceRegistration.findUnique({
+      where: { deviceId: TEST_DEVICE_ID },
+    });
+    expect(deviceRow?.pushFailures).toBe(0);
 
     const retryFailLog = req.capturedLogs.find((l) =>
       l.msg.includes("PayloadTooLarge retry failed"),

--- a/tests/notifications-payload-guard.test.ts
+++ b/tests/notifications-payload-guard.test.ts
@@ -12,7 +12,14 @@ const fcmSendMock = mock(() =>
   Promise.resolve({ success: true } as { success: boolean; error?: string }),
 );
 
+// Spread the real module so model-level exports (e.g. ApnsPushService) survive:
+// this mock.module registration is global and leaks to any file loaded after
+// this one (apns-push-service.test.ts imports the real ApnsPushService and does
+// not self-defend). Only the network-touching createApnsService + the wire
+// builder are overridden.
+const realApnsModule = await import("@/api/v2/notifications/apns-push.service");
 void mock.module("@/api/v2/notifications/apns-push.service", () => ({
+  ...realApnsModule,
   createApnsService: () => ({ sendPushNotification: apnsSendMock }),
   buildApnsWirePayload: (args: {
     notification: {


### PR DESCRIPTION
## Summary

`tests/notifications-payload-guard.test.ts` (added in #224) globally `mock.module("@/utils/prisma", …)` with an incomplete stub (only `deviceRegistration` / `clientIdentifier` / `$transaction`). Bun hoists module mocks and **never restores them**, so that stub replaced the real Prisma client for every test file loaded after this one — each DB test then died with `TypeError: undefined is not an object (evaluating 'prisma.agentTemplate.deleteMany')`.

That's the cause of the **262 failures** in `Validate code quality` since #224 merged (first failing run 2026-05-19 10:08 UTC). It also blocks every other open PR to `otr-dev` (the failures are inherited from the base, not from those PRs). The file's *own* tests pass; the damage is purely the cross-file mock leak. The same trap applies to its `@/utils/jwt` mock.

## Fix

Move this file onto the repo's standard **real-DB integration** pattern (40 other test files already use it; this was the lone outlier mocking `@/utils/prisma`):

- Drop the `@/utils/prisma` and `@/utils/jwt` module mocks.
- Seed/clean real `deviceRegistration` + `clientIdentifier` rows in `beforeEach`/`afterAll`, scoped to this file's ids.
- Assert `pushFailures` from the DB instead of from the removed transaction mock.
- Keep the apns/fcm push-service mocks — they only affect the push-domain tests and don't leak destructively (verified: `apns-push-service` / `fcm-push` pass).

## Validation

`tsc`, ESLint, Prettier all clean locally. Real-DB behavior is validated by CI on this PR. Expectation: the 262 `prisma is undefined` failures clear and this file's tests still pass.

Once this lands, dependent PRs (e.g. #225) go green on their own merits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix notifications-payload-guard test suite to stop poisoning other tests with global module mocks
> - Replaces global prisma and JWT module mocks in [notifications-payload-guard.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/226/files#diff-19e673267a03d7baf4803548a83afd0207891d33e87b5f1a453a55f5d592aa66) with real DB-backed setup using `TEST_DEVICE_ID` and `TEST_CLIENT_ID` constants.
> - `beforeEach` now seeds real `deviceRegistration` and `clientIdentifier` rows; `afterAll` cleans them up to avoid state leakage between test runs.
> - Narrows the APNS module mock to only override `createApnsService` and `buildApnsWirePayload`, preserving other exports via spread.
> - Replaces assertions against mocked prisma transaction calls with direct DB state checks (e.g., verifying `pushFailures` remains 0 via a real prisma query).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c96762b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for notification payload handling with enhanced database state isolation and cleanup procedures.
  * Strengthened test assertions to verify actual system behavior under various payload scenarios instead of mocked interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->