### PR TITLE
feat(agent-templates): create accepts asserted ownerAccountId for agent-key callers

### DIFF
--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { pickCollisionFreeId } from "@/api/v2/agent-templates/lib/pick-collision-free-id";
@@ -25,6 +26,12 @@ const bodySchema = z
       }),
     slug: z.string().optional(),
     tools: z.array(z.string()).optional(),
+    // Asserted owner — honoured only when the caller is agent-key-auth'd;
+    // ignored for JWT (the JWT account always wins) and anonymous. Mirrors
+    // the generations POST endpoint's owner-assertion contract so a trusted
+    // agent runtime can attribute a created template to the user it's acting
+    // on behalf of rather than the ADMIN seed account.
+    ownerAccountId: z.string().uuid().optional(),
   })
   .passthrough();
 
@@ -85,7 +92,33 @@ export async function createHandler(req: Request, res: Response) {
     return;
   }
 
-  const ownerAccountId = getEffectiveOwnerId(res);
+  // Owner resolution mirrors the generations POST endpoint:
+  //   - Agent-key auth: the caller may assert which account to attribute the
+  //     row to via body.ownerAccountId, validated against the Account table
+  //     (invalid → 400 rather than a phantom owner). Absent an assertion it
+  //     falls back to the agent-key default (ADMIN, via getEffectiveOwnerId).
+  //   - JWT auth: the JWT account always wins; body.ownerAccountId is ignored
+  //     (users can't create rows owned by someone else).
+  //   - Anonymous: no account → 403 below.
+  const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+  let ownerAccountId: string | undefined;
+  if (isApiKeyListener && parsed.data.ownerAccountId !== undefined) {
+    const assertedAccountId = parsed.data.ownerAccountId;
+    // Best-effort early validation; the FK constraint on the insert is the
+    // canonical check and covers the delete-between-check-and-insert race
+    // (handled in the catch block below).
+    const exists = await prisma.account.findUnique({
+      where: { id: assertedAccountId },
+      select: { id: true },
+    });
+    if (!exists) {
+      res.status(400).json({ error: "Asserted ownerAccountId does not exist" });
+      return;
+    }
+    ownerAccountId = assertedAccountId;
+  } else {
+    ownerAccountId = getEffectiveOwnerId(res);
+  }
   if (!ownerAccountId) {
     res.status(403).json({ error: "Account required" });
     return;
@@ -115,6 +148,17 @@ export async function createHandler(req: Request, res: Response) {
     });
     res.status(201).json(serializeAgentTemplate(template));
   } catch (error) {
+    // Race: the asserted owner account was deleted between the pre-check and
+    // this insert, so the ownerAccountId → Account.id FK fires. Map back to
+    // the same 400 as the pre-check so the error code is stable regardless of
+    // race timing.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2003"
+    ) {
+      res.status(400).json({ error: "Asserted ownerAccountId does not exist" });
+      return;
+    }
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to create agent template",

--- a/tests/agent-templates.create.owner-assertion.test.ts
+++ b/tests/agent-templates.create.owner-assertion.test.ts
@@ -1,0 +1,144 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+import {
+  agentKeyHeaders,
+  createTemplate,
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+
+// Owner-assertion coverage for POST /api/v2/agent-templates — mirrors the
+// generations POST endpoint's contract. The runtime's assistant-builder
+// create-then-publish fallback relies on this: a template minted on behalf of
+// a joining user must land owned by that user, not the ADMIN seed account.
+
+const ASSERTED_ACCOUNT_ID = "00000000-0000-4000-8000-cccccccc0aa1";
+const NONEXISTENT_ACCOUNT_ID = "00000000-0000-4000-8000-deaddead0aa1";
+const TEST_PORT = 4087;
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const cleanup = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: { in: [ADMIN_ACCOUNT_ID, ASSERTED_ACCOUNT_ID] },
+      slug: { startsWith: "create-owner-test-" },
+    },
+  });
+
+describe("Agent template create — owner assertion", () => {
+  beforeAll(async () => {
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+    // Owner-assertion tests need a real account row to assert against.
+    await prisma.account.upsert({
+      where: { id: ASSERTED_ACCOUNT_ID },
+      update: {},
+      create: { id: ASSERTED_ACCOUNT_ID },
+    });
+    const server = await startAgentTemplatesServer(TEST_PORT);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.account
+      .delete({ where: { id: ASSERTED_ACCOUNT_ID } })
+      .catch(() => {
+        /* idempotent */
+      });
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
+    await closeServer();
+  });
+
+  beforeEach(cleanup);
+
+  test("agent-key auth + body.ownerAccountId → row owned by the asserted account", async () => {
+    const { body, response } = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Create Owner Test A",
+        prompt: "You are helpful",
+        slug: "create-owner-test-asserted",
+        ownerAccountId: ASSERTED_ACCOUNT_ID,
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.ownerAccountId).toBe(ASSERTED_ACCOUNT_ID);
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: body.id as string },
+    });
+    expect(row.ownerAccountId).toBe(ASSERTED_ACCOUNT_ID);
+  });
+
+  test("agent-key auth without assertion → row owner falls back to ADMIN", async () => {
+    const { body, response } = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Create Owner Test B",
+        prompt: "You are helpful",
+        slug: "create-owner-test-default",
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.ownerAccountId).toBe(ADMIN_ACCOUNT_ID);
+  });
+
+  test("agent-key auth + nonexistent ownerAccountId → 400, no row created", async () => {
+    const { body, response } = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Create Owner Test C",
+        prompt: "You are helpful",
+        slug: "create-owner-test-missing",
+        ownerAccountId: NONEXISTENT_ACCOUNT_ID,
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect((body.error as string).toLowerCase()).toContain("owneraccountid");
+
+    const rows = await prisma.agentTemplate.findMany({
+      where: { slug: "create-owner-test-missing" },
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  test("JWT auth + body.ownerAccountId → JWT account wins, body field ignored", async () => {
+    const jwt = await createJwtToken({
+      deviceId: "create-owner-jwt",
+      accountId: ASSERTED_ACCOUNT_ID,
+    });
+    // Body asserts ADMIN — must be ignored because JWT auth wins.
+    const { body, response } = await createTemplate({
+      baseURL,
+      headers: { "Content-Type": "application/json", "X-Convos-AuthToken": jwt },
+      body: {
+        agentName: "Create Owner Test D",
+        prompt: "You are helpful",
+        slug: "create-owner-test-jwt",
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.ownerAccountId).toBe(ASSERTED_ACCOUNT_ID);
+  });
+});

--- a/tests/agent-templates.create.owner-assertion.test.ts
+++ b/tests/agent-templates.create.owner-assertion.test.ts
@@ -129,7 +129,10 @@ describe("Agent template create — owner assertion", () => {
     // Body asserts ADMIN — must be ignored because JWT auth wins.
     const { body, response } = await createTemplate({
       baseURL,
-      headers: { "Content-Type": "application/json", "X-Convos-AuthToken": jwt },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Convos-AuthToken": jwt,
+      },
       body: {
         agentName: "Create Owner Test D",
         prompt: "You are helpful",


### PR DESCRIPTION
Companion to xmtplabs/convos-assistants#1695 (runtime #1694).

> **Stacking / CI:** based on **#226** (`fix/notifications-test-prisma-mock-leak`) so the `bun test` job is green — that PR fixes a Prisma mock leak that was poisoning the whole suite on `otr-dev`. The diff here is just the 2 commits below; GitHub auto-retargets the base to `otr-dev` when #226 merges. The follow-on `forkedFromId` change is a **separate PR (#228, stacked on this one)** — kept out of this PR so ownerAccountId and forkedFromId land independently.

## What

`POST /api/v2/agent-templates` (the `create` handler) now honours a body `ownerAccountId` when the caller is **agent-key-auth'd**, validated against the `Account` table. Mirrors the owner-resolution contract already on `POST /generations`:

| Auth | body.ownerAccountId | Owner of created row |
|---|---|---|
| Agent key | present + exists | the asserted account |
| Agent key | present + missing | **400** `Asserted ownerAccountId does not exist` |
| Agent key | absent | ADMIN (unchanged) |
| JWT | anything | JWT account (body ignored) |
| Anonymous | — | 403 (unchanged) |

`P2003` on insert (account deleted between pre-check and write) maps to the same 400 so the error code is stable across race timings.

## Why

The runtime assistant-builder's **create-then-publish / fork** path (convos-assistants #1695) mints a template on a joining user's behalf. Without this, `create` always assigns ADMIN (via `getEffectiveOwnerId`), so the user's published/forked copy wouldn't be theirs. The runtime already asserts `ownerAccountId` on create (forward-compatible); this makes it take effect.

## Scope

Only the `create` handler + body schema. Read/visibility, publish, patch, delete, and the JWT path are unchanged — the existing create test asserting JWT callers can't pin `ownerAccountId` still holds.

## Tests

`tests/agent-templates.create.owner-assertion.test.ts` — agent-key asserts owner; agent-key without assertion → ADMIN; agent-key + nonexistent account → 400 (no row); JWT ignores the body field. Mirrors the `generations-post` owner-assertion harness.

> Written but not executed in my environment (needs the live Postgres test DB). `tsc` + prettier clean on the changed files.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept asserted `ownerAccountId` in POST /api/v2/agent-templates for agent-key callers
> - Agent-key authenticated requests to [create.ts](https://github.com/ephemeraHQ/convos-backend/pull/227/files#diff-714fff4a3ad1a492d81a2b2d8d50c7f554618c6ecb35734dab8f9256eced205b) may now include `ownerAccountId` (UUID) in the request body to set the new template's owner to a different account.
> - If the asserted account does not exist, the handler returns 400 and creates no row; JWT callers have `ownerAccountId` silently ignored; unauthenticated callers receive 403.
> - Foreign key violations (`P2003`) on `ownerAccountId` are now caught and mapped to 400 instead of 500.
> - Covered by a new test file [agent-templates.create.owner-assertion.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/227/files#diff-cd5537f07f501b7a197c3211d6dcb3885ede1648075145eb8d2d562843dbc082) exercising all four auth/assertion scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized beb4ddb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->