### PR TITLE
feat(agent-templates): create accepts forkedFromId (fork provenance)

### DIFF
--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -32,6 +32,12 @@ const bodySchema = z
     // agent runtime can attribute a created template to the user it's acting
     // on behalf of rather than the ADMIN seed account.
     ownerAccountId: z.string().uuid().optional(),
+    // Provenance for forks. When a row is created as a copy of an existing
+    // template (e.g. the runtime forking a catalog template a group adopted),
+    // this records the source id. The FK (`forkedFromId → AgentTemplate.id`,
+    // ON DELETE SET NULL) is the canonical check — a dangling reference fails
+    // the insert and maps to the same 400 as a bad ownerAccountId below.
+    forkedFromId: z.string().uuid().optional(),
   })
   .passthrough();
 
@@ -66,7 +72,7 @@ const createTemplateRow = (args: {
       id: args.id,
       slug: args.slug,
       ownerAccountId: args.ownerAccountId,
-      forkedFromId: null,
+      forkedFromId: args.body.forkedFromId ?? null,
       agentName: args.body.agentName,
       description: args.body.description ?? null,
       prompt: args.body.prompt,
@@ -124,6 +130,20 @@ export async function createHandler(req: Request, res: Response) {
     return;
   }
 
+  // Validate the fork source if asserted. Like ownerAccountId, the FK is the
+  // canonical check (handled in the catch below); this pre-check fails fast
+  // with a clear error before the collision-free-id lookup.
+  if (parsed.data.forkedFromId !== undefined) {
+    const source = await prisma.agentTemplate.findUnique({
+      where: { id: parsed.data.forkedFromId },
+      select: { id: true },
+    });
+    if (!source) {
+      res.status(400).json({ error: "forkedFromId does not exist" });
+      return;
+    }
+  }
+
   // Slugs are not unique. An explicit slug is taken verbatim; an absent one
   // is derived from agentName. Either way it only has to pass format /
   // reserved-word validation — duplicate slugs (within or across owners) are
@@ -148,15 +168,17 @@ export async function createHandler(req: Request, res: Response) {
     });
     res.status(201).json(serializeAgentTemplate(template));
   } catch (error) {
-    // Race: the asserted owner account was deleted between the pre-check and
-    // this insert, so the ownerAccountId → Account.id FK fires. Map back to
-    // the same 400 as the pre-check so the error code is stable regardless of
+    // Race: a referenced row (ownerAccountId → Account, or forkedFromId →
+    // AgentTemplate) was deleted between the pre-check and this insert, so its
+    // FK fires. Map back to a 400 so the error code is stable regardless of
     // race timing.
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === "P2003"
     ) {
-      res.status(400).json({ error: "Asserted ownerAccountId does not exist" });
+      res.status(400).json({
+        error: "Referenced ownerAccountId or forkedFromId does not exist",
+      });
       return;
     }
     req.log.error(

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -133,6 +133,16 @@ export async function createHandler(req: Request, res: Response) {
   // Validate the fork source if asserted. Like ownerAccountId, the FK is the
   // canonical check (handled in the catch below); this pre-check fails fast
   // with a clear error before the collision-free-id lookup.
+  //
+  // Policy: forking is intentionally NOT gated on the source's visibility or
+  // ownership. `forkedFromId` is provenance only — a bare id pointer that
+  // grants no access to the source's content (a non-owner still 404s when
+  // resolving a draft/private source), so recording it can't leak anything.
+  // Source ids are unguessable UUIDs, so the existence check ("does not exist"
+  // vs created) is not a useful oracle. Keeping it ungated also lets the
+  // agent-key path (which can see every row) fork the catalog template a group
+  // adopted without a special case. If a visibility rule is ever wanted, add
+  // it here.
   if (parsed.data.forkedFromId !== undefined) {
     const source = await prisma.agentTemplate.findUnique({
       where: { id: parsed.data.forkedFromId },

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -39,6 +39,12 @@ const bodySchema = z
     // the insert and maps to the same 400 as a bad ownerAccountId below.
     forkedFromId: z.string().uuid().optional(),
   })
+  // .passthrough() (not .strict()) is intentional: create accepts a full
+  // AgentTemplate-shaped body and silently IGNORES the fields it derives
+  // server-side (status, version, firstPublishedAt, …) instead of 400ing, so a
+  // caller can POST a serialized template verbatim. The "ignores server-pinned
+  // fields" test pins this. (generations-post.ts uses .strict() because its
+  // body is a bespoke request envelope, not a template — different by design.)
   .passthrough();
 
 type CreateBody = z.infer<typeof bodySchema>;

--- a/tests/agent-templates.create.fork.test.ts
+++ b/tests/agent-templates.create.fork.test.ts
@@ -1,0 +1,133 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  agentKeyHeaders,
+  createTemplate,
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+
+// forkedFromId coverage for POST /api/v2/agent-templates. The runtime sets it
+// when publishing forks an adopted catalog template, so the new row records
+// the source it was copied from.
+
+const SOURCE_ID = "00000000-0000-4000-8000-cccccccc0fc1";
+const NONEXISTENT_ID = "00000000-0000-4000-8000-deaddead0fc1";
+const TEST_PORT = 4089;
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const cleanup = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      slug: { startsWith: "create-fork-test-" },
+    },
+  });
+
+describe("Agent template create — forkedFromId", () => {
+  beforeAll(async () => {
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+    // A persistent source row to fork from. Its slug intentionally does NOT
+    // match the per-test cleanup prefix, so beforeEach won't delete it.
+    await prisma.agentTemplate.upsert({
+      where: { id: SOURCE_ID },
+      update: {},
+      create: {
+        id: SOURCE_ID,
+        slug: "fork-source-fixture",
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+        agentName: "Fork Source",
+        prompt: "You are the source",
+        tools: [],
+        connections: [],
+        version: 1,
+        status: "published",
+        featured: false,
+      },
+    });
+    const server = await startAgentTemplatesServer(TEST_PORT);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.agentTemplate
+      .delete({ where: { id: SOURCE_ID } })
+      .catch(() => {
+        /* idempotent */
+      });
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
+    await closeServer();
+  });
+
+  beforeEach(cleanup);
+
+  test("records forkedFromId when it references an existing template", async () => {
+    const { body, response } = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Fork Test A",
+        prompt: "You are a fork",
+        slug: "create-fork-test-a",
+        forkedFromId: SOURCE_ID,
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.forkedFromId).toBe(SOURCE_ID);
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: body.id as string },
+    });
+    expect(row.forkedFromId).toBe(SOURCE_ID);
+  });
+
+  test("defaults forkedFromId to null when omitted", async () => {
+    const { body, response } = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Fork Test B",
+        prompt: "plain",
+        slug: "create-fork-test-b",
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.forkedFromId).toBeNull();
+  });
+
+  test("rejects a forkedFromId that does not exist with 400", async () => {
+    const { body, response } = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Fork Test C",
+        prompt: "x",
+        slug: "create-fork-test-c",
+        forkedFromId: NONEXISTENT_ID,
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect((body.error as string).toLowerCase()).toContain("forkedfromid");
+
+    const rows = await prisma.agentTemplate.findMany({
+      where: { slug: "create-fork-test-c" },
+    });
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/agent-templates.create.fork.test.ts
+++ b/tests/agent-templates.create.fork.test.ts
@@ -126,7 +126,7 @@ describe("Agent template create — forkedFromId", () => {
     expect((body.error as string).toLowerCase()).toContain("forkedfromid");
 
     const rows = await prisma.agentTemplate.findMany({
-      where: { slug: "create-fork-test-c" },
+      where: { ownerAccountId: ADMIN_ACCOUNT_ID, slug: "create-fork-test-c" },
     });
     expect(rows).toHaveLength(0);
   });

--- a/tests/agent-templates.create.test.ts
+++ b/tests/agent-templates.create.test.ts
@@ -146,6 +146,9 @@ describe("Agent template create endpoint", () => {
   });
 
   test("ignores server-pinned fields from the body and persists pinned values", async () => {
+    // forkedFromId is no longer server-pinned — it's a caller-settable provenance
+    // field validated against the AgentTemplate table (see the dedicated
+    // agent-templates.create.fork.test.ts), so it's not exercised here.
     const { body, response } = await createTemplate({
       agentName: "Create Test Sneaky",
       prompt: "You are still a draft",
@@ -154,7 +157,6 @@ describe("Agent template create endpoint", () => {
       status: "published",
       version: 99,
       firstPublishedAt: "2020-01-01T00:00:00.000Z",
-      forkedFromId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
     });
 
     expect(response.status).toBe(201);


### PR DESCRIPTION
Companion to xmtplabs/convos-assistants#1695. **Stacked on #227** (base = `create-owner-assertion`); review/merge #227 first. Kept separate from #227 so the ownerAccountId and forkedFromId changes land independently.

## What

`POST /api/v2/agent-templates` now accepts a body `forkedFromId` and persists it on the new row (was hardcoded `null`). When provided it must reference an existing template — pre-checked with a fast 400, and the `forkedFromId → AgentTemplate.id` FK (+ `P2003 → 400` mapping) as the canonical safety net for the delete-between-check-and-insert race.

The fork relation (`forkedFrom`/`forks`, `ON DELETE SET NULL`) and the reserved `fork` slug already existed in the schema — this adds the first **write** path.

## Why

The runtime assistant-builder model (convos-assistants #1695): `build --import` adopts a catalog template **verbatim** (runs it as-is, not a copy). When the group then **publishes** an adopted template, the runtime forks it into a user-owned copy and sets `forkedFromId` to the source so the catalog records lineage and the source row is never mutated. The runtime already sends `forkedFromId` on create (forward-compatible — passthrough ignored it until now).

## Scope

Only the `create` handler + body schema. No read/visibility, publish, patch, or delete changes.

## Tests

`tests/agent-templates.create.fork.test.ts` — records `forkedFromId` when it references an existing template; defaults to null when omitted; rejects a nonexistent `forkedFromId` with 400 (no row created).

> Written but not executed in my environment (needs the live Postgres test DB). `tsc` + prettier clean on the changed files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forkedFromId` field to agent template creation endpoint
> - The `POST /api/v2/agent-templates` body now accepts an optional `forkedFromId` UUID, which is persisted on the created `AgentTemplate` row (previously always `null`).
> - A pre-insert existence check rejects unknown `forkedFromId` values with HTTP 400 before an ID is allocated; FK violations on `ownerAccountId` or `forkedFromId` are also mapped to HTTP 400.
> - New test suite in [tests/agent-templates.create.fork.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/228/files#diff-425c522b7eebae593d7ac08f54e059c676c4755789143fe800a6645ad21a5d41) covers valid fork, omitted field, and non-existent ID cases.
> - Behavioral Change: `forkedFromId` is no longer treated as a server-pinned field; client-supplied values are now accepted and validated rather than stripped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c13d1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent templates can be created as forks of existing templates; provenance can be set on create and defaults to null when omitted.

* **Bug Fixes**
  * Improved validation and stable 400 error behavior when a referenced source template is missing.

* **Tests**
  * Added and updated tests covering fork creation, defaulting behavior, validation, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->