### PR TITLE
fix(lint): type free-tier credits test responses to unblock CI

### DIFF
--- a/src/api/v2/notifications/handlers/webhook.ts
+++ b/src/api/v2/notifications/handlers/webhook.ts
@@ -454,7 +454,6 @@ export async function handleV2Notification(args: {
 
         // Then attempt notification server cleanup
         try {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           await notificationClient.deleteInstallation({
             installationId: client.id,
           });

--- a/tests/subscriptions/account-credits.test.ts
+++ b/tests/subscriptions/account-credits.test.ts
@@ -313,11 +313,12 @@ describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
       .get("/v2/accounts/me/credits")
       .set("X-Convos-AuthToken", token);
     expect(res.status).toBe(200);
-    expect(res.body.balance).toBe(0);
-    expect(res.body.monthlyGrant).toBe(100);
-    expect(res.body.monthlyGrantUsed).toBe(100);
-    expect(res.body.periodLabel).toBe("Daily");
-    expect(typeof res.body.nextRefreshAt).toBe("string");
+    const body = res.body as BalanceBody;
+    expect(body.balance).toBe(0);
+    expect(body.monthlyGrant).toBe(100);
+    expect(body.monthlyGrantUsed).toBe(100);
+    expect(body.periodLabel).toBe("Daily");
+    expect(typeof body.nextRefreshAt).toBe("string");
   });
 
   test("partial balance (60) → balance:60, monthlyGrantUsed:40", async () => {
@@ -327,9 +328,10 @@ describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
     const res = await request(makeApp())
       .get("/v2/accounts/me/credits")
       .set("X-Convos-AuthToken", token);
-    expect(res.body.balance).toBe(60);
-    expect(res.body.monthlyGrant).toBe(100);
-    expect(res.body.monthlyGrantUsed).toBe(40);
+    const body = res.body as BalanceBody;
+    expect(body.balance).toBe(60);
+    expect(body.monthlyGrant).toBe(100);
+    expect(body.monthlyGrantUsed).toBe(40);
   });
 
   test("balance above cap (150) → balance:150, monthlyGrantUsed:0", async () => {
@@ -339,9 +341,10 @@ describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
     const res = await request(makeApp())
       .get("/v2/accounts/me/credits")
       .set("X-Convos-AuthToken", token);
-    expect(res.body.balance).toBe(150);
-    expect(res.body.monthlyGrant).toBe(100);
-    expect(res.body.monthlyGrantUsed).toBe(0);
+    const body = res.body as BalanceBody;
+    expect(body.balance).toBe(150);
+    expect(body.monthlyGrant).toBe(100);
+    expect(body.monthlyGrantUsed).toBe(0);
   });
 
   test("negative balance → balance:0 (clamped), monthlyGrantUsed:cap", async () => {
@@ -351,9 +354,10 @@ describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
     const res = await request(makeApp())
       .get("/v2/accounts/me/credits")
       .set("X-Convos-AuthToken", token);
-    expect(res.body.balance).toBe(0);
-    expect(res.body.monthlyGrant).toBe(100);
-    expect(res.body.monthlyGrantUsed).toBe(100);
+    const body = res.body as BalanceBody;
+    expect(body.balance).toBe(0);
+    expect(body.monthlyGrant).toBe(100);
+    expect(body.monthlyGrantUsed).toBe(100);
   });
 
   test("expired subscription → takes free-tier branch (NOT stale tierGrant)", async () => {
@@ -379,7 +383,8 @@ describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
       .get("/v2/accounts/me/credits")
       .set("X-Convos-AuthToken", token);
     expect(res.status).toBe(200);
-    expect(res.body.periodLabel).toBe("Daily");
-    expect(res.body.monthlyGrant).toBe(100);
+    const body = res.body as BalanceBody;
+    expect(body.periodLabel).toBe("Daily");
+    expect(body.monthlyGrant).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary

The free-tier credits tests added in #219 read fields directly off `res.body` (typed `any` by supertest), tripping `@typescript-eslint/no-unsafe-member-access` under the repo's type-aware lint. That's **16 errors** in `tests/subscriptions/account-credits.test.ts` plus a now-unused `no-unsafe-call` disable in the notifications webhook handler.

These fail `bun check` (the "Validate code quality" gate) on **every** PR whose merge build includes the current `otr-dev` — and because lint runs before `bun test` in the workflow, the test job never executes. So the whole queue is effectively blocked.

## Fix

- Apply the file's existing `res.body as BalanceBody` cast (already used by the subscription tests above) to all five free-tier cases.
- Drop the unused `// eslint-disable-next-line @typescript-eslint/no-unsafe-call` in `webhook.ts` (the call is properly typed now).

No runtime behavior change — the casts are erased at compile time.

## Verification

`bun check` (tsc + prettier + eslint) passes locally with exit 0 after generating protobuf types.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781892904&installation_id=128169237&pr_number=230&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F230&signature=5c7bfea6116ae5ff0d383fa0f5834a1fc452677559360dbb7fdb3669aba7caaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix type assertions in free-tier credits tests to unblock CI
> Adds explicit `BalanceBody` type assertions to `res.body` in [account-credits.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/230/files#diff-2f736181e686dfa2528043ed50d2f76a37133501fdc4efa08fc040e35c2b2f6c) to satisfy the TypeScript linter. Also removes a stale ESLint suppression comment in [webhook.ts](https://github.com/ephemeraHQ/convos-backend/pull/230/files#diff-2c3cc6a8c68731e072d96d296d1318af672d2c799e8c7ff791fd047ffea30e87). No test logic or runtime behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6aadae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->