### PR TITLE
fix(generations): replace dead haiku model with Gemini 3.1 Flash-Lite + consolidate moderation model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ BUILDER_MODEL=
 BUILDER_EXA_SERVICE_KEY=
 POSTHOG_PROJECT_TOKEN=
 POSTHOG_HOST=
-# Content moderation model override (default: anthropic/claude-3-5-haiku-20241022)
+# Content moderation model override (default: google/gemini-3.1-flash-lite)
 CONTENT_MODERATION_MODEL=
 
 # Generation pipeline knobs (all optional — sensible defaults applied)

--- a/src/api/v2/agent-templates/services/compose-reply.ts
+++ b/src/api/v2/agent-templates/services/compose-reply.ts
@@ -2,7 +2,8 @@
  * Twitter Reply Composition Service — composes tweet replies for
  * agent templates built from Twitter @mention requests.
  *
- * Uses Claude Haiku via OpenRouter (same BUILDER_OPENROUTER_API_KEY as templateGen).
+ * Uses a fast model via OpenRouter — default Gemini Flash-Lite (same
+ * BUILDER_OPENROUTER_API_KEY as templateGen).
  * Composes a tweet reply that:
  *   - Starts with @{handle}
  *   - Contains the template URL
@@ -17,7 +18,7 @@
  *
  * Env vars:
  *   BUILDER_OPENROUTER_API_KEY — required for LLM calls
- *   TWITTER_REPLY_MODEL        — model override (default: anthropic/claude-3-5-haiku-20241022)
+ *   TWITTER_REPLY_MODEL        — model override (default: google/gemini-3.1-flash-lite)
  *   BUILDER_SITE_URL           — base URL for builder (default: https://dev.convos.org)
  *
  * Test seam: __resetComposeReplyForTests(override | null).

--- a/src/api/v2/agent-templates/services/moderation.ts
+++ b/src/api/v2/agent-templates/services/moderation.ts
@@ -25,11 +25,7 @@
  *     checkContent passes, only when twitterContext is present.
  */
 
-import {
-  BUILDER_OPENROUTER_API_KEY,
-  CONTENT_MODERATION_MODEL,
-  TWITTER_MODERATION_MODEL,
-} from "@/config";
+import { BUILDER_OPENROUTER_API_KEY, CONTENT_MODERATION_MODEL } from "@/config";
 import logger from "@/utils/logger";
 import {
   openRouterChatCompletion,
@@ -81,13 +77,11 @@ export function __setBuilderApiKeyOverrideForTests(
   _apiKeyOverride = key;
 }
 
-/** Override `CONTENT_MODERATION_MODEL` for tests. Pass `null` to clear. */
+/** Override `CONTENT_MODERATION_MODEL` for tests. Pass `null` to clear.
+ *  Applies to both the content-safety and twitter-intent checks (they share
+ *  the same model). */
 export function __setContentModelOverrideForTests(model: string | null): void {
   _contentModelOverride = model;
-}
-
-function getTwitterIntentModel(): string {
-  return TWITTER_MODERATION_MODEL;
 }
 
 // ---------------------------------------------------------------------------
@@ -254,7 +248,8 @@ async function _checkTwitterIntent(
     input,
     promptBuilder: buildTwitterIntentPrompt,
     labelMapper: mapTwitterIntentLabel,
-    model: getTwitterIntentModel(),
+    // Shares CONTENT_MODERATION_MODEL — same cheap-classifier knob.
+    model: getContentModel(),
     logTag: "[moderation:twitter-intent]",
     stage: "twitter-intent",
     trace,

--- a/src/api/v2/agent-templates/services/moderation.ts
+++ b/src/api/v2/agent-templates/services/moderation.ts
@@ -2,7 +2,8 @@
  * Moderation Service — universal content safety check for agent-template
  * generation requests.
  *
- * Uses Claude Haiku via OpenRouter (same BUILDER_OPENROUTER_API_KEY as templateGen).
+ * Uses a fast model via OpenRouter — default Gemini Flash-Lite (same
+ * BUILDER_OPENROUTER_API_KEY as templateGen).
  * Classifies arbitrary input text into safe vs unsafe content.
  *
  * **Fails open**: on any OpenRouter error (network, non-2xx, parse failure),
@@ -11,7 +12,7 @@
  *
  * Env vars:
  *   BUILDER_OPENROUTER_API_KEY — required for LLM calls (unset → fails open)
- *   CONTENT_MODERATION_MODEL   — model override (default: anthropic/claude-3-5-haiku-20241022)
+ *   CONTENT_MODERATION_MODEL   — model override (default: google/gemini-3.1-flash-lite)
  *
  * Test seam: __resetModerationForTests(override | null) mirrors the
  * singleton-override pattern used by templateGen and PostHog.

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,7 +129,7 @@ export const BUILDER_OPENROUTER_API_KEY =
 export const BUILDER_MODEL = process.env.BUILDER_MODEL?.trim() || "";
 export const CONTENT_MODERATION_MODEL =
   process.env.CONTENT_MODERATION_MODEL?.trim() ||
-  "anthropic/claude-3-5-haiku-20241022";
+  "google/gemini-3.1-flash-lite";
 export const BUILDER_EXA_SERVICE_KEY =
   process.env.BUILDER_EXA_SERVICE_KEY?.trim() || "";
 
@@ -139,10 +139,9 @@ export const BUILDER_EXA_SERVICE_KEY =
 // model if desired).
 export const TWITTER_MODERATION_MODEL =
   process.env.TWITTER_MODERATION_MODEL?.trim() ||
-  "anthropic/claude-3-5-haiku-20241022";
+  "google/gemini-3.1-flash-lite";
 export const TWITTER_REPLY_MODEL =
-  process.env.TWITTER_REPLY_MODEL?.trim() ||
-  "anthropic/claude-3-5-haiku-20241022";
+  process.env.TWITTER_REPLY_MODEL?.trim() || "google/gemini-3.1-flash-lite";
 // Required — public template URLs (`<origin>/a/<slug>`) are user-facing, so a
 // missing value must fail the deploy rather than silently misroute to a wrong
 // origin. Tests seed it via tests/preload.ts.

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,13 +133,9 @@ export const CONTENT_MODERATION_MODEL =
 export const BUILDER_EXA_SERVICE_KEY =
   process.env.BUILDER_EXA_SERVICE_KEY?.trim() || "";
 
-// Twitter integration (optional — moderation/reply paths only fire when
-// twitterContext is present on a generation; defaults match the content
-// moderation model so a single env var change can pin everything to one
-// model if desired).
-export const TWITTER_MODERATION_MODEL =
-  process.env.TWITTER_MODERATION_MODEL?.trim() ||
-  "google/gemini-3.1-flash-lite";
+// Twitter reply composition (optional — only fires when twitterContext is
+// present on a generation). The twitter intent check reuses
+// CONTENT_MODERATION_MODEL (both are the same cheap-classifier knob).
 export const TWITTER_REPLY_MODEL =
   process.env.TWITTER_REPLY_MODEL?.trim() || "google/gemini-3.1-flash-lite";
 // Required — public template URLs (`<origin>/a/<slug>`) are user-facing, so a


### PR DESCRIPTION
## Problem

The builder's moderation and twitter paths called OpenRouter with `anthropic/claude-3-5-haiku-20241022`, which OpenRouter **no longer serves**:

```
No endpoints found for anthropic/claude-3-5-haiku-20241022
```

It was the default for three config values: `CONTENT_MODERATION_MODEL` (runs on **every** generation), `TWITTER_MODERATION_MODEL`, and `TWITTER_REPLY_MODEL`. Moderation fails open, so submissions didn't hard-break — but the content-safety check was **effectively not running** (every call errored), and the calls showed as failed `$ai_generation`s in PostHog.

## Fix

- Switch the defaults to `google/gemini-3.1-flash-lite` — a concrete, currently-served OpenRouter model id (verified against `GET /api/v1/models`). Concrete id (not an `@preset/...` alias) so PostHog prices `$ai_total_cost_usd`. Updated docstrings + `.env.example`.
- **Consolidate the moderation model knob.** `TWITTER_MODERATION_MODEL` was redundant — it always defaulted to the same model as `CONTENT_MODERATION_MODEL`, was never documented in `.env.example`, and had no test-override seam. Removed it; the twitter-intent check now reuses `CONTENT_MODERATION_MODEL`. One knob for both moderation classifiers (content-safety + intent); the content-model test override now applies to both. `TWITTER_REPLY_MODEL` is a separate task (reply composition) and is unchanged aside from the model swap.

## Notes

- Independent of #229 (which only changed the *generation* model to `anthropic/claude-opus-4.7`); these defaults were already on the dead haiku id. Branched off latest `otr-dev`.
- The live haiku slug is now `anthropic/claude-3.5-haiku` (the dated form lost its endpoints); switched to Gemini per request.
- **Severity:** because moderation fails open, content safety has effectively been off for as long as that model has been dead — this restores it, so it's more than cosmetic.

## Testing

- `bun typecheck` clean (only the 2 pre-existing `@/gen/*` protobuf errors).
- `eslint` clean on touched files.
- Moderation suite 9/9 pass (asserts behavior, not model strings; no test referenced the removed var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace default model from Claude Haiku to `google/gemini-3.1-flash-lite` for reply and moderation
> - Changes the default for `CONTENT_MODERATION_MODEL` and `TWITTER_REPLY_MODEL` in [config.ts](https://github.com/ephemeraHQ/convos-backend/pull/232/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012) from `anthropic/claude-3-5-haiku-20241022` to `google/gemini-3.1-flash-lite`.
> - Removes the separate `TWITTER_MODERATION_MODEL` constant and config export; Twitter intent classification now reuses `CONTENT_MODERATION_MODEL` via `getContentModel()`.
> - Updates [.env.example](https://github.com/ephemeraHQ/convos-backend/pull/232/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c) and inline comments to reflect the new defaults.
> - Behavioral Change: Twitter intent checks and content moderation now share a single model, so changing `CONTENT_MODERATION_MODEL` affects both.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e45439a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->