### PR TITLE
perf(generations): prefer Amazon Bedrock provider for OpenRouter calls

### DIFF
--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -42,8 +42,13 @@ const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 // doesn't serve — e.g. Google Gemini, used by moderation/reply — transparently
 // route elsewhere. `order` is a *preference*, not a hard pin; an unavailable or
 // throttled Bedrock falls back automatically, so this is self-healing. Confirm
-// the actual latency win via PostHog p50 `$ai_latency` after deploy.
-const PROVIDER_ROUTING = { order: ["amazon-bedrock"] };
+// the actual latency win via PostHog p50 `$ai_latency` after deploy (segment by
+// the `upstream_provider` recorded on `builder.generation.llm_call`).
+const DEFAULT_PROVIDER_PREFERENCE = { order: ["amazon-bedrock"] };
+
+/** PostHog event recording the upstream provider that served one LLM call.
+ *  One per call, alongside the wrapper's `$ai_generation`. */
+export const LLM_CALL_EVENT = "builder.generation.llm_call";
 
 /**
  * Per-generation trace context threaded from the executor down to each LLM
@@ -167,12 +172,58 @@ export async function openRouterChatCompletion(
   if (typeof opts.timeoutMs === "number")
     requestOptions.timeout = opts.timeoutMs;
 
-  return client.chat.completions.create(
+  const startedMs = performance.now();
+  const response = await client.chat.completions.create(
     // `provider` is an OpenRouter extension (passed through by the OpenAI SDK).
     // Default first so a caller-supplied `body.provider` can still override.
-    { provider: PROVIDER_ROUTING, ...opts.body, ...monitoring } as any,
+    {
+      provider: DEFAULT_PROVIDER_PREFERENCE,
+      ...opts.body,
+      ...monitoring,
+    } as any,
     requestOptions,
   );
+
+  // Record which upstream OpenRouter actually served the call. The @posthog/ai
+  // wrapper hardcodes `$ai_provider: "openai"` (the SDK), so without this we
+  // can't tell from telemetry whether the Bedrock preference took effect or
+  // fell back — and can't segment latency by provider. Fire-and-forget; only on
+  // success (errors propagate and are captured by the wrapper's own event).
+  captureProviderTelemetry(opts, response, performance.now() - startedMs);
+  return response;
+}
+
+/** Custom event recording the resolved upstream provider + served model for one
+ *  OpenRouter call, so latency can be segmented by `upstream_provider` in
+ *  PostHog. No-op when PostHog/trace is absent; never throws. */
+function captureProviderTelemetry(
+  opts: OpenRouterChatOptions,
+  response: OpenAI.Chat.Completions.ChatCompletion,
+  latencyMs: number,
+): void {
+  if (!opts.trace) return;
+  const ph = getPostHogClient();
+  if (!ph) return;
+  try {
+    const r = response as unknown as { model?: string; provider?: string };
+    ph.capture({
+      distinctId: opts.trace.distinctId ?? `request:${opts.trace.traceId}`,
+      event: LLM_CALL_EVENT,
+      properties: {
+        ...opts.trace.properties,
+        $ai_trace_id: opts.trace.traceId,
+        ai_stage: opts.stage,
+        requested_model: opts.body.model,
+        served_model: r.model,
+        // OpenRouter's resolved upstream (e.g. "Amazon Bedrock"); undefined on
+        // providers/responses that don't report it.
+        upstream_provider: r.provider,
+        latency_ms: latencyMs,
+      },
+    });
+  } catch {
+    /* analytics never breaks the request */
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -37,6 +37,14 @@ import { getPostHogClient } from "@/api/v2/agent-templates/services/posthog";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
+// OpenRouter provider routing: prefer Amazon Bedrock (lower-latency Anthropic
+// serving) but keep fallbacks on (the OpenRouter default) so models Bedrock
+// doesn't serve — e.g. Google Gemini, used by moderation/reply — transparently
+// route elsewhere. `order` is a *preference*, not a hard pin; an unavailable or
+// throttled Bedrock falls back automatically, so this is self-healing. Confirm
+// the actual latency win via PostHog p50 `$ai_latency` after deploy.
+const PROVIDER_ROUTING = { order: ["amazon-bedrock"] };
+
 /**
  * Per-generation trace context threaded from the executor down to each LLM
  * call. `traceId` groups the calls under one PostHog LLM Analytics trace;
@@ -160,7 +168,9 @@ export async function openRouterChatCompletion(
     requestOptions.timeout = opts.timeoutMs;
 
   return client.chat.completions.create(
-    { ...opts.body, ...monitoring } as any,
+    // `provider` is an OpenRouter extension (passed through by the OpenAI SDK).
+    // Default first so a caller-supplied `body.provider` can still override.
+    { provider: PROVIDER_ROUTING, ...opts.body, ...monitoring } as any,
     requestOptions,
   );
 }

--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -158,6 +158,12 @@ export async function openRouterChatCompletion(
       ? {
           posthogTraceId: opts.trace.traceId,
           posthogDistinctId: opts.trace.distinctId,
+          // Correct the native `$ai_provider` field. The wrapper defaults it to
+          // "openai" (the SDK), but we call OpenRouter — so the gateway is
+          // OpenRouter. The *resolved upstream* it routed to (Bedrock /
+          // Anthropic / Google) is only known post-response and has no native
+          // field; that's captured separately on `builder.generation.llm_call`.
+          posthogProviderOverride: "openrouter",
           posthogProperties: {
             ...opts.trace.properties,
             ai_stage: opts.stage,
@@ -184,11 +190,13 @@ export async function openRouterChatCompletion(
     requestOptions,
   );
 
-  // Record which upstream OpenRouter actually served the call. The @posthog/ai
-  // wrapper hardcodes `$ai_provider: "openai"` (the SDK), so without this we
-  // can't tell from telemetry whether the Bedrock preference took effect or
-  // fell back — and can't segment latency by provider. Fire-and-forget; only on
-  // success (errors propagate and are captured by the wrapper's own event).
+  // Record which upstream OpenRouter actually routed to. `$ai_provider` is the
+  // native API-provider field (now "openrouter" — the gateway), but it can't
+  // hold the resolved upstream: that's only on the response, after the wrapper
+  // has captured `$ai_generation`. So we emit it ourselves to tell whether the
+  // Bedrock preference took effect or fell back, and to segment latency by
+  // upstream. Fire-and-forget; only on success (errors are captured by the
+  // wrapper's own event).
   captureProviderTelemetry(opts, response, performance.now() - startedMs);
   return response;
 }

--- a/tests/template-gen.posthog-trace.test.ts
+++ b/tests/template-gen.posthog-trace.test.ts
@@ -103,6 +103,9 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
     const props = gens[0].properties ?? {};
     expect(gens[0].distinctId).toBe("acct-42");
     expect(props.$ai_trace_id).toBe("gen-abc");
+    // Native provider field corrected from the SDK default ("openai") to the
+    // actual gateway we call.
+    expect(props.$ai_provider).toBe("openrouter");
     expect(props.$ai_input_tokens).toBe(11);
     expect(props.$ai_output_tokens).toBe(7);
     // Our per-call segmentation properties ride along.

--- a/tests/template-gen.posthog-trace.test.ts
+++ b/tests/template-gen.posthog-trace.test.ts
@@ -113,6 +113,8 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
     );
     expect(leaked).toEqual([]);
     expect(lastSentBody.model).toBe("anthropic/claude-opus-4.7");
+    // Provider routing prefers Bedrock (fallbacks left on by default).
+    expect(lastSentBody.provider).toEqual({ order: ["amazon-bedrock"] });
   });
 
   test("no posthog client → no events, clean body, call still works", async () => {
@@ -138,6 +140,8 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
       k.startsWith("posthog"),
     );
     expect(leaked).toEqual([]);
+    // Provider routing applies on the plain-client path too.
+    expect(lastSentBody.provider).toEqual({ order: ["amazon-bedrock"] });
   });
 
   test("same trace id groups multiple stages under one trace", async () => {

--- a/tests/template-gen.posthog-trace.test.ts
+++ b/tests/template-gen.posthog-trace.test.ts
@@ -16,6 +16,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   __resetOpenRouterClientForTests,
+  LLM_CALL_EVENT,
   openRouterChatCompletion,
   withAiSpan,
 } from "@/api/v2/agent-templates/services/openrouter-client";
@@ -40,6 +41,8 @@ function installFetch() {
         object: "chat.completion",
         created: 0,
         model: "anthropic/claude-sonnet-4.5",
+        // OpenRouter extension: the upstream that actually served the call.
+        provider: "Amazon Bedrock",
         choices: [
           {
             index: 0,
@@ -115,6 +118,40 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
     expect(lastSentBody.model).toBe("anthropic/claude-opus-4.7");
     // Provider routing prefers Bedrock (fallbacks left on by default).
     expect(lastSentBody.provider).toEqual({ order: ["amazon-bedrock"] });
+  });
+
+  test("records resolved upstream provider on builder.generation.llm_call", async () => {
+    const captured: CapturedEvent[] = [];
+    __setPostHogClientForTests({
+      capture: (e: CapturedEvent) => captured.push(e),
+      on: () => {},
+    });
+    __resetOpenRouterClientForTests();
+
+    await openRouterChatCompletion({
+      apiKey: "test-or-key",
+      stage: "generate",
+      body: {
+        model: "anthropic/claude-opus-4.7",
+        messages: [{ role: "user", content: "go" }],
+      },
+      trace: {
+        traceId: "gen-bedrock",
+        distinctId: "acct-1",
+        properties: { generation_id: "gen-bedrock" },
+      },
+    });
+
+    const calls = captured.filter((c) => c.event === LLM_CALL_EVENT);
+    expect(calls.length).toBe(1);
+    const p = calls[0].properties ?? {};
+    expect(calls[0].distinctId).toBe("acct-1");
+    expect(p.upstream_provider).toBe("Amazon Bedrock"); // from OpenRouter response
+    expect(p.ai_stage).toBe("generate");
+    expect(p.requested_model).toBe("anthropic/claude-opus-4.7");
+    expect(p.served_model).toBe("anthropic/claude-sonnet-4.5"); // mock response.model
+    expect(p.$ai_trace_id).toBe("gen-bedrock");
+    expect(typeof p.latency_ms).toBe("number");
   });
 
   test("no posthog client → no events, clean body, call still works", async () => {


### PR DESCRIPTION
## Why

Builder generations are slow — the `generate` stage (Opus 4.7) dominates wall-clock (~50s in observed `$ai_generation` traces). OpenRouter lets us steer which upstream provider serves a model; preferring **Amazon Bedrock** for Anthropic serving is a low-risk lever to cut that latency.

## Change

- `openRouterChatCompletion` sends `provider: { order: ["amazon-bedrock"] }` (constant `DEFAULT_PROVIDER_PREFERENCE`) on every OpenRouter call.
  - **Fallbacks stay on** (OpenRouter default), so it's a *preference*, not a hard pin:
    - `generate` (Opus 4.7) → prefers Bedrock (verified it serves `anthropic/claude-opus-4.7`, us + eu-west-1).
    - moderation / twitter-intent / compose-reply (`google/gemini-3.1-flash-lite`) → Bedrock can't serve Gemini, so they transparently route elsewhere.
    - A throttled/unavailable Bedrock self-heals via fallback.
  - **Default-first spread** lets a caller-supplied `body.provider` override.
- **Closes the observability gap** (raised in review): the `@posthog/ai` wrapper hardcodes `$ai_provider: "openai"` and never reads OpenRouter's resolved provider, so telemetry couldn't show whether Bedrock actually served a call or fell back. Every successful call now also emits **`builder.generation.llm_call`** with the resolved **`upstream_provider`**, plus `served_model`, `requested_model`, `ai_stage`, `latency_ms`, and `$ai_trace_id`. So **"p50 latency by provider" is a one-query answer** — the win is now measurable, not just hoped for.

## How to confirm the win

OpenRouter's published throughput stats for Opus 4.7 are empty (too new), so I couldn't confirm the speedup from their API — only that Bedrock is available. After deploy, segment `builder.generation.llm_call.latency_ms` (or `$ai_latency`) by `upstream_provider` where `ai_stage = 'generate'`. If Bedrock isn't faster, revert is a one-line change.

## Testing

- `bun typecheck` clean (only the 2 pre-existing `@/gen/*` protobuf errors); `eslint` clean.
- Tests: provider routing reaches the request body (wrapped + plain paths); `upstream_provider` is captured from the OpenRouter response onto `builder.generation.llm_call`. Zero new failures vs. baseline.

Builds on #229 (OpenRouter client) and #232 (Gemini moderation/reply), both merged to `otr-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer Amazon Bedrock via OpenRouter and emit per-call provider telemetry
> - Adds a default `provider: { order: ["amazon-bedrock"] }` hint to every OpenRouter request body in `openRouterChatCompletion`, routing calls through Amazon Bedrock unless the caller overrides it.
> - Introduces a `captureProviderTelemetry` helper that fires a `builder.generation.llm_call` PostHog event on each successful completion, recording `upstream_provider`, `requested_model`, `served_model`, `$ai_trace_id`, `ai_stage`, and `latency_ms`.
> - Sets `$ai_provider` to `"openrouter"` on PostHog `$ai_generation` events instead of the SDK default.
> - Behavioral Change: all OpenRouter calls now route to Amazon Bedrock by default; callers must explicitly pass `body.provider` to override this routing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6be979b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->