### PR TITLE
perf(generations): prompt-cache the static system prompt

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -1145,7 +1145,24 @@ export async function generateTemplate(
   const reqBody: any = {
     model,
     messages: [
-      { role: "system", content: SYSTEM_PROMPT },
+      // Prompt-caching breakpoint on the static ~12k-token system prompt. It's
+      // byte-identical across every generation, so caching its prefix cuts
+      // input cost ~90% on cache hits and trims prefill latency. Uses a
+      // PER-BLOCK `cache_control` breakpoint (not top-level) so the Bedrock
+      // provider preference still applies — top-level cache_control forces
+      // Anthropic-only routing on OpenRouter. The varying user message after
+      // the breakpoint is re-processed each call. Cache usage is observable via
+      // `$ai_cache_read_input_tokens` / `$ai_cache_creation_input_tokens`.
+      {
+        role: "system",
+        content: [
+          {
+            type: "text",
+            text: SYSTEM_PROMPT,
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+      },
       { role: "user", content: userContent },
     ],
     temperature: 0.7,

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -1153,13 +1153,19 @@ export async function generateTemplate(
       // Anthropic-only routing on OpenRouter. The varying user message after
       // the breakpoint is re-processed each call. Cache usage is observable via
       // `$ai_cache_read_input_tokens` / `$ai_cache_creation_input_tokens`.
+      //
+      // 1-hour TTL (vs the 5-min default): builder traffic is bursty, so the
+      // default would expire between generations and re-write (no read benefit).
+      // The only cost of 1h is a higher write multiplier on misses (2x input vs
+      // 1.25x); reads are 0.1x either way. Net cheaper + faster whenever two
+      // generations land within an hour. Supported per-block on Bedrock.
       {
         role: "system",
         content: [
           {
             type: "text",
             text: SYSTEM_PROMPT,
-            cache_control: { type: "ephemeral" },
+            cache_control: { type: "ephemeral", ttl: "1h" },
           },
         ],
       },

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -993,7 +993,7 @@ describe("templateGen service — OpenRouter integration", () => {
     const systemPart = req.body.messages[0].content[0];
     expect(systemPart.type).toBe("text");
     expect(systemPart.text).toBe(SYSTEM_PROMPT);
-    expect(systemPart.cache_control).toEqual({ type: "ephemeral" });
+    expect(systemPart.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   // -----------------------------------------------------------------------

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -953,9 +953,10 @@ describe("templateGen service — OpenRouter integration", () => {
   });
 
   // -----------------------------------------------------------------------
-  // SYSTEM_PROMPT is forwarded verbatim as the system message
+  // SYSTEM_PROMPT is forwarded verbatim as the system message, with a
+  // per-block prompt-caching breakpoint.
   // -----------------------------------------------------------------------
-  test("system prompt forwarded verbatim to OpenRouter", async () => {
+  test("system prompt forwarded verbatim with cache breakpoint", async () => {
     const mod = await import("@/api/v2/agent-templates/services/templateGen");
     generateTemplate = mod.generateTemplate;
 
@@ -986,7 +987,13 @@ describe("templateGen service — OpenRouter integration", () => {
 
     const req = getLastOpenRouterRequest();
     expect(req.body.messages[0].role).toBe("system");
-    expect(req.body.messages[0].content).toBe(SYSTEM_PROMPT);
+    // System content is now a content-part array carrying the verbatim prompt
+    // plus a per-block ephemeral cache breakpoint (works on Bedrock; preserves
+    // provider routing, unlike top-level cache_control).
+    const systemPart = req.body.messages[0].content[0];
+    expect(systemPart.type).toBe("text");
+    expect(systemPart.text).toBe(SYSTEM_PROMPT);
+    expect(systemPart.cache_control).toEqual({ type: "ephemeral" });
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Why

The `generate` call sends a static **~12k-token system prompt** (`data/template-generator-prompt.txt`) that is byte-identical on every generation — yet it's re-billed and re-prefilled each time. Observed `$ai_generation` events show **no cache reads**, and input is the larger half of per-call cost (~$0.087 of ~$0.156 in one trace).

## Change

Add an Anthropic prompt-caching breakpoint on the system message, with a **1-hour TTL**:

```ts
{
  role: "system",
  content: [
    { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral", ttl: "1h" } },
  ],
}
```

**Per-block, not top-level — the load-bearing detail.** On OpenRouter, top-level `cache_control` forces Anthropic-only routing and would silently undo the Bedrock provider preference from #233. Per-block breakpoints cache across Anthropic / Bedrock / Vertex, so Bedrock routing is preserved. The varying user message sits after the breakpoint and is re-processed each call. Only the `generate` call is cached (the other stages have no large static prefix).

## Why 1h instead of the 5-min default

The only difference between TTLs is the **write** multiplier; reads are 0.1× either way:

| TTL | write (miss) | read (hit) |
|---|---|---|
| 5-min | 1.25× input | 0.1× |
| 1-hour | 2.0× input | 0.1× |

Builder traffic is bursty (generations are sporadic), so a 5-min window would usually expire between calls and re-write with no read benefit. 1h converts those misses into reads. Net cost depends on the inter-call gap:
- **Gap < 5 min:** 5-min already stays warm (reads refresh the TTL); 1h overpays the write trivially.
- **Gap 5–60 min:** 1h is much cheaper *and* faster. ← expected case.
- **Gap > 60 min:** both miss; 1h overpays writes (caching is a wash vs none here regardless).

The only cost of 1h is ~0.75× extra on the cached tokens per *miss* (~$0.045 in our numbers) — bounded, and outweighed whenever two generations land within the hour.

## How to verify (telemetry already in place)

The `@posthog/ai` wrapper captures `$ai_cache_read_input_tokens` / `$ai_cache_creation_input_tokens`. After deploy, check the read/write ratio on `$ai_generation where ai_stage = 'generate'`. If reads stay zero, cross-check `builder.generation.llm_call.upstream_provider` (#233) to tell a traffic problem from a provider not honoring the breakpoint.

## Testing

- `bun typecheck` clean (only the 2 pre-existing `@/gen/*` protobuf errors); `eslint` clean.
- Updated the "system prompt forwarded verbatim" test to assert the content-part shape + `cache_control: { type: "ephemeral", ttl: "1h" }`. Touched suites green; zero new failures vs. baseline.

Builds on #233 (Bedrock routing + provider telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prompt-cache the static system prompt in `generateTemplate` requests
> Converts the system message in [templateGen.ts](https://github.com/ephemeraHQ/convos-backend/pull/234/files#diff-d151881c4ab5cd2005df4016ac6a564fb6094e4ce06b69fbf9529fb70e59148a) from a plain string to a content-part array with `cache_control: { type: "ephemeral", ttl: "1h" }`. Providers that support per-block cache control (e.g. Anthropic via OpenRouter) can reuse the cached system prompt across requests, reducing latency and token costs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0670451.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->