### PR TITLE
fix(subscriptions): make Apple JWS verification work on bun

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,17 @@ PAYMENTS_RESERVED_MAX_TURN_CREDITS=1
 # allows mild overdraft within a turn; e.g. -1000 ≈ -$1.
 PAYMENTS_MIN_BALANCE_CREDITS=-1000
 
+# Per-tier monthly credit allotment (required — `GET /v2/accounts/me/credits`
+# throws "PAYMENTS_GRANT_<TIER>_MONTHLY is not configured" without them).
+# These are the source of truth for the iOS `monthlyGrant` field. Annual
+# subscriptions are computed as 12× the monthly value at read time, so we
+# only configure the monthly numbers. Both vars must be positive integers.
+# Real launch values pending Saul's pricing pass; the values below are
+# placeholders sized roughly to Builder $9.99 / Pro $29.99 with
+# PAYMENTS_MARKUP_RATE=2.0 and PAYMENTS_CREDITS_PER_USD=1000.
+PAYMENTS_GRANT_BUILDER_MONTHLY=3000
+PAYMENTS_GRANT_PRO_MONTHLY=9000
+
 # --- Apple In-App Purchases ---
 # Routing for both JWS verification (incoming receipts) and the App Store
 # Server API client. Values: "production" | "sandbox" | "local-testing".

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "convos-backend",
@@ -76,6 +75,9 @@
         "zod-prisma-types": "^3.2.4",
       },
     },
+  },
+  "patchedDependencies": {
+    "@apple/app-store-server-library@3.1.0": "patches/@apple%2Fapp-store-server-library@3.1.0.patch",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],

--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "patchedDependencies": {
+    "@apple/app-store-server-library@3.1.0": "patches/@apple%2Fapp-store-server-library@3.1.0.patch"
   }
 }

--- a/patches/@apple%2Fapp-store-server-library@3.1.0.patch
+++ b/patches/@apple%2Fapp-store-server-library@3.1.0.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/jws_verification.js b/dist/jws_verification.js
+index aadaf43fef6c927da909a343192be0cb50d9ea67..f8206c7bef3fcc3fbe8fb9136d6a2d2aba6e579d 100644
+--- a/dist/jws_verification.js
++++ b/dist/jws_verification.js
+@@ -213,10 +213,22 @@ class SignedDataVerifier {
+             }
+             const effectiveDate = this.enableOnlineChecks ? new Date() : signedDateExtractor(decodedJWT);
+             const publicKey = await this.verifyCertificateChain(this.rootCertificates, certificateChain[0], certificateChain[1], effectiveDate);
+-            const encodedKey = publicKey.export({
+-                type: "spki",
+-                format: "pem"
+-            });
++            // bun compat: X509Certificate.publicKey returns a Node KeyObject
++            // (has .export()) on Node, but a Web Crypto CryptoKey on bun.
++            // jsonwebtoken needs an SPKI public-key PEM specifically (cert
++            // PEM works on Node but trips bun's createPublicKey, which then
++            // defaults to RSA algorithm guesses and rejects ES256). So:
++            //   Node path: use the existing .export().
++            //   Bun path:  exportKey('spki', cryptoKey) + manual PEM wrap.
++            let encodedKey;
++            if (typeof publicKey.export === "function") {
++                encodedKey = publicKey.export({ type: "spki", format: "pem" });
++            } else {
++                const spki = await crypto.subtle.exportKey("spki", publicKey);
++                const b64 = Buffer.from(spki).toString("base64");
++                const lines = b64.match(/.{1,64}/g) ?? [b64];
++                encodedKey = "-----BEGIN PUBLIC KEY-----\n" + lines.join("\n") + "\n-----END PUBLIC KEY-----\n";
++            }
+             jsonwebtoken.verify(jwt, encodedKey);
+             return decodedJWT;
+         }

--- a/src/api/v2/accounts/handlers/subscription-verify.ts
+++ b/src/api/v2/accounts/handlers/subscription-verify.ts
@@ -105,6 +105,16 @@ export async function subscriptionVerifyHandler(req: Request, res: Response) {
   let decoded: JWSTransactionDecodedPayload;
   try {
     decoded = await verifyAndDecodeTransaction(parsed.data.jwsRepresentation);
+    req.log.info(
+      {
+        accountId,
+        transactionId: decoded.transactionId,
+        originalTransactionId: decoded.originalTransactionId,
+        productId: decoded.productId,
+        environment: decoded.environment,
+      },
+      "JWS transaction verification succeeded",
+    );
   } catch (err) {
     req.log.warn(
       { err: err instanceof Error ? err.message : err, accountId },


### PR DESCRIPTION
## Summary

Patches `@apple/app-store-server-library` so `/v2/accounts/me/subscription/verify` actually works under bun. Without this every iOS purchase fails with `Invalid signed transaction` even when iOS produces a valid sandbox JWS. Documents the two `PAYMENTS_GRANT_*` env vars that `/me/credits` requires. Adds a success log to the verify path.

## Why the library breaks under bun

Apple's library calls Node-only crypto APIs that bun implements differently:

1. `X509Certificate.publicKey` returns a Node `KeyObject` (with `.export()`) on Node, but a Web Crypto `CryptoKey` (without `.export()`) on bun → `TypeError: .export is not a function`.
2. Falling back to a cert PEM doesn't help either: bun's `jsonwebtoken.createPublicKey(certPem)` doesn't surface `asymmetricKeyType === "ec"`, so jsonwebtoken defaults to `RS256/RS384/RS512` and rejects ES256 with `invalid algorithm`.

Upstream has explicitly declined to support bun ([issue #173](https://github.com/apple/app-store-server-library-node/issues/173) closed without resolution, also [#198](https://github.com/apple/app-store-server-library-node/issues/198)).

## What the patch does

In the library's `verifyJWT`, after `verifyCertificateChain` returns the leaf's public key:

- **Node**: unchanged — use the existing `KeyObject.export({type:"spki", format:"pem"})`.
- **Bun**: detect the missing `.export` and round-trip via Web Crypto — `crypto.subtle.exportKey('spki', cryptoKey)`, base64-encode, wrap as `BEGIN PUBLIC KEY` PEM. `jsonwebtoken` then infers ECDSA correctly and ES256 verifies.

Patched via `bun patch` (native; applies automatically on every `bun install`). No postinstall hook.

## Also in this PR

- **`.env.example`**: document `PAYMENTS_GRANT_BUILDER_MONTHLY` / `PAYMENTS_GRANT_PRO_MONTHLY`. `GET /me/credits` 500s without these and a fresh checkout would hit this on the first authenticated credits request. Placeholders sized roughly to Builder \$9.99 / Pro \$29.99 — real numbers pending Saul.
- **`subscription-verify.ts`**: add an `info` log when JWS verification succeeds. Until now success was silent (only `warn` on failure), so "did this actually verify?" was unanswerable without DB inspection.

## Test plan

- [x] `bun check` clean (typecheck + prettier + eslint)
- [x] Manually validated end-to-end with iOS Sandbox StoreKit + Dev backend: real `app.convos.subs.builder.monthly` purchase → JWS sent → backend returns 200 → `Subscription` row persisted with correct `accountId`, `tier`, `currentPeriodEnd`.
- [x] Patch survives a clean `rm -rf node_modules && bun install`.
- [ ] CI green.

## Follow-ups (not blocking)

- Consider replacing the library's verifier with an in-house ~150 LOC `node:crypto` implementation. Removes the patch surface entirely and isolates us from future Apple lib upgrades breaking on bun.
- `verifyAndDecodeNotification` (the S2S webhook path) shares `verifyJWT` so the patch covers it, but the path hasn't been smoke-tested against a real Apple notification yet — we should before launch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781964432&installation_id=128169237&pr_number=237&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F237&signature=5faaa86084235a4e7414bca0a65922cb39150a78d967e5f4a78e6ab15c4475ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Apple JWS verification in `SignedDataVerifier` to work on Bun
> - Applies a patch to `@apple/app-store-server-library@3.1.0` via [`patches/@apple%2Fapp-store-server-library@3.1.0.patch`](https://github.com/ephemeraHQ/convos-backend/pull/237/files#diff-561c693dbaa9067519e9a91bce7e6d964b7d478551d78e3db21497c3b80e0b6d) to handle both Node `KeyObject` and Web Crypto `CryptoKey` public keys in the `verify` method.
> - On Bun, `publicKey.export()` is not available, so the patch falls back to `crypto.subtle.exportKey('spki', publicKey)` and wraps the result in a PEM block.
> - Adds two new required env vars (`PAYMENTS_GRANT_BUILDER_MONTHLY`, `PAYMENTS_GRANT_PRO_MONTHLY`) for per-tier monthly credit allotments, documented in [`.env.example`](https://github.com/ephemeraHQ/convos-backend/pull/237/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c).
> - Adds an info-level log on successful JWS transaction verification in [`subscription-verify.ts`](https://github.com/ephemeraHQ/convos-backend/pull/237/files#diff-5045dc2ccbf9d7609f86bbb6fd5c608c1a0370b6a0180d50e5d47f62518baa44).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cbf110.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable monthly credit allotments for subscription tiers (Builder and Pro), with automatic scaling for annual subscriptions.

* **Bug Fixes**
  * Improved subscription verification reliability across different runtime environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->