### PR TITLE
docs: plan Bun to Node/pnpm migration

### DIFF
--- a/docs/plans/bun-to-node-pnpm-master-plan.md
+++ b/docs/plans/bun-to-node-pnpm-master-plan.md
@@ -6,7 +6,7 @@
 
 ## Decision
 
-Default target: **Node.js 22 LTS + pnpm 10 via Corepack**.
+Default target: **Node.js 24 LTS + pnpm 10 via Corepack**.
 
 Why pnpm over Yarn here: fast, strict, widely used, boring in CI/Docker, and no Yarn Berry/PnP footguns. Use a committed `pnpm-lock.yaml`; do not use zero-install.
 
@@ -31,7 +31,7 @@ No runtime `src/` Bun API dependency was found in the initial scan; the largest 
 
 | Slice                 | Change                                                                                                         | Gate                                                                                                                                                          |
 | --------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1. Toolchain          | Pin Node 22, add `packageManager: pnpm@...`, add `pnpm-lock.yaml`, install via Corepack.                       | `pnpm install --frozen-lockfile`                                                                                                                              |
+| 1. Toolchain          | Pin Node 24, add `packageManager: pnpm@...`, add `pnpm-lock.yaml`, install via Corepack.                       | `pnpm install --frozen-lockfile`                                                                                                                              |
 | 2. Runtime            | Replace Bun TS execution with Node-compatible tooling: `tsx` for dev/scripts/evals; bundled JS for production. | `pnpm dev`, `pnpm build`, `pnpm start`                                                                                                                        |
 | 3. Tests              | Move `bun:test` to Vitest; port mocks/preload/setup.                                                           | `pnpm test`                                                                                                                                                   |
 | 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/pnpm; remove Bun pins/lock/config.                           | CI green + Docker image boots + `/healthcheck` + POST `/v2/accounts/me/subscription/verify` with a real Sandbox JWS returns 200 + persists `Subscription` row |
@@ -41,7 +41,7 @@ These slices can be stacked or split into small PRs. Do not start slice 4 cleanu
 ## Proposed implementation defaults
 
 - **Package manager:** pnpm 10, Corepack-managed, `pnpm install --frozen-lockfile` in CI.
-- **Node version:** Node 22 LTS, pinned consistently in `.nvmrc`, `.node-version`, Docker, and GitHub Actions.
+- **Node version:** Node 24 LTS, pinned consistently in `.nvmrc`, `.node-version`, Docker, and GitHub Actions.
 - **Dev runtime:** `tsx watch src/index.ts`.
 - **One-off TS scripts/evals:** `tsx <script>.ts` through package scripts.
 - **Production runtime:** bundle `src/index.ts` to `dist/` with a Node-targeted bundler, then run `node dist/index.js`; keep native deps like `@xmtp/node-bindings` external.

--- a/docs/plans/bun-to-node-pnpm-master-plan.md
+++ b/docs/plans/bun-to-node-pnpm-master-plan.md
@@ -6,11 +6,6 @@
 
 ## Decision
 
-This is **not** `pnpm` vs `node`:
-
-- **Node.js** = runtime.
-- **pnpm** = package manager.
-
 Default target: **Node.js 22 LTS + pnpm 10 via Corepack**.
 
 Why pnpm over Yarn here: fast, strict, widely used, boring in CI/Docker, and no Yarn Berry/PnP footguns. Use a committed `pnpm-lock.yaml`; do not use zero-install.
@@ -39,7 +34,7 @@ No runtime `src/` Bun API dependency was found in the initial scan; the largest 
 | 1. Toolchain | Pin Node 22, add `packageManager: pnpm@...`, add `pnpm-lock.yaml`, install via Corepack. | `pnpm install --frozen-lockfile` |
 | 2. Runtime | Replace Bun TS execution with Node-compatible tooling: `tsx` for dev/scripts/evals; bundled JS for production. | `pnpm dev`, `pnpm build`, `pnpm start` |
 | 3. Tests | Move `bun:test` to Vitest; port mocks/preload/setup. | `pnpm test` |
-| 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/pnpm; remove Bun pins/lock/config. | CI green + Docker image boots + `/healthcheck` |
+| 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/pnpm; remove Bun pins/lock/config. | CI green + Docker image boots + `/healthcheck` + POST `/v2/accounts/me/subscription/verify` with a real Sandbox JWS returns 200 + persists `Subscription` row |
 
 These slices can be stacked or split into small PRs. Do not start slice 4 cleanup until slices 1–3 are green.
 
@@ -52,9 +47,14 @@ These slices can be stacked or split into small PRs. Do not start slice 4 cleanu
 - **Production runtime:** bundle `src/index.ts` to `dist/` with a Node-targeted bundler, then run `node dist/index.js`; keep native deps like `@xmtp/node-bindings` external.
 - **Test runner:** Vitest, because it is the closest replacement for `bun:test` ergonomics and mocking.
 
+## PR #237 disposition
+
+PR #237 patches `@apple/app-store-server-library` to work around bun's `X509Certificate.publicKey` / `jsonwebtoken.verify` incompatibilities. Once this migration lands those incompatibilities disappear — Node runs the library natively. **Do not merge PR #237.** Close it. The migration replaces it.
+
 ## Definition of done
 
 - `bun` is not required locally, in CI, in Docker, or in production.
 - `bun.lock`, `bunfig.toml`, `.bun-version`, and Bun docs references are removed.
 - `pnpm install --frozen-lockfile && pnpm check && pnpm test` pass.
 - Docker build succeeds and the container serves `/healthcheck`.
+- iOS IAP `subscription/verify` succeeds end-to-end against a real Sandbox JWS, with no patches applied to `@apple/app-store-server-library`.

--- a/docs/plans/bun-to-node-pnpm-master-plan.md
+++ b/docs/plans/bun-to-node-pnpm-master-plan.md
@@ -1,4 +1,4 @@
-# Bun → Node/Yarn Master Plan
+# Bun → Node/pnpm Master Plan
 
 > **Status:** Proposed  
 > **Base:** `otr-dev`  
@@ -6,18 +6,20 @@
 
 ## Decision
 
-This is **not** `yarn` vs `node`:
+This is **not** `pnpm` vs `node`:
 
 - **Node.js** = runtime.
-- **Yarn** = package manager.
+- **pnpm** = package manager.
 
-Default target: **Node.js 22 LTS + Yarn 4 via Corepack**.
+Default target: **Node.js 22 LTS + pnpm 10 via Corepack**.
+
+Why pnpm over Yarn here: fast, strict, widely used, boring in CI/Docker, and no Yarn Berry/PnP footguns. Use a committed `pnpm-lock.yaml`; do not use zero-install.
 
 Guardrails:
 
-- Use Yarn with `node_modules` linker first. No PnP / zero-install during the migration.
 - Avoid dependency upgrades unless they unblock the migration.
 - Keep API/runtime behavior unchanged.
+- Fix undeclared dependency issues surfaced by pnpm instead of relaxing pnpm.
 
 ## Current Bun surface
 
@@ -34,25 +36,25 @@ No runtime `src/` Bun API dependency was found in the initial scan; the largest 
 
 | Slice | Change | Gate |
 | --- | --- | --- |
-| 1. Toolchain | Pin Node 22, add `packageManager: yarn@...`, add Yarn lock/config, install via Corepack. | `yarn install --immutable` |
-| 2. Runtime | Replace Bun TS execution with Node-compatible tooling: `tsx` for dev/scripts/evals; bundled JS for production. | `yarn dev`, `yarn build`, `yarn start` |
-| 3. Tests | Move `bun:test` to Vitest; port mocks/preload/setup. | `yarn test` |
-| 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/Yarn; remove Bun pins/lock/config. | CI green + Docker image boots + `/healthcheck` |
+| 1. Toolchain | Pin Node 22, add `packageManager: pnpm@...`, add `pnpm-lock.yaml`, install via Corepack. | `pnpm install --frozen-lockfile` |
+| 2. Runtime | Replace Bun TS execution with Node-compatible tooling: `tsx` for dev/scripts/evals; bundled JS for production. | `pnpm dev`, `pnpm build`, `pnpm start` |
+| 3. Tests | Move `bun:test` to Vitest; port mocks/preload/setup. | `pnpm test` |
+| 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/pnpm; remove Bun pins/lock/config. | CI green + Docker image boots + `/healthcheck` |
 
 These slices can be stacked or split into small PRs. Do not start slice 4 cleanup until slices 1–3 are green.
 
 ## Proposed implementation defaults
 
-- **Package manager:** Yarn 4, Corepack-managed, `yarn install --immutable` in CI.
+- **Package manager:** pnpm 10, Corepack-managed, `pnpm install --frozen-lockfile` in CI.
 - **Node version:** Node 22 LTS, pinned consistently in `.nvmrc`, `.node-version`, Docker, and GitHub Actions.
 - **Dev runtime:** `tsx watch src/index.ts`.
-- **One-off TS scripts/evals:** `tsx <script>.ts` through Yarn scripts.
-- **Production runtime:** build to `dist/` and run with `node`; keep native deps like `@xmtp/node-bindings` external.
+- **One-off TS scripts/evals:** `tsx <script>.ts` through package scripts.
+- **Production runtime:** bundle `src/index.ts` to `dist/` with a Node-targeted bundler, then run `node dist/index.js`; keep native deps like `@xmtp/node-bindings` external.
 - **Test runner:** Vitest, because it is the closest replacement for `bun:test` ergonomics and mocking.
 
 ## Definition of done
 
 - `bun` is not required locally, in CI, in Docker, or in production.
 - `bun.lock`, `bunfig.toml`, `.bun-version`, and Bun docs references are removed.
-- `yarn install --immutable && yarn check && yarn test` pass.
+- `pnpm install --frozen-lockfile && pnpm check && pnpm test` pass.
 - Docker build succeeds and the container serves `/healthcheck`.

--- a/docs/plans/bun-to-node-pnpm-master-plan.md
+++ b/docs/plans/bun-to-node-pnpm-master-plan.md
@@ -29,12 +29,12 @@ No runtime `src/` Bun API dependency was found in the initial scan; the largest 
 
 ## Migration shape
 
-| Slice | Change | Gate |
-| --- | --- | --- |
-| 1. Toolchain | Pin Node 22, add `packageManager: pnpm@...`, add `pnpm-lock.yaml`, install via Corepack. | `pnpm install --frozen-lockfile` |
-| 2. Runtime | Replace Bun TS execution with Node-compatible tooling: `tsx` for dev/scripts/evals; bundled JS for production. | `pnpm dev`, `pnpm build`, `pnpm start` |
-| 3. Tests | Move `bun:test` to Vitest; port mocks/preload/setup. | `pnpm test` |
-| 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/pnpm; remove Bun pins/lock/config. | CI green + Docker image boots + `/healthcheck` + POST `/v2/accounts/me/subscription/verify` with a real Sandbox JWS returns 200 + persists `Subscription` row |
+| Slice                 | Change                                                                                                         | Gate                                                                                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Toolchain          | Pin Node 22, add `packageManager: pnpm@...`, add `pnpm-lock.yaml`, install via Corepack.                       | `pnpm install --frozen-lockfile`                                                                                                                              |
+| 2. Runtime            | Replace Bun TS execution with Node-compatible tooling: `tsx` for dev/scripts/evals; bundled JS for production. | `pnpm dev`, `pnpm build`, `pnpm start`                                                                                                                        |
+| 3. Tests              | Move `bun:test` to Vitest; port mocks/preload/setup.                                                           | `pnpm test`                                                                                                                                                   |
+| 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/pnpm; remove Bun pins/lock/config.                           | CI green + Docker image boots + `/healthcheck` + POST `/v2/accounts/me/subscription/verify` with a real Sandbox JWS returns 200 + persists `Subscription` row |
 
 These slices can be stacked or split into small PRs. Do not start slice 4 cleanup until slices 1–3 are green.
 

--- a/docs/plans/bun-to-node-yarn-master-plan.md
+++ b/docs/plans/bun-to-node-yarn-master-plan.md
@@ -1,0 +1,58 @@
+# Bun → Node/Yarn Master Plan
+
+> **Status:** Proposed  
+> **Base:** `otr-dev`  
+> **Goal:** remove Bun from local dev, CI, Docker, and production runtime with minimal behavior change.
+
+## Decision
+
+This is **not** `yarn` vs `node`:
+
+- **Node.js** = runtime.
+- **Yarn** = package manager.
+
+Default target: **Node.js 22 LTS + Yarn 4 via Corepack**.
+
+Guardrails:
+
+- Use Yarn with `node_modules` linker first. No PnP / zero-install during the migration.
+- Avoid dependency upgrades unless they unblock the migration.
+- Keep API/runtime behavior unchanged.
+
+## Current Bun surface
+
+- `package.json` scripts use `bun build`, `bun run`, `bun test`, `bun --watch`.
+- `bun.lock`, `bunfig.toml`, `.bun-version` pin Bun.
+- Docker installs Bun and `dev/entrypoint.sh` invokes Bun.
+- CI uses `oven-sh/setup-bun` and `bun ...` commands.
+- Tests import from `bun:test` and use Bun mocks/preload behavior.
+- Docs/scripts/eval docs reference Bun commands.
+
+No runtime `src/` Bun API dependency was found in the initial scan; the largest code migration is the test runner.
+
+## Migration shape
+
+| Slice | Change | Gate |
+| --- | --- | --- |
+| 1. Toolchain | Pin Node 22, add `packageManager: yarn@...`, add Yarn lock/config, install via Corepack. | `yarn install --immutable` |
+| 2. Runtime | Replace Bun TS execution with Node-compatible tooling: `tsx` for dev/scripts/evals; bundled JS for production. | `yarn dev`, `yarn build`, `yarn start` |
+| 3. Tests | Move `bun:test` to Vitest; port mocks/preload/setup. | `yarn test` |
+| 4. Infra/docs cleanup | Switch CI/Docker/entrypoint/docs from Bun to Node/Yarn; remove Bun pins/lock/config. | CI green + Docker image boots + `/healthcheck` |
+
+These slices can be stacked or split into small PRs. Do not start slice 4 cleanup until slices 1–3 are green.
+
+## Proposed implementation defaults
+
+- **Package manager:** Yarn 4, Corepack-managed, `yarn install --immutable` in CI.
+- **Node version:** Node 22 LTS, pinned consistently in `.nvmrc`, `.node-version`, Docker, and GitHub Actions.
+- **Dev runtime:** `tsx watch src/index.ts`.
+- **One-off TS scripts/evals:** `tsx <script>.ts` through Yarn scripts.
+- **Production runtime:** build to `dist/` and run with `node`; keep native deps like `@xmtp/node-bindings` external.
+- **Test runner:** Vitest, because it is the closest replacement for `bun:test` ergonomics and mocking.
+
+## Definition of done
+
+- `bun` is not required locally, in CI, in Docker, or in production.
+- `bun.lock`, `bunfig.toml`, `.bun-version`, and Bun docs references are removed.
+- `yarn install --immutable && yarn check && yarn test` pass.
+- Docker build succeeds and the container serves `/healthcheck`.


### PR DESCRIPTION
## Summary
- Adds a synthetic master plan to migrate from Bun to Node.js + pnpm.
- Clarifies that Node is the runtime and pnpm is the package manager.
- Captures migration slices, defaults, and definition of done.

## Notes
- Plan only; no runtime/code changes.
- Recommends Node.js 22 LTS + pnpm 10 via Corepack.

## Tests
- Not run (documentation only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781966710&installation_id=128169237&pr_number=238&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F238&signature=acf334f83bff2852cb830c2e484e1f74903d53301ee89b49e8107e4804b85400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration plan document for moving from Bun to Node.js 24 and pnpm 10
> Adds [bun-to-node-pnpm-master-plan.md](https://github.com/ephemeraHQ/convos-backend/pull/238/files#diff-33f0c56590c5c3c413e65af4c13af23291539f14c48d454a11acd590c4a1c952) outlining a phased migration away from Bun across the monorepo.
>
> - Defines four migration slices: toolchain swap, runtime replacement, test migration to Vitest, and infra/docs cleanup, each with explicit gate criteria
> - Specifies proposed defaults: Corepack-managed pnpm 10, Node 24 version pinning, `tsx` for dev scripts, and bundled output for production
> - Includes a definition of done covering CI, Docker, and iOS IAP verification
> - Proposes closing PR #237 as part of the cleanup slice
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3f9a35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->