### PR TITLE
fix(evals): retry transient OpenRouter 429/5xx with backoff

### DIFF
--- a/tests/evals/lib/generate.ts
+++ b/tests/evals/lib/generate.ts
@@ -22,6 +22,7 @@
  */
 
 import type * as TemplateGenModule from "../../../src/api/v2/agent-templates/services/templateGen";
+import { withRetry } from "./retry";
 import type { GeneratedTemplateLite, GenMetrics } from "./types";
 
 function setDefault(key: string, value: string): void {
@@ -90,7 +91,18 @@ export function generateForModel(
     tg.__setBuilderModelOverrideForTests(model);
     // null restores the loaded prompt, so model-only runs are unaffected.
     tg.__setSystemPromptOverrideForTests(systemPrompt ?? null);
-    const { template, metrics } = await tg.generateTemplate({ text: input });
+    // Retry transient throttles (429) / 5xx. Runs inside the serialized chain,
+    // so the backoff also re-paces the queue and prevents a 429 cascade.
+    const { template, metrics } = await withRetry(
+      () => tg.generateTemplate({ text: input }),
+      {
+        onRetry: (err, attempt, delayMs) => {
+          console.warn(
+            `  ↻ generate retry ${attempt} [${model}] in ${Math.round(delayMs)}ms: ${String(err)}`,
+          );
+        },
+      },
+    );
     // connections is always server-injected as []; drop it from the eval view.
     const { connections: _connections, ...lite } = template;
     return { template: lite, metrics };

--- a/tests/evals/lib/llm.ts
+++ b/tests/evals/lib/llm.ts
@@ -10,7 +10,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 
-import { withRetry } from "./retry";
+import { NonRetryableError, withRetry } from "./retry";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
@@ -35,10 +35,18 @@ function parseJson(content: string): unknown {
     // Tolerate a fenced or prose-wrapped object, mirroring templateGen's
     // parser fallback.
     const match = content.match(/\{[\s\S]*\}/);
-    if (!match) {
-      throw new Error(`Judge response was not JSON: ${content.slice(0, 200)}`);
+    if (match) {
+      try {
+        return JSON.parse(match[0]) as unknown;
+      } catch {
+        /* fall through to the terminal error */
+      }
     }
-    return JSON.parse(match[0]) as unknown;
+    // A malformed judge response is a quality failure, not a transient one —
+    // NonRetryableError so the embedded `content` snippet can never look retryable.
+    throw new NonRetryableError(
+      `Judge response was not JSON: ${content.slice(0, 200)}`,
+    );
   }
 }
 
@@ -95,13 +103,17 @@ export async function openRouterJSON(
 
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      throw new Error(`Judge HTTP ${res.status}: ${body.slice(0, 300)}`);
+      const msg = `Judge HTTP ${res.status}: ${body.slice(0, 300)}`;
+      // Retry throttles / server errors by STATUS (not body text); other 4xx
+      // (e.g. 400 bad schema) are terminal.
+      if (res.status === 429 || res.status >= 500) throw new Error(msg);
+      throw new NonRetryableError(msg);
     }
 
     const data: any = await res.json();
     const content = data?.choices?.[0]?.message?.content;
     if (typeof content !== "string") {
-      throw new Error("Judge returned no message content");
+      throw new NonRetryableError("Judge returned no message content");
     }
     return parseJson(content);
   });

--- a/tests/evals/lib/llm.ts
+++ b/tests/evals/lib/llm.ts
@@ -10,6 +10,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 
+import { withRetry } from "./retry";
+
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
 /** Per-call wallclock cap for judge requests; override via env for slow models
@@ -64,40 +66,43 @@ export async function openRouterJSON(
     );
   }
 
-  const res = await fetch(OPENROUTER_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: opts.model,
-      temperature: opts.temperature ?? 0,
-      messages: [
-        { role: "system", content: opts.system },
-        { role: "user", content: opts.user },
-      ],
-      response_format: {
-        type: "json_schema",
-        json_schema: {
-          name: opts.schemaName,
-          strict: true,
-          schema: opts.schema,
-        },
+  // Retry transient throttles (429) / 5xx; the signal is re-created per attempt.
+  return withRetry(async () => {
+    const res = await fetch(OPENROUTER_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
       },
-    }),
-    signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_JUDGE_TIMEOUT_MS),
+      body: JSON.stringify({
+        model: opts.model,
+        temperature: opts.temperature ?? 0,
+        messages: [
+          { role: "system", content: opts.system },
+          { role: "user", content: opts.user },
+        ],
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: opts.schemaName,
+            strict: true,
+            schema: opts.schema,
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_JUDGE_TIMEOUT_MS),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Judge HTTP ${res.status}: ${body.slice(0, 300)}`);
+    }
+
+    const data: any = await res.json();
+    const content = data?.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      throw new Error("Judge returned no message content");
+    }
+    return parseJson(content);
   });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Judge HTTP ${res.status}: ${body.slice(0, 300)}`);
-  }
-
-  const data: any = await res.json();
-  const content = data?.choices?.[0]?.message?.content;
-  if (typeof content !== "string") {
-    throw new Error("Judge returned no message content");
-  }
-  return parseJson(content);
 }

--- a/tests/evals/lib/retry.ts
+++ b/tests/evals/lib/retry.ts
@@ -14,10 +14,25 @@
  * model.
  */
 
+/** A definite, terminal failure (e.g. a model quality / parse error). Never
+ *  retried, regardless of message content — so embedded model output can't
+ *  accidentally trigger a retry. */
+export class NonRetryableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NonRetryableError";
+  }
+}
+
+// Status codes are anchored to our known error-message prefixes ("OpenRouter API
+// error 429", "Judge HTTP 503: …") so a stray "503"/"429" inside *model output*
+// embedded in an error message can't match. Network tokens are specific enough
+// to be safe on their own.
 const RETRYABLE =
-  /\b(429|408|425|500|502|503|504)\b|rate[ -]?limit|too many requests|overloaded|fetch failed|terminated|ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i;
+  /(?:OpenRouter API error|Judge HTTP)\s*(?:429|408|425|5\d\d)\b|Connection error|fetch failed|terminated|ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i;
 
 export function isRetryableError(err: unknown): boolean {
+  if (err instanceof NonRetryableError) return false;
   return RETRYABLE.test(err instanceof Error ? err.message : String(err));
 }
 

--- a/tests/evals/lib/retry.ts
+++ b/tests/evals/lib/retry.ts
@@ -1,0 +1,64 @@
+/**
+ * Bounded retry with exponential backoff + jitter for transient OpenRouter
+ * failures (429 / 5xx / network).
+ *
+ * Why this exists: qwen3.5-plus (and other models with a single, capacity-limited
+ * upstream provider) returns 429 under sustained eval load. Generation is
+ * serialized through a promise chain that paces calls by *completion* time — but
+ * a 429 returns instantly, so without a delay one throttle cascades into a burst
+ * of back-to-back failures. Retrying with backoff both recovers the transient
+ * failure (no unfairly-zeroed data points) and re-paces the serialized queue.
+ *
+ * Scope: transient infra only. A malformed-JSON / schema failure is a model
+ * quality signal, not infra, so it is NOT retried — it should count against the
+ * model.
+ */
+
+const RETRYABLE =
+  /\b(429|408|425|500|502|503|504)\b|rate[ -]?limit|too many requests|overloaded|fetch failed|terminated|ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i;
+
+export function isRetryableError(err: unknown): boolean {
+  return RETRYABLE.test(err instanceof Error ? err.message : String(err));
+}
+
+export interface RetryOptions {
+  /** Max additional attempts after the first. Default 4. */
+  retries?: number;
+  /** Base delay in ms. Default 1000. */
+  baseMs?: number;
+  /** Backoff multiplier. Default 2. */
+  factor?: number;
+  /** Cap on a single backoff in ms. Default 20000. */
+  maxMs?: number;
+  isRetryable?: (err: unknown) => boolean;
+  onRetry?: (err: unknown, attempt: number, delayMs: number) => void;
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions = {},
+): Promise<T> {
+  const {
+    retries = 4,
+    baseMs = 1000,
+    factor = 2,
+    maxMs = 20_000,
+    isRetryable = isRetryableError,
+    onRetry,
+  } = opts;
+
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= retries || !isRetryable(err)) throw err;
+      const backoff = Math.min(maxMs, baseMs * factor ** attempt);
+      // Jitter across [50%, 100%] of the backoff so concurrent retries spread.
+      const delayMs = backoff * (0.5 + Math.random() * 0.5);
+      onRetry?.(err, attempt + 1, delayMs);
+      await new Promise((r) => setTimeout(r, delayMs));
+      attempt++;
+    }
+  }
+}

--- a/tests/evals/retry.test.ts
+++ b/tests/evals/retry.test.ts
@@ -3,16 +3,17 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { isRetryableError, withRetry } from "./lib/retry";
+import { isRetryableError, NonRetryableError, withRetry } from "./lib/retry";
 
 describe("isRetryableError", () => {
-  test("429 / 5xx / rate-limit / network are retryable", () => {
+  test("our transient HTTP + network errors are retryable", () => {
     for (const m of [
       "OpenRouter API error 429",
+      "OpenRouter API error 503",
+      "Judge HTTP 429: too many requests",
       "Judge HTTP 503: upstream",
-      "rate limit exceeded",
-      "Provider overloaded",
       "fetch failed",
+      "Connection error",
       "ETIMEDOUT",
     ]) {
       expect(isRetryableError(new Error(m))).toBe(true);
@@ -28,6 +29,24 @@ describe("isRetryableError", () => {
     ]) {
       expect(isRetryableError(new Error(m))).toBe(false);
     }
+  });
+
+  test("a status/rate token embedded in model text is NOT retryable (anchored)", () => {
+    // Status codes only match when prefixed by our own error wording; "rate
+    // limit"/"overloaded" aren't matched at all. So a malformed model response
+    // quoting these can't look retryable.
+    expect(
+      isRetryableError(
+        new Error("LLM output mentioned 503, rate limit, and overloaded"),
+      ),
+    ).toBe(false);
+  });
+
+  test("NonRetryableError is never retried, even if its message embeds tokens", () => {
+    const e = new NonRetryableError(
+      'Judge response was not JSON: {"idea":"a 429 / 503 rate-limit fetch-failed monitor"}',
+    );
+    expect(isRetryableError(e)).toBe(false);
   });
 });
 
@@ -64,7 +83,7 @@ describe("withRetry", () => {
       await withRetry(
         () => {
           calls++;
-          return Promise.reject(new Error("503 overloaded"));
+          return Promise.reject(new Error("OpenRouter API error 503"));
         },
         { ...fast, retries: 2 },
       );
@@ -87,6 +106,23 @@ describe("withRetry", () => {
       err = e;
     }
     expect(String(err)).toMatch(/400/);
+    expect(calls).toBe(1);
+  });
+
+  test("does not retry a NonRetryableError even with retry tokens in the message", async () => {
+    let calls = 0;
+    let err: unknown;
+    try {
+      await withRetry(() => {
+        calls++;
+        return Promise.reject(
+          new NonRetryableError("malformed: contains 429 and 503"),
+        );
+      }, fast);
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/malformed/);
     expect(calls).toBe(1);
   });
 });

--- a/tests/evals/retry.test.ts
+++ b/tests/evals/retry.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Offline unit tests for retry/backoff classification + control flow. No network.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { isRetryableError, withRetry } from "./lib/retry";
+
+describe("isRetryableError", () => {
+  test("429 / 5xx / rate-limit / network are retryable", () => {
+    for (const m of [
+      "OpenRouter API error 429",
+      "Judge HTTP 503: upstream",
+      "rate limit exceeded",
+      "Provider overloaded",
+      "fetch failed",
+      "ETIMEDOUT",
+    ]) {
+      expect(isRetryableError(new Error(m))).toBe(true);
+    }
+  });
+
+  test("4xx (non-429) and quality errors are NOT retryable", () => {
+    for (const m of [
+      "Judge HTTP 400: bad schema",
+      "OpenRouter API error 401",
+      "Failed to parse JSON",
+      "LLM response missing prompt",
+    ]) {
+      expect(isRetryableError(new Error(m))).toBe(false);
+    }
+  });
+});
+
+describe("withRetry", () => {
+  const fast = { baseMs: 1, maxMs: 4 };
+
+  test("returns immediately on success (no retry)", async () => {
+    let calls = 0;
+    const out = await withRetry(() => {
+      calls++;
+      return Promise.resolve("ok");
+    }, fast);
+    expect(out).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  test("retries a retryable error, then succeeds", async () => {
+    let calls = 0;
+    const out = await withRetry(
+      () =>
+        ++calls < 3
+          ? Promise.reject(new Error("OpenRouter API error 429"))
+          : Promise.resolve(calls),
+      fast,
+    );
+    expect(out).toBe(3);
+    expect(calls).toBe(3);
+  });
+
+  test("gives up after `retries` attempts and throws the last error", async () => {
+    let calls = 0;
+    let err: unknown;
+    try {
+      await withRetry(
+        () => {
+          calls++;
+          return Promise.reject(new Error("503 overloaded"));
+        },
+        { ...fast, retries: 2 },
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/503/);
+    expect(calls).toBe(3); // initial + 2 retries
+  });
+
+  test("does not retry a non-retryable error", async () => {
+    let calls = 0;
+    let err: unknown;
+    try {
+      await withRetry(() => {
+        calls++;
+        return Promise.reject(new Error("Judge HTTP 400: bad schema"));
+      }, fast);
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/400/);
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
Follow-up to #236 (merged). Fixes the qwen3.5-plus 429 failures observed in a full model bake-off.

## Why (diagnosed before fixing)

In a 12-case × 3-sample run of opus vs qwen3.5-plus, **only qwen generation 429'd (9×), never the judge** — and the key has no account-level rate limit (`is_free_tier: false`, `limit: null`). Root cause:

1. **qwen3.5-plus has a single upstream provider (Alibaba)** with no fallback, so under sustained load OpenRouter returns its throttle straight through. opus/gpt-5.5 have ample capacity.
2. **Our generation mutex turned one throttle into a cascade.** Generations serialize through a promise chain that paces by *completion time*. A successful qwen call takes ~96s, so calls are naturally spaced — but a 429 returns instantly, so once throttling started the queue drained in milliseconds and **8 consecutive calls 429'd back-to-back**. With no retry, each transient throttle permanently zeroed that data point, unfairly dragging qwen's score down.

## Fix

Bounded **exponential backoff + jitter** on **transient infra only** (429 / 5xx / network), in `tests/evals/lib/retry.ts`, wired into the generation adapter and the judge transport. It:

- recovers the transient throttle (no more unfairly-zeroed runs), and
- runs **inside** the serialized chain, so the backoff delay **re-paces the queue and breaks the cascade**.

Scope guards:
- **Quality failures are NOT retried** — a malformed-JSON / schema miss is a model signal and should keep counting against the model.
- **Eval-only** — production `templateGen` keeps its deliberate `maxRetries: 0`.

## Tests

`tests/evals/retry.test.ts` (offline): classification (429/5xx/network retryable; 4xx + quality errors not), success-without-retry, retry-then-succeed, give-up-after-max, no-retry-on-non-retryable. Full eval offline suite: 24 pass; eslint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781972213&installation_id=128169237&pr_number=240&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F240&signature=9dab150b8d56c5d64994d7b487448079c6838c033432d4060724c17e57e84efb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add retry with exponential backoff for transient OpenRouter 429/5xx errors in evals
> - Adds a new [retry.ts](https://github.com/ephemeraHQ/convos-backend/pull/240/files#diff-a064518c1f66327db4f36894c07190c3073d504f9d64019339fedba90f65637e) module with `withRetry`, `isRetryableError`, and `NonRetryableError` — providing bounded exponential backoff with jitter for async operations.
> - Wraps the `openRouterJSON` fetch call and `generateForModel` template call in `withRetry`, logging warnings on each retry attempt.
> - Classifies 429/5xx and common network errors as retryable; other 4xx, malformed JSON, and missing content throw `NonRetryableError` to abort immediately.
> - Adds unit tests in [retry.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/240/files#diff-edf1cd31cd7249317b6e070c86b8edf24596bbc064bebf52d9b01ee835665fe1) covering classification and retry control flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9984c55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic retry capability for transient service interruptions with exponential backoff
  * Improved system resilience to temporary infrastructure failures

* **Tests**
  * Added comprehensive test coverage for retry behavior and error classification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->