### PR TITLE
chore(pnpm): move onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,22 +114,5 @@
   "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=24"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@bufbuild/buf",
-      "@firebase/util",
-      "@google/genai",
-      "@prisma/client",
-      "@prisma/engines",
-      "bufferutil",
-      "esbuild",
-      "keccak",
-      "prisma",
-      "protobufjs",
-      "secp256k1",
-      "sharp",
-      "utf-8-validate"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+onlyBuiltDependencies:
+  - "@bufbuild/buf"
+  - "@firebase/util"
+  - "@google/genai"
+  - "@prisma/client"
+  - "@prisma/engines"
+  - bufferutil
+  - esbuild
+  - keccak
+  - prisma
+  - protobufjs
+  - secp256k1
+  - sharp
+  - utf-8-validate


### PR DESCRIPTION
## Summary
- pnpm 10+ no longer reads the `pnpm` field in `package.json`; on every install it prints `[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies"`.
- Moves the `onlyBuiltDependencies` list verbatim to `pnpm-workspace.yaml` at repo root, per https://pnpm.io/settings.
- Package list unchanged; only the file it lives in changed.

## Test plan
- [x] `pnpm install` exits clean, no `pnpm.onlyBuiltDependencies` deprecation warning.
- [ ] CI green on this branch (install + build + tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782020024&installation_id=128169237&pr_number=244&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F244&signature=0212ccb2d5d31f3f4f73f9a356d337f2c9c114e3df7988040a0175ce3fc5da89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `onlyBuiltDependencies` from `package.json` to `pnpm-workspace.yaml`
> Relocates the `pnpm.onlyBuiltDependencies` config from [package.json](https://github.com/ephemeraHQ/convos-backend/pull/244/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to [pnpm-workspace.yaml](https://github.com/ephemeraHQ/convos-backend/pull/244/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c), which is the preferred location for workspace-level pnpm settings. The list of packages is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a09bf87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->