### PR TITLE
fix(prisma): wrap prisma generate to pre-clean zod output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pnpm install
 pnpm migrate:deploy
 
 # Generate Prisma client + zod schemas + protobufs
-pnpm prisma generate
+pnpm prisma:generate
 pnpm buf:generate
 
 # Run the app in watch mode

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint .",
     "migrate:deploy": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev",
+    "prisma:generate": "rimraf prisma/generated/zod && prisma generate",
     "start": "node --enable-source-maps --env-file-if-exists=.env --import @opentelemetry/instrumentation/hook.mjs --import ./dist/instrumentation.js dist/index.js",
     "test": "vitest run",
     "test:local": "pnpm prisma migrate reset --force && vitest run",


### PR DESCRIPTION
## Summary
- `zod-prisma-types` 3.x (including latest 3.3.11) calls `fs.rmdirSync(path, { recursive: true })` in its `DirectoryHelper.removeDir`. Node 24 removed support for that option, so every `prisma generate` against an existing `prisma/generated/zod` dir errors:
  ```
  Error while deleting old data in path .../prisma/generated/zod: The property 'options.recursive' is no longer supported. Received true
  ```
- The helper early-returns when the target directory is missing, so deleting it ourselves before invoking `prisma generate` sidesteps the broken call entirely — no monkey-patching, no fork.
- Adds `pnpm prisma:generate` (rimraf + prisma generate) and points the README at it.

## Test plan
- [x] `pnpm prisma:generate` succeeds with the zod dir present (was failing).
- [x] Second `pnpm prisma:generate` (zod dir now re-created) also succeeds.
- [x] CI green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782020430&installation_id=128169237&pr_number=245&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F245&signature=b6b4ae6b82dcb08f38e3f2b6bb98c55f2b3571afeba2e162728204b0b079c65f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `prisma:generate` script to pre-clean zod output before generating Prisma client
> Adds a `prisma:generate` npm script in [package.json](https://github.com/ephemeraHQ/convos-backend/pull/245/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) that runs `rimraf prisma/generated/zod` before `prisma generate`, preventing stale generated zod files from persisting across runs. Updates [README.md](https://github.com/ephemeraHQ/convos-backend/pull/245/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reference `pnpm prisma:generate` instead of `pnpm prisma generate`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7313cdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->