### PR TITLE
chore(buf): silence Node 25 localStorage warning in buf:generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "buf:generate": "buf generate",
+    "buf:generate": "NODE_NO_WARNINGS=1 buf generate",
     "build": "tsup",
     "check": "pnpm typecheck && pnpm format:check && pnpm lint",
     "clean": "rimraf node_modules",


### PR DESCRIPTION
## Summary
- Node 25 added an experimental global `localStorage` accessor that prints `Warning: --localstorage-file was provided without a valid path` the first time the property is touched without the matching flag.
- `@typescript/vfs` (transitive dep of `@bufbuild/protoc-gen-es`) probes `typeof localStorage !== "undefined"` at module load to detect a browser environment, so every `buf generate` run emits the warning twice (once per protoc plugin invocation). Code generation itself succeeds.
- Prefix the `buf:generate` script with `NODE_NO_WARNINGS=1` so the noise is gone for that single script; nothing else in the dev/test workflow is affected.

## Test plan
- [x] `pnpm buf:generate` exits clean, no `--localstorage-file` warnings.
- [ ] CI green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782021784&installation_id=128169237&pr_number=246&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F246&signature=138386bbc56e0b663f23a7a16478d75b4a4c40bc701df0cb14654e19f2e31bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Silence Node 25 localStorage warning in `buf:generate` script
> Prefixes the `buf:generate` npm script with `NODE_NO_WARNINGS=1` in [package.json](https://github.com/ephemeraHQ/convos-backend/pull/246/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to suppress Node.js warnings emitted by Node-based subprocesses during code generation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46e406d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->