### PR TITLE
feat(subscriptions): log happy-path JWS validation + S2S apply

### DIFF
--- a/src/api/v2/accounts/handlers/subscription-verify.ts
+++ b/src/api/v2/accounts/handlers/subscription-verify.ts
@@ -114,6 +114,23 @@ export async function subscriptionVerifyHandler(req: Request, res: Response) {
     return;
   }
 
+  // JWS chain verified against Apple Root CA G2/G3 and signature is valid.
+  // Log the decoded transaction shape so sandbox testing can confirm what
+  // Apple is sending (no JWS / PII fields).
+  req.log.info(
+    {
+      accountId,
+      productId: decoded.productId,
+      originalTransactionId: decoded.originalTransactionId,
+      transactionId: decoded.transactionId,
+      environment: decoded.environment,
+      purchaseDate: decoded.purchaseDate,
+      expiresDate: decoded.expiresDate,
+      offerType: decoded.offerType,
+    },
+    "subscription.verify.jws_decoded",
+  );
+
   // appAccountToken comes from the verified JWS — iOS set it at purchase
   // time via StoreKit. Apple persists it; subsequent receipts echo it back.
   // Reject if Apple's payload doesn't carry one (would mean a misconfigured
@@ -165,6 +182,19 @@ export async function subscriptionVerifyHandler(req: Request, res: Response) {
     // + per-tier config at read time (see GET /v2/accounts/me/credits); we
     // intentionally do NOT write a grant() ledger row on verify. grant() is
     // reserved for additive credits — top-ups, NUX trial, manual ops, promo.
+    req.log.info(
+      {
+        accountId,
+        subscriptionId: subscription.id,
+        productId: subscription.productId,
+        tier: subscription.tier,
+        period: subscription.period,
+        status: subscription.status,
+        originalTransactionId: subscription.originalTransactionId,
+        environment: subscription.environment,
+      },
+      "subscription.verify.applied",
+    );
     res.status(200).json({
       subscription: serializeUserSubscription(subscription),
     });

--- a/src/api/v2/subscriptions/handlers/apple-ssn.ts
+++ b/src/api/v2/subscriptions/handlers/apple-ssn.ts
@@ -148,6 +148,19 @@ export async function appleSsnHandler(req: Request, res: Response) {
     // GET /v2/accounts/me/credits). Renewal updates currentPeriodStart, which
     // resets monthlyGrantUsed on the next read. grant() is reserved for
     // additive credits (top-ups, NUX trial, manual ops, promo).
+    req.log.info(
+      {
+        notificationType: notification.notificationType,
+        notificationSubtype: notification.subtype,
+        notificationUUID,
+        originalTransactionId,
+        transactionId,
+        accountId: result.subscription.accountId,
+        subscriptionStatus: result.subscription.status,
+        replayed: result.kind === "replayed",
+      },
+      "subscription.ssn.applied",
+    );
     res.status(200).json({ ok: true, applied: result.kind === "applied" });
     return;
   } catch (error) {


### PR DESCRIPTION
## Why

When Apple Sandbox starts sending notifications to the Convos Dev backend, the operator currently can't tell from logs:

- Whether the JWS chain verified successfully on a `/verify` call (we only log on failure)
- Which Apple notification (type, UUID, original transaction) just got applied or replayed on the S2S webhook

Both paths return 200 silently on the happy case. The only signal is the generic `pino-http` access log — *that* request happened, status code, response time — with no body context. For sandbox debugging where you want to *see* renewals firing or confirm a JWS landed, that's not enough.

## What

Two new `req.log.info` lines, no behavioral change:

### `POST /v2/accounts/me/subscription/verify` (`subscription-verify.ts`)

After `verifyAndDecodeTransaction()` returns successfully, log the decoded transaction shape:

```
{ accountId, productId, originalTransactionId, transactionId, environment,
  purchaseDate, expiresDate, offerType }
"subscription.verify.jws_decoded"
```

Then after `upsertFromVerify()` succeeds, log the resulting subscription:

```
{ accountId, subscriptionId, productId, tier, period, status,
  originalTransactionId, environment }
"subscription.verify.applied"
```

### `POST /v2/webhooks/apple/ssn` (`apple-ssn.ts`)

After `applyNotification()` returns with `kind === "applied"` or `"replayed"`, log:

```
{ notificationType, notificationSubtype, notificationUUID,
  originalTransactionId, transactionId, accountId, subscriptionStatus, replayed }
"subscription.ssn.applied"
```

Logs use existing log keys (no PII, no JWS body), and the structured `req.log` so they pick up Datadog trace correlation via the existing pino-http middleware.

## Test plan

- [x] `bun typecheck` — clean for the touched files (pre-existing `balanceAfter` errors in `tests/payments/payments.integration.test.ts` are unrelated; PR #247 baseline noise pending a `prisma generate`)
- [x] `bun lint` — clean for the touched files
- [x] `bunx prettier --check` — clean
- [ ] After deploy: confirm `curl -X POST .../v2/webhooks/apple/ssn -d '{}'` still returns 400 with the unchanged "Invalid request body" copy.
- [ ] After App Store Connect S2S URL is wired: confirm `subscription.ssn.applied` appears in dev backend logs on the first sandbox `DID_RENEW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782052390&installation_id=128169237&pr_number=248&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F248&signature=863bac2da123da9d463557485e01d1f4c061cc3db3aa39df8d0fdcd29e203306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured info logs for successful JWS validation and S2S notification apply in subscription handlers
> - Adds a `subscription.verify.jws_decoded` log in [`subscription-verify.ts`](https://github.com/ephemeraHQ/convos-backend/pull/248/files#diff-5045dc2ccbf9d7609f86bbb6fd5c608c1a0370b6a0180d50e5d47f62518baa44) after successful JWS verification, recording decoded fields like `accountId`, `productId`, `transactionId`, and `expiresDate`.
> - Adds a `subscription.verify.applied` log after a successful `upsertFromVerify` call, recording persisted subscription fields including `tier`, `period`, and `status`.
> - Adds a `subscription.ssn.applied` log in [`apple-ssn.ts`](https://github.com/ephemeraHQ/convos-backend/pull/248/files#diff-1af995eead831ac657947747d0afdd6e2405f468d93dcd6e0105bf6414276bf7) before responding 200, capturing notification fields and whether the notification was replayed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7be99a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced logging for subscription verification to capture decoded authentication details and subscription application events.
  * Improved monitoring of Apple Server-to-Server notifications by adding structured logging for notification processing, including transaction IDs and subscription status updates.
  * These improvements support better debugging and operational visibility without changing functional behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->