### PR TITLE
fix(subscriptions): log err.status on JWS-verify failure (follow-up to #248)

### DIFF
--- a/src/api/v2/accounts/handlers/subscription-verify.ts
+++ b/src/api/v2/accounts/handlers/subscription-verify.ts
@@ -106,8 +106,23 @@ export async function subscriptionVerifyHandler(req: Request, res: Response) {
   try {
     decoded = await verifyAndDecodeTransaction(parsed.data.jwsRepresentation);
   } catch (err) {
+    // VerificationException carries `.status` (enum), not `.message`.
+    // See apple-ssn.ts for the rationale.
     req.log.warn(
-      { err: err instanceof Error ? err.message : err, accountId },
+      {
+        accountId,
+        errName: err instanceof Error ? err.constructor.name : undefined,
+        errStatus: (err as { status?: number } | undefined)?.status,
+        errMessage: err instanceof Error ? err.message : String(err),
+        causeName:
+          err instanceof Error && err.cause instanceof Error
+            ? err.cause.constructor.name
+            : undefined,
+        causeMessage:
+          err instanceof Error && err.cause instanceof Error
+            ? err.cause.message
+            : undefined,
+      },
       "JWS transaction verification failed",
     );
     res.status(400).json({ error: "Invalid signed transaction" });

--- a/src/api/v2/accounts/handlers/subscription-verify.ts
+++ b/src/api/v2/accounts/handlers/subscription-verify.ts
@@ -114,6 +114,23 @@ export async function subscriptionVerifyHandler(req: Request, res: Response) {
     return;
   }
 
+  // JWS chain verified against Apple Root CA G2/G3 and signature is valid.
+  // Log the decoded transaction shape so sandbox testing can confirm what
+  // Apple is sending (no JWS / PII fields).
+  req.log.info(
+    {
+      accountId,
+      productId: decoded.productId,
+      originalTransactionId: decoded.originalTransactionId,
+      transactionId: decoded.transactionId,
+      environment: decoded.environment,
+      purchaseDate: decoded.purchaseDate,
+      expiresDate: decoded.expiresDate,
+      offerType: decoded.offerType,
+    },
+    "subscription.verify.jws_decoded",
+  );
+
   // appAccountToken comes from the verified JWS — iOS set it at purchase
   // time via StoreKit. Apple persists it; subsequent receipts echo it back.
   // Reject if Apple's payload doesn't carry one (would mean a misconfigured
@@ -165,6 +182,19 @@ export async function subscriptionVerifyHandler(req: Request, res: Response) {
     // + per-tier config at read time (see GET /v2/accounts/me/credits); we
     // intentionally do NOT write a grant() ledger row on verify. grant() is
     // reserved for additive credits — top-ups, NUX trial, manual ops, promo.
+    req.log.info(
+      {
+        accountId,
+        subscriptionId: subscription.id,
+        productId: subscription.productId,
+        tier: subscription.tier,
+        period: subscription.period,
+        status: subscription.status,
+        originalTransactionId: subscription.originalTransactionId,
+        environment: subscription.environment,
+      },
+      "subscription.verify.applied",
+    );
     res.status(200).json({
       subscription: serializeUserSubscription(subscription),
     });

--- a/src/api/v2/subscriptions/handlers/apple-ssn.ts
+++ b/src/api/v2/subscriptions/handlers/apple-ssn.ts
@@ -148,6 +148,19 @@ export async function appleSsnHandler(req: Request, res: Response) {
     // GET /v2/accounts/me/credits). Renewal updates currentPeriodStart, which
     // resets monthlyGrantUsed on the next read. grant() is reserved for
     // additive credits (top-ups, NUX trial, manual ops, promo).
+    req.log.info(
+      {
+        notificationType: notification.notificationType,
+        notificationSubtype: notification.subtype,
+        notificationUUID,
+        originalTransactionId,
+        transactionId,
+        accountId: result.subscription.accountId,
+        subscriptionStatus: result.subscription.status,
+        replayed: result.kind === "replayed",
+      },
+      "subscription.ssn.applied",
+    );
     res.status(200).json({ ok: true, applied: result.kind === "applied" });
     return;
   } catch (error) {

--- a/src/api/v2/subscriptions/handlers/apple-ssn.ts
+++ b/src/api/v2/subscriptions/handlers/apple-ssn.ts
@@ -41,8 +41,26 @@ export async function appleSsnHandler(req: Request, res: Response) {
   try {
     notification = await verifyAndDecodeNotification(signedPayload);
   } catch (err) {
+    // VerificationException from @apple/app-store-server-library carries
+    // its actionable info on `.status` (enum 0-7), not `.message`
+    // (`super()` is called with no args, so message is "").
+    // Log both so ops can tell INVALID_APP_IDENTIFIER (3) /
+    // INVALID_ENVIRONMENT (4) / INVALID_CERTIFICATE (6) apart from a
+    // signature failure (1).
     req.log.warn(
-      { err: err instanceof Error ? err.message : err },
+      {
+        errName: err instanceof Error ? err.constructor.name : undefined,
+        errStatus: (err as { status?: number } | undefined)?.status,
+        errMessage: err instanceof Error ? err.message : String(err),
+        causeName:
+          err instanceof Error && err.cause instanceof Error
+            ? err.cause.constructor.name
+            : undefined,
+        causeMessage:
+          err instanceof Error && err.cause instanceof Error
+            ? err.cause.message
+            : undefined,
+      },
       "Apple S2S notification JWS verification failed",
     );
     res.status(400).json({ error: "Invalid signed notification" });
@@ -80,7 +98,17 @@ export async function appleSsnHandler(req: Request, res: Response) {
   } catch (err) {
     req.log.warn(
       {
-        err: err instanceof Error ? err.message : err,
+        errName: err instanceof Error ? err.constructor.name : undefined,
+        errStatus: (err as { status?: number } | undefined)?.status,
+        errMessage: err instanceof Error ? err.message : String(err),
+        causeName:
+          err instanceof Error && err.cause instanceof Error
+            ? err.cause.constructor.name
+            : undefined,
+        causeMessage:
+          err instanceof Error && err.cause instanceof Error
+            ? err.cause.message
+            : undefined,
         notificationUUID: notification.notificationUUID,
       },
       "Apple S2S inner transaction JWS verification failed",


### PR DESCRIPTION
## Why

Found while debugging the first real Apple S2S notification on the dev backend. PR #248 added a happy-path log, but the existing failure-path catch logged only `err.message`, which is **always empty** for `@apple/app-store-server-library`'s `VerificationException` — its constructor calls `super()` with no message argument.

Real-world symptom: Datadog log entries with `msg: "Apple S2S notification JWS verification failed"` and an `err` field that's an empty string. No way to tell whether the failure is bundle mismatch (status 3), env mismatch (status 4), cert chain (status 6), or signature (status 1) without re-instrumenting and re-deploying.

## What

Enriches the three JWS-verify catches to log the actionable fields:

```
errName       — e.g. "VerificationException"
errStatus     — the VerificationStatus enum int (0-7)
errMessage    — still captured even if ""
causeName     — wrapped Error's class, when present
causeMessage  — wrapped Error's message, when present
```

The mapping for ops:

| `errStatus` | Meaning | Fix |
|---|---|---|
| 1 | `VERIFICATION_FAILURE` | Real signature problem — investigate cert chain |
| 2 | `RETRYABLE_VERIFICATION_FAILURE` | Transient; Apple will resend |
| 3 | `INVALID_APP_IDENTIFIER` | `APPLE_BUNDLE_ID` mismatch — env var wrong for this app record |
| 4 | `INVALID_ENVIRONMENT` | `APPLE_ENV` doesn't match what Apple sent (sandbox vs production) |
| 5 | `INVALID_CHAIN_LENGTH` | x5c chain has wrong number of certs — rare |
| 6 | `INVALID_CERTIFICATE` | Cert chain didn't validate against Apple Root CA G2/G3 |
| 7 | `FAILURE` | Generic — check `errMessage` / `causeMessage` |

Affected handlers:
- `src/api/v2/subscriptions/handlers/apple-ssn.ts` — outer notification verify + inner transaction verify
- `src/api/v2/accounts/handlers/subscription-verify.ts` — iOS-posted JWS verify

No behavioral change, observability only. Test cases unchanged.

## Test plan

- [x] `bun typecheck` — clean for touched files
- [x] `bun lint` — clean for touched files
- [x] `bunx prettier --check` — clean
- [ ] After deploy: re-trigger the failing sandbox notification (or wait for Apple's next retry) and confirm Datadog now shows `errStatus`, `errName`, etc. in the structured fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782052949&installation_id=128169237&pr_number=249&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F249&signature=097efadf4e29c9a2fb0377050856c569918b67405b12247dca2ff57258a1cc1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand structured error and success logging for JWS verification in subscription handlers
> - Replaces single-field `message` error logs with structured fields (`errName`, `errStatus`, `errMessage`, `causeName`, `causeMessage`) in the JWS verification catch blocks of [`subscription-verify.ts`](https://github.com/ephemeraHQ/convos-backend/pull/249/files#diff-5045dc2ccbf9d7609f86bbb6fd5c608c1a0370b6a0180d50e5d47f62518baa44) and [`apple-ssn.ts`](https://github.com/ephemeraHQ/convos-backend/pull/249/files#diff-1af995eead831ac657947747d0afdd6e2405f468d93dcd6e0105bf6414276bf7).
> - Adds info-level logs on successful JWS verification to record decoded transaction fields, and after successful upsert/notification apply to record applied subscription details.
> - HTTP response semantics and acknowledgment behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d47055.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->