### PR TITLE
fix(docker): drop --env-file-if-exists from container entrypoint

### DIFF
--- a/dev/entrypoint.sh
+++ b/dev/entrypoint.sh
@@ -4,9 +4,11 @@ set -e
 # Use the local prisma CLI directly — release image is pnpm-less.
 node ./node_modules/prisma/build/index.js migrate deploy
 
+# No --env-file flag: container env is supplied by the runtime (ECS task
+# definition, docker run -e, etc). We never bake a .env into the image, so
+# --env-file-if-exists=.env would only ever print "not found" noise.
 exec node \
   --enable-source-maps \
-  --env-file-if-exists=.env \
   --import @opentelemetry/instrumentation/hook.mjs \
   --import file:///app/dist/instrumentation.js \
   /app/dist/index.js

--- a/dev/entrypoint.sh
+++ b/dev/entrypoint.sh
@@ -4,9 +4,6 @@ set -e
 # Use the local prisma CLI directly — release image is pnpm-less.
 node ./node_modules/prisma/build/index.js migrate deploy
 
-# No --env-file flag: container env is supplied by the runtime (ECS task
-# definition, docker run -e, etc). We never bake a .env into the image, so
-# --env-file-if-exists=.env would only ever print "not found" noise.
 exec node \
   --enable-source-maps \
   --import @opentelemetry/instrumentation/hook.mjs \


### PR DESCRIPTION
## Summary

- Post Bun→Node migration (PR #241), every ECS task boot logged `.env not found. Continuing without it.` — Node's own stderr output when `--env-file-if-exists=<file>` points at a missing path.
- Container images never bundle a `.env` (Dockerfile does not `COPY` it; runtime env comes from the ECS task definition / `docker run -e`), so the flag was pure noise.
- Drop the flag from `dev/entrypoint.sh`. Local dev (`pnpm dev` → `tsx --env-file=.env`) is unaffected.
- Comment left in the entrypoint to prevent re-add.

## Test plan

- [ ] Build image locally: `docker build -t convos-backend:env-fix .`
- [ ] Run with no `.env` mounted, env supplied via `-e`: confirm boot logs no longer contain `.env not found`.
- [ ] Confirm app reads required env vars (DATABASE_URL, JWT_*, etc.) correctly from the runtime env.
- [ ] Deploy to staging, tail CloudWatch on first task boot: noise gone, app healthy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782053676&installation_id=128169237&pr_number=250&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F250&signature=83d9e06e0022060201f2a96e0e8d44daffea970c83603bc7be3aad9d1587fd19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `--env-file-if-exists=.env` flag from container entrypoint
> Drops the Node.js `--env-file-if-exists=.env` flag from [entrypoint.sh](https://github.com/ephemeraHQ/convos-backend/pull/250/files#diff-10d510964ce9ed2077edb5b60d2f3068155850a5bc6a6ab6c608fad9a02d996f). The container no longer auto-loads a `.env` file on startup; environment variables must be injected via other means (e.g. Docker environment configuration).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bf06dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment environment configuration to use container runtime variables instead of configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->