### PR TITLE
fix(docker): restore curl for ECS container health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ FROM node:24-bookworm-slim AS release
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openssl ca-certificates tini \
+  && apt-get install -y --no-install-recommends openssl ca-certificates tini curl \
   && rm -rf /var/lib/apt/lists/* \
   && useradd --system --create-home --uid 10001 appuser
 


### PR DESCRIPTION
## Summary

- Post Bun→Node migration (PR #241), ECS tasks were repeatedly killed with `SIGTERM signal received: closing Convos API service` and the AWS console reporting `Task failed container health checks`.
- Root cause: the ECS task definition health check command is
  ```
  ["CMD-SHELL", "curl -f http://localhost:${local.api_port}/${local.api_health_check_path}?container=true || exit 1"]
  ```
  The pre-migration Ubuntu+Bun image installed `curl` in both build and release stages. The new `node:24-bookworm-slim` base does not ship `curl`, and the migration Dockerfile only added `openssl ca-certificates tini`.
- Inside the container: `curl` → 127 (command not found) → health check fails → ECS marks task UNHEALTHY → SIGTERM. The Express `/healthcheck` endpoint itself was always serving 200 OK; nothing was wrong at the application layer.

## Fix

Add `curl` to the release-stage `apt-get install` line. ~2 MB image growth, matches the previous image's capabilities, no Terraform change required.

## Why not change Terraform instead

A node-native check (`node -e "require('http').get(...)"`) would also work and keep the image minimal, but it requires a coordinated Terraform PR + redeploy and leaves the image without `curl` for any future in-container debugging. This fix unblocks immediately and is the same lever the old image already pulled.

## Test plan

- [ ] `docker build -t convos-backend:curl-fix .`
- [ ] `docker run --rm convos-backend:curl-fix curl --version` → prints curl version.
- [ ] Manually exercise the health check inside the container:
  ```
  docker run -d --name convos-test -e DATABASE_URL=... -e JWT_PRIVATE_KEY=... -e JWT_PUBLIC_KEY=... -e PORT=4040 convos-backend:curl-fix
  docker exec convos-test curl -f http://localhost:4040/healthcheck?container=true && echo OK
  ```
- [ ] Push to dev, watch CloudWatch + ECS task state — no `Task failed container health checks`, no SIGTERM loop, no app-side regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782054253&installation_id=128169237&pr_number=251&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F251&signature=450b29f00ab982fdb6bb59f54e44a12aa44a7ad9f98f3efbd8d90f567826a70c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `curl` in Docker release image for ECS container health check
> Adds `curl` back to the `apt-get install` list in the release stage of [Dockerfile](https://github.com/ephemeraHQ/convos-backend/pull/251/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557), alongside `openssl`, `ca-certificates`, and `tini`. Without it, ECS health checks that rely on `curl` would fail at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43722a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->