### PR TITLE
fix(subscriptions): allow APPLE_ENV=sandbox under NODE_ENV=production

### DIFF
--- a/src/subscriptions/jws-verifier.ts
+++ b/src/subscriptions/jws-verifier.ts
@@ -32,15 +32,22 @@ const resolveEnvironment = () => {
   const isProd = isProductionEnv();
   if (raw === "production") return Environment.PRODUCTION;
   if (raw === "sandbox") {
-    if (isProd) {
-      throw new AppError(500, "APPLE_ENV=sandbox is forbidden in production");
-    }
+    // Sandbox is a legitimate combination with NODE_ENV=production for any
+    // non-laptop deploy pointed at Apple's sandbox endpoint (e.g. otr-dev,
+    // staging, TestFlight backend). The previous defense-in-depth check
+    // rejected this combination, breaking the dev deploy. Real prod
+    // misconfigured with APPLE_ENV=sandbox still fails closed at signature
+    // time — Apple-Production-signed notifications fail INVALID_ENVIRONMENT
+    // against a Sandbox-configured verifier — so the operator-error blast
+    // radius is "no notifications work", not "forged ones accepted".
     return Environment.SANDBOX;
   }
   if (raw === "local-testing") {
-    // LOCAL_TESTING skips JWS signature + chain verification entirely. A
-    // misconfigured prod env with APPLE_ENV=local-testing would silently
-    // accept forged transactions. Fail loudly instead.
+    // LOCAL_TESTING bypasses JWS signature + chain verification entirely
+    // (the library treats payloads as pre-verified). A misconfigured prod
+    // env with APPLE_ENV=local-testing would silently accept any forged
+    // transaction as real. Fail loudly instead — this is the one APPLE_ENV
+    // value that is unsafe under NODE_ENV=production.
     if (isProd) {
       throw new AppError(
         500,

--- a/tests/subscriptions/jws-verifier.test.ts
+++ b/tests/subscriptions/jws-verifier.test.ts
@@ -164,14 +164,13 @@ describe("buildVerifierConfig", () => {
     }
   });
 
-  test("APPLE_ENV=sandbox throws 500 in production (prod must verify production JWS only)", () => {
+  test("APPLE_ENV=sandbox is allowed under NODE_ENV=production (legitimate combo for staging / dev deploys)", () => {
     const priorNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "production";
     process.env.APPLE_ENV = "sandbox";
     try {
-      expect(() => buildVerifierConfig()).toThrow(
-        /sandbox is forbidden in production/,
-      );
+      const cfg = buildVerifierConfig();
+      expect(cfg.environment).toBe(Environment.SANDBOX);
     } finally {
       if (priorNodeEnv === undefined) {
         delete process.env.NODE_ENV;


### PR DESCRIPTION
## What this fixes

The dev backend (`api.dev.convos.xyz`) is rejecting every inbound Apple S2S notification with:

```
errMessage: "APPLE_ENV=sandbox is forbidden in production"
errName: "_AppError"
errStatus: 500
```

(Visible thanks to the enriched logging in #248 + #249.)

## Root cause

In `src/subscriptions/jws-verifier.ts`, `resolveEnvironment()` conflated two orthogonal axes:

| Axis | Meaning |
|---|---|
| `NODE_ENV` | Is this a developer's laptop (`development`) or a deployed service (`production`)? |
| `APPLE_ENV` | Which App Store endpoint is this service talking to (`sandbox` / `production` / `local-testing`)? |

Every ECS deploy runs `NODE_ENV=production`, including the otr-dev cluster which legitimately needs `APPLE_ENV=sandbox` to talk to Apple Sandbox. The guard rejected this combination as a security risk and threw `AppError(500)`, breaking the entire S2S webhook pipeline on dev.

## Why the guard was wrong

Originally I added the sandbox-in-prod guard as defense-in-depth. But the defense doesn't actually defend anything:

- `APPLE_ENV=sandbox` configures `SignedDataVerifier` with `Environment.SANDBOX`
- A real production notification (with `data.environment = "Production"`) **fails closed** against a Sandbox-configured verifier — Apple's library throws `INVALID_ENVIRONMENT` (status 4)
- So worst-case operator error is "**no notifications work**", not "forged sandbox transactions accepted as real subscribers"

In other words: the guard rejected legitimate dev/staging deploys to prevent a failure mode (forged sandbox acceptance) that the library already prevents on its own.

`LOCAL_TESTING` is genuinely different — it bypasses signature + chain verification entirely, so a misconfigured prod with that value would accept any forged JWS. **That guard stays.**

## Change

- `src/subscriptions/jws-verifier.ts:30-53` — drop the sandbox-in-prod throw; add comment explaining why
- `tests/subscriptions/jws-verifier.test.ts:167-181` — rewrite the previously-asserted-rejection test to assert the now-allowed combination resolves to `Environment.SANDBOX`

## After this lands

Once deployed to otr-dev, Apple's next S2S notification retry (or the next iOS sandbox purchase that fires a `SUBSCRIBED` notification) should produce a green `subscription.ssn.applied` info log instead of a red `JWS verification failed` warn log.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bunx vitest run tests/subscriptions/jws-verifier.test.ts` — 17 tests pass
- [ ] After deploy: Apple sends a sandbox `DID_RENEW` (or send a TEST notification from ASC). Confirm log contains `"subscription.ssn.applied"` not `"JWS verification failed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782055045&installation_id=128169237&pr_number=252&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F252&signature=6b7575a0ecf6ea11ace4b4815616daae77da489a0d50c225945baf176ba9bc09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `APPLE_ENV=sandbox` under `NODE_ENV=production` in JWS verifier
> Previously, `resolveEnvironment` in [jws-verifier.ts](https://github.com/ephemeraHQ/convos-backend/pull/252/files#diff-ba97d161a549202f2ef5b83e8e3e3f1980e1df19c6f017e5ba3c62cef68e4115) threw an `AppError` when `APPLE_ENV=sandbox` was set in a production Node environment, blocking legitimate staging/dev deploys. Now `APPLE_ENV=sandbox` unconditionally returns `Environment.SANDBOX` regardless of `NODE_ENV`. The guard against `APPLE_ENV=local-testing` in production is retained, since that mode bypasses verification entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12ac1c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->