### PR TITLE
fix(generations): static-import posthog-node to fix ESM bundle 502

### DIFF
--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -13,8 +13,7 @@
  * singleton-override pattern used throughout the codebase.
  */
 
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
-
+import { PostHog } from "posthog-node";
 import { POSTHOG_HOST, POSTHOG_PROJECT_TOKEN } from "@/config";
 import logger from "@/utils/logger";
 import type { GenerationMetrics } from "./templateGen";
@@ -142,28 +141,27 @@ export function resolveActor(p: ActorSignals): ResolvedActor {
 // Lazy PostHog client singleton
 // ---------------------------------------------------------------------------
 
-let _posthogClient: any = null;
+let _posthogClient: PostHog | null = null;
 
 /**
  * Return the PostHog client if both env vars are set, otherwise `null`.
  * The client is created once and cached for the lifetime of the process.
- * Lazy-loads `posthog-node` so the import cost is only paid when the
- * feature is actually configured.
+ *
+ * `posthog-node` is imported statically (not via `require()`): the production
+ * build bundles to ESM, where a surviving `require()` degrades to esbuild's
+ * `__require` shim and throws "Dynamic require of posthog-node is not
+ * supported" at call time. A static `import` also shares the one ESM entry
+ * `@posthog/ai` already pulls in, so there's a single posthog-node instance.
  *
  * Exported so the OpenRouter client (`openrouter-client.ts`) can hand the
  * SAME posthog-node instance to `@posthog/ai`'s wrapper — one client, one
  * flush on shutdown, shared event buffer.
  */
-export function getPostHogClient(): any {
+export function getPostHogClient(): PostHog | null {
   if (_posthogClient) return _posthogClient;
 
   if (!POSTHOG_PROJECT_TOKEN || !POSTHOG_HOST) return null;
 
-  // Dynamic import would require top-level await; use require() for
-  // synchronous lazy init at call time (matches mission constraint).
-  const { PostHog } = require("posthog-node") as {
-    PostHog: new (apiKey: string, opts: { host: string }) => any;
-  };
   _posthogClient = new PostHog(POSTHOG_PROJECT_TOKEN, { host: POSTHOG_HOST });
   // Surface async capture failures (auth 401s on a wrong token, wrong host,
   // network errors). capture() is fire-and-forget so these are otherwise
@@ -206,7 +204,9 @@ export function __resetPostHogForTests(
  * cache (`__resetOpenRouterClientForTests`) so the wrapper picks up the stub.
  */
 export function __setPostHogClientForTests(client: unknown): void {
-  _posthogClient = client;
+  // Tests inject a minimal stub (e.g. just a `capture` spy), not a real
+  // PostHog — cast through the public type so the seam stays loose.
+  _posthogClient = client as PostHog | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -229,10 +229,9 @@ export function capturePostHog(properties: PostHogCaptureProperties): void {
 
   // Fire-and-forget: capture is buffered internally by the SDK.
   // No await — the route returns immediately. Wrap in try/catch so a
-  // synchronous SDK failure (serialization, internal state, or lazy
-  // `require("posthog-node")` / `new PostHog()` failure inside
-  // getPostHogClient) cannot bubble up and break the request that
-  // triggered this analytics call.
+  // synchronous SDK failure (serialization, internal state, or a
+  // `new PostHog()` failure inside getPostHogClient) cannot bubble up
+  // and break the request that triggered this analytics call.
   try {
     const client = getPostHogClient();
     if (!client) return; // silent no-op when env not set

--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -145,17 +145,10 @@ let _posthogClient: PostHog | null = null;
 
 /**
  * Return the PostHog client if both env vars are set, otherwise `null`.
- * The client is created once and cached for the lifetime of the process.
+ * Created once and cached for the lifetime of the process.
  *
- * `posthog-node` is imported statically (not via `require()`): the production
- * build bundles to ESM, where a surviving `require()` degrades to esbuild's
- * `__require` shim and throws "Dynamic require of posthog-node is not
- * supported" at call time. A static `import` also shares the one ESM entry
- * `@posthog/ai` already pulls in, so there's a single posthog-node instance.
- *
- * Exported so the OpenRouter client (`openrouter-client.ts`) can hand the
- * SAME posthog-node instance to `@posthog/ai`'s wrapper — one client, one
- * flush on shutdown, shared event buffer.
+ * Exported so the OpenRouter client can hand the SAME instance to
+ * `@posthog/ai`'s wrapper — one client, one flush on shutdown.
  */
 export function getPostHogClient(): PostHog | null {
   if (_posthogClient) return _posthogClient;

--- a/src/api/v2/agent-templates/services/posthog.ts
+++ b/src/api/v2/agent-templates/services/posthog.ts
@@ -207,7 +207,7 @@ export function __setPostHogClientForTests(client: unknown): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Fire a `builder.template.generated` PostHog event.
+ * Fire a `builder.generation.completed` PostHog event.
  *
  * - When a test override is installed, delegates to the override.
  * - When `POSTHOG_PROJECT_TOKEN` is unset, returns immediately (no-op).


### PR DESCRIPTION
## Summary

The generation server was returning **502 (`Dynamic require of "posthog-node" is not supported`)**.

Root cause: `src/api/v2/agent-templates/services/posthog.ts` loaded the SDK with a lazy `require("posthog-node")`. The production `build` script (`bun build … --target bun`) emits an **ESM** bundle, where a surviving `require()` becomes esbuild/bun's `__require` shim that throws at call time. That call happens inside `getPostHogClient()` on the generation path, so it surfaced as a 502.

The fix:
- Replace the lazy `require()` with a static `import { PostHog } from "posthog-node"`. The repo imports every other dependency statically (zero `require()`/dynamic `import()` in `src/`), and `openrouter-client.ts` already eagerly bundles the same ESM entry via `@posthog/ai` — so this adds no startup cost and collapses to a **single** posthog-node instance (the bundle shrank ~230 KB), matching the file's documented "one client, one flush" design. The old lazy module-load bought nothing.
- With the `require` gone, tighten `_posthogClient` / `getPostHogClient()` from `any` to `PostHog | null` (matching the `T | null` singleton convention in the sibling services) and drop the now-unused `eslint-disable` directive. The test-injection seam keeps a single `as PostHog | null` cast with a comment.

## Verification

- Production bundle (`bun build … --target bun`) now contains **0** `Dynamic require of` shims; `getPostHogClient()` uses the bundled `PostHog` directly.
- `bun typecheck`: no new errors (the pre-existing `#private` mismatch on `openrouter-client.ts:89` is unrelated and untouched).
- Lint clean on the file.
- Tests: `posthog.service`, `template-gen.posthog-trace`, `openrouter-errors`, `openrouter-timeout`, `builder-deps-env` — **32 pass, 0 fail**.

## Test plan

- [ ] Deploy and confirm the generation endpoint no longer 502s
- [ ] Confirm `builder.generation.completed` / `$ai_generation` events still land in PostHog when `POSTHOG_PROJECT_TOKEN` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782059267&installation_id=128169237&pr_number=253&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F253&signature=cc2b91a8ac7a2d21f53e2ab3d1eb5ed2b3764a6f5136d1b91e137f6b856dbab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety for analytics client handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ESM bundle 502 by converting `posthog-node` to a static import in `posthog.ts`
> The dynamic `require('posthog-node')` inside `getPostHogClient()` was incompatible with the ESM bundle, causing 502 errors. Replaces it with a top-level static import in [posthog.ts](https://github.com/ephemeraHQ/convos-backend/pull/253/files#diff-542f2fa8706fd2fc425fdfbf7c593fbab3b52265f4ec6025fa64cb3661637d81). Client instantiation still only occurs when `POSTHOG_PROJECT_TOKEN` and `POSTHOG_HOST` are set; only the module load timing changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 619f4bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->