### PR TITLE
fix(agents/join): align onboarding wire value to "agent-builder" for iOS PR 830

### DIFF
--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -11,7 +11,11 @@ import {
   getJoinWaitBudgetMs,
 } from "./assistant-config";
 
-const ASSISTANT_BUILDER_ONBOARDING = "assistant-builder";
+// Wire value the iOS agent-builder flow sends to signal the in-conversation
+// builder onboarding. Forwarded verbatim to convos-assistants, which
+// normalizes it to the runtime's internal `"assistant-builder"` name (a
+// deferred bulk-rename — see xmtplabs/convos-assistants#1772).
+const AGENT_BUILDER_ONBOARDING = "agent-builder";
 
 type TemplateRow = Awaited<ReturnType<typeof prisma.agentTemplate.findUnique>>;
 type TemplateFinder = (id: string) => Promise<TemplateRow>;
@@ -309,13 +313,13 @@ export async function joinHandler(req: Request, res: Response) {
   // (e.g. `"first-impression"`) compose fine with `templateId`.
   if (
     templateId !== undefined &&
-    options?.onboarding === ASSISTANT_BUILDER_ONBOARDING
+    options?.onboarding === AGENT_BUILDER_ONBOARDING
   ) {
     res.status(400).json({
       success: false,
       error: "INVALID_REQUEST",
       message:
-        "templateId cannot be combined with options.onboarding=assistant-builder",
+        "templateId cannot be combined with options.onboarding=agent-builder",
     });
     return;
   }

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -11,10 +11,6 @@ import {
   getJoinWaitBudgetMs,
 } from "./assistant-config";
 
-// Wire value the iOS agent-builder flow sends to signal the in-conversation
-// builder onboarding. Forwarded verbatim to convos-assistants, which
-// normalizes it to the runtime's internal `"assistant-builder"` name (a
-// deferred bulk-rename — see xmtplabs/convos-assistants#1772).
 const AGENT_BUILDER_ONBOARDING = "agent-builder";
 
 type TemplateRow = Awaited<ReturnType<typeof prisma.agentTemplate.findUnique>>;

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -359,7 +359,7 @@ describe("agents join (assistant API)", () => {
           const body = JSON.parse(init.body as string) as {
             options?: Record<string, unknown>;
           };
-          expect(body.options).toEqual({ onboarding: "assistant-builder" });
+          expect(body.options).toEqual({ onboarding: "agent-builder" });
           return Promise.resolve(jsonResponse(200, { instanceId: "inst-ob" }));
         }
         return Promise.resolve(
@@ -372,7 +372,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post({
         slug: "x",
-        options: { onboarding: "assistant-builder" },
+        options: { onboarding: "agent-builder" },
       });
       expect(res.status).toBe(200);
     });
@@ -385,7 +385,7 @@ describe("agents join (assistant API)", () => {
           };
           expect(body.options).toEqual({
             skipGreeting: false,
-            onboarding: "assistant-builder",
+            onboarding: "agent-builder",
           });
           return Promise.resolve(jsonResponse(200, { instanceId: "inst-bo" }));
         }
@@ -399,7 +399,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post({
         slug: "x",
-        options: { skipGreeting: false, onboarding: "assistant-builder" },
+        options: { skipGreeting: false, onboarding: "agent-builder" },
       });
       expect(res.status).toBe(200);
     });
@@ -711,13 +711,13 @@ describe("agents join (assistant API)", () => {
       expect(data.error).toBe("TEMPLATE_FORBIDDEN");
     });
 
-    test("rejects templateId + onboarding=assistant-builder (mutually exclusive)", async () => {
+    test("rejects templateId + onboarding=agent-builder (mutually exclusive)", async () => {
       // Validation happens before the template lookup, so no finder needed.
       const res = await post(
         {
           slug: "x",
           templateId: "33333333-3333-4333-8333-333333333333",
-          options: { onboarding: "assistant-builder" },
+          options: { onboarding: "agent-builder" },
         },
         { accountId: "user-1" },
       );


### PR DESCRIPTION
## Summary
iOS [PR 830](https://github.com/ephemeraHQ/convos-ios/pull/830) renamed its in-app builder flow from `assistant-*` to `agent-*` and started sending `options.onboarding: "agent-builder"` to `POST /api/v2/agents/join`. The upstream `convos-assistants` service only accepted `"assistant-builder"` / `"first-impression"`, so the zod validator rejected every iOS builder join with `invalid_value` and the backend returned 502 (`AGENT_PROVISION_FAILED`).

This change renames the backend's `ASSISTANT_BUILDER_ONBOARDING` constant + mutex check + error message to the new `"agent-builder"` wire value. Companion PR on `convos-assistants` (xmtplabs/convos-assistants#1772) accepts `"agent-builder"` and normalizes it to the runtime's existing internal `"assistant-builder"` at the trust boundary — so the on-disk skill, runtime gating, and Python-side type names don't churn yet (deferred bulk-rename).

## Test plan
- [x] Updated `agents-join` test suite to drive the new wire value (`onboarding: "agent-builder"`)
- [ ] After both PRs ship, smoke iOS PR 830 builder join end-to-end (hammer button on conversations list → Make → agent joins)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782366470&installation_id=128169237&pr_number=254&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F254&signature=a30c9f89bc42d7006f50a8ed583b8bc33264416c7ee008512831e0133dd4fbaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix onboarding wire value from "assistant-builder" to "agent-builder" in agents join handler
> Updates the `AGENT_BUILDER_ONBOARDING` constant and validation logic in [join.ts](https://github.com/ephemeraHQ/convos-backend/pull/254/files#diff-56b3806a78b9509421cf23cd82891715d11c219bad27f45a5a9ff9665a18cd7c) to use `"agent-builder"` instead of `"assistant-builder"`. The 400 error message and test expectations in [agents-join.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/254/files#diff-202ec27d5261c9aab1f0b94004767f758c621d973083a5b2b55fdc01b51642b6) are updated to match. Behavioral Change: requests with `onboarding=assistant-builder` combined with a `templateId` are no longer rejected by this check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9f6305.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated agent-builder onboarding flow processing and validation rules to prevent incompatible parameter combinations

* **Tests**
  * Updated onboarding-related test assertions to reflect new behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->