### PR TITLE
fix(tests): swap leftover bun:test import for vitest in revalidate-dashboard

### DIFF
--- a/tests/revalidate-dashboard.service.test.ts
+++ b/tests/revalidate-dashboard.service.test.ts
@@ -8,7 +8,7 @@
  *   - revalidateTemplate emits templates + template:<id> + template:<urlSlug>
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   __setBaseUrlForTests,
   __setFetchForTests,


### PR DESCRIPTION
## Summary
`tests/revalidate-dashboard.service.test.ts` was missed in the Bun→Node+pnpm migration (#241) and still imported test helpers from `bun:test`. `pnpm tsc --noEmit` fails on it:

```
tests/revalidate-dashboard.service.test.ts(11,63): error TS2307: Cannot find module 'bun:test' or its corresponding type declarations.
```

Swap the import to `vitest`, matching every other file under `tests/`. No behavioral or assertion changes.

## Test plan
- [x] `pnpm tsc --noEmit` no longer reports the `bun:test` error
- [ ] CI: `pnpm test tests/revalidate-dashboard.service.test.ts` green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782368216&installation_id=128169237&pr_number=255&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F255&signature=31bba6f3fae19f6f057ce87a21101f0365a2878cab2d9f703e7c9c2077d8f613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix leftover `bun:test` import in `revalidate-dashboard` service test
> Replaces the `bun:test` import with `vitest` in [revalidate-dashboard.service.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/255/files#diff-239a2a22532cc7edcd31cb7cbdd1f638506732e6f22521fa56aadaed57c03f31), aligning it with the rest of the test suite.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 153ca3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->