### PR TITLE
Default passthrough template name to "Agent"

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -1026,8 +1026,8 @@ async function tryContentPassthrough(
   const template = wrapAsPassthroughTemplate(
     content,
     {
-      agentName: classification.agentName || "Assistant",
-      description: classification.description || "A Convos assistant.",
+      agentName: classification.agentName || "Agent",
+      description: classification.description || "A Convos agent.",
       category: classification.category || "Work",
       emoji: classification.emoji || "🤖",
     },


### PR DESCRIPTION
## Summary

- `templateGen.ts` was defaulting an unclassified agent template's `agentName` to `"Assistant"` and its `description` to `"A Convos assistant."`
- iOS surfaces those values verbatim as the agent's profile name + description, so users still saw "Assistant" in the chat header / member list after a `+ Invite members -> Add an agent` join into an existing conversation
- Flip both literals to align with the Agent-Builder rebrand that already shipped in iOS PR #830

## Test plan

- [ ] Trigger an unclassified passthrough template generation locally and confirm the resulting template lands with `agentName = "Agent"` and `description = "A Convos agent."`
- [ ] On iOS, invite an agent into an existing conversation; verify the join row, sender label, and contact card all read "Agent"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782494211&installation_id=128169237&pr_number=258&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F258&signature=0a7c1299b11e384a941aacf8de973284cd7dcdf98796482d57dadfe77943d19c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default passthrough template name to "Agent" instead of "Assistant"
> Updates the fallback `agentName` from `"Assistant"` to `"Agent"` and `description` from `"A Convos assistant."` to `"A Convos agent."` in the `tryContentPassthrough` function in [templateGen.ts](https://github.com/ephemeraHQ/convos-backend/pull/258/files#diff-d151881c4ab5cd2005df4016ac6a564fb6094e4ce06b69fbf9529fb70e59148a). These defaults apply only when classification does not provide these fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1464988.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default naming conventions in template generation from "Assistant" to "Agent" terminology to ensure consistent branding across generated templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->