### PR TITLE
chore(notifications): log accountId on subscribe handler

### DIFF
--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -38,6 +38,7 @@ export async function subscribe(
 
     req.log.info(
       {
+        accountId: res.locals.accountId,
         deviceId: body.deviceId,
         clientId: body.clientId,
         topicCount: body.topics.length,
@@ -90,7 +91,11 @@ export async function subscribe(
     // Register installation with notification server (only if pushToken exists)
     if (!device.pushToken) {
       req.log.info(
-        { deviceId: body.deviceId, clientId: body.clientId },
+        {
+          accountId: res.locals.accountId,
+          deviceId: body.deviceId,
+          clientId: body.clientId,
+        },
         "Device has no push token yet - subscription will be activated once token is registered",
       );
     } else {
@@ -158,7 +163,11 @@ export async function subscribe(
     }
 
     req.log.info(
-      { deviceId: body.deviceId, clientId: body.clientId },
+      {
+        accountId: res.locals.accountId,
+        deviceId: body.deviceId,
+        clientId: body.clientId,
+      },
       "Subscribed successfully",
     );
     res.status(200).send();


### PR DESCRIPTION
## Summary

Add `accountId` (from the JWT — `res.locals.accountId`) to the three structured log lines in `src/api/v2/notifications/handlers/subscribe.ts`:

- `Subscribing to topics`
- `Device has no push token yet - subscription will be activated once token is registered`
- `Subscribed successfully`

## Why

Debugging the iOS push notification wedge this week, we needed to filter Datadog logs by `accountId`, but the existing structured log fields only included `deviceId`. The iOS debug surface doesn't expose `deviceId` either (it will once convos-ios Stack 2's `DebugPushNotificationsView` ships, but that's later). Today the only practical filter is `accountId`.

This is the smallest possible change that fixes that: add `accountId` to the existing structured-field bag at each log site. One line per site, no behavior change, no perf impact.

## Scope kept tight

- **Three log lines in `subscribe.ts`** — the ones we actually hit while debugging.
- Intentionally NOT touching `unsubscribe.ts`, `unregister.ts`, `webhook.ts` in this PR. Happy to follow up if it's useful elsewhere; wanted this one as a stand-alone tiny PR for fast review.

## Test plan

- `npm run typecheck` ✅
- `npx eslint src/api/v2/notifications/handlers/subscribe.ts` ✅
- After merge, verify in Datadog that new `Subscribing to topics` entries carry the `accountId` field and that filter `@accountId:<uuid>` returns the expected entries.

## Cross-reference

This is **T11.5** from the convos-ios Stack 2 prep in [convos-ios PR #907 plan](https://github.com/xmtplabs/convos-ios/pull/907). Filed as its own PR (instead of bundled with the larger Stack 2 work) so it can ship today and unblock debugging immediately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782648279&installation_id=128169237&pr_number=260&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F260&signature=6f1fc5a6ff16e90a3de71196b81e4885b717f9d6248b4d4305f42c207477f06e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging for subscription events to improve system observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `accountId` to structured logs in the notifications subscribe handler
> Adds `accountId` from `res.locals` to the logging context in [subscribe.ts](https://github.com/ephemeraHQ/convos-backend/pull/260/files#diff-ceb1529a284486613f3b036bdbc51ee98edad2a540aaf02fca7bfa8bac4715cc) for three log points: initial subscribe attempt, missing push token, and successful subscription.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3f4895.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->