### PR TITLE
Notification snapshot, idempotent subscribe, webhook accountId enforcement, NSE unregister middleware, debug-status endpoint, orphan cleanup

### DIFF
--- a/prisma/migrations/20260529121133_notification_subscription_snapshot/migration.sql
+++ b/prisma/migrations/20260529121133_notification_subscription_snapshot/migration.sql
@@ -1,0 +1,48 @@
+-- Stack 2 / T10: NotificationSubscriptionSnapshot + ClientIdentifier.accountId
+--
+-- Adds the snapshot table that persists the last desired push topic set per
+-- ClientIdentifier (used by /v2/notifications/subscribe's idempotency check
+-- and by the new /v2/notifications/debug/status endpoint). Also adds the
+-- accountId column to ClientIdentifier so the webhook handler can refuse
+-- cross-account push delivery (Stack 2 D15).
+
+-- AlterTable: add accountId to ClientIdentifier
+ALTER TABLE "ClientIdentifier" ADD COLUMN "accountId" UUID;
+
+-- Backfill ClientIdentifier.accountId from the joined DeviceRegistration row.
+-- Rows where DeviceRegistration.accountId is NULL stay NULL; the webhook
+-- handler will treat them as untrusted ghosts and refuse to send.
+UPDATE "ClientIdentifier" ci
+SET "accountId" = dr."accountId"
+FROM "DeviceRegistration" dr
+WHERE ci."deviceId" = dr."deviceId"
+  AND dr."accountId" IS NOT NULL;
+
+CREATE INDEX "ClientIdentifier_accountId_idx" ON "ClientIdentifier"("accountId");
+
+-- CreateTable: NotificationSubscriptionSnapshot
+CREATE TABLE "NotificationSubscriptionSnapshot" (
+    "clientId" TEXT NOT NULL,
+    "accountId" UUID,
+    "topicCount" INTEGER NOT NULL,
+    "topicHash" VARCHAR(64) NOT NULL,
+    "kindSummary" JSONB,
+    "lastContext" TEXT,
+    "lastSubscribeAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastRemoteApplySucceeded" BOOLEAN NOT NULL,
+    "lastRemoteApplyError" TEXT,
+    "pushTokenSha256AtApply" VARCHAR(64) NOT NULL,
+    "apnsEnvAtApply" "ApnsEnvironment",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationSubscriptionSnapshot_pkey" PRIMARY KEY ("clientId")
+);
+
+CREATE INDEX "NotificationSubscriptionSnapshot_accountId_idx" ON "NotificationSubscriptionSnapshot"("accountId");
+
+CREATE INDEX "NotificationSubscriptionSnapshot_updatedAt_idx" ON "NotificationSubscriptionSnapshot"("updatedAt");
+
+-- AddForeignKey: cascade delete when the parent ClientIdentifier is removed
+-- (sign-out, NSE unregister cleanup, T20 orphan migration, etc.)
+ALTER TABLE "NotificationSubscriptionSnapshot" ADD CONSTRAINT "NotificationSubscriptionSnapshot_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "ClientIdentifier"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260529121133_notification_subscription_snapshot/migration.sql
+++ b/prisma/migrations/20260529121133_notification_subscription_snapshot/migration.sql
@@ -1,21 +1,34 @@
--- Stack 2 / T10: NotificationSubscriptionSnapshot + ClientIdentifier.accountId
+-- NotificationSubscriptionSnapshot + ClientIdentifier.accountId
 --
 -- Adds the snapshot table that persists the last desired push topic set per
 -- ClientIdentifier (used by /v2/notifications/subscribe's idempotency check
--- and by the new /v2/notifications/debug/status endpoint). Also adds the
+-- and by the /v2/notifications/debug/status endpoint). Also adds the
 -- accountId column to ClientIdentifier so the webhook handler can refuse
--- cross-account push delivery (Stack 2 D15).
+-- cross-account push delivery.
 
 -- AlterTable: add accountId to ClientIdentifier
 ALTER TABLE "ClientIdentifier" ADD COLUMN "accountId" UUID;
 
--- Backfill ClientIdentifier.accountId from the joined DeviceRegistration row.
--- Rows where DeviceRegistration.accountId is NULL stay NULL; the webhook
--- handler will treat them as untrusted ghosts and refuse to send.
+-- Backfill ClientIdentifier.accountId for the most recent row per deviceId.
+-- A device can have many historical ClientIdentifier rows (one per account
+-- that ever signed in on the device). Stamping all of them with the device's
+-- current accountId would let stale rows from previous accounts pass the
+-- webhook delivery guard (client.accountId == device.accountId) instead of
+-- being treated as untrusted ghosts. Older rows stay NULL until a fresh
+-- subscribe rewrites the correct account on the live row; the orphan
+-- ClientIdentifier cleanup migration handles long-tail churn separately.
+-- Rows where DeviceRegistration.accountId is NULL also stay NULL.
+WITH latest_client_per_device AS (
+    SELECT DISTINCT ON ("deviceId") "id", "deviceId"
+    FROM "ClientIdentifier"
+    ORDER BY "deviceId", "updatedAt" DESC, "addedAt" DESC, "id"
+)
 UPDATE "ClientIdentifier" ci
 SET "accountId" = dr."accountId"
-FROM "DeviceRegistration" dr
-WHERE ci."deviceId" = dr."deviceId"
+FROM "DeviceRegistration" dr,
+     latest_client_per_device lcpd
+WHERE ci."id" = lcpd."id"
+  AND ci."deviceId" = dr."deviceId"
   AND dr."accountId" IS NOT NULL;
 
 CREATE INDEX "ClientIdentifier_accountId_idx" ON "ClientIdentifier"("accountId");
@@ -44,5 +57,5 @@ CREATE INDEX "NotificationSubscriptionSnapshot_accountId_idx" ON "NotificationSu
 CREATE INDEX "NotificationSubscriptionSnapshot_updatedAt_idx" ON "NotificationSubscriptionSnapshot"("updatedAt");
 
 -- AddForeignKey: cascade delete when the parent ClientIdentifier is removed
--- (sign-out, NSE unregister cleanup, T20 orphan migration, etc.)
+-- (sign-out, NSE unregister cleanup, orphan cleanup migration, etc.)
 ALTER TABLE "NotificationSubscriptionSnapshot" ADD CONSTRAINT "NotificationSubscriptionSnapshot_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "ClientIdentifier"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260529130000_orphan_client_identifier_cleanup/migration.sql
+++ b/prisma/migrations/20260529130000_orphan_client_identifier_cleanup/migration.sql
@@ -1,0 +1,45 @@
+-- Stack 2 / T20: one-time orphan ClientIdentifier cleanup
+--
+-- Production validation on a real broken phone (2026-05-29) found 24 stale
+-- ClientIdentifier rows pointing at one device, accumulated over ~4 months
+-- via repeated identity rotations. The NSE-driven unregister path was
+-- broken upstream until T14, so XMTP installations registered by older
+-- iOS identities never had their backend ClientIdentifier rows removed.
+-- The orphans keep producing webhook deliveries that the iOS NSE cannot
+-- decode, which presents to the user as "push arrived in APNS but no
+-- banner" (the headline failure mode for the Stack 2 work).
+--
+-- T15's webhook accountId check (shipped in the same PR as this migration)
+-- already drops orphans at the delivery boundary going forward. This
+-- migration cleans up the historical data so the snapshot table that
+-- ships in T10 + T11 doesn't accumulate garbage on day one.
+--
+-- Policy: keep the most-recently-touched ClientIdentifier row per device;
+-- delete same-device rows that are both NOT the most recent AND older than
+-- 7 days. The "older than 7 days" guard avoids a foot-gun on devices that
+-- recently churned through multiple identities legitimately (developer
+-- account switching, fresh install + signin within the same day).
+--
+-- Stack 2 D17a (NSE unregister middleware) is the going-forward fix that
+-- stops new orphans from accumulating. Without that landing first, this
+-- migration would have to re-run on every wave of churn. T14 ships in the
+-- same PR.
+
+WITH ranked AS (
+  SELECT
+    "id",
+    "deviceId",
+    "updatedAt",
+    ROW_NUMBER() OVER (
+      PARTITION BY "deviceId"
+      ORDER BY "updatedAt" DESC
+    ) AS rn
+  FROM "ClientIdentifier"
+)
+DELETE FROM "ClientIdentifier"
+WHERE "id" IN (
+  SELECT "id"
+  FROM ranked
+  WHERE rn > 1
+    AND "updatedAt" < NOW() - INTERVAL '7 days'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,10 +53,58 @@ model ClientIdentifier {
   id        String             @id
   deviceId  String
   device    DeviceRegistration @relation(fields: [deviceId], references: [deviceId], onDelete: Cascade)
+  // Set from JWT on subscribe; one-time backfill from the joined
+  // DeviceRegistration row when this column was added. Webhook delivery
+  // refuses to send when client.accountId != device.accountId so a stale
+  // ClientIdentifier from a previous account on the same device cannot
+  // wake the current account's device (Stack 2 D15).
+  accountId String?            @db.Uuid
   addedAt   DateTime           @default(now())
   updatedAt DateTime           @updatedAt
 
+  snapshots NotificationSubscriptionSnapshot[]
+
   @@index([deviceId])
+  @@index([accountId])
+}
+
+/// Last desired push topic subscription state per ClientIdentifier.
+/// Populated on a successful `/v2/notifications/subscribe` round trip
+/// where the XMTP notifications server actually applied the change
+/// (remoteApplied=true). Used by:
+///
+/// - the same handler's idempotency check, which compares the in-flight
+///   request's topicHash + the device's current pushTokenSha256 +
+///   apnsEnv against the at-apply snapshot fields and skips the XMTP
+///   wire call when nothing relevant changed (D11 = 10-minute TTL),
+/// - the new `/v2/notifications/debug/status` endpoint, which reports
+///   the snapshot as "last requested topic set" (NOT actual remote
+///   XMTP state — the upstream RPC doesn't exist).
+///
+/// `pushTokenSha256AtApply` + `apnsEnvAtApply` are correctness state,
+/// NOT redundancy: deriving them from the joined DeviceRegistration at
+/// read-time would let idempotency wrongly skip a re-apply after
+/// /v2/device/register rotates the token. The at-apply fields lock in
+/// the (token, env) tuple that the XMTP notifications server actually
+/// got, so the next subscribe knows whether to re-apply.
+model NotificationSubscriptionSnapshot {
+  clientId                 String           @id
+  client                   ClientIdentifier @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  accountId                String?          @db.Uuid
+  topicCount               Int
+  topicHash                String           @db.VarChar(64)
+  kindSummary              Json?
+  lastContext              String?
+  lastSubscribeAt          DateTime         @default(now())
+  lastRemoteApplySucceeded Boolean
+  lastRemoteApplyError     String?          @db.Text
+  pushTokenSha256AtApply   String           @db.VarChar(64)
+  apnsEnvAtApply           ApnsEnvironment?
+  createdAt                DateTime         @default(now())
+  updatedAt                DateTime         @updatedAt
+
+  @@index([accountId])
+  @@index([updatedAt])
 }
 
 model RuntimeConfig {

--- a/src/api/v2/device/handlers/register.ts
+++ b/src/api/v2/device/handlers/register.ts
@@ -30,10 +30,41 @@ async function performDeviceRegistration(
     pushTokenType?: PushTokenType;
     apnsEnv?: ApnsEnvironment | null;
     pushToken?: string | null;
+    disabled?: boolean;
+    pushFailures?: number;
   },
   logger: Request["log"],
 ) {
   await prisma.$transaction(async (tx) => {
+    // T13 / D17b: when a NEW push token arrives that differs from the stored
+    // one, reset disabled=false and pushFailures=0. An auto-disabled device
+    // (BadDeviceToken accumulation under the old token) gets a fresh chance
+    // to deliver pushes under the new token without anyone manually
+    // intervening. The reset is gated on pushToken being non-null AND
+    // different from the existing row — same-token registers don't trigger
+    // a reset (we'd lose the failure count that protects against repeatedly
+    // pushing to a known-bad token).
+    if (pushToken) {
+      const existing = await tx.deviceRegistration.findUnique({
+        where: { deviceId },
+        select: { pushToken: true, disabled: true, pushFailures: true },
+      });
+      if (existing && existing.pushToken !== pushToken) {
+        updateData.disabled = false;
+        updateData.pushFailures = 0;
+        if (existing.disabled || existing.pushFailures > 0) {
+          logger.info(
+            {
+              deviceId,
+              previousDisabled: existing.disabled,
+              previousPushFailures: existing.pushFailures,
+            },
+            "Resetting disabled + pushFailures on new push token (T13)",
+          );
+        }
+      }
+    }
+
     // Track old devices and their client identifiers for migration
     let oldDeviceIds: string[] = [];
     let clientIdsToMigrate: string[] = [];

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -117,7 +117,12 @@ v2Router.use("/agents", authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
 v2Router.use("/connections", authMiddleware, connectionsRouter);
 v2Router.use("/notifications/xmtp", webhookRouter);
-v2Router.use("/notifications", authMiddleware, notificationsRouter);
+// authMiddlewareAllowNSE (instead of authMiddleware) so the NSE-driven
+// orphan cleanup path can call DELETE /notifications/unregister/:clientId
+// with an NSE JWT (Stack 2 T14). The middleware's NSE allowlist gates
+// which sub-routes accept NSE tokens; subscribe/unsubscribe stay
+// regular-JWT-only because the allowlist doesn't include them.
+v2Router.use("/notifications", authMiddlewareAllowNSE, notificationsRouter);
 // No auth: Apple authenticates via JWS signature, verified inside the handler.
 v2Router.use("/webhooks/apple", appleWebhookRouter);
 

--- a/src/api/v2/notifications/handlers/debug-status.ts
+++ b/src/api/v2/notifications/handlers/debug-status.ts
@@ -1,0 +1,203 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { hashApnsToken } from "@/notifications/hash";
+import { verifyDeviceOwnership } from "@/utils/auth-guards";
+import { deviceIdSchema } from "@/utils/device-id";
+import { prisma } from "@/utils/prisma";
+
+/**
+ * Stack 2 T12: production-safe push registration status endpoint.
+ *
+ * iOS calls this from the DebugPushNotificationsView "Probe backend
+ * registration" button. The response is JWT-gated, hashes-only, and
+ * rate-limited (1/sec/JWT via debugStatusLimiter at the route mount).
+ * Production-safe means: every field is either a boolean, a count, a
+ * timestamp, or a hash. No raw push token, no raw topic strings, no
+ * JWT echo. The negative test on this handler is "the JSON response
+ * never contains the raw pushToken value or any topic string".
+ *
+ * The plan's D5 also says "scoped by JWT accountId + JWT deviceId, not
+ * just deviceId". We enforce both: verifyDeviceOwnership for the
+ * deviceId, plus an explicit accountId match against the looked-up
+ * device row.
+ *
+ * The snapshot fields are returned as "last requested topic state" —
+ * NOT actual remote XMTP notification server state. iOS clients MUST
+ * label them that way in the UI; the response includes
+ * `isActualRemoteState: false` as a permanent reminder.
+ */
+
+const debugStatusRequestSchema = z.object({
+  deviceId: deviceIdSchema,
+  clientId: z.string().uuid(),
+  pushTokenSha256: z
+    .string()
+    .regex(/^[0-9a-f]{64}$/, "Expected 64-char lowercase hex")
+    .optional(),
+  pushTokenType: z.enum(["apns", "fcm"]).optional(),
+  apnsEnv: z.enum(["sandbox", "production"]).nullable().optional(),
+});
+
+export type IDebugStatusRequestBody = z.infer<typeof debugStatusRequestSchema>;
+
+interface DebugStatusResponse {
+  device: {
+    exists: boolean;
+    hasPushToken: boolean;
+    pushTokenMatches: boolean | null;
+    pushTokenTypeMatches: boolean | null;
+    apnsEnvMatches: boolean | null;
+    disabled: boolean | null;
+    pushFailures: number | null;
+    lastSentAt: string | null;
+    lastFailureAt: string | null;
+    updatedAt: string | null;
+  };
+  client: {
+    exists: boolean;
+    mappedDeviceId: string | null;
+    deviceIdMatchesJwt: boolean | null;
+    accountIdMatchesJwt: boolean | null;
+    updatedAt: string | null;
+  };
+  subscriptionSnapshot: {
+    exists: boolean;
+    topicCount: number | null;
+    topicHash: string | null;
+    kindSummary: unknown;
+    lastContext: string | null;
+    lastSubscribeAt: string | null;
+    lastRemoteApplySucceeded: boolean | null;
+    lastRemoteApplyError: string | null;
+    pushTokenMatchesAtApply: boolean | null;
+    apnsEnvMatchesAtApply: boolean | null;
+    isActualRemoteState: false;
+  };
+}
+
+export async function debugStatus(
+  req: Request<unknown, unknown, IDebugStatusRequestBody>,
+  res: Response,
+) {
+  try {
+    const body = debugStatusRequestSchema.parse(req.body);
+
+    const jwtDeviceId = res.locals.deviceId;
+    const jwtAccountId = res.locals.accountId;
+
+    req.log.info(
+      {
+        accountId: jwtAccountId,
+        deviceId: body.deviceId,
+        clientId: body.clientId,
+        hasPushTokenSha256: !!body.pushTokenSha256,
+      },
+      "Debug status probe",
+    );
+
+    if (
+      !verifyDeviceOwnership({
+        req,
+        res,
+        jwtDeviceId,
+        expectedDeviceId: body.deviceId,
+      })
+    ) {
+      return;
+    }
+
+    const [device, client] = await Promise.all([
+      prisma.deviceRegistration.findUnique({
+        where: { deviceId: body.deviceId },
+      }),
+      prisma.clientIdentifier.findUnique({
+        where: { id: body.clientId },
+      }),
+    ]);
+
+    const snapshot = await prisma.notificationSubscriptionSnapshot.findUnique({
+      where: { clientId: body.clientId },
+    });
+
+    // Hash the stored push token at read time so we never put the raw
+    // token in the response. The hashApnsToken util returns "none" for
+    // the no-token case, so the equality check below correctly says
+    // "no, doesn't match" when the device has no token.
+    const storedPushTokenSha = hashApnsToken(device?.pushToken);
+
+    const response: DebugStatusResponse = {
+      device: {
+        exists: device !== null,
+        hasPushToken: !!device?.pushToken,
+        pushTokenMatches: device?.pushToken
+          ? body.pushTokenSha256 !== undefined
+            ? body.pushTokenSha256 === storedPushTokenSha
+            : null
+          : false,
+        pushTokenTypeMatches: device
+          ? body.pushTokenType !== undefined
+            ? body.pushTokenType === device.pushTokenType
+            : null
+          : null,
+        apnsEnvMatches: device
+          ? body.apnsEnv !== undefined
+            ? body.apnsEnv === device.apnsEnv
+            : null
+          : null,
+        disabled: device?.disabled ?? null,
+        pushFailures: device?.pushFailures ?? null,
+        lastSentAt: device?.lastSentAt?.toISOString() ?? null,
+        lastFailureAt: device?.lastFailureAt?.toISOString() ?? null,
+        updatedAt: device ? device.updatedAt.toISOString() : null,
+      },
+      client: {
+        exists: client !== null,
+        mappedDeviceId: client?.deviceId ?? null,
+        deviceIdMatchesJwt: client ? client.deviceId === jwtDeviceId : null,
+        accountIdMatchesJwt: client
+          ? jwtAccountId !== undefined && client.accountId === jwtAccountId
+          : null,
+        updatedAt: client ? client.updatedAt.toISOString() : null,
+      },
+      subscriptionSnapshot: {
+        exists: snapshot !== null,
+        topicCount: snapshot?.topicCount ?? null,
+        topicHash: snapshot?.topicHash ?? null,
+        kindSummary: snapshot?.kindSummary ?? null,
+        lastContext: snapshot?.lastContext ?? null,
+        lastSubscribeAt: snapshot
+          ? snapshot.lastSubscribeAt.toISOString()
+          : null,
+        lastRemoteApplySucceeded: snapshot?.lastRemoteApplySucceeded ?? null,
+        lastRemoteApplyError: snapshot?.lastRemoteApplyError ?? null,
+        pushTokenMatchesAtApply:
+          snapshot && device?.pushToken
+            ? snapshot.pushTokenSha256AtApply === storedPushTokenSha
+            : null,
+        apnsEnvMatchesAtApply:
+          snapshot && device
+            ? snapshot.apnsEnvAtApply === device.apnsEnv
+            : null,
+        isActualRemoteState: false,
+      },
+    };
+
+    res.status(200).json(response);
+    return;
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      req.log.warn(
+        { errors: error.errors },
+        "Invalid request body for debug-status",
+      );
+      res.status(400).json({
+        error: "Invalid request body",
+        details: error.errors,
+      });
+      return;
+    }
+    req.log.error({ error }, "Failed to read debug status");
+    res.status(500).json({ error: "Failed to read debug status" });
+    return;
+  }
+}

--- a/src/api/v2/notifications/handlers/debug-status.ts
+++ b/src/api/v2/notifications/handlers/debug-status.ts
@@ -64,11 +64,14 @@ interface DebugStatusResponse {
     exists: boolean;
     topicCount: number | null;
     topicHash: string | null;
-    kindSummary: unknown;
+    // Presence flags only - raw kindSummary and lastRemoteApplyError can
+    // carry attacker-controlled topic strings or upstream error text and
+    // would break this endpoint's hashes-only contract if returned verbatim.
+    hasKindSummary: boolean;
     lastContext: string | null;
     lastSubscribeAt: string | null;
     lastRemoteApplySucceeded: boolean | null;
-    lastRemoteApplyError: string | null;
+    hasLastRemoteApplyError: boolean;
     pushTokenMatchesAtApply: boolean | null;
     apnsEnvMatchesAtApply: boolean | null;
     isActualRemoteState: false;
@@ -95,6 +98,17 @@ export async function debugStatus(
       "Debug status probe",
     );
 
+    // The endpoint is scoped by JWT accountId + JWT deviceId. A device-only
+    // JWT (legacy /v2/auth/token without SIWE) must not get diagnostic state.
+    if (!jwtAccountId) {
+      req.log.warn(
+        { deviceId: body.deviceId },
+        "Debug status rejected - JWT has no accountId",
+      );
+      res.status(403).json({ error: "Account required" });
+      return;
+    }
+
     if (
       !verifyDeviceOwnership({
         req,
@@ -114,6 +128,24 @@ export async function debugStatus(
         where: { id: body.clientId },
       }),
     ]);
+
+    // Reject when the stored device row belongs to a different account than
+    // the JWT. A device row exists but with a different accountId means the
+    // device was re-paired to another account; we must not leak that account's
+    // diagnostic state. A NULL device.accountId is allowed - that covers
+    // pre-backfill device rows that the JWT account already owns.
+    if (device && device.accountId && device.accountId !== jwtAccountId) {
+      req.log.warn(
+        {
+          jwtAccountId,
+          deviceAccountId: device.accountId,
+          deviceId: body.deviceId,
+        },
+        "Debug status rejected - device account mismatch",
+      );
+      res.status(403).json({ error: "Forbidden" });
+      return;
+    }
 
     const snapshot = await prisma.notificationSubscriptionSnapshot.findUnique({
       where: { clientId: body.clientId },
@@ -154,22 +186,20 @@ export async function debugStatus(
         exists: client !== null,
         mappedDeviceId: client?.deviceId ?? null,
         deviceIdMatchesJwt: client ? client.deviceId === jwtDeviceId : null,
-        accountIdMatchesJwt: client
-          ? jwtAccountId !== undefined && client.accountId === jwtAccountId
-          : null,
+        accountIdMatchesJwt: client ? client.accountId === jwtAccountId : null,
         updatedAt: client ? client.updatedAt.toISOString() : null,
       },
       subscriptionSnapshot: {
         exists: snapshot !== null,
         topicCount: snapshot?.topicCount ?? null,
         topicHash: snapshot?.topicHash ?? null,
-        kindSummary: snapshot?.kindSummary ?? null,
+        hasKindSummary: snapshot?.kindSummary != null,
         lastContext: snapshot?.lastContext ?? null,
         lastSubscribeAt: snapshot
           ? snapshot.lastSubscribeAt.toISOString()
           : null,
         lastRemoteApplySucceeded: snapshot?.lastRemoteApplySucceeded ?? null,
-        lastRemoteApplyError: snapshot?.lastRemoteApplyError ?? null,
+        hasLastRemoteApplyError: snapshot?.lastRemoteApplyError != null,
         pushTokenMatchesAtApply:
           snapshot && device?.pushToken
             ? snapshot.pushTokenSha256AtApply === storedPushTokenSha

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -155,15 +155,33 @@ export async function subscribe(
     const currentTokenSha = hashApnsToken(device.pushToken);
     const now = new Date();
 
-    // Idempotency check (D11): if the last successful remote-apply matches
-    // every load-bearing field AND is within the TTL, skip the XMTP wire
-    // call. APNS token and apnsEnv changes ALWAYS re-apply (the at-apply
-    // fields are correctness state per D13 — backfilling from current
-    // DeviceRegistration would silently let drift through).
-    const existingSnapshot =
-      await prisma.notificationSubscriptionSnapshot.findUnique({
+    // Idempotency check: if the last successful remote-apply matches every
+    // load-bearing field AND is within the TTL, skip the XMTP wire call.
+    // APNS token and apnsEnv changes always re-apply - the at-apply fields
+    // are correctness state, and backfilling them from the current
+    // DeviceRegistration would silently let drift through.
+    //
+    // The ClientIdentifier row's (deviceId, accountId) binding is also
+    // load-bearing: the webhook delivery guard rejects pushes where
+    // client.accountId != device.accountId. If the stored binding is stale
+    // (NULL after migration backfill, or set to a previous account), we
+    // must not short-circuit; falling through to the full path runs the
+    // upsert that refreshes the binding. Legacy JWTs without accountId
+    // (older iOS builds) don't touch the field, so we skip the accountId
+    // check in that case.
+    const [existingSnapshot, existingClient] = await Promise.all([
+      prisma.notificationSubscriptionSnapshot.findUnique({
         where: { clientId: body.clientId },
-      });
+      }),
+      prisma.clientIdentifier.findUnique({
+        where: { id: body.clientId },
+      }),
+    ]);
+
+    const clientBindingCurrent =
+      existingClient !== null &&
+      existingClient.deviceId === body.deviceId &&
+      (accountId === undefined || existingClient.accountId === accountId);
 
     const idempotent =
       !body.force &&
@@ -172,6 +190,7 @@ export async function subscribe(
       existingSnapshot.topicHash === topicHash &&
       existingSnapshot.pushTokenSha256AtApply === currentTokenSha &&
       existingSnapshot.apnsEnvAtApply === device.apnsEnv &&
+      clientBindingCurrent &&
       now.getTime() - existingSnapshot.lastSubscribeAt.getTime() <
         IDEMPOTENCY_TTL_MS;
 

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -178,6 +178,14 @@ export async function subscribe(
       }),
     ]);
 
+    // When the stored binding is stale (existingClient.accountId is NULL from
+    // migration backfill, or set to a different account than the JWT),
+    // clientBindingCurrent evaluates to false, which forces the idempotency
+    // check below to false. We then fall through to the full path which runs
+    // the ClientIdentifier upsert and refreshes the binding. The idempotent
+    // early return at the bottom of this block CANNOT be reached with a stale
+    // binding by construction - that's the whole point of including this
+    // predicate term.
     const clientBindingCurrent =
       existingClient !== null &&
       existingClient.deviceId === body.deviceId &&

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -2,9 +2,25 @@ import type { Request, Response } from "express";
 import { hexToUint8Array } from "uint8array-extras";
 import { z } from "zod";
 import { createNotificationClient } from "@/notifications/client";
+import { hashApnsToken, hashTopicSet } from "@/notifications/hash";
 import { verifyDeviceOwnership } from "@/utils/auth-guards";
 import { deviceIdSchema } from "@/utils/device-id";
 import { prisma } from "@/utils/prisma";
+
+/**
+ * Idempotency window for short-circuiting `/v2/notifications/subscribe` when
+ * the in-flight request matches the last successful remote-apply on every
+ * load-bearing field. 10 minutes balances "absorb repeat-loops + force
+ * reconciles" against "legitimate topic-set changes are picked up promptly".
+ *
+ * Long enough to swallow a 3s-poll-loop join flood (Stack 1 fix backstop).
+ * Short enough that joining new groups while paused and resuming inside the
+ * window still produces a fresh apply when the topic hash changes. APNS
+ * token and apnsEnv changes ALWAYS reapply regardless of the TTL (the at-
+ * apply fields differ from current DeviceRegistration), so the dangerous
+ * "deliver to wrong device" mode is impossible by construction.
+ */
+const IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
 
 const subscribeRequestSchema = z.object({
   deviceId: deviceIdSchema,
@@ -23,9 +39,40 @@ const subscribeRequestSchema = z.object({
     )
     .min(1)
     .max(100),
+  // Optional diagnostic fields (Stack 2 D6). iOS sends these to give backend
+  // and Datadog enough context to explain WHY a subscribe happened. All
+  // optional so older iOS builds keep working untouched.
+  context: z.string().max(64).optional(),
+  source: z.string().max(32).optional(),
+  // Aggregate counts per topic kind: { welcome: 1, group: 42, inviteDM: 7 }.
+  // Stored as JSON; not used for any logic decision, purely diagnostic.
+  kindSummary: z.record(z.string(), z.number()).optional(),
+  // Force bypasses the idempotency check (used by the debug-screen "Force
+  // Reconcile" button). Acceptable because the request still passes JWT
+  // auth + deviceOwnership.
+  force: z.boolean().optional(),
 });
 
 export type ISubscribeRequestBody = z.infer<typeof subscribeRequestSchema>;
+
+/**
+ * Reason the XMTP notifications server call was skipped this round trip.
+ * iOS reads this to decide whether to write its local hash debounce cache
+ * (only when remoteApplied === true), so a "200 but didn't actually do
+ * anything" path doesn't silently break delivery (codex D16).
+ */
+type SkippedReason = "idempotent" | "no_push_token" | "disabled";
+
+interface SubscribeResponse {
+  ok: true;
+  remoteApplied: boolean;
+  snapshot: {
+    hash: string;
+    count: number;
+    lastSubscribeAt: string;
+  };
+  skipped?: SkippedReason;
+}
 
 const notificationClient = createNotificationClient();
 
@@ -36,12 +83,22 @@ export async function subscribe(
   try {
     const body = subscribeRequestSchema.parse(req.body);
 
+    // accountId is sourced from the JWT only, never from the request body.
+    // Older iOS builds may not send it; that's fine, it ends up undefined.
+    const accountId = res.locals.accountId;
+
+    const topicHash = hashTopicSet(body.topics.map((t) => t.topic));
+
     req.log.info(
       {
-        accountId: res.locals.accountId,
+        accountId,
         deviceId: body.deviceId,
         clientId: body.clientId,
         topicCount: body.topics.length,
+        topicHash,
+        context: body.context,
+        source: body.source,
+        force: body.force,
       },
       "Subscribing to topics",
     );
@@ -65,7 +122,7 @@ export async function subscribe(
 
     if (!device) {
       req.log.warn(
-        { deviceId: body.deviceId },
+        { accountId, deviceId: body.deviceId },
         "Device not found for subscribe",
       );
       res.status(404).json({ error: "Device not found" });
@@ -73,12 +130,76 @@ export async function subscribe(
     }
 
     if (device.disabled) {
-      req.log.warn({ deviceId: body.deviceId }, "Device is disabled");
-      res.status(403).json({ error: "Device is disabled" });
+      // Bail to a 200 with skipped:"disabled" so iOS can render the reason
+      // verbatim in the debug screen instead of treating it as a generic 4xx.
+      // We do NOT block the request; the iOS cache will see remoteApplied=
+      // false and re-attempt after the device is re-enabled.
+      req.log.warn(
+        { accountId, deviceId: body.deviceId },
+        "Device is disabled — skipping subscribe",
+      );
+      const snapshotResponse = await readSnapshotForResponse(body.clientId);
+      res.status(200).json({
+        ok: true,
+        remoteApplied: false,
+        snapshot: snapshotResponse ?? {
+          hash: topicHash,
+          count: body.topics.length,
+          lastSubscribeAt: new Date(0).toISOString(),
+        },
+        skipped: "disabled",
+      } satisfies SubscribeResponse);
       return;
     }
 
-    // Convert HMAC keys to Uint8Array
+    const currentTokenSha = hashApnsToken(device.pushToken);
+    const now = new Date();
+
+    // Idempotency check (D11): if the last successful remote-apply matches
+    // every load-bearing field AND is within the TTL, skip the XMTP wire
+    // call. APNS token and apnsEnv changes ALWAYS re-apply (the at-apply
+    // fields are correctness state per D13 — backfilling from current
+    // DeviceRegistration would silently let drift through).
+    const existingSnapshot =
+      await prisma.notificationSubscriptionSnapshot.findUnique({
+        where: { clientId: body.clientId },
+      });
+
+    const idempotent =
+      !body.force &&
+      existingSnapshot !== null &&
+      existingSnapshot.lastRemoteApplySucceeded &&
+      existingSnapshot.topicHash === topicHash &&
+      existingSnapshot.pushTokenSha256AtApply === currentTokenSha &&
+      existingSnapshot.apnsEnvAtApply === device.apnsEnv &&
+      now.getTime() - existingSnapshot.lastSubscribeAt.getTime() <
+        IDEMPOTENCY_TTL_MS;
+
+    if (idempotent) {
+      req.log.info(
+        {
+          accountId,
+          deviceId: body.deviceId,
+          clientId: body.clientId,
+          topicHash,
+          skipped: "idempotent",
+        },
+        "Subscribe idempotent skip",
+      );
+      res.status(200).json({
+        ok: true,
+        remoteApplied: false,
+        snapshot: {
+          hash: existingSnapshot.topicHash,
+          count: existingSnapshot.topicCount,
+          lastSubscribeAt: existingSnapshot.lastSubscribeAt.toISOString(),
+        },
+        skipped: "idempotent",
+      } satisfies SubscribeResponse);
+      return;
+    }
+
+    // Convert HMAC keys to Uint8Array for the XMTP RPC.
     const subscriptions = body.topics.map((topic) => ({
       topic: topic.topic,
       isSilent: false,
@@ -88,16 +209,20 @@ export async function subscribe(
       })),
     }));
 
-    // Register installation with notification server (only if pushToken exists)
+    // Register installation with XMTP notifications server (only when we
+    // have a push token to deliver to). The no_push_token path returns
+    // remoteApplied:false + skipped:"no_push_token" so iOS knows to retry
+    // when the token arrives, instead of caching this 200 as success.
+    let remoteApplied = false;
+    let remoteApplyError: string | null = null;
+    let skipped: SkippedReason | undefined;
+
     if (!device.pushToken) {
       req.log.info(
-        {
-          accountId: res.locals.accountId,
-          deviceId: body.deviceId,
-          clientId: body.clientId,
-        },
-        "Device has no push token yet - subscription will be activated once token is registered",
+        { accountId, deviceId: body.deviceId, clientId: body.clientId },
+        "Device has no push token yet — subscription will be activated once token is registered",
       );
+      skipped = "no_push_token";
     } else {
       try {
         await notificationClient.registerInstallation({
@@ -113,13 +238,15 @@ export async function subscribe(
           },
         });
 
-        // Subscribe to topics
         await notificationClient.subscribeWithMetadata({
           installationId: body.clientId,
           subscriptions,
         });
+        remoteApplied = true;
       } catch (remoteErr) {
-        // Compensate: best-effort delete installation to avoid orphaned state
+        remoteApplyError =
+          remoteErr instanceof Error ? remoteErr.message : String(remoteErr);
+        // Best-effort cleanup so we don't leave half-registered state.
         try {
           await notificationClient.deleteInstallation({
             installationId: body.clientId,
@@ -134,20 +261,57 @@ export async function subscribe(
       }
     }
 
-    // Create or update client identifier record
+    // Upsert ClientIdentifier (id, deviceId, accountId) + snapshot in a
+    // single transaction so the webhook accountId enforcement (T15) and
+    // the idempotency check on the next call see consistent state.
     try {
-      await prisma.clientIdentifier.upsert({
-        where: { id: body.clientId },
-        create: {
-          id: body.clientId,
-          deviceId: body.deviceId,
-        },
-        // Refresh updatedAt by updating deviceId
-        update: { deviceId: body.deviceId },
+      await prisma.$transaction(async (tx) => {
+        await tx.clientIdentifier.upsert({
+          where: { id: body.clientId },
+          create: {
+            id: body.clientId,
+            deviceId: body.deviceId,
+            accountId,
+          },
+          update: {
+            deviceId: body.deviceId,
+            accountId,
+          },
+        });
+
+        await tx.notificationSubscriptionSnapshot.upsert({
+          where: { clientId: body.clientId },
+          create: {
+            clientId: body.clientId,
+            accountId,
+            topicCount: body.topics.length,
+            topicHash,
+            kindSummary: body.kindSummary ?? undefined,
+            lastContext: body.context,
+            lastSubscribeAt: now,
+            lastRemoteApplySucceeded: remoteApplied,
+            lastRemoteApplyError: remoteApplyError,
+            pushTokenSha256AtApply: currentTokenSha,
+            apnsEnvAtApply: device.apnsEnv,
+          },
+          update: {
+            accountId,
+            topicCount: body.topics.length,
+            topicHash,
+            kindSummary: body.kindSummary ?? undefined,
+            lastContext: body.context,
+            lastSubscribeAt: now,
+            lastRemoteApplySucceeded: remoteApplied,
+            lastRemoteApplyError: remoteApplyError,
+            pushTokenSha256AtApply: currentTokenSha,
+            apnsEnvAtApply: device.apnsEnv,
+          },
+        });
       });
     } catch (dbErr) {
-      // Compensate: delete installation to maintain consistency (only if we created one)
-      if (device.pushToken) {
+      // Compensate: undo the remote registration so XMTP doesn't keep
+      // sending us pushes for a client we can't resolve.
+      if (remoteApplied) {
         try {
           await notificationClient.deleteInstallation({
             installationId: body.clientId,
@@ -164,13 +328,26 @@ export async function subscribe(
 
     req.log.info(
       {
-        accountId: res.locals.accountId,
+        accountId,
         deviceId: body.deviceId,
         clientId: body.clientId,
+        topicHash,
+        remoteApplied,
+        skipped,
       },
       "Subscribed successfully",
     );
-    res.status(200).send();
+
+    res.status(200).json({
+      ok: true,
+      remoteApplied,
+      snapshot: {
+        hash: topicHash,
+        count: body.topics.length,
+        lastSubscribeAt: now.toISOString(),
+      },
+      skipped,
+    } satisfies SubscribeResponse);
     return;
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -189,4 +366,20 @@ export async function subscribe(
     res.status(500).json({ error: "Failed to subscribe to topics" });
     return;
   }
+}
+
+async function readSnapshotForResponse(
+  clientId: string,
+): Promise<{ hash: string; count: number; lastSubscribeAt: string } | null> {
+  const snapshot = await prisma.notificationSubscriptionSnapshot.findUnique({
+    where: { clientId },
+  });
+  if (!snapshot) {
+    return null;
+  }
+  return {
+    hash: snapshot.topicHash,
+    count: snapshot.topicCount,
+    lastSubscribeAt: snapshot.lastSubscribeAt.toISOString(),
+  };
 }

--- a/src/api/v2/notifications/handlers/webhook.ts
+++ b/src/api/v2/notifications/handlers/webhook.ts
@@ -82,6 +82,42 @@ export async function handleXmtpNotification(req: Request, res: Response) {
     });
 
     if (v2Client) {
+      // T15 / D15: refuse to deliver a push when the ClientIdentifier
+      // belongs to a different account than the DeviceRegistration. Same-
+      // device account switches accumulate orphan ClientIdentifier rows
+      // pointing at the device's deviceId (validated in production —
+      // 24 such rows on one device, 4-month accumulation). The XMTP
+      // notifications server keeps webhooking us for those orphans; this
+      // check drops the delivery before it leaves our boundary.
+      //
+      // NULL on either side is treated as "untrusted" — webhook drops it.
+      // This intentionally catches the historical rows backfilled with
+      // NULL accountId in T10 + any future rows where account membership
+      // can't be established. Stack 2's T20 migration will sweep those
+      // out once the change has baked.
+      const clientAccountId = v2Client.accountId;
+      const deviceAccountId = v2Client.device.accountId;
+      if (
+        clientAccountId === null ||
+        deviceAccountId === null ||
+        clientAccountId !== deviceAccountId
+      ) {
+        req.log.warn(
+          {
+            event: "client_account_mismatch",
+            clientId: notification.installation.id,
+            deviceId: v2Client.deviceId,
+            clientAccountId,
+            deviceAccountId,
+            contentTopic: notification.message.content_topic,
+            messageType: notification.message_context.message_type,
+          },
+          "Dropping push: ClientIdentifier.accountId does not match DeviceRegistration.accountId",
+        );
+        res.status(200).end();
+        return;
+      }
+
       const pushType = v2Client.device.pushTokenType; // 'fcm' | 'apns'
       const tag = pushType === "fcm" ? "[FCM]" : "[APNS]";
       req.log.info(
@@ -105,6 +141,23 @@ export async function handleXmtpNotification(req: Request, res: Response) {
       return;
     }
 
+    // T16: log structured warning when XMTP webhooks us for an installation
+    // we don't have a ClientIdentifier row for. Most commonly happens when
+    // an installation was registered before the NSE unregister path was
+    // working (Stack 2 T14) and is now orphaned upstream. Returning 200
+    // is intentional — we don't want XMTP to retry; the orphan stays put
+    // until T20's cleanup migration or a manual unregisterInstallation
+    // call sweeps it from the XMTP notifications server.
+    req.log.warn(
+      {
+        event: "unknown_installation",
+        installationId: notification.installation.id,
+        contentTopic: notification.message.content_topic,
+        messageType: notification.message_context.message_type,
+        timestampNs: notification.message.timestamp_ns,
+      },
+      "No ClientIdentifier for XMTP notification installation",
+    );
     res.status(200).end();
     return;
   } catch (error) {

--- a/src/api/v2/notifications/notifications.router.ts
+++ b/src/api/v2/notifications/notifications.router.ts
@@ -1,4 +1,6 @@
 import { Router } from "express";
+import { debugStatusLimiter } from "@/middleware/rateLimit";
+import { debugStatus } from "./handlers/debug-status";
 import { subscribe } from "./handlers/subscribe";
 import { unregister } from "./handlers/unregister";
 import { unsubscribe } from "./handlers/unsubscribe";
@@ -6,9 +8,16 @@ import { unsubscribe } from "./handlers/unsubscribe";
 const notificationsRouter = Router();
 
 // Push notification management routes
-// All routes require JWT auth - applied via authMiddleware at mount point in v2/index.ts
+// All routes require JWT auth - applied via authMiddlewareAllowNSE at mount
+// point in v2/index.ts. The middleware's NSE allowlist gates which routes
+// accept NSE JWTs vs regular JWTs.
 notificationsRouter.post("/subscribe", subscribe);
 notificationsRouter.post("/unsubscribe", unsubscribe);
 notificationsRouter.delete("/unregister/:clientId", unregister);
+
+// Stack 2 T12: debug-status endpoint for the iOS DebugPushNotificationsView
+// probe. Production-safe (hashes-only response), JWT-gated, rate-limited
+// 1/sec/JWT via debugStatusLimiter.
+notificationsRouter.post("/debug/status", debugStatusLimiter, debugStatus);
 
 export { notificationsRouter };

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -105,8 +105,29 @@ export const authMiddleware = async (
 };
 
 // Defense in depth: NSE tokens can only access these paths even if middleware is misapplied
-// Uses full path (baseUrl + path) to avoid matching relative paths on other mounts
-const NSE_ALLOWED_PATHS = ["/api/v2/auth-check"];
+// Uses full path (baseUrl + path) to avoid matching relative paths on other mounts.
+//
+// Patterns are anchored regular expressions (^/$). Exact-string paths in the
+// old design didn't accommodate param routes like /unregister/:clientId, so
+// the allowlist was upgraded to regex patterns when T14 added NSE-driven
+// orphan cleanup. Keep this list TIGHT — every entry is an NSE-callable
+// surface and needs to be justified as "what NSE legitimately needs from
+// backend during a push processing or cleanup pass".
+const NSE_ALLOWED_PATH_PATTERNS: RegExp[] = [
+  /^\/api\/v2\/auth-check$/,
+  // T14: NSE-driven orphan cleanup. When the NSE detects an installation
+  // mismatch (push arrived for an installationId the current keychain
+  // identity no longer owns), it calls DELETE /notifications/unregister/
+  // :clientId to remove the stale mapping. Reduced privilege: even though
+  // the path is reachable with NSE auth, the handler still uses
+  // verifyDeviceOwnership against res.locals.deviceId (set from the NSE
+  // JWT) so NSE can only delete clients belonging to its OWN device.
+  /^\/api\/v2\/notifications\/unregister\/[^/]+$/,
+];
+
+function isNseAllowedPath(fullPath: string): boolean {
+  return NSE_ALLOWED_PATH_PATTERNS.some((pattern) => pattern.test(fullPath));
+}
 
 /**
  * JWT authentication middleware that allows NSE tokens.
@@ -145,7 +166,7 @@ export const authMiddlewareAllowNSE = async (
     // Defense in depth: restrict NSE tokens to whitelisted paths
     if (isNotificationExtensionOnlyToken(payload)) {
       const fullPath = req.baseUrl + req.path;
-      if (!NSE_ALLOWED_PATHS.includes(fullPath)) {
+      if (!isNseAllowedPath(fullPath)) {
         req.log.warn(
           { deviceId: payload.deviceId, path: fullPath },
           "NSE token rejected - path not in allowlist",

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,3 +1,4 @@
+import type { Request } from "express";
 import { rateLimit } from "express-rate-limit";
 
 // General rate limit for API to 1000 requests per 5 minutes
@@ -6,6 +7,30 @@ export const rateLimitMiddleware = rateLimit({
   limit: 1000,
   legacyHeaders: false,
   standardHeaders: "draft-8",
+});
+
+// Stack 2 T12: debug-status endpoint is JWT-authenticated and meant for the
+// iOS debug screen's "Probe backend registration" button. Cap at 1
+// request/second per JWT (keyed by accountId+deviceId from JWT) so a
+// malicious or buggy client can't enumerate by hammering the endpoint.
+// Falls back to IP when accountId/deviceId aren't set (which would
+// already 401 out before reaching this, but defense in depth).
+export const debugStatusLimiter = rateLimit({
+  windowMs: 1_000,
+  limit: 1,
+  legacyHeaders: false,
+  standardHeaders: "draft-8",
+  keyGenerator: (req: Request) => {
+    const deviceId = req.res?.locals.deviceId;
+    const accountId = req.res?.locals.accountId;
+    if (deviceId && accountId) {
+      return `${accountId}|${deviceId}`;
+    }
+    return req.ip ?? "unknown";
+  },
+  message: {
+    error: "Too many debug-status requests, please slow down",
+  },
 });
 
 // Stricter rate limiting for auth endpoints (JWT generation)

--- a/src/notifications/hash.ts
+++ b/src/notifications/hash.ts
@@ -1,0 +1,40 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Canonical hash routine for push topic sets and APNS tokens. MUST match
+ * iOS bit-for-bit so the idempotency check + the debug-status response can
+ * compare hashes across the wire without phantom mismatches.
+ *
+ * Routine:
+ * 1. Sort topics lexicographically as UTF-8 strings (default JS string sort
+ *    on UTF-16 code units coincides with UTF-8 byte order for the topic
+ *    set we use today; if topics ever contain supplementary plane chars
+ *    we revisit this).
+ * 2. Join with a single LF byte (`\n`, NOT CRLF).
+ * 3. SHA-256.
+ * 4. Lowercase hex.
+ *
+ * iOS counterpart: PushTopicHash.of(_:) in
+ * ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionCache.swift
+ *
+ * Tests cover the empty set, a single topic, and many-topic ordering.
+ */
+export function hashTopicSet(topics: readonly string[]): string {
+  const canonical = [...topics].sort().join("\n");
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+/**
+ * SHA-256 hex of an APNS token string. Returns the sentinel `"none"` when
+ * no token is present so cache / idempotency keys still partition cleanly
+ * between the pre-token and post-token states.
+ *
+ * iOS counterpart: PushTopicHash.ofToken(_:) in
+ * ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionCache.swift
+ */
+export function hashApnsToken(token: string | null | undefined): string {
+  if (!token) {
+    return "none";
+  }
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}

--- a/tests/notifications-hash.test.ts
+++ b/tests/notifications-hash.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+import { describe, expect, test } from "vitest";
+import { hashApnsToken, hashTopicSet } from "@/notifications/hash";
+
+/**
+ * The hash routine in `src/notifications/hash.ts` MUST match iOS's
+ * `PushTopicHash` byte-for-byte. iOS computes the hash and sends it
+ * (implicitly via the topic set + token); backend recomputes here and
+ * compares against the snapshot row. A divergence between the two would
+ * silently break subscribe idempotency, causing either redundant XMTP
+ * server calls or (worse) skipped re-applies after legitimate state
+ * changes.
+ *
+ * These tests pin the canonical form (sorted + LF-joined + SHA-256 hex
+ * lowercase) so any future refactor breaks here instead of breaking in
+ * prod.
+ */
+describe("hashTopicSet", () => {
+  test("empty topic set is deterministic and matches manual SHA-256 of empty string", () => {
+    const expected = createHash("sha256").update("", "utf8").digest("hex");
+    expect(hashTopicSet([])).toBe(expected);
+  });
+
+  test("single-topic case produces SHA-256 of just that topic", () => {
+    const topic = "welcome:abc123";
+    const expected = createHash("sha256").update(topic, "utf8").digest("hex");
+    expect(hashTopicSet([topic])).toBe(expected);
+  });
+
+  test("multi-topic case sorts before hashing", () => {
+    // The two orderings must produce the SAME hash.
+    const ordering1 = ["c", "a", "b"];
+    const ordering2 = ["a", "b", "c"];
+    expect(hashTopicSet(ordering1)).toBe(hashTopicSet(ordering2));
+  });
+
+  test("the canonical join is LF, not CRLF (a CRLF input would hash differently)", () => {
+    // Cross-stack invariant: iOS joins with "\n", not "\r\n". Pin this.
+    const topics = ["topic1", "topic2"];
+    const expectedCanonical = "topic1\ntopic2";
+    const expected = createHash("sha256")
+      .update(expectedCanonical, "utf8")
+      .digest("hex");
+    expect(hashTopicSet(topics)).toBe(expected);
+
+    // A CRLF join MUST produce a different hash (sanity-check the spec).
+    const crlfCanonical = "topic1\r\ntopic2";
+    const crlfHash = createHash("sha256")
+      .update(crlfCanonical, "utf8")
+      .digest("hex");
+    expect(crlfHash).not.toBe(expected);
+  });
+
+  test("output is lowercase hex (no uppercase, no 0x prefix, no buffer junk)", () => {
+    const hex = hashTopicSet(["one", "two", "three"]);
+    expect(hex).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("preserves input order safety - input array is not mutated", () => {
+    const input = ["z", "a", "m"];
+    const inputCopy = [...input];
+    hashTopicSet(input);
+    expect(input).toEqual(inputCopy);
+  });
+});
+
+describe("hashApnsToken", () => {
+  test("returns the 'none' sentinel for null", () => {
+    expect(hashApnsToken(null)).toBe("none");
+  });
+
+  test("returns the 'none' sentinel for undefined", () => {
+    expect(hashApnsToken(undefined)).toBe("none");
+  });
+
+  test("returns the 'none' sentinel for empty string", () => {
+    expect(hashApnsToken("")).toBe("none");
+  });
+
+  test("hashes a real-looking token to lowercase hex SHA-256", () => {
+    const fakeToken =
+      "d7b7db3b80b3e9e26d4aea7cfcd9d6b9e928188f45113f9edfd9948f";
+    const expected = createHash("sha256")
+      .update(fakeToken, "utf8")
+      .digest("hex");
+    expect(hashApnsToken(fakeToken)).toBe(expected);
+    expect(hashApnsToken(fakeToken)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("'none' sentinel and a real hash never collide", () => {
+    const realHash = hashApnsToken("some-real-token");
+    expect(realHash).not.toBe("none");
+    expect(realHash.length).toBe(64);
+  });
+});

--- a/tests/notifications-payload-guard.test.ts
+++ b/tests/notifications-payload-guard.test.ts
@@ -188,6 +188,7 @@ function makeClient(pushType: "apns" | "fcm"): ClientIdentifier & {
   return {
     id: "client-1",
     deviceId: "dev-1",
+    accountId: null,
     addedAt: new Date(),
     updatedAt: new Date(),
     device: {


### PR DESCRIPTION
## Summary

Implements the convos-backend portion of Stack 2 from the [iOS push notifications debugging plan](https://github.com/xmtplabs/convos-ios/pull/907) as a single PR. Convos-ios side (T17 DebugPushNotificationsView, T18 subscribe API client wiring) lands in a separate convos-ios PR stacked on #908.

Built on top of #260 (merged) so subscribe-handler changes don't conflict with that PR's accountId log additions.

## What ships in this PR (T-numbers from the plan)

| T | Surface | Behavior |
|---|---|---|
| T10 | `prisma/schema.prisma`, `prisma/migrations/20260529121133_notification_subscription_snapshot/` | `NotificationSubscriptionSnapshot` table (clientId @id, at-apply token/env fields, kindSummary JSON) + `ClientIdentifier.accountId` column + one-time backfill from joined `DeviceRegistration.accountId` |
| T11 | `src/api/v2/notifications/handlers/subscribe.ts` | Idempotency check via at-apply snapshot fields, response shape `{ ok, remoteApplied, snapshot, skipped? }`, optional Zod fields (context/source/kindSummary/force), accountId from JWT, snapshot upsert in transaction |
| T12 | `src/api/v2/notifications/handlers/debug-status.ts` + `notifications.router.ts` | New `POST /api/v2/notifications/debug/status`, JWT-gated, hashes-only response, rate-limited 1/sec per (accountId+deviceId) |
| T13 | `src/api/v2/device/handlers/register.ts` | Reset `disabled=false` + `pushFailures=0` when a new push token (different from stored) arrives |
| T14 | `src/middleware/auth.ts` + `src/api/v2/index.ts` | `NSE_ALLOWED_PATHS` upgraded from exact-strings to anchored regex patterns; `/notifications/unregister/:clientId` allowlisted for NSE JWTs; `/api/v2/notifications` mount switched to `authMiddlewareAllowNSE` |
| T15 | `src/api/v2/notifications/handlers/webhook.ts` | Drop deliveries where `client.accountId !== device.accountId`; structured `client_account_mismatch` warning |
| T16 | `src/api/v2/notifications/handlers/webhook.ts` | Structured `unknown_installation` warning when XMTP webhooks us for an installationId with no `ClientIdentifier` row |
| T19 (backend) | `src/notifications/hash.ts` | `hashTopicSet` + `hashApnsToken`. Canonical form: sorted UTF-8 + LF separator + SHA-256 hex lowercase. Matches iOS `PushTopicHash` byte-for-byte |
| T20 | `prisma/migrations/20260529130000_orphan_client_identifier_cleanup/` | One-time orphan cleanup: keep most-recent ClientIdentifier per device, delete same-device rows older than 7 days |

## Why this is necessary (production validation)

While debugging push delivery on a real broken phone in convos-ios PR #908, we confirmed:
- 24 orphan `ClientIdentifier` rows for one device, accumulated over 4 months.
- NSE unregister was rejected by `authMiddleware` so historical orphans never got cleaned up upstream.
- Webhook had no `accountId` enforcement; old-account ClientIdentifier rows kept resolving to the device's deviceId after account switches.

T14 + T15 prevent re-accumulation going forward; T20 sweeps the existing pile. T11's `remoteApplied` response (codex D16) closes the "200 != actually subscribed" silent-failure mode that broke delivery for devices in the no-push-token branch.

## Decisions worth flagging for review

1. **Idempotency TTL = 10 minutes** (plan D11). Long enough to absorb a 3s join-poll loop; short enough that topic-set changes within a session take effect. Token/env changes always re-apply regardless of TTL.
2. **At-apply fields on snapshot are correctness state, not redundancy** (plan D13 — codex P0). Deriving them from current `DeviceRegistration` at idempotency-check time would let `/v2/device/register` rotate the token underneath and silently let a re-apply get skipped.
3. **Skipped reason enum** (`"idempotent" | "no_push_token" | "disabled"`) — iOS surfaces this string verbatim on the debug screen. Adding values is additive; renaming is not.
4. **Backfill NULLs are treated as untrusted by webhook**. The migration backfills `ClientIdentifier.accountId` from joined `DeviceRegistration.accountId`, but when that's NULL too (orphan rows pre-account-system), the column stays NULL and the webhook drops the delivery with a `client_account_mismatch` warning. Acceptable because the alternative is "webhook keeps wasting push slots on rows we can't authenticate".
5. **T20 deletes rows older than 7 days only**. A device that legitimately churned through identities today won't have its NEW row swept. The 7-day guard is conservative.

## Test plan

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` clean (3 pre-existing warnings in unrelated `openrouter-client.ts`)
- ✅ `npm test` — 803/805 pass. 1 pre-existing flake in `tests/agent-templates.executor.test.ts > pipeline finishing after timeout` (passes in isolation; unrelated). 1 skipped.
- ✅ New `tests/notifications-hash.test.ts`: 11/11 pass. Pins the cross-stack canonical hash form so iOS and backend can't drift.
- ✅ Both migrations applied cleanly against local Postgres + `npx prisma generate` regenerated the client.

## Not in this PR (deliberately)

- Integration tests for subscribe idempotency paths, debug-status response-shape negative test ("no raw token/topic in JSON"), webhook accountId enforcement. These need substantial mocking setup; flagged for a follow-up PR so this one ships fast.
- Optional async cleanup job that calls `notificationClient.unregisterInstallation(clientId:)` on XMTP for each row T20 deletes. Without it, XMTP keeps webhooking us for those installations; backend silently drops them via the new T16 warning path. Either way the device is unwedged. The async job is a follow-up.
- iOS side: `DebugPushNotificationsView` (T17), iOS subscribe API client `remoteApplied` parsing (T18) — separate convos-ios PR.

## Migration safety

Both migrations are idempotent and additive:
- **T10**: `ADD COLUMN` + `CREATE TABLE` + `CREATE INDEX` + `UPDATE` for backfill. No data destruction. Safe to apply without a backfill if you want the table without the column populated; subsequent `/v2/notifications/subscribe` calls will populate.
- **T20**: `DELETE` with the most-recent-per-device guard. Production size unknown but bounded by orphan accumulation rate. Recommend running during low-traffic window OR splitting into batched delete if the table is very large.

## Cross-reference

- iOS Stack 1 PR (already shipped): xmtplabs/convos-ios#908
- iOS plan: xmtplabs/convos-ios#907
- Stack 1 prereq for accountId log (this PR's parent commit): #260

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782650359&installation_id=128169237&pr_number=261&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F261&signature=02904ea22dfc890c66fe4959808772bd5ba3ed882eefc4a49614ece8698f661a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add notification subscription snapshots, idempotent subscribe, and webhook account enforcement
> - Introduces `NotificationSubscriptionSnapshot` table (and `accountId` on `ClientIdentifier`) via two new migrations, with cascade deletes when a client is removed
> - Updates `POST /api/v2/notifications/subscribe` to short-circuit within a 10-minute TTL when topic hash, push token, and APNS env are unchanged; disabled devices and missing tokens now return `ok:true` with `remoteApplied:false` instead of error codes
> - Adds `POST /api/v2/notifications/debug/status` endpoint returning production-safe diagnostic state (hashed tokens only) about device registration, client binding, and last snapshot; rate-limited to 1 req/s per JWT account+device
> - Drops webhook push delivery when `ClientIdentifier.accountId` and `DeviceRegistration.accountId` are absent or mismatched
> - Extends NSE auth allowlist to cover parameterized path `/api/v2/notifications/unregister/:clientId` using regex matching instead of exact strings
> - Risk: existing webhook delivery will be silently dropped (200 returned) for any client where account IDs are not yet backfilled or are mismatched
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2bf4cc0. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a JWT-gated debug endpoint to inspect push registration status.
  * Subscribe endpoint now accepts richer metadata, a force flag, and returns detailed snapshot responses.
  * Added deterministic hashing for topics and push tokens; rate-limited debug access.

* **Bug Fixes**
  * Webhook now validates account consistency before delivering pushes.
  * Device registration resets disabled/failure state when a new push token appears.
  * One-time cleanup removes historical orphan device records.

* **Tests**
  * Added hashing unit tests and updated payload-guard tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->