### PR TITLE
fix(invites): use default import for secp256k1 so ecdsaRecover resolves under Node

### DIFF
--- a/src/api/v2/invites/handlers/decode-invite-slug.ts
+++ b/src/api/v2/invites/handlers/decode-invite-slug.ts
@@ -2,7 +2,7 @@ import { createHash } from "crypto";
 import { inflateRawSync } from "zlib";
 import { fromBinary } from "@bufbuild/protobuf";
 import type { Request, Response } from "express";
-import * as secp256k1 from "secp256k1";
+import secp256k1 from "secp256k1";
 import { z } from "zod";
 import {
   InvitePayloadSchema,


### PR DESCRIPTION
## Problem

All v2 invite decodes are failing in dev with `INVALID_INVITE` — app-generated invites, and even this repo's own passing test fixtures:

```
curl https://api.dev.convos.xyz/api/v2/invites/<any-valid-slug>
{"success":false,"error":"INVALID_INVITE","message":"The invite link is invalid"}
```

The slugs are valid. Decoding them against this source (base64url -> protobuf `SignedInvite` -> `ecdsaRecover` -> `InvitePayload`) succeeds locally. The failure is a runtime interop bug introduced by the Bun -> pnpm/Node migration.

## Root cause

`src/api/v2/invites/handlers/decode-invite-slug.ts` imported the CommonJS `secp256k1` package with a namespace import:

```ts
import * as secp256k1 from "secp256k1";
...
secp256k1.ecdsaRecover(signatureData, recoveryId, messageHash, false);
```

- Under **Bun**, the CJS `module.exports` is hoisted onto the `import *` namespace, so `secp256k1.ecdsaRecover` is callable.
- Under **Node** ESM->CJS interop, the exports land on `.default`, so `secp256k1.ecdsaRecover` is `undefined`.

Every invite then throws `TypeError: secp256k1.ecdsaRecover is not a function` inside `verifySignature`, which is caught and returned as `INVALID_INVITE`. This is why *every* invite fails identically regardless of contents.

Proven under Node ESM (matches prod: `type: module`, tsup `format: ["esm"]`, `node dist/index.js`):

```
import * as ns:        ns.ecdsaRecover         = undefined
                       ns.default.ecdsaRecover = function
import secp256k1 (def): def.ecdsaRecover        = function
```

## Fix

```diff
-import * as secp256k1 from "secp256k1";
+import secp256k1 from "secp256k1";
```

Call site unchanged. `moduleResolution: bundler` allows the synthetic default import, so it typechecks; at runtime Node resolves it to the module's exports.

## Verification

- `tsc --noEmit`: clean
- Runtime: `typeof ecdsaRecover === "function"`; the reported failing app slug and the existing `invites.test.ts` fixtures decode again.

## Deploy note

This needs a redeploy of `api.dev.convos.xyz` to take effect. After deploy, the failing slug should return `success: true`.

## Out of scope (noted, not fixed here)

- `proto/invite/v2/invite.proto` is missing the `emoji = 10` field the iOS app now sends (harmless — unknown fields are skipped and the signature is over raw payload bytes).
- Decompress ceiling mismatch: iOS allows 1 MB, backend caps at 64 KB (`MAX_DECOMPRESSED_SIZE`). Latent only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782662070&installation_id=128169237&pr_number=262&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F262&signature=c277b0c14c98d41b7356c0205f7f823a71630c70a874fefa708680e7080f4646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ecdsaRecover` resolution in Node by using default import for `secp256k1`
> Changes the import in [decode-invite-slug.ts](https://github.com/ephemeraHQ/convos-backend/pull/262/files#diff-2d0c3ad748e88210424de2d0b48e5626544596ebf6ccc022f69a51d90b5faa43) from `* as secp256k1` to a default import. The namespace import caused `ecdsaRecover` to be unresolvable at runtime under Node.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bdd4b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->