### PR TITLE
Drop SubscriptionTier enum, switch tier column to text, backfill to plus

### DIFF
--- a/prisma/migrations/20260529190000_drop_subscription_tier_enum/migration.sql
+++ b/prisma/migrations/20260529190000_drop_subscription_tier_enum/migration.sql
@@ -1,0 +1,26 @@
+-- Drop the SubscriptionTier Postgres enum in favor of a plain text
+-- column. The enum carried `builder` and `pro` values that were the
+-- internal DB names for what iOS displays as "Plus" — the asymmetry
+-- forced an iOS-side decoder that mapped the legacy strings to .plus.
+--
+-- After this migration:
+--   - `Subscription.tier` is a TEXT column.
+--   - All existing rows are backfilled from `builder`/`pro` -> `plus`.
+--   - The Postgres enum type is dropped.
+--   - The application defines the valid tier set in TypeScript
+--     (src/subscriptions/tiers.ts) and validates writes there.
+--
+-- All three statements run in a single transaction. Postgres allows
+-- DROP TYPE on an enum once no column references it, and the
+-- preceding ALTER TABLE removes the only reference. Same-transaction
+-- ordering is safe because the type isn't referenced after the
+-- ALTER TABLE.
+
+ALTER TABLE "Subscription"
+  ALTER COLUMN "tier" TYPE TEXT USING tier::TEXT;
+
+UPDATE "Subscription"
+SET "tier" = 'plus'
+WHERE "tier" IN ('builder', 'pro');
+
+DROP TYPE "SubscriptionTier";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -263,11 +263,6 @@ model CreditLedger {
   @@index([grantKindId])
 }
 
-enum SubscriptionTier {
-  builder
-  pro
-}
-
 enum SubscriptionPeriod {
   monthly
   annual
@@ -291,7 +286,11 @@ model Subscription {
   id                    String             @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   accountId             String             @db.Uuid
   productId             String
-  tier                  SubscriptionTier
+  // Plain string column (no Postgres enum). Application code defines
+  // the valid set in src/subscriptions/tiers.ts. Currently only `plus`
+  // is written; the previous `builder`/`pro` values were backfilled to
+  // `plus` in migration 20260529190000_drop_subscription_tier_enum.
+  tier                  String
   period                SubscriptionPeriod
   status                SubscriptionStatus
   // Apple's stable per-subscription-line identifier (constant across renewals

--- a/src/api/v2/accounts/handlers/credits-get.ts
+++ b/src/api/v2/accounts/handlers/credits-get.ts
@@ -6,6 +6,7 @@ import { startOfNextUtcDay } from "@/payments/daily-refill/utc";
 import { findCurrentByAccountId } from "@/subscriptions/repository";
 import { isEntitledSubscription } from "@/subscriptions/status";
 import { tierGrant } from "@/subscriptions/tier-config";
+import { requireSubscriptionTier } from "@/subscriptions/tiers";
 import { prisma } from "@/utils/prisma";
 
 const MONTH_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", {
@@ -76,7 +77,10 @@ export async function creditsGetHandler(req: Request, res: Response) {
       return;
     }
 
-    const grant = tierGrant(subscription.tier, subscription.period);
+    const grant = tierGrant(
+      requireSubscriptionTier(subscription.tier),
+      subscription.period,
+    );
     const rawUsed = await sumPeriodConsumes(
       accountId,
       subscription.currentPeriodStart,

--- a/src/subscriptions/product-mapping.ts
+++ b/src/subscriptions/product-mapping.ts
@@ -1,4 +1,8 @@
-import { SubscriptionPeriod, SubscriptionTier } from "@prisma/client";
+import { SubscriptionPeriod } from "@prisma/client";
+import {
+  SUBSCRIPTION_TIER_PLUS,
+  type SubscriptionTier,
+} from "@/subscriptions/tiers";
 import { AppError } from "@/utils/errors";
 
 export type ProductMapping = {
@@ -6,10 +10,16 @@ export type ProductMapping = {
   period: SubscriptionPeriod;
 };
 
-// Matches "app.convos.subs.<tier>.<period>" where tier is builder|pro and
-// period is monthly|annual. Anchored so trailing junk fails fast.
-const PRODUCT_ID_PATTERN =
-  /^app\.convos\.subs\.(builder|pro)\.(monthly|annual)$/;
+// Matches:
+//   - "app.convos.subs.plus.<period>" (prod ASC bundle org.convos.ios)
+//   - "app.convos.subs.<period>" (dev/preview ASC bundles — unprefixed,
+//     locked in because ASC product IDs are globally unique per
+//     developer account and prod claimed the `plus.*` ID)
+// period is always monthly|annual. Anchored so trailing junk fails fast.
+//
+// We ship a single tier (Plus). Everything matched here decodes to
+// SUBSCRIPTION_TIER_PLUS.
+const PRODUCT_ID_PATTERN = /^app\.convos\.subs\.(?:plus\.)?(monthly|annual)$/;
 
 /**
  * Decode a StoreKit product identifier into its tier + period.
@@ -24,13 +34,12 @@ export const productMapping = (productId: string): ProductMapping => {
   if (!match) {
     throw new AppError(
       400,
-      `Unrecognized productId: "${productId}". Expected app.convos.subs.<builder|pro>.<monthly|annual>`,
+      `Unrecognized productId: "${productId}". Expected app.convos.subs.<monthly|annual> (dev) or app.convos.subs.plus.<monthly|annual> (prod)`,
     );
   }
-  const [, tierRaw, periodRaw] = match;
+  const [, periodRaw] = match;
   return {
-    tier:
-      tierRaw === "builder" ? SubscriptionTier.builder : SubscriptionTier.pro,
+    tier: SUBSCRIPTION_TIER_PLUS,
     period:
       periodRaw === "monthly"
         ? SubscriptionPeriod.monthly

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -5,20 +5,24 @@ import {
   type AppleReceipt,
   type Subscription,
   type SubscriptionPeriod,
-  type SubscriptionTier,
 } from "@prisma/client";
 import {
   effectiveSubscriptionStatus,
   ENTITLED_SUBSCRIPTION_STATUSES,
 } from "@/subscriptions/status";
+import {
+  requireSubscriptionTier,
+  SUBSCRIPTION_TIER_PLUS,
+  type SubscriptionTier,
+} from "@/subscriptions/tiers";
 import { prisma } from "@/utils/prisma";
 
-export type { Subscription, AppleReceipt };
+export type { Subscription, AppleReceipt, SubscriptionTier };
+export { SUBSCRIPTION_TIER_PLUS };
 export {
   AppleEnv,
   SubscriptionPeriod,
   SubscriptionStatus,
-  SubscriptionTier,
 } from "@prisma/client";
 
 /**
@@ -332,7 +336,7 @@ export const serializeUserSubscription = (
 ): UserSubscriptionDto => {
   const status = effectiveSubscriptionStatus(subscription);
   return {
-    tier: subscription.tier,
+    tier: requireSubscriptionTier(subscription.tier),
     period: subscription.period,
     status,
     productId: subscription.productId,

--- a/src/subscriptions/tier-config.ts
+++ b/src/subscriptions/tier-config.ts
@@ -1,4 +1,5 @@
-import { SubscriptionPeriod, SubscriptionTier } from "@prisma/client";
+import { SubscriptionPeriod } from "@prisma/client";
+import type { SubscriptionTier } from "@/subscriptions/tiers";
 import { AppError } from "@/utils/errors";
 
 const parsePositiveInt = (key: string, raw: string | undefined): number => {
@@ -22,21 +23,22 @@ const parsePositiveInt = (key: string, raw: string | undefined): number => {
  * Annual subscriptions inherit the monthly amount per period; the renewal
  * cycle is just 12× longer. iOS displays `monthlyGrant` either way; the
  * `period` field distinguishes the billing cadence.
+ *
+ * We ship a single tier (Plus), so this collapses to one env var read.
+ * The `tier` parameter is preserved so call sites still document which
+ * tier they're asking about; when a second tier is added, the lookup
+ * branches on `tier` again.
  */
-const monthlyAmountForTier = (tier: SubscriptionTier): number => {
-  switch (tier) {
-    case SubscriptionTier.builder:
-      return parsePositiveInt(
-        "PAYMENTS_GRANT_BUILDER_MONTHLY",
-        process.env.PAYMENTS_GRANT_BUILDER_MONTHLY,
-      );
-    case SubscriptionTier.pro:
-      return parsePositiveInt(
-        "PAYMENTS_GRANT_PRO_MONTHLY",
-        process.env.PAYMENTS_GRANT_PRO_MONTHLY,
-      );
-  }
-};
+const monthlyAmount = (): number =>
+  // Falls back to the legacy `PAYMENTS_GRANT_BUILDER_MONTHLY` env var if
+  // the new `PAYMENTS_GRANT_PLUS_MONTHLY` isn't set, so deploys don't
+  // need to be coordinated with the env var rename. Drop the fallback
+  // once all environments set the new name.
+  parsePositiveInt(
+    "PAYMENTS_GRANT_PLUS_MONTHLY",
+    process.env.PAYMENTS_GRANT_PLUS_MONTHLY ??
+      process.env.PAYMENTS_GRANT_BUILDER_MONTHLY,
+  );
 
 export type TierGrant = {
   tier: SubscriptionTier;
@@ -55,7 +57,7 @@ export const tierGrant = (
   tier: SubscriptionTier,
   period: SubscriptionPeriod,
 ): TierGrant => {
-  const monthly = monthlyAmountForTier(tier);
+  const monthly = monthlyAmount();
   return {
     tier,
     period,

--- a/src/subscriptions/tiers.ts
+++ b/src/subscriptions/tiers.ts
@@ -1,0 +1,31 @@
+/**
+ * Subscription tier identifiers stored in the `Subscription.tier` text
+ * column. Single source of truth for valid tier values now that the
+ * Postgres `SubscriptionTier` enum has been dropped.
+ *
+ * iOS reads the same string and translates it to its own
+ * `SubscriptionTier` enum case. Keep the wire-format values aligned.
+ */
+export const SUBSCRIPTION_TIER_PLUS = "plus";
+
+export const SUBSCRIPTION_TIERS = [SUBSCRIPTION_TIER_PLUS] as const;
+
+export type SubscriptionTier = (typeof SUBSCRIPTION_TIERS)[number];
+
+export const isSubscriptionTier = (value: string): value is SubscriptionTier =>
+  (SUBSCRIPTION_TIERS as readonly string[]).includes(value);
+
+/**
+ * Narrow a raw string (e.g. `Subscription.tier` straight from Prisma) to
+ * a typed `SubscriptionTier`. Throws if the value is not one of the
+ * known tiers — anything else in the DB is a backfill/migration bug
+ * that the application can't reason about.
+ */
+export const requireSubscriptionTier = (value: string): SubscriptionTier => {
+  if (!isSubscriptionTier(value)) {
+    throw new Error(
+      `Unknown subscription tier in DB: "${value}". Expected one of: ${SUBSCRIPTION_TIERS.join(", ")}`,
+    );
+  }
+  return value;
+};

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -50,8 +50,8 @@ async function seedActiveSubscription(accountId: string): Promise<void> {
   await prisma.subscription.create({
     data: {
       accountId,
-      productId: "com.example.builder.monthly",
-      tier: "builder",
+      productId: "com.example.plus.monthly",
+      tier: "plus",
       period: "monthly",
       status: "active",
       originalTransactionId: `otx-${randomUUID()}`,
@@ -130,8 +130,8 @@ describe("runDailyRefill — eligibility", () => {
     await prisma.subscription.create({
       data: {
         accountId,
-        productId: "com.example.builder.monthly",
-        tier: "builder",
+        productId: "com.example.plus.monthly",
+        tier: "plus",
         period: "monthly",
         status: "revoked",
         originalTransactionId: `otx-${randomUUID()}`,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -60,9 +60,7 @@ process.env.PAYMENTS_CRON_API_KEY =
   process.env.PAYMENTS_CRON_API_KEY ||
   "test-cron-api-key-that-is-at-least-32-characters-long";
 
-// Subscription tier credit allotments — placeholder values for tests.
-// Final numbers are set by ops via env in each deploy environment.
-process.env.PAYMENTS_GRANT_BUILDER_MONTHLY =
-  process.env.PAYMENTS_GRANT_BUILDER_MONTHLY || "2500";
-process.env.PAYMENTS_GRANT_PRO_MONTHLY =
-  process.env.PAYMENTS_GRANT_PRO_MONTHLY || "10000";
+// Subscription credit allotment — placeholder value for tests. Final
+// number is set by ops via env in each deploy environment.
+process.env.PAYMENTS_GRANT_PLUS_MONTHLY =
+  process.env.PAYMENTS_GRANT_PLUS_MONTHLY || "2500";

--- a/tests/subscriptions/account-credits.test.ts
+++ b/tests/subscriptions/account-credits.test.ts
@@ -7,9 +7,9 @@ import { authMiddleware } from "@/middleware/auth";
 import { pinoMiddleware } from "@/middleware/pino";
 import {
   AppleEnv,
+  SUBSCRIPTION_TIER_PLUS,
   SubscriptionPeriod,
   SubscriptionStatus,
-  SubscriptionTier,
   upsertFromVerify,
 } from "@/subscriptions/repository";
 import { createJwtToken, validateJWTKeys } from "@/utils/jwt";
@@ -64,12 +64,12 @@ afterEach(async () => {
   await wipe();
 });
 
-const seedBuilderMonthly = async (accountId: string) =>
+const seedPlusMonthly = async (accountId: string) =>
   upsertFromVerify({
     accountId,
     appAccountToken: `${accountId.slice(0, 8)}-2222-3333-4444-555555555555`,
-    productId: "app.convos.subs.builder.monthly",
-    tier: SubscriptionTier.builder,
+    productId: "app.convos.subs.monthly",
+    tier: SUBSCRIPTION_TIER_PLUS,
     period: SubscriptionPeriod.monthly,
     status: SubscriptionStatus.active,
     originalTransactionId: `otid-${accountId}`,
@@ -143,7 +143,7 @@ describe("GET /v2/accounts/me/credits", () => {
 
   test("active Builder monthly with zero consumes: balance == monthlyGrant", async () => {
     const accountId = await newAccount();
-    await seedBuilderMonthly(accountId);
+    await seedPlusMonthly(accountId);
     const token = await tokenFor(accountId);
     const res = await request(makeApp())
       .get("/v2/accounts/me/credits")
@@ -167,8 +167,8 @@ describe("GET /v2/accounts/me/credits", () => {
     await upsertFromVerify({
       accountId,
       appAccountToken: "99999999-2222-3333-4444-555555555555",
-      productId: "app.convos.subs.builder.monthly",
-      tier: SubscriptionTier.builder,
+      productId: "app.convos.subs.monthly",
+      tier: SUBSCRIPTION_TIER_PLUS,
       period: SubscriptionPeriod.monthly,
       status: SubscriptionStatus.expired,
       originalTransactionId: `otid-expired-${accountId}`,
@@ -198,8 +198,8 @@ describe("GET /v2/accounts/me/credits", () => {
     await upsertFromVerify({
       accountId,
       appAccountToken: "88888888-2222-3333-4444-555555555555",
-      productId: "app.convos.subs.builder.monthly",
-      tier: SubscriptionTier.builder,
+      productId: "app.convos.subs.monthly",
+      tier: SUBSCRIPTION_TIER_PLUS,
       period: SubscriptionPeriod.monthly,
       status: SubscriptionStatus.active,
       originalTransactionId: `otid-past-active-${accountId}`,
@@ -227,7 +227,7 @@ describe("GET /v2/accounts/me/credits", () => {
 
   test("consumes within current period count against monthlyGrantUsed", async () => {
     const accountId = await newAccount();
-    await seedBuilderMonthly(accountId);
+    await seedPlusMonthly(accountId);
     await writeConsume(
       accountId,
       300,
@@ -251,7 +251,7 @@ describe("GET /v2/accounts/me/credits", () => {
 
   test("consumes before currentPeriodStart do NOT count (previous period burn)", async () => {
     const accountId = await newAccount();
-    await seedBuilderMonthly(accountId);
+    await seedPlusMonthly(accountId);
     // Burn in the prior period — should not affect this period's display.
     await writeConsume(
       accountId,
@@ -270,7 +270,7 @@ describe("GET /v2/accounts/me/credits", () => {
 
   test("monthlyGrantUsed is capped at monthlyGrant (over-burn doesn't go negative)", async () => {
     const accountId = await newAccount();
-    await seedBuilderMonthly(accountId);
+    await seedPlusMonthly(accountId);
     await writeConsume(
       accountId,
       9999,
@@ -286,17 +286,17 @@ describe("GET /v2/accounts/me/credits", () => {
     expect(body.balance).toBe(0);
   });
 
-  test("Pro annual: monthlyGrant = 12 × monthly amount", async () => {
+  test("Plus annual: monthlyGrant = 12 × monthly amount", async () => {
     const accountId = await newAccount();
     await upsertFromVerify({
       accountId,
       appAccountToken: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-      productId: "app.convos.subs.pro.annual",
-      tier: SubscriptionTier.pro,
+      productId: "app.convos.subs.annual",
+      tier: SUBSCRIPTION_TIER_PLUS,
       period: SubscriptionPeriod.annual,
       status: SubscriptionStatus.active,
-      originalTransactionId: "otid-pro-annual",
-      transactionId: "tx-pro-annual",
+      originalTransactionId: "otid-plus-annual",
+      transactionId: "tx-plus-annual",
       startedAt: new Date("2026-05-01T00:00:00.000Z"),
       currentPeriodStart: new Date("2026-05-01T00:00:00.000Z"),
       currentPeriodEnd: new Date("2027-05-01T00:00:00.000Z"),
@@ -310,8 +310,8 @@ describe("GET /v2/accounts/me/credits", () => {
       .get("/v2/accounts/me/credits")
       .set("X-Convos-AuthToken", token);
     const body = res.body as BalanceBody;
-    expect(body.monthlyGrant).toBe(10000 * 12);
-    expect(body.balance).toBe(10000 * 12);
+    expect(body.monthlyGrant).toBe(2500 * 12);
+    expect(body.balance).toBe(2500 * 12);
     expect(body.nextRefreshAt).toBe("2027-05-01T00:00:00.000Z");
   });
 });
@@ -378,8 +378,8 @@ describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
     await prisma.subscription.create({
       data: {
         accountId,
-        productId: "app.convos.subs.builder.monthly",
-        tier: SubscriptionTier.builder,
+        productId: "app.convos.subs.monthly",
+        tier: SUBSCRIPTION_TIER_PLUS,
         period: SubscriptionPeriod.monthly,
         status: SubscriptionStatus.expired,
         originalTransactionId: `otx-expired-${accountId}`,

--- a/tests/subscriptions/account-subscription.test.ts
+++ b/tests/subscriptions/account-subscription.test.ts
@@ -99,7 +99,7 @@ const signTransaction = async (overrides: Record<string, unknown>) => {
     transactionId: "2000000000000001",
     originalTransactionId: "2000000000000001",
     bundleId: TEST_BUNDLE_ID,
-    productId: "app.convos.subs.builder.monthly",
+    productId: "app.convos.subs.monthly",
     purchaseDate: new Date("2026-05-01T00:00:00.000Z").getTime(),
     originalPurchaseDate: new Date("2026-05-01T00:00:00.000Z").getTime(),
     expiresDate: new Date("2026-06-01T00:00:00.000Z").getTime(),
@@ -153,10 +153,10 @@ describe("GET /v2/accounts/me/subscription", () => {
       .set("X-Convos-AuthToken", token);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
-      tier: "builder",
+      tier: "plus",
       period: "monthly",
       status: "active",
-      productId: "app.convos.subs.builder.monthly",
+      productId: "app.convos.subs.monthly",
       currentPeriodEnd: "2026-06-01T00:00:00.000Z",
       willRenew: true,
       isInTrial: false,
@@ -253,17 +253,17 @@ describe("POST /v2/accounts/me/subscription/verify", () => {
       .set("X-Convos-AuthToken", token)
       .send({
         jwsRepresentation: await signTransaction({
-          productId: "app.convos.subs.pro.annual",
+          productId: "app.convos.subs.annual",
           appAccountToken: "11111111-2222-3333-4444-555555555555",
         }),
       });
     expect(res.status).toBe(200);
     const body = res.body as VerifyBody;
     expect(body.subscription).toEqual({
-      tier: "pro",
+      tier: "plus",
       period: "annual",
       status: "active",
-      productId: "app.convos.subs.pro.annual",
+      productId: "app.convos.subs.annual",
       currentPeriodEnd: "2026-06-01T00:00:00.000Z",
       willRenew: true,
       isInTrial: false,
@@ -276,7 +276,7 @@ describe("POST /v2/accounts/me/subscription/verify", () => {
     expect(persisted?.appAccountToken).toBe(
       "11111111-2222-3333-4444-555555555555",
     );
-    expect(persisted?.tier).toBe("pro");
+    expect(persisted?.tier).toBe("plus");
   });
 
   test("introductory offer → status=trial, isInTrial=true", async () => {

--- a/tests/subscriptions/apple-ssn.test.ts
+++ b/tests/subscriptions/apple-ssn.test.ts
@@ -15,10 +15,11 @@ import {
 } from "@/subscriptions/jws-verifier";
 import {
   AppleEnv,
+  SUBSCRIPTION_TIER_PLUS,
   SubscriptionPeriod,
   SubscriptionStatus,
-  SubscriptionTier,
   upsertFromVerify,
+  type SubscriptionTier,
 } from "@/subscriptions/repository";
 import { prisma } from "@/utils/prisma";
 
@@ -94,7 +95,7 @@ const signTransaction = (overrides: Record<string, unknown>) =>
     transactionId: "3000000000000001",
     originalTransactionId: "1000000000000001",
     bundleId: TEST_BUNDLE_ID,
-    productId: "app.convos.subs.builder.monthly",
+    productId: "app.convos.subs.monthly",
     purchaseDate: new Date("2026-06-01T00:00:00.000Z").getTime(),
     originalPurchaseDate: new Date("2026-05-01T00:00:00.000Z").getTime(),
     expiresDate: new Date("2026-07-01T00:00:00.000Z").getTime(),
@@ -135,8 +136,8 @@ const seedSubscription = async (
   const { subscription } = await upsertFromVerify({
     accountId,
     appAccountToken: "00000000-0000-0000-0000-000000000001",
-    productId: "app.convos.subs.builder.monthly",
-    tier: overrides.tier ?? SubscriptionTier.builder,
+    productId: "app.convos.subs.monthly",
+    tier: overrides.tier ?? SUBSCRIPTION_TIER_PLUS,
     period: SubscriptionPeriod.monthly,
     status: SubscriptionStatus.active,
     originalTransactionId,
@@ -201,7 +202,7 @@ describe("POST /v2/webhooks/apple/ssn", () => {
     const transactionJws = await signTransaction({
       originalTransactionId: otid,
       transactionId: "3000000000000010",
-      productId: "app.convos.subs.builder.monthly",
+      productId: "app.convos.subs.monthly",
       purchaseDate: new Date("2026-06-01T00:00:00.000Z").getTime(),
       expiresDate: new Date("2026-07-01T00:00:00.000Z").getTime(),
     });
@@ -369,7 +370,7 @@ describe("POST /v2/webhooks/apple/ssn", () => {
     expect(updated?.status).toBe(SubscriptionStatus.active); // unchanged
   });
 
-  test("DID_CHANGE_RENEWAL_PREF: tier upgrade Builder → Pro", async () => {
+  test("DID_CHANGE_RENEWAL_PREF: period change monthly → annual updates productId", async () => {
     installLocalTestingVerifier();
     const otid = "1000000000000070";
     const { subscription } = await seedSubscription(otid);
@@ -380,7 +381,7 @@ describe("POST /v2/webhooks/apple/ssn", () => {
       signedTransactionInfo: await signTransaction({
         originalTransactionId: otid,
         transactionId: "3000000000000070",
-        productId: "app.convos.subs.pro.monthly",
+        productId: "app.convos.subs.annual",
       }),
     });
 
@@ -393,8 +394,8 @@ describe("POST /v2/webhooks/apple/ssn", () => {
     const updated = await prisma.subscription.findUnique({
       where: { id: subscription.id },
     });
-    expect(updated?.tier).toBe(SubscriptionTier.pro);
-    expect(updated?.productId).toBe("app.convos.subs.pro.monthly");
+    expect(updated?.tier).toBe(SUBSCRIPTION_TIER_PLUS);
+    expect(updated?.productId).toBe("app.convos.subs.annual");
   });
 
   test("unrecognized productId on DID_RENEW: acks 200, no crash, status still updates", async () => {

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -5,10 +5,10 @@ import {
   findCurrentByAccountId,
   findReceiptByTransactionId,
   serializeUserSubscription,
+  SUBSCRIPTION_TIER_PLUS,
   SubscriptionAccountMismatchError,
   SubscriptionPeriod,
   SubscriptionStatus,
-  SubscriptionTier,
   upsertFromVerify,
   type VerifyInput,
 } from "@/subscriptions/repository";
@@ -37,8 +37,8 @@ const verifyInput = (overrides: Partial<VerifyInput>): VerifyInput => ({
   accountId: overrides.accountId ?? "",
   appAccountToken:
     overrides.appAccountToken ?? "11111111-2222-3333-4444-555555555555",
-  productId: overrides.productId ?? "app.convos.subs.builder.monthly",
-  tier: overrides.tier ?? SubscriptionTier.builder,
+  productId: overrides.productId ?? "app.convos.subs.monthly",
+  tier: overrides.tier ?? SUBSCRIPTION_TIER_PLUS,
   period: overrides.period ?? SubscriptionPeriod.monthly,
   status: overrides.status ?? SubscriptionStatus.active,
   originalTransactionId:
@@ -82,7 +82,7 @@ describe("upsertFromVerify", () => {
       }),
     );
     expect(subscription.accountId).toBe(accountId);
-    expect(subscription.tier).toBe(SubscriptionTier.builder);
+    expect(subscription.tier).toBe(SUBSCRIPTION_TIER_PLUS);
     expect(subscription.status).toBe(SubscriptionStatus.active);
     expect(receiptCreated).toBe(true);
 
@@ -517,20 +517,20 @@ describe("serializeUserSubscription", () => {
         accountId,
         originalTransactionId: "otid-serialize",
         transactionId: "tx-serialize",
-        tier: SubscriptionTier.pro,
+        tier: SUBSCRIPTION_TIER_PLUS,
         period: SubscriptionPeriod.annual,
         status: SubscriptionStatus.trial,
-        productId: "app.convos.subs.pro.annual",
+        productId: "app.convos.subs.annual",
         isInTrial: true,
         willRenew: true,
         currentPeriodEnd: new Date("2027-05-01T00:00:00.000Z"),
       }),
     );
     expect(serializeUserSubscription(subscription)).toEqual({
-      tier: SubscriptionTier.pro,
+      tier: SUBSCRIPTION_TIER_PLUS,
       period: SubscriptionPeriod.annual,
       status: SubscriptionStatus.trial,
-      productId: "app.convos.subs.pro.annual",
+      productId: "app.convos.subs.annual",
       currentPeriodEnd: "2027-05-01T00:00:00.000Z",
       willRenew: true,
       isInTrial: true,

--- a/tests/subscriptions/tier-config.test.ts
+++ b/tests/subscriptions/tier-config.test.ts
@@ -1,25 +1,26 @@
-import { SubscriptionPeriod, SubscriptionTier } from "@prisma/client";
+import { SubscriptionPeriod } from "@prisma/client";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { tierGrant } from "@/subscriptions/tier-config";
+import { SUBSCRIPTION_TIER_PLUS } from "@/subscriptions/tiers";
 
 const snap = () => ({
+  plus: process.env.PAYMENTS_GRANT_PLUS_MONTHLY,
   builder: process.env.PAYMENTS_GRANT_BUILDER_MONTHLY,
-  pro: process.env.PAYMENTS_GRANT_PRO_MONTHLY,
 });
 
 const restore = (s: {
+  plus: string | undefined;
   builder: string | undefined;
-  pro: string | undefined;
 }) => {
+  if (s.plus === undefined) {
+    delete process.env.PAYMENTS_GRANT_PLUS_MONTHLY;
+  } else {
+    process.env.PAYMENTS_GRANT_PLUS_MONTHLY = s.plus;
+  }
   if (s.builder === undefined) {
     delete process.env.PAYMENTS_GRANT_BUILDER_MONTHLY;
   } else {
     process.env.PAYMENTS_GRANT_BUILDER_MONTHLY = s.builder;
-  }
-  if (s.pro === undefined) {
-    delete process.env.PAYMENTS_GRANT_PRO_MONTHLY;
-  } else {
-    process.env.PAYMENTS_GRANT_PRO_MONTHLY = s.pro;
   }
 };
 
@@ -28,56 +29,53 @@ describe("tierGrant", () => {
 
   beforeEach(() => {
     s = snap();
-    process.env.PAYMENTS_GRANT_BUILDER_MONTHLY = "2500";
-    process.env.PAYMENTS_GRANT_PRO_MONTHLY = "10000";
+    process.env.PAYMENTS_GRANT_PLUS_MONTHLY = "2500";
+    delete process.env.PAYMENTS_GRANT_BUILDER_MONTHLY;
   });
 
   afterEach(() => {
     restore(s);
   });
 
-  test("builder monthly → 2500", () => {
+  test("plus monthly → 2500", () => {
     expect(
-      tierGrant(SubscriptionTier.builder, SubscriptionPeriod.monthly).perPeriod,
+      tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.monthly).perPeriod,
     ).toBe(2500);
   });
 
-  test("pro monthly → 10000", () => {
+  test("plus annual → 12 × monthly", () => {
     expect(
-      tierGrant(SubscriptionTier.pro, SubscriptionPeriod.monthly).perPeriod,
-    ).toBe(10000);
-  });
-
-  test("builder annual → 12 × monthly", () => {
-    expect(
-      tierGrant(SubscriptionTier.builder, SubscriptionPeriod.annual).perPeriod,
+      tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.annual).perPeriod,
     ).toBe(2500 * 12);
   });
 
-  test("pro annual → 12 × monthly", () => {
+  test("falls back to legacy PAYMENTS_GRANT_BUILDER_MONTHLY when the new var isn't set", () => {
+    delete process.env.PAYMENTS_GRANT_PLUS_MONTHLY;
+    process.env.PAYMENTS_GRANT_BUILDER_MONTHLY = "4321";
     expect(
-      tierGrant(SubscriptionTier.pro, SubscriptionPeriod.annual).perPeriod,
-    ).toBe(10000 * 12);
+      tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.monthly).perPeriod,
+    ).toBe(4321);
   });
 
-  test("missing PAYMENTS_GRANT_BUILDER_MONTHLY throws 500", () => {
+  test("missing both env vars throws 500", () => {
+    delete process.env.PAYMENTS_GRANT_PLUS_MONTHLY;
     delete process.env.PAYMENTS_GRANT_BUILDER_MONTHLY;
     expect(() =>
-      tierGrant(SubscriptionTier.builder, SubscriptionPeriod.monthly),
-    ).toThrow(/PAYMENTS_GRANT_BUILDER_MONTHLY/);
+      tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.monthly),
+    ).toThrow(/PAYMENTS_GRANT_PLUS_MONTHLY/);
   });
 
-  test("non-positive PAYMENTS_GRANT_PRO_MONTHLY throws", () => {
-    process.env.PAYMENTS_GRANT_PRO_MONTHLY = "0";
+  test("non-positive value throws", () => {
+    process.env.PAYMENTS_GRANT_PLUS_MONTHLY = "0";
     expect(() =>
-      tierGrant(SubscriptionTier.pro, SubscriptionPeriod.monthly),
+      tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.monthly),
     ).toThrow(/positive integer/);
   });
 
   test("non-numeric throws", () => {
-    process.env.PAYMENTS_GRANT_BUILDER_MONTHLY = "lots";
+    process.env.PAYMENTS_GRANT_PLUS_MONTHLY = "lots";
     expect(() =>
-      tierGrant(SubscriptionTier.builder, SubscriptionPeriod.monthly),
+      tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.monthly),
     ).toThrow(/positive integer/);
   });
 });


### PR DESCRIPTION
## Summary

Two concerns landed together because they're really the same change.

### (1) Accept new iOS product IDs

iOS [PR #913](https://github.com/xmtplabs/convos-ios/pull/913) picks subscription product IDs by bundle:

- **Prod** (`org.convos.ios`): `app.convos.subs.plus.monthly` / `app.convos.subs.plus.annual`
- **Dev / Local / App Clip / PR**: `app.convos.subs.monthly` / `app.convos.subs.annual`

ASC product IDs are globally unique per developer account, so dev and prod must use different IDs.

Tightened the regex to `^app\.convos\.subs\.(?:plus\.)?(monthly|annual)$` — exactly these two shapes — and dropped legacy `(builder|pro)` support. One Dev sandbox subscriber on the old `builder.monthly` product re-subscribes in one tap; stale sandbox ASSN webhooks 400 and get dropped (non-events); prod has zero exposure.

### (2) Drop the `SubscriptionTier` Postgres enum, switch to text + backfill

Before: DB stored `tier = "builder"` even when the productId clearly named "Plus" — incoherent, and only worked because iOS carried a decoder that translated the legacy string.

After: DB stores `tier = "plus"` everywhere, matching the productId. iOS can drop the legacy mapping (separate cleanup PR).

Application defines the valid tier set in `src/subscriptions/tiers.ts`. `requireSubscriptionTier(value: string)` narrows raw DB reads to the typed `SubscriptionTier`, throwing on any unknown value (anything other than `"plus"` is a backfill/migration bug).

## Migration

Single migration `20260529190000_drop_subscription_tier_enum`:

```sql
ALTER TABLE "Subscription" ALTER COLUMN "tier" TYPE TEXT USING tier::TEXT;
UPDATE "Subscription" SET "tier" = 'plus' WHERE "tier" IN ('builder', 'pro');
DROP TYPE "SubscriptionTier";
```

All three statements run safely in a single transaction.

## Env vars

`tier-config.ts` reads `PAYMENTS_GRANT_PLUS_MONTHLY` with a fallback to `PAYMENTS_GRANT_BUILDER_MONTHLY`, so deploys don't need to be coordinated with the env var rename. Drop the fallback in a follow-up once all envs set the new name.

## Tests

- All `SubscriptionTier.builder` / `.pro` fixtures rewritten to `SUBSCRIPTION_TIER_PLUS` (or wire-format `"plus"`)
- `tier-config.test.ts` rewritten to test the single-tier + fallback flow
- The `Builder -> Pro tier upgrade` SSN test repurposed to a `monthly -> annual` period-change test, exercising the same `DID_CHANGE_RENEWAL_PREF` code path with a now-valid scenario
- `tests/setup.ts` switches to `PAYMENTS_GRANT_PLUS_MONTHLY`
- `pnpm check` (typecheck + format + lint) passes

## Why this is urgent

Without (1), prod purchase verification will 400 on the unknown `plus.*` product ID. **This must deploy before the iOS prod build ships.**

## Follow-up

- iOS PR to remove the `Subscription.init(from:)` legacy decoder (currently maps `"builder"` / `"pro"` -> `.plus`)
- Drop the `PAYMENTS_GRANT_BUILDER_MONTHLY` env var fallback in `tier-config.ts` once all environments set `PAYMENTS_GRANT_PLUS_MONTHLY`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `SubscriptionTier` Postgres enum and backfill tier column to 'plus'
> - Replaces the Postgres `SubscriptionTier` enum with a plain `TEXT` column and migrates all `'builder'` and `'pro'` rows to `'plus'` in [migration.sql](https://github.com/ephemeraHQ/convos-backend/pull/263/files#diff-5e130c8b09ea775c99c86a7b79822c2b1b68129e05ab6dd6a338628210cedb7f).
> - Introduces a new [tiers.ts](https://github.com/ephemeraHQ/convos-backend/pull/263/files#diff-d535dbb3ff75b6a54967795c7f0e1adf1a0e2f9aa0d247003611775d20108ab1) module defining `SUBSCRIPTION_TIER_PLUS`, the `SubscriptionTier` type, and a `requireSubscriptionTier` validator that throws on unrecognized values; this replaces the Prisma-generated enum throughout the app.
> - Updates product ID decoding in [product-mapping.ts](https://github.com/ephemeraHQ/convos-backend/pull/263/files#diff-3f9e05ce855082a5d1546a57be0dbf18ba990072397e87e3a40daf16e8f96096) to accept unprefixed dev/preview IDs (`app.convos.subs.<period>`) in addition to the production format, always mapping to `'plus'`.
> - Replaces per-tier env var switching in [tier-config.ts](https://github.com/ephemeraHQ/convos-backend/pull/263/files#diff-ae2142f94bf5def9e2feb828f9e010655ecf8625d968f2adf75a07e1cf13bd71) with a single `PAYMENTS_GRANT_PLUS_MONTHLY` var (falling back to `PAYMENTS_GRANT_BUILDER_MONTHLY`).
> - Risk: `requireSubscriptionTier` will throw at runtime if any stored tier value is not `'plus'`; the migration should eliminate these cases, but any out-of-band data will cause errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7065b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->