### PR TITLE
fix(error-handler): fall back to base logger when req.log is unset

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -2,6 +2,7 @@ import type express from "express";
 import { type NextFunction, type Request, type Response } from "express";
 import { ZodError } from "zod";
 import { IS_DEVELOPMENT } from "@/config";
+import logger from "@/utils/logger";
 import { AppError } from "../utils/errors";
 
 // Express requires error handling middleware to have exactly 4 parameters
@@ -12,8 +13,13 @@ function errorHandler(
   // Rename 'next' to '_next' to satisfy the linter while keeping the 4 params Express needs
   _next: NextFunction,
 ) {
-  // Log the error with request context
-  req.log.error(err);
+  // Log the error with request context. `req.log` is typed as always-present,
+  // but pino-http only attaches it once its middleware runs — errors thrown
+  // earlier (e.g. body-parser rejecting malformed JSON) reach this handler with
+  // `req.log` undefined. Fall back to the base logger so logging here can't
+  // itself throw and collapse the response into a raw HTML 500.
+  const log = (req as { log?: typeof logger }).log ?? logger;
+  log.error(err);
 
   // If response is already sent, just log the error and return
   if (res.headersSent) {


### PR DESCRIPTION
## Summary

`errorHandler` logs via `req.log.error(err)`, but `pino-http` only attaches `req.log` **after** its middleware runs. Errors thrown earlier in the chain — e.g. `body-parser` rejecting a malformed-JSON request body — reach the error handler with `req.log` still `undefined`. The logging call then throws a `TypeError: Cannot read properties of undefined (reading 'error')`, that secondary throw escapes the error handler, and Express falls back to its default `finalhandler` — returning a raw **HTML 500** instead of the intended structured JSON error.

## Fix

Fall back to the base logger (`@/utils/logger`) when `req.log` is absent, so the handler always logs and returns its JSON body:

```ts
const log = (req as { log?: typeof logger }).log ?? logger;
log.error(err);
```

The typed cast is deliberate: `req.log` is typed non-nullable (the pino-http augmentation), so a plain `req.log ?? logger` would trip `strictTypeChecked`'s `no-unnecessary-condition`. Casting `req` to a shape where `log` is optional makes the nullish-coalescing genuinely warranted and keeps the lint clean.

## How it surfaced

Hit while debugging the `convos-twitter-bot` worker against `api.dev.convos.xyz`. A `POST /api/v2/agent-templates/generations` with a malformed body returned an HTML 500 whose stack traced back to `errorHandler.ts` (`req.log.error`), rather than a clean `{"error": ...}` JSON 500. The worker only ever sends valid JSON so it doesn't trigger this, but any malformed inbound request does.

## Notes

- One file, behavior-preserving for the normal path (when `req.log` exists, it's used exactly as before).
- `eslint` + `prettier` pass on the change. Local `tsc --noEmit` surfaces unrelated `@prisma/client` errors (missing generated exports — `prisma generate` not run in the checkout); none touch `errorHandler.ts`, and CI regenerates Prisma before typechecking.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782687410&installation_id=128169237&pr_number=264&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F264&signature=d4a9db1295f52914de8efe26767389bd0e5e3c091d34aed609dba7f23dce7ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `errorHandler` middleware to fall back to base logger when `req.log` is unset
> Previously, the Express error handler called `req.log.error(...)` directly, causing a runtime exception when `req.log` was undefined. [errorHandler.ts](https://github.com/ephemeraHQ/convos-backend/pull/264/files#diff-700a0272fd9808834a4a61705cc95a03bb8523f08fa719efc93341d21175a3cb) now imports the base logger and selects it as a fallback when `req.log` is absent, ensuring errors are always logged and the JSON error response is always sent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 283e63d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging reliability to ensure errors are consistently captured even when request-level logging is unavailable. The system now uses a fallback mechanism to maintain visibility into errors for better troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->