### PR TITLE
fix(builder): passthrough classifier leans agent-shaped, runs on minimax-m3

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -10,8 +10,9 @@
  *
  * OpenRouter raw fetch to https://openrouter.ai/api/v1/chat/completions with
  * strict response_format json_schema, temp 0.7, no max_tokens.
- * Helper calls (GitHub-instructions selector, content-classifier) at temp 0.2
- * without response_format.
+ * Helper calls run at temp 0.2 without response_format: the GitHub-instructions
+ * selector uses the main model; the content-classifier uses the cheap
+ * BUILDER_CLASSIFIER_MODEL and leans toward passthrough.
  *
  * Soft defaults for non-name fields. Server-injects connections: [].
  */
@@ -20,6 +21,7 @@
 
 import { APIConnectionTimeoutError, APIError, APIUserAbortError } from "openai";
 import {
+  BUILDER_CLASSIFIER_MODEL,
   BUILDER_EXA_SERVICE_KEY,
   BUILDER_MODEL,
   BUILDER_OPENROUTER_API_KEY,
@@ -91,6 +93,7 @@ function describeLlmError(err: unknown): string {
 
 let _apiKeyOverride: string | null | undefined = undefined;
 let _builderModelOverride: string | null = null;
+let _classifierModelOverride: string | null = null;
 let _exaKeyOverride: string | null | undefined = undefined;
 let _systemPromptOverride: string | null = null;
 
@@ -122,6 +125,19 @@ export function __setBuilderApiKeyOverrideForTests(
 /** Override `BUILDER_MODEL` for tests. Pass `null` to clear. */
 export function __setBuilderModelOverrideForTests(model: string | null): void {
   _builderModelOverride = model;
+}
+
+/** Model for the passthrough classifier (`classifyPastedContent`) — a cheap
+ *  model separate from the main `getModel()`. Override `BUILDER_CLASSIFIER_MODEL`. */
+export function getClassifierModel(): string {
+  return _classifierModelOverride ?? BUILDER_CLASSIFIER_MODEL;
+}
+
+/** Override `BUILDER_CLASSIFIER_MODEL` for tests. Pass `null` to clear. */
+export function __setClassifierModelOverrideForTests(
+  model: string | null,
+): void {
+  _classifierModelOverride = model;
 }
 
 /** The system prompt actually used for generation — the loaded file unless an
@@ -896,21 +912,23 @@ Pasted content:
 ${truncated}
 ---
 
-Two kinds of content count as "passthrough" (use verbatim, do not re-generate):
+Choose PASSTHROUGH (use the text verbatim, do not re-generate) whenever the content is AGENT-SHAPED — i.e. it reads like instructions written FOR an AI agent rather than prose written for a human reader. Two common shapes:
 
 Type A — install-instructions: setup choreography addressed to an AI agent
 - Second-person language: "Read this, then follow the steps", "Ask the user for API keys"
 - Setup commands: git clone, npm install, bun install, export env vars
 - Agent workflow: clone → install → configure → adopt skills → report progress
-- Clearly addressed to an AI, not to a human developer
+- Addressed to an AI, not (only) to a human developer
 
-Type B — skill-definition: a complete system prompt already written for an agent
-- Often has YAML frontmatter with name: and description:
-- Direct instructions to an AI: "You are...", "You must...", "Your job is to..."
-- Section headers like BRAIN/SOUL/HEART, or THE HOOK, or rules/behavior definitions
-- A ready-to-use agent definition, not content ABOUT a topic
+Type B — skill-definition: a system prompt / agent definition already written for an agent
+- YAML frontmatter with name:/description:, or a title plus a role/identity line
+- Direct instructions to an AI: "You are...", "You must...", "Your job is to...", "Always/Never..."
+- A defined persona, voice, or behavioral rules; section headers like BRAIN/SOUL/HEART, THE HOOK, GUIDELINES, RULES, TONE, WELCOME MESSAGE
+- A ready-to-run agent definition — even a rough, partial, or unconventional one — rather than an article ABOUT a topic
 
-Anything else is "source material" — an article, essay, README-for-humans, product spec, book excerpt, etc. — and should NOT be passthrough. For those, return false.
+Lean PASSTHROUGH. If the text is structured as an agent persona, behavioral brief, or instruction set — even if it's imperfect, incomplete, or you would have written it differently — classify it as passthrough and preserve the author's wording. The author already wrote a prompt; respect it instead of rewriting it.
+
+Return false ONLY for genuine SOURCE MATERIAL — text written for humans that an agent would have to be DESIGNED from rather than run on directly: an article, essay, news story, README-for-humans, marketing/landing copy, product spec, or book/transcript excerpt, with no instructions addressed to an agent.
 
 If passthrough, also produce metadata:
 - agentName: memorable name derived from the content
@@ -931,8 +949,8 @@ Respond with ONLY a JSON object (no markdown fences, no explanation):
 
 Rules:
 - If isPassthrough is false, all other fields MUST be null.
-- When ambiguous, lean toward false. Better to over-generate than over-passthrough.
-- The content must be READY-TO-USE as an agent prompt on its own — if it's merely ABOUT agents or references them in passing, that's false.`;
+- When borderline between "agent-shaped" and "source material", lean toward TRUE (passthrough). Better to preserve a real prompt than to rewrite one.
+- Always pick a passthroughType when isPassthrough is true: install-instructions for setup choreography, skill-definition for a persona/system prompt. When both fit, prefer skill-definition.`;
 
   const t0 = performance.now();
   let data: any;
@@ -941,7 +959,7 @@ Rules:
       apiKey,
       stage: "classifier",
       body: {
-        model: getModel(),
+        model: getClassifierModel(),
         messages: [{ role: "user", content: classifierPrompt }],
         temperature: 0.2,
       },

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -207,6 +207,11 @@ interface PassthroughTokens {
 
 interface PassthroughBundle {
   template: GeneratedTemplate;
+  /** Model that produced `tokens` — the selector (`getModel()`) for a GitHub
+   *  repo scan, or the classifier (`getClassifierModel()`) for pasted content
+   *  and direct GitHub file links. Carried so passthrough metrics attribute
+   *  cost to the model actually billed, not the main generation model. */
+  model: string;
   tokens: PassthroughTokens;
 }
 
@@ -871,7 +876,7 @@ async function tryGithubPassthrough(
 
   return {
     kind: "passthrough",
-    bundle: { template, tokens: selectorTokens },
+    bundle: { template, model: getModel(), tokens: selectorTokens },
   };
 }
 
@@ -1052,7 +1057,7 @@ async function tryContentPassthrough(
     classification.passthroughType,
   );
 
-  return { template, tokens: classifierTokens };
+  return { template, model: getClassifierModel(), tokens: classifierTokens };
 }
 
 /** Extract content via the configured upstream services. Twitter URLs go
@@ -1170,7 +1175,7 @@ export async function generateTemplate(
         return {
           template: bundle.template,
           metrics: {
-            model: getModel(),
+            model: bundle.model,
             promptTokens: bundle.tokens.promptTokens,
             completionTokens: bundle.tokens.completionTokens,
             latencyMs: Math.round(performance.now() - funcStart),
@@ -1199,7 +1204,7 @@ export async function generateTemplate(
       return {
         template: passthroughBundle.template,
         metrics: {
-          model: getModel(),
+          model: passthroughBundle.model,
           promptTokens: passthroughBundle.tokens.promptTokens,
           completionTokens: passthroughBundle.tokens.completionTokens,
           latencyMs: Math.round(performance.now() - funcStart),

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,6 +127,10 @@ export const NONCE_HMAC_SECRET = process.env.NONCE_HMAC_SECRET;
 export const BUILDER_OPENROUTER_API_KEY =
   process.env.BUILDER_OPENROUTER_API_KEY?.trim() || "";
 export const BUILDER_MODEL = process.env.BUILDER_MODEL?.trim() || "";
+// Cheap model for the pre-generation passthrough classifier
+// (`classifyPastedContent`); concrete OpenRouter id so PostHog can price it.
+export const BUILDER_CLASSIFIER_MODEL =
+  process.env.BUILDER_CLASSIFIER_MODEL?.trim() || "minimax/minimax-m3";
 export const CONTENT_MODERATION_MODEL =
   process.env.CONTENT_MODERATION_MODEL?.trim() ||
   "google/gemini-3.1-flash-lite";

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -733,6 +733,58 @@ describe("templateGen service — OpenRouter integration", () => {
     globalThis.fetch = originalMockFetch;
   });
 
+  test("content passthrough metrics report the classifier model + its tokens", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    // >= 300 chars so the content classifier runs and returns passthrough. The
+    // classifier is the only LLM call on this path, so the metrics must report
+    // its model + tokens — not the main generation model.
+    const longText = "You are a test agent. ".repeat(20);
+
+    const originalMockFetch = globalThis.fetch;
+    globalThis.fetch = ((input: any, init?: any) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url === OPENROUTER_URL) {
+        return new Response(
+          JSON.stringify({
+            model: "@preset/assistants-pro",
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    isPassthrough: true,
+                    passthroughType: "skill-definition",
+                    agentName: "PassthroughBot",
+                    emoji: "🤖",
+                    description: "A passthrough bot",
+                    category: "Work",
+                  }),
+                },
+              },
+            ],
+            usage: { prompt_tokens: 100, completion_tokens: 50 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return (originalMockFetch as any)(input, init);
+    }) as any;
+
+    const { metrics } = await generateTemplate({ text: longText });
+
+    expect(metrics.model).toBe(BUILDER_CLASSIFIER_MODEL);
+    expect(metrics.promptTokens).toBe(100);
+    expect(metrics.completionTokens).toBe(50);
+
+    globalThis.fetch = originalMockFetch;
+  });
+
   // -----------------------------------------------------------------------
   // Soft defaults: agentName is the only fatal-required parse field
   // -----------------------------------------------------------------------

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -10,6 +10,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-imports */
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { BUILDER_CLASSIFIER_MODEL } from "@/config";
 
 // ---------------------------------------------------------------------------
 // Fetch interceptor — captures all outbound fetch calls so we can assert
@@ -1110,7 +1111,7 @@ describe("templateGen service — OpenRouter integration", () => {
   // -----------------------------------------------------------------------
   // Helper calls use same model + Authorization, temp 0.2, no response_format
   // -----------------------------------------------------------------------
-  test("content classifier helper call uses temp 0.2, no response_format, same model+auth", async () => {
+  test("content classifier helper call uses temp 0.2, no response_format, cheap classifier model + auth", async () => {
     const mod = await import("@/api/v2/agent-templates/services/templateGen");
     generateTemplate = mod.generateTemplate;
 
@@ -1194,7 +1195,7 @@ describe("templateGen service — OpenRouter integration", () => {
     const classifierReq = getOpenRouterRequests()[0];
     expect(classifierReq.body.temperature).toBe(0.2);
     expect(classifierReq.body.response_format).toBeUndefined();
-    expect(classifierReq.body.model).toBe("anthropic/claude-opus-4.7");
+    expect(classifierReq.body.model).toBe(BUILDER_CLASSIFIER_MODEL);
     expect(classifierReq.headers["authorization"]).toBe(
       `Bearer ${TEST_API_KEY}`,
     );


### PR DESCRIPTION
## Summary

Tunes the pre-generation **passthrough classifier** (`templateGen.classifyPastedContent`) — the step that decides whether pasted text is *already an agent prompt* (use verbatim) or *source material* (generate a persona from it).

- **Bias toward passthrough for agent-shaped input.** The prompt previously told the model to lean `false` when ambiguous and to require content be "ready-to-use as an agent prompt on its own." Reframed around "is this agent-shaped?", broadened the skill-definition shape (personas, role/identity lines, behavioral rules, more section headers, rough/partial definitions), and flipped the borderline tie-break to `true`. Genuine source material (articles, READMEs-for-humans, specs, excerpts) still returns `false`.
- **Run the classifier on a cheap, fast model.** New `BUILDER_CLASSIFIER_MODEL` env knob (default `minimax/minimax-m3`), replacing the main generation model (Opus) for this helper call. Concrete OpenRouter id so PostHog LLM Analytics prices its `$ai_generation`. Main generation and the GitHub selector are unchanged (still `getModel()`).

## Why

Agent-shaped pastes — a persona, a behavioral brief, a partial system prompt — were being classified as source material and **rewritten** by the generator instead of preserved verbatim, losing the author's wording. The stricter-than-needed prompt and the over-powered model were both contributing; this leans the call toward respecting a real prompt when it sees one.

## Notes

- Behavior unchanged below `PASSTHROUGH_MIN_LENGTH = 300` and beyond the 8k-char classify window — those floors still bound what's even considered.
- `BUILDER_CLASSIFIER_MODEL` is overridable per-env if `minimax/minimax-m3` needs swapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782933519&installation_id=128169237&pr_number=265&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F265&signature=ef41735519e84d0e157dccda135a2f7937e576802d52ea2673e7a9efdbd39184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix passthrough classifier to lean agent-shaped and run on `minimax-m3`
> - Adds `BUILDER_CLASSIFIER_MODEL` to [config.ts](https://github.com/ephemeraHQ/convos-backend/pull/265/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012), defaulting to `minimax/minimax-m3`, so the passthrough classifier uses a dedicated model separate from the main builder model.
> - Updates `classifyPastedContent` in [templateGen.ts](https://github.com/ephemeraHQ/convos-backend/pull/265/files#diff-d151881c4ab5cd2005df4016ac6a564fb6094e4ce06b69fbf9529fb70e59148a) to call `getClassifierModel()` instead of `getModel()`, and updates the prompt to bias toward classifying agent-shaped content as passthrough.
> - Adds a test hook `__setClassifierModelOverrideForTests` to allow overriding the classifier model in tests.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #265 opened
>
> - Added model tracking to passthrough operations and updated metrics reporting [f6b772d]
> - Added test coverage for classifier model metrics reporting during content passthrough [f6b772d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de22bbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved pasted content classification in agent template generation with refined decision logic.
  * Separated classifier model configuration from the main generation model to optimize performance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->