### PR TITLE
fix(credits): log silent error branches across credits paths

### DIFF
--- a/src/api/v2/accounts/handlers/credits-by-id-get.ts
+++ b/src/api/v2/accounts/handlers/credits-by-id-get.ts
@@ -54,5 +54,6 @@ export const creditsByIdGetHandler = async (
       "credits.read.failed",
     );
     res.status(500).json({ error: "Failed to read credits balance" });
+    return;
   }
 };

--- a/src/api/v2/accounts/handlers/credits-by-id-get.ts
+++ b/src/api/v2/accounts/handlers/credits-by-id-get.ts
@@ -20,26 +20,39 @@ export const creditsByIdGetHandler = async (
 ): Promise<void> => {
   const accountId = req.params.accountId; // meGuard already validated UUID shape
 
-  // 404 if the Account row itself doesn't exist. Spec § 4.1 perf note: this
-  // adds one PK lookup per GET vs the prior check handler which skipped it.
-  const account = await prisma.account.findUnique({
-    where: { id: accountId },
-    select: { id: true },
-  });
-  if (!account) {
-    res.status(404).json({ code: "account_not_found" });
-    return;
-  }
+  try {
+    // 404 if the Account row itself doesn't exist. Spec § 4.1 perf note: this
+    // adds one PK lookup per GET vs the prior check handler which skipped it.
+    const account = await prisma.account.findUnique({
+      where: { id: accountId },
+      select: { id: true },
+    });
+    if (!account) {
+      req.log.warn({ accountId }, "credits.read.account_not_found");
+      res.status(404).json({ code: "account_not_found" });
+      return;
+    }
 
-  const balance = await getBalance(accountId);
-  const allowed = isAllowedFromBalance(balance);
-  req.log.info(
-    { accountId, balance: balance.toString(), allowed },
-    "credits.read.served",
-  );
-  res.status(200).json({
-    accountId,
-    balance: balance.toString(),
-    allowed,
-  });
+    const balance = await getBalance(accountId);
+    const allowed = isAllowedFromBalance(balance);
+    req.log.info(
+      { accountId, balance: balance.toString(), allowed },
+      "credits.read.served",
+    );
+    res.status(200).json({
+      accountId,
+      balance: balance.toString(),
+      allowed,
+    });
+  } catch (error) {
+    req.log.error(
+      {
+        error,
+        stack: error instanceof Error ? error.stack : undefined,
+        accountId,
+      },
+      "credits.read.failed",
+    );
+    res.status(500).json({ error: "Failed to read credits balance" });
+  }
 };

--- a/src/api/v2/accounts/handlers/credits-grants-post.ts
+++ b/src/api/v2/accounts/handlers/credits-grants-post.ts
@@ -37,12 +37,24 @@ export const creditsGrantsPostHandler = async (
   const headerKey = req.get("Idempotency-Key") ?? "";
   const keyResult = idempotencyKeySchema.safeParse(headerKey);
   if (!keyResult.success) {
+    req.log.warn(
+      {
+        accountId,
+        keyLength: headerKey.length,
+        disallowedChars: [...new Set(headerKey.replace(/[A-Za-z0-9_-]/g, ""))],
+      },
+      "credits.grant.invalid_idempotency_key",
+    );
     res.status(400).json({ code: "invalid_idempotency_key" });
     return;
   }
 
   const bodyResult = grantRequestSchema.safeParse(req.body);
   if (!bodyResult.success) {
+    req.log.warn(
+      { accountId, issueCount: bodyResult.error.issues.length },
+      "credits.grant.invalid_request",
+    );
     res
       .status(400)
       .json({ code: "invalid_request", issues: bodyResult.error.issues });
@@ -105,6 +117,7 @@ export const creditsGrantsPostHandler = async (
         (err.code === "P2010" &&
           (err.meta as { code?: string } | undefined)?.code === "23503"))
     ) {
+      req.log.warn({ accountId }, "credits.grant.account_not_found");
       res.status(404).json({ code: "account_not_found" });
       return;
     }

--- a/src/api/v2/accounts/handlers/credits-transactions-post.ts
+++ b/src/api/v2/accounts/handlers/credits-transactions-post.ts
@@ -37,12 +37,24 @@ export const creditsTransactionsPostHandler = async (
   const headerKey = req.get("Idempotency-Key") ?? "";
   const keyResult = idempotencyKeySchema.safeParse(headerKey);
   if (!keyResult.success) {
+    req.log.warn(
+      {
+        accountId,
+        keyLength: headerKey.length,
+        disallowedChars: [...new Set(headerKey.replace(/[A-Za-z0-9_-]/g, ""))],
+      },
+      "credits.transaction.invalid_idempotency_key",
+    );
     res.status(400).json({ code: "invalid_idempotency_key" });
     return;
   }
 
   const bodyResult = transactionRequestSchema.safeParse(req.body);
   if (!bodyResult.success) {
+    req.log.warn(
+      { accountId, issueCount: bodyResult.error.issues.length },
+      "credits.transaction.invalid_request",
+    );
     res
       .status(400)
       .json({ code: "invalid_request", issues: bodyResult.error.issues });
@@ -105,6 +117,7 @@ export const creditsTransactionsPostHandler = async (
         (err.code === "P2010" &&
           (err.meta as { code?: string } | undefined)?.code === "23503"))
     ) {
+      req.log.warn({ accountId }, "credits.transaction.account_not_found");
       res.status(404).json({ code: "account_not_found" });
       return;
     }

--- a/src/api/v2/accounts/middleware/meGuard.ts
+++ b/src/api/v2/accounts/middleware/meGuard.ts
@@ -18,6 +18,10 @@ export const meGuard = (
 ): void => {
   const r = accountIdSchema.safeParse(req.params.accountId);
   if (!r.success) {
+    req.log.warn(
+      { accountIdParam: String(req.params.accountId).slice(0, 64) },
+      "accounts.invalid_account_id",
+    );
     res.status(400).json({ code: "invalid_account_id" });
     return;
   }

--- a/src/api/v2/credits/handlers/daily-refill.ts
+++ b/src/api/v2/credits/handlers/daily-refill.ts
@@ -4,7 +4,15 @@ import {
   type DailyRefillSummary,
 } from "@/payments/daily-refill/service";
 
-export async function dailyRefill(req: Request, res: Response): Promise<void> {
+/**
+ * POST /v2/credits/daily
+ *
+ * Cron-gated daily refill. Runs the top-up-to-cap job and returns a summary.
+ *   200  { skipped: true, reason, lastRunAt }                   — already ran this UTC day
+ *   200  { skipped: false, refilled, noOp, errors, runAt }      — ran
+ *   500  { error: "Daily refill failed" }                       — job threw
+ */
+export async function dailyRefill(req: Request, res: Response) {
   let summary: DailyRefillSummary;
   try {
     summary = await runDailyRefill();

--- a/src/api/v2/credits/handlers/daily-refill.ts
+++ b/src/api/v2/credits/handlers/daily-refill.ts
@@ -1,8 +1,22 @@
 import type { Request, Response } from "express";
-import { runDailyRefill } from "@/payments/daily-refill/service";
+import {
+  runDailyRefill,
+  type DailyRefillSummary,
+} from "@/payments/daily-refill/service";
 
 export async function dailyRefill(req: Request, res: Response): Promise<void> {
-  const summary = await runDailyRefill();
+  let summary: DailyRefillSummary;
+  try {
+    summary = await runDailyRefill();
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "credits.daily_refill.failed",
+    );
+    res.status(500).json({ error: "Daily refill failed" });
+    return;
+  }
+
   req.log.info(
     {
       skipped: summary.skipped,
@@ -13,6 +27,12 @@ export async function dailyRefill(req: Request, res: Response): Promise<void> {
     },
     "credits.daily_refill.completed",
   );
+  if (summary.errors.length > 0) {
+    req.log.warn(
+      { errorCount: summary.errors.length, errors: summary.errors },
+      "credits.daily_refill.partial_errors",
+    );
+  }
   if (summary.skipped) {
     res.status(200).json({
       skipped: true,

--- a/src/api/v2/credits/middleware/cron-api-key.ts
+++ b/src/api/v2/credits/middleware/cron-api-key.ts
@@ -1,5 +1,6 @@
 import { createHash, timingSafeEqual } from "crypto";
 import type { NextFunction, Request, Response } from "express";
+import { maskKeyPrefix } from "@/utils/mask";
 
 const MIN_CRON_API_KEY_LENGTH = 32;
 
@@ -29,11 +30,6 @@ function constantTimeSecretCompare(
   const a = createHash("sha256").update(provided, "utf8").digest();
   const b = createHash("sha256").update(expected, "utf8").digest();
   return timingSafeEqual(a, b);
-}
-
-function maskKeyPrefix(key: string): string {
-  if (key.length === 0) return "(empty)";
-  return `${key.slice(0, 4)}... (len=${key.length})`;
 }
 
 export const requireCronApiKey = (

--- a/src/api/v2/credits/middleware/cron-api-key.ts
+++ b/src/api/v2/credits/middleware/cron-api-key.ts
@@ -44,6 +44,7 @@ export const requireCronApiKey = (
   const expectedKey = getCronApiKey();
 
   if (!expectedKey) {
+    req.log.error("cron_api_key.not_configured");
     res.status(503).json({ error: "Cron API key not configured" });
     return;
   }

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -2,6 +2,7 @@ import { createHash, timingSafeEqual } from "crypto";
 import type { NextFunction, Request, Response } from "express";
 import { AGENT_ASSETS_API_KEY } from "@/config";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { maskKeyPrefix } from "@/utils/mask";
 import { authMiddleware } from "./auth";
 
 export const AGENT_API_KEY_HEADER = "X-Agent-API-Key";
@@ -41,11 +42,6 @@ function constantTimeSecretCompare(
   const providedDigest = createHash("sha256").update(provided, "utf8").digest();
   const expectedDigest = createHash("sha256").update(expected, "utf8").digest();
   return timingSafeEqual(providedDigest, expectedDigest);
-}
-
-function maskKeyPrefix(key: string): string {
-  if (key.length === 0) return "(empty)";
-  return `${key.slice(0, 4)}... (len=${key.length})`;
 }
 
 export const agentApiKeyAuth = (

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -43,6 +43,11 @@ function constantTimeSecretCompare(
   return timingSafeEqual(providedDigest, expectedDigest);
 }
 
+function maskKeyPrefix(key: string): string {
+  if (key.length === 0) return "(empty)";
+  return `${key.slice(0, 4)}... (len=${key.length})`;
+}
+
 export const agentApiKeyAuth = (
   req: Request,
   res: Response,
@@ -51,6 +56,7 @@ export const agentApiKeyAuth = (
   const expectedKey = getAgentAssetsApiKey();
 
   if (!expectedKey) {
+    req.log.error("agent_api_key.not_configured");
     res.status(503).json({ error: "Agent assets API key not configured" });
     return;
   }
@@ -69,12 +75,17 @@ export const agentApiKeyAuth = (
 
   const providedKey = req.header(AGENT_API_KEY_HEADER)?.trim() ?? "";
   if (!providedKey) {
+    req.log.warn({ reason: "missing" }, "agent_api_key.unauthorized");
     res.status(401).json({ error: "Invalid or missing agent API key" });
     return;
   }
 
   const valid = constantTimeSecretCompare(providedKey, expectedKey);
   if (!valid) {
+    req.log.warn(
+      { reason: "mismatch", providedPrefix: maskKeyPrefix(providedKey) },
+      "agent_api_key.unauthorized",
+    );
     res.status(401).json({ error: "Invalid or missing agent API key" });
     return;
   }

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -1,0 +1,9 @@
+/**
+ * Mask a secret key for logging: first 4 chars + length, never the full value.
+ * Used by API-key middlewares so Datadog can correlate a bad key without
+ * leaking it.
+ */
+export function maskKeyPrefix(key: string): string {
+  if (key.length === 0) return "(empty)";
+  return `${key.slice(0, 4)}... (len=${key.length})`;
+}

--- a/tests/api/v2/accounts/middleware/meGuard.unit.test.ts
+++ b/tests/api/v2/accounts/middleware/meGuard.unit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
 
 const makeReq = (accountId: string): Request =>
-  ({ params: { accountId } }) as unknown as Request;
+  ({ params: { accountId }, log: { warn: vi.fn() } }) as unknown as Request;
 
 const makeRes = () => {
   const json = vi.fn();


### PR DESCRIPTION
## Summary

Every error/anomaly branch on the credits surface was logging-silent, so a real incident (Hermes generating idempotency keys as `consume:<instanceId>:<generationId>` — colons rejected by the `^[A-Za-z0-9_-]{1,255}$` regex) returned `400 invalid_idempotency_key` with **zero trace in Datadog**. The validation guards were early `return`s with no `req.log` call, and the one automatic pino-http request line has `req.headers` redacted, so the offending key value never appeared anywhere. The precheck/read 5xx likewise only surfaced as a bare errorHandler line without `accountId`.

This adds structured logging to every previously-silent branch across the credits paths:

- **consume** (`credits-transactions-post`): `credits.transaction.{invalid_idempotency_key, invalid_request, account_not_found}`
- **grant** (`credits-grants-post`): `credits.grant.{invalid_idempotency_key, invalid_request, account_not_found}`
- **precheck/read** (`credits-by-id-get`): `credits.read.account_not_found` + new `try/catch` → `credits.read.failed` (500 now logs with `accountId`/stack)
- **meGuard**: `accounts.invalid_account_id`
- **agentApiKeyAuth** (shared front door): `agent_api_key.not_configured` (503), `agent_api_key.unauthorized` (401, missing/mismatch)
- **cron gate**: `cron_api_key.not_configured` (503) — the only branch that was still silent
- **daily refill**: `try/catch` → `credits.daily_refill.failed` (500) + `credits.daily_refill.partial_errors` warn (previously logged the error *count* only)

**Levels:** 4xx → `warn`, 5xx / server-misconfig → `error`.

**Key-leak guard:** invalid idempotency keys log `keyLength` + `disallowedChars` (the set of chars failing the regex) — never the raw key. The colon wave shows `disallowedChars:[":"]` in Datadog without dumping the key.

## Notes

- `agentApiKeyAuth` is **shared** with `/assets` and `/agents` — those routes now also emit `agent_api_key.unauthorized` on bad key. Intended (front door for credits), flagging for log-volume awareness.

## Test Plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec eslint` clean on all 7 files
- [x] Credits + agent-auth integration/unit tests: 68 passed / 2 skipped (pre-existing skips)
- [x] New log lines observed firing in handler runs at correct levels — confirmed `disallowedChars:[" "]` projection on a bad-charset key, `accounts.invalid_account_id` with `accountIdParam`, `credits.read.account_not_found`
- [ ] Reviewer: confirm log volume on shared `agentApiKeyAuth` 401 path is acceptable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782937983&installation_id=128169237&pr_number=266&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F266&signature=772dac8a1e590967a1402f72d8c77fe4f2a113f7a77b8a941e8ca8ce8bd4a232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured error logging and 500 responses to silent failure paths in credits handlers
> - Wraps `creditsByIdGetHandler` and `dailyRefill` in try/catch blocks, returning HTTP 500 with a JSON error body instead of propagating unhandled errors.
> - Adds `warn`/`info`/`error` structured logs across credits handlers ([credits-by-id-get.ts](https://github.com/ephemeraHQ/convos-backend/pull/266/files#diff-a6160277ee6cae7c389a75169c181a3e6284ed92732140a7f2e485458440ddca), [credits-grants-post.ts](https://github.com/ephemeraHQ/convos-backend/pull/266/files#diff-966e8d379f9ac5b56962633244d2b839e4fbb8cfbac8c071f1f2076704ec22a4), [credits-transactions-post.ts](https://github.com/ephemeraHQ/convos-backend/pull/266/files#diff-5954a51a505acb8fc51f053c1c8762c37374735b607157afcede7d0eb43b7b5a), [daily-refill.ts](https://github.com/ephemeraHQ/convos-backend/pull/266/files#diff-3333fda06f00e60b67a40313168215489fd72250cb8f23ad52816e3d04761057)) for not-found, validation failure, and error cases.
> - Extracts a shared `maskKeyPrefix` utility to [src/utils/mask.ts](https://github.com/ephemeraHQ/convos-backend/pull/266/files#diff-6202a4bda03f9e1d5b437b2b441801da15f75bf5b85e418ef5c388389ae164af), replacing local implementations in `agentAuth` and `cron-api-key` middleware.
> - Adds error/warn logs to `meGuard`, `agentApiKeyAuth`, and `requireCronApiKey` for misconfiguration and unauthorized cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 523046e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent error responses and logging for missing accounts (404) and unexpected failures (500).
  * Clearer diagnostics and structured warnings for invalid idempotency keys and malformed requests.
  * Daily refill now reports failures and summarizes partial errors while keeping existing outcomes.
  * Improved diagnostics and masked prefixes in logs for API key validation/authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->