### PR TITLE
feat(agent-templates): allow PATCH to set `featured`

### DIFF
--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -20,6 +20,7 @@ const bodySchema = z
     connections: z.array(z.string()).optional(),
     description: z.string().nullable().optional(),
     emoji: z.string().nullable().optional(),
+    featured: z.boolean().optional(),
     prompt: z
       .string()
       .max(50_000, {
@@ -85,6 +86,12 @@ const applyContentFields = (
   }
   if (body.emoji !== undefined) {
     data.emoji = body.emoji;
+  }
+  // Gallery curation: the admin templates dashboard toggles `featured` via
+  // PATCH (independent of publish state, so a draft can be featured and a
+  // published template un-featured without a status change).
+  if (body.featured !== undefined) {
+    data.featured = body.featured;
   }
   if (body.prompt !== undefined) {
     data.prompt = body.prompt;

--- a/tests/agent-templates.featured.test.ts
+++ b/tests/agent-templates.featured.test.ts
@@ -1,0 +1,110 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  agentKeyHeaders,
+  createTemplate,
+  getTemplate,
+  patchTemplate,
+  startAgentTemplatesServer,
+} from "./agent-templates.cross.helpers";
+
+// `featured` is gallery-curation state. It can be set at create time, and —
+// since the admin templates dashboard added a per-row toggle — flipped via
+// PATCH by an agent-key (admin) caller, independent of publish status.
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const cleanup = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "featured-toggle-" } },
+        { agentName: { startsWith: "Featured Toggle" } },
+      ],
+    },
+  });
+
+describe("Agent template featured toggle (admin PATCH)", () => {
+  beforeAll(async () => {
+    const server = await startAgentTemplatesServer(4091);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await closeServer();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  test("PATCH { featured } flips the flag and persists for an agent-key caller", async () => {
+    const created = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Featured Toggle Brew",
+        prompt: "Curate the gallery",
+        slug: "featured-toggle-brew",
+      },
+    });
+    expect(created.response.status).toBe(201);
+    expect(created.body.featured).toBe(false);
+    const id = created.body.id as string;
+
+    // Turn it on.
+    const on = await patchTemplate({
+      baseURL,
+      id,
+      headers: agentKeyHeaders(),
+      body: { featured: true },
+    });
+    expect(on.response.status).toBe(200);
+    expect(on.body.featured).toBe(true);
+
+    // …and back off.
+    const off = await patchTemplate({
+      baseURL,
+      id,
+      headers: agentKeyHeaders(),
+      body: { featured: false },
+    });
+    expect(off.response.status).toBe(200);
+    expect(off.body.featured).toBe(false);
+
+    // Persisted, not just echoed back from the patch handler.
+    const fetched = await getTemplate({
+      baseURL,
+      path: id,
+      headers: agentKeyHeaders(),
+    });
+    expect(fetched.body.featured).toBe(false);
+  });
+
+  test("featured can be set at create time too", async () => {
+    const created = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Featured Toggle Seed",
+        prompt: "Seeded as featured",
+        slug: "featured-toggle-seed",
+        featured: true,
+      },
+    });
+    expect(created.response.status).toBe(201);
+    expect(created.body.featured).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Lets `PATCH /api/v2/agent-templates/:id` accept `featured` (added to the body schema + `applyContentFields`), so the new admin Templates dashboard in convos-assistants can toggle gallery curation. `featured` was settable only at create time before; PATCH is the right home because it's independent of publish state (a draft can be featured, a published template un-featured without a status change) and idempotent (publish bumps `version`).

Adds `tests/agent-templates.featured.test.ts` asserting an agent-key (admin) PATCH toggles `featured` and it persists (runs against the test DB in CI).

Paired with convos-assistants#1884 (the dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782940255&installation_id=128169237&pr_number=267&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F267&signature=0f8300c36f8eb502d757887bc274a0e909606e5ff6faf933501cfb365cd67a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow PATCH on agent templates to set the `featured` flag
> Adds an optional `featured` boolean field to the PATCH request body schema in [patch.ts](https://github.com/ephemeraHQ/convos-backend/pull/267/files#diff-8872ad4771345ef728de9b21bd46361b9d67d94241aaedbe6b8fff7173b0c336). When provided, the value is written to the `AgentTemplate` record and returned in the response. A new test suite in [agent-templates.featured.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/267/files#diff-105b6f042861dbd2d7f298373ee2949b60763e4e680ef6f9d9cd3920f9e401af) covers toggling `featured` via PATCH and setting it at create time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19eab2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent templates now support a "featured" toggle for gallery curation, allowing templates to be marked as featured or unfeatured independently of their publish status.

* **Tests**
  * Added comprehensive test coverage for the featured toggle functionality to ensure proper behavior when managing agent template curation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->