### PR TITLE
fix(agent-templates): register agent API key in featured test (503 → 201)

### DIFF
--- a/tests/agent-templates.featured.test.ts
+++ b/tests/agent-templates.featured.test.ts
@@ -6,6 +6,7 @@ import {
   expect,
   test,
 } from "vitest";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
 import {
@@ -14,6 +15,7 @@ import {
   getTemplate,
   patchTemplate,
   startAgentTemplatesServer,
+  validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
 
 // `featured` is gallery-curation state. It can be set at create time, and —
@@ -36,6 +38,9 @@ const cleanup = () =>
 
 describe("Agent template featured toggle (admin PATCH)", () => {
   beforeAll(async () => {
+    // Register the agent API key so X-Agent-API-Key auth resolves to ADMIN
+    // instead of 503-ing (mirrors the other agent-key router tests).
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
     const server = await startAgentTemplatesServer(4091);
     baseURL = server.baseURL;
     closeServer = server.close;
@@ -44,6 +49,7 @@ describe("Agent template featured toggle (admin PATCH)", () => {
   afterAll(async () => {
     await cleanup();
     await closeServer();
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary
Fixes the 2 failing tests in `tests/agent-templates.featured.test.ts` (added in #267). They call `POST /agent-templates` + `PATCH /:id` with `agentKeyHeaders()`, but the test never registered the agent assets API key — so `agentApiKeyAuth` returned **503 "Agent assets API key not configured"** and the `expected 503 to be 201` assertions failed.

Set `__setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey)` in `beforeAll` and reset it in `afterAll`, exactly as the other agent-key router tests do (e.g. `agent-templates.create.owner-assertion.test.ts`).

Follow-up to #267 (already merged).

> Note: the `subscriptions/*` failures in that same CI run (grant amounts 2500/500/trial) are **unrelated** to this change and pre-date it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782949381&installation_id=128169237&pr_number=269&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F269&signature=32126e7bf4c54e7af75d363ee2ba024857e37f0f2d89021a70cc086cd445d317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 503 in featured agent template test by registering agent API key override
> The featured toggle test suite was returning 503s because `X-Agent-API-Key` auth failed during tests. Registers the API key override via `__setAgentAssetsApiKeyOverrideForTests` in `beforeAll` and clears it in `afterAll` so auth resolves to ADMIN for the duration of the suite.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 662c193.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication setup for agent template tests to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->