### PR TITLE
feat(agent-templates): list search (q), sort/order + /counts endpoint (#268 items 1-3)

### DIFF
--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -10,6 +10,7 @@ import { detailHandler } from "./handlers/detail";
 import { generationsGetHandler } from "./handlers/generations-get";
 import { generationsPostHandler } from "./handlers/generations-post";
 import { listHandler } from "./handlers/list";
+import { listCountsHandler } from "./handlers/list-counts";
 import { patchHandler } from "./handlers/patch";
 import { publishHandler } from "./handlers/publish";
 
@@ -41,6 +42,14 @@ agentTemplatesRouter.get(
   "/generations/:generationId",
   optionalAuthOrAgentApiKeyAuth,
   generationsGetHandler,
+);
+
+// Aggregate counts for the dashboard facet rail. Mounted before /:idOrUrlSlug
+// so the wildcard doesn't capture "counts" as a slug-or-id.
+agentTemplatesRouter.get(
+  "/counts",
+  optionalAuthOrAgentApiKeyAuth,
+  listCountsHandler,
 );
 
 agentTemplatesRouter.patch(

--- a/src/api/v2/agent-templates/handlers/list-counts.ts
+++ b/src/api/v2/agent-templates/handlers/list-counts.ts
@@ -1,0 +1,57 @@
+import type { Request, Response } from "express";
+import { prisma } from "@/utils/prisma";
+import { visibilityWhere } from "../lib/visibility";
+
+const STATUSES = ["published", "draft", "unlisted", "archived"] as const;
+
+/**
+ * GET /api/v2/agent-templates/counts
+ *
+ * Aggregate counts over the caller's visible template set — for the admin
+ * dashboard's facet rail (e.g. "Published 1.2k", "Drafts 340"). Counts reflect
+ * visibility only (not the active status/category/search filters), so the rail
+ * always shows the shape of the whole catalog the caller can see.
+ *
+ * Response: { total, byStatus: {published,draft,unlisted,archived}, byCategory, featured }
+ */
+export async function listCountsHandler(req: Request, res: Response) {
+  const accountId: string | undefined = res.locals.accountId;
+  const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+  const where = visibilityWhere(accountId, isApiKeyListener);
+
+  try {
+    const [total, byStatusRows, byCategoryRows, featured] = await Promise.all([
+      prisma.agentTemplate.count({ where }),
+      prisma.agentTemplate.groupBy({
+        by: ["status"],
+        where,
+        _count: { _all: true },
+      }),
+      prisma.agentTemplate.groupBy({
+        by: ["category"],
+        where,
+        _count: { _all: true },
+      }),
+      prisma.agentTemplate.count({
+        where: { AND: [where, { featured: true }] },
+      }),
+    ]);
+
+    const byStatus: Record<string, number> = {};
+    for (const status of STATUSES) byStatus[status] = 0;
+    for (const row of byStatusRows) byStatus[row.status] = row._count._all;
+
+    const byCategory: Record<string, number> = {};
+    for (const row of byCategoryRows) {
+      byCategory[row.category ?? "uncategorized"] = row._count._all;
+    }
+
+    res.status(200).json({ total, byStatus, byCategory, featured });
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to count agent templates",
+    );
+    res.status(500).json({ error: "Failed to count agent templates" });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
 import { serializeAgentTemplate } from "../lib/serialize-agent-template";
+import { visibilityWhere } from "../lib/visibility";
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -192,21 +193,11 @@ export async function listHandler(req: Request, res: Response) {
         { ownerAccountId: accountId },
       ];
     }
-  } else if (isApiKeyListener) {
-    // API key listener sees everything (admin-like access). No filter needed.
-  } else if (accountId === undefined) {
-    // Anonymous caller with no status filter: published-only view.
-    where.status = "published";
   } else {
-    // Regular authenticated user without status filter:
-    // Published templates from any owner + own drafts/unlisted/archived.
-    where.OR = [
-      { status: "published" },
-      {
-        status: { in: ["draft", "unlisted", "archived"] },
-        ownerAccountId: accountId,
-      },
-    ];
+    // No status filter: the caller's full visible set (admin → everything,
+    // anonymous → published, user → published + own). Shared with the counts
+    // handler via visibilityWhere so the two never drift.
+    Object.assign(where, visibilityWhere(accountId, isApiKeyListener));
   }
 
   if (parsed.data.category !== undefined) {

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -14,13 +14,22 @@ const VALID_STATUS_FILTERS = [
   "archived",
 ] as const;
 
+// Columns the list can be sorted by. `createdAt` desc is the default and
+// preserves prior behavior. Each is keyset-paginatable: the cursor encodes
+// the active column's value plus `id` as the tiebreaker.
+const SORT_FIELDS = ["createdAt", "updatedAt", "agentName"] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+
 const querySchema = z
   .object({
     category: z.string().optional(),
     cursor: z.string().optional(),
     featured: z.string().optional(),
     limit: z.string().optional(),
+    order: z.enum(["asc", "desc"]).optional(),
     owner: z.string().optional(),
+    q: z.string().optional(),
+    sort: z.enum(SORT_FIELDS).optional(),
     status: z.string().optional(),
   })
   .passthrough();
@@ -28,7 +37,10 @@ const querySchema = z
 const cursorPayloadSchema = z
   .object({
     id: z.string().min(1),
-    createdAt: z.string().min(1),
+    // `s` = the sort field the cursor was built for; `v` = that field's value
+    // on the last row (ISO string for dates, the raw string for agentName).
+    s: z.enum(SORT_FIELDS),
+    v: z.string().min(1),
   })
   .strict();
 
@@ -56,15 +68,22 @@ const parseLimit = (value: string | undefined) => {
   return Math.min(parsed, MAX_LIMIT);
 };
 
-const encodeCursor = (template: AgentTemplate) =>
+const cursorValue = (template: AgentTemplate, sort: SortField): string =>
+  sort === "agentName" ? template.agentName : template[sort].toISOString();
+
+const encodeCursor = (template: AgentTemplate, sort: SortField) =>
   Buffer.from(
     JSON.stringify({
       id: template.id,
-      createdAt: template.createdAt.toISOString(),
+      s: sort,
+      v: cursorValue(template, sort),
     }),
   ).toString("base64url");
 
-const decodeCursor = (cursor: string | undefined) => {
+// Returns null when absent, undefined when malformed OR built for a different
+// sort than the active one (the latter forces a client that changed `sort`
+// mid-pagination to restart from the first page).
+const decodeCursor = (cursor: string | undefined, sort: SortField) => {
   if (cursor === undefined) {
     return null;
   }
@@ -79,19 +98,19 @@ const decodeCursor = (cursor: string | undefined) => {
     );
     const parsed = cursorPayloadSchema.safeParse(decoded);
 
-    if (!parsed.success) {
+    if (!parsed.success || parsed.data.s !== sort) {
       return undefined;
     }
 
-    const createdAt = new Date(parsed.data.createdAt);
-    if (Number.isNaN(createdAt.getTime())) {
+    // Date columns must round-trip to a valid Date.
+    if (
+      sort !== "agentName" &&
+      Number.isNaN(new Date(parsed.data.v).getTime())
+    ) {
       return undefined;
     }
 
-    return {
-      id: parsed.data.id,
-      createdAt,
-    };
+    return { id: parsed.data.id, value: parsed.data.v };
   } catch {
     return undefined;
   }
@@ -141,7 +160,10 @@ export async function listHandler(req: Request, res: Response) {
     return;
   }
 
-  const cursor = decodeCursor(parsed.data.cursor);
+  const sort: SortField = parsed.data.sort ?? "createdAt";
+  const order: "asc" | "desc" = parsed.data.order ?? "desc";
+
+  const cursor = decodeCursor(parsed.data.cursor, sort);
   if (cursor === undefined) {
     sendInvalidQuery(res, "cursor is malformed");
     return;
@@ -219,30 +241,53 @@ export async function listHandler(req: Request, res: Response) {
     where.featured = true;
   }
 
-  // Cursor pagination: compose with existing AND/OR clauses
-  if (cursor !== null) {
-    const cursorFilter = {
+  // Free-text search: case-insensitive match on agentName OR description.
+  // ANDed with the visibility/filter clauses so it narrows the visible set.
+  const q = parsed.data.q?.trim();
+  if (q) {
+    const qFilter: Prisma.AgentTemplateWhereInput = {
       OR: [
-        { createdAt: { lt: cursor.createdAt } },
+        { agentName: { contains: q, mode: "insensitive" } },
+        { description: { contains: q, mode: "insensitive" } },
+      ],
+    };
+    where.AND = where.AND
+      ? [...(where.AND as Prisma.AgentTemplateWhereInput[]), qFilter]
+      : [qFilter];
+  }
+
+  // Keyset cursor pagination, generalized over the active sort column.
+  if (cursor) {
+    const dir = order === "asc" ? "gt" : "lt";
+    const value: string | Date =
+      sort === "agentName" ? cursor.value : new Date(cursor.value);
+    const cursorFilter: Prisma.AgentTemplateWhereInput = {
+      OR: [
+        { [sort]: { [dir]: value } },
         {
-          createdAt: cursor.createdAt,
-          id: { lt: cursor.id },
+          [sort]: value,
+          id: { [dir]: cursor.id },
         },
       ],
     };
 
     if (where.AND) {
-      // Already have an AND clause from visibility rules — append cursor filter
+      // Already have an AND clause from visibility/search — append cursor filter
       (where.AND as Prisma.AgentTemplateWhereInput[]).push(cursorFilter);
     } else {
       where.AND = [cursorFilter];
     }
   }
 
+  const orderBy: Prisma.AgentTemplateOrderByWithRelationInput[] = [
+    { [sort]: order },
+    { id: order },
+  ];
+
   try {
     const templates = await prisma.agentTemplate.findMany({
       where,
-      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      orderBy,
       take: limit + 1,
     });
 
@@ -255,7 +300,7 @@ export async function listHandler(req: Request, res: Response) {
       hasMore,
       nextCursor:
         hasMore && lastTemplate !== undefined
-          ? encodeCursor(lastTemplate)
+          ? encodeCursor(lastTemplate, sort)
           : null,
     });
   } catch (error) {

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -7,6 +7,10 @@ import { visibilityWhere } from "../lib/visibility";
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
+// Upper bound on the free-text search term — far longer than any real name or
+// description query, but caps the LIKE pattern so a client can't push a
+// multi-megabyte string into the query / logs.
+const MAX_SEARCH_LENGTH = 200;
 
 const VALID_STATUS_FILTERS = [
   "draft",
@@ -29,7 +33,7 @@ const querySchema = z
     limit: z.string().optional(),
     order: z.enum(["asc", "desc"]).optional(),
     owner: z.string().optional(),
-    q: z.string().optional(),
+    q: z.string().max(MAX_SEARCH_LENGTH).optional(),
     sort: z.enum(SORT_FIELDS).optional(),
     status: z.string().optional(),
   })
@@ -38,8 +42,11 @@ const querySchema = z
 const cursorPayloadSchema = z
   .object({
     id: z.string().min(1),
-    // `s` = the sort field the cursor was built for; `v` = that field's value
-    // on the last row (ISO string for dates, the raw string for agentName).
+    // `s` = the sort field the cursor was built for; `o` = the order; `v` =
+    // the sort field's value on the last row (ISO string for dates, the raw
+    // string for agentName). Both `s` and `o` are validated against the
+    // active request so a cursor can't traverse from the wrong end.
+    o: z.enum(["asc", "desc"]),
     s: z.enum(SORT_FIELDS),
     v: z.string().min(1),
   })
@@ -50,6 +57,19 @@ const sendInvalidQuery = (res: Response, message: string) => {
     error: "Invalid request query",
     message,
   });
+};
+
+// Conjoin a filter onto `where.AND`, creating the array if needed. Status,
+// search, and cursor filters all narrow the same query, so they accumulate
+// here rather than each reaching for `where.AND` independently (which would
+// silently clobber whatever a sibling already set).
+const addAnd = (
+  where: Prisma.AgentTemplateWhereInput,
+  filter: Prisma.AgentTemplateWhereInput,
+) => {
+  where.AND = where.AND
+    ? [...(where.AND as Prisma.AgentTemplateWhereInput[]), filter]
+    : [filter];
 };
 
 const parseLimit = (value: string | undefined) => {
@@ -72,19 +92,30 @@ const parseLimit = (value: string | undefined) => {
 const cursorValue = (template: AgentTemplate, sort: SortField): string =>
   sort === "agentName" ? template.agentName : template[sort].toISOString();
 
-const encodeCursor = (template: AgentTemplate, sort: SortField) =>
+const encodeCursor = (
+  template: AgentTemplate,
+  sort: SortField,
+  order: "asc" | "desc",
+) =>
   Buffer.from(
     JSON.stringify({
       id: template.id,
+      o: order,
       s: sort,
       v: cursorValue(template, sort),
     }),
   ).toString("base64url");
 
 // Returns null when absent, undefined when malformed OR built for a different
-// sort than the active one (the latter forces a client that changed `sort`
-// mid-pagination to restart from the first page).
-const decodeCursor = (cursor: string | undefined, sort: SortField) => {
+// sort/order than the active one. A cursor encodes the comparator it was built
+// for (sort column + direction); reusing it under a different sort or order
+// would traverse from the wrong end of the dataset and skip/duplicate rows, so
+// a mismatch forces the client to restart from the first page.
+const decodeCursor = (
+  cursor: string | undefined,
+  sort: SortField,
+  order: "asc" | "desc",
+) => {
   if (cursor === undefined) {
     return null;
   }
@@ -99,7 +130,7 @@ const decodeCursor = (cursor: string | undefined, sort: SortField) => {
     );
     const parsed = cursorPayloadSchema.safeParse(decoded);
 
-    if (!parsed.success || parsed.data.s !== sort) {
+    if (!parsed.success || parsed.data.s !== sort || parsed.data.o !== order) {
       return undefined;
     }
 
@@ -164,7 +195,7 @@ export async function listHandler(req: Request, res: Response) {
   const sort: SortField = parsed.data.sort ?? "createdAt";
   const order: "asc" | "desc" = parsed.data.order ?? "desc";
 
-  const cursor = decodeCursor(parsed.data.cursor, sort);
+  const cursor = decodeCursor(parsed.data.cursor, sort, order);
   if (cursor === undefined) {
     sendInvalidQuery(res, "cursor is malformed");
     return;
@@ -188,10 +219,8 @@ export async function listHandler(req: Request, res: Response) {
       }
       where.status = "published";
     } else {
-      where.AND = [
-        { status: statusFilter as Prisma.EnumPublishStatusFilter },
-        { ownerAccountId: accountId },
-      ];
+      addAnd(where, { status: statusFilter as Prisma.EnumPublishStatusFilter });
+      addAnd(where, { ownerAccountId: accountId });
     }
   } else {
     // No status filter: the caller's full visible set (admin → everything,
@@ -242,9 +271,7 @@ export async function listHandler(req: Request, res: Response) {
         { description: { contains: q, mode: "insensitive" } },
       ],
     };
-    where.AND = where.AND
-      ? [...(where.AND as Prisma.AgentTemplateWhereInput[]), qFilter]
-      : [qFilter];
+    addAnd(where, qFilter);
   }
 
   // Keyset cursor pagination, generalized over the active sort column.
@@ -262,12 +289,7 @@ export async function listHandler(req: Request, res: Response) {
       ],
     };
 
-    if (where.AND) {
-      // Already have an AND clause from visibility/search — append cursor filter
-      (where.AND as Prisma.AgentTemplateWhereInput[]).push(cursorFilter);
-    } else {
-      where.AND = [cursorFilter];
-    }
+    addAnd(where, cursorFilter);
   }
 
   const orderBy: Prisma.AgentTemplateOrderByWithRelationInput[] = [
@@ -291,7 +313,7 @@ export async function listHandler(req: Request, res: Response) {
       hasMore,
       nextCursor:
         hasMore && lastTemplate !== undefined
-          ? encodeCursor(lastTemplate, sort)
+          ? encodeCursor(lastTemplate, sort, order)
           : null,
     });
   } catch (error) {

--- a/src/api/v2/agent-templates/lib/visibility.ts
+++ b/src/api/v2/agent-templates/lib/visibility.ts
@@ -1,0 +1,28 @@
+import type { Prisma } from "@prisma/client";
+
+/**
+ * Base "what can this caller see" filter for agent templates, mirroring the
+ * visibility rules in the list handler (minus the optional status / owner /
+ * search narrowing):
+ *   - API key listener (admin): everything.
+ *   - Anonymous: published only.
+ *   - Authenticated user: published from anyone + their own non-published.
+ *
+ * Shared by the list and counts handlers so the two never drift.
+ */
+export function visibilityWhere(
+  accountId: string | undefined,
+  isApiKeyListener: boolean,
+): Prisma.AgentTemplateWhereInput {
+  if (isApiKeyListener) return {};
+  if (accountId === undefined) return { status: "published" };
+  return {
+    OR: [
+      { status: "published" },
+      {
+        status: { in: ["draft", "unlisted", "archived"] },
+        ownerAccountId: accountId,
+      },
+    ],
+  };
+}

--- a/src/api/v2/agent-templates/lib/visibility.ts
+++ b/src/api/v2/agent-templates/lib/visibility.ts
@@ -1,14 +1,14 @@
 import type { Prisma } from "@prisma/client";
 
 /**
- * Base "what can this caller see" filter for agent templates, mirroring the
- * visibility rules in the list handler (minus the optional status / owner /
- * search narrowing):
+ * Base "what can this caller see" filter for agent templates:
  *   - API key listener (admin): everything.
  *   - Anonymous: published only.
  *   - Authenticated user: published from anyone + their own non-published.
  *
- * Shared by the list and counts handlers so the two never drift.
+ * The single source of truth for visibility — the list handler composes the
+ * optional status / category / owner / search narrowing on top of this, and
+ * the counts handler aggregates over it, so the two never drift.
  */
 export function visibilityWhere(
   accountId: string | undefined,

--- a/tests/agent-templates.list-search-sort.test.ts
+++ b/tests/agent-templates.list-search-sort.test.ts
@@ -186,10 +186,12 @@ describe("Agent templates list — search / sort / counts", () => {
 
   test("a cursor built for a different sort is rejected with 400", async () => {
     const res = await fetch(
-      // a createdAt cursor shape used with sort=agentName → malformed
+      // a well-formed createdAt cursor (order matches the default desc) used
+      // with sort=agentName → sort mismatch → rejected.
       `${baseURL}/api/v2/agent-templates?sort=agentName&cursor=${Buffer.from(
         JSON.stringify({
           id: "x",
+          o: "desc",
           s: "createdAt",
           v: new Date().toISOString(),
         }),
@@ -197,6 +199,89 @@ describe("Agent templates list — search / sort / counts", () => {
       { headers: agentKeyHeaders() },
     );
     expect(res.status).toBe(400);
+  });
+
+  test("a cursor built for a different order is rejected with 400", async () => {
+    for (const name of ["Zsort Order A", "Zsort Order B"]) {
+      await createTemplate({
+        baseURL,
+        headers: agentKeyHeaders(),
+        body: {
+          agentName: name,
+          prompt: "p",
+          slug: `lss-${name.toLowerCase().replace(/\s+/g, "-")}`,
+          description: "zsortordermarker",
+        },
+      });
+    }
+
+    // A real cursor minted under order=desc...
+    const desc = await listTemplates({
+      baseURL,
+      query: "?q=zsortordermarker&sort=agentName&order=desc&limit=1",
+      headers: agentKeyHeaders(),
+    });
+    expect(desc.body.nextCursor).toEqual(expect.any(String));
+    const cursor = encodeURIComponent(desc.body.nextCursor as string);
+
+    // ...reused under order=asc would flip the keyset comparator (lt↔gt) and
+    // traverse from the opposite end → rejected.
+    const flipped = await fetch(
+      `${baseURL}/api/v2/agent-templates?q=zsortordermarker&sort=agentName&order=asc&limit=1&cursor=${cursor}`,
+      { headers: agentKeyHeaders() },
+    );
+    expect(flipped.status).toBe(400);
+
+    // ...but reused under the same order=desc still paginates fine.
+    const same = await listTemplates({
+      baseURL,
+      query: `?q=zsortordermarker&sort=agentName&order=desc&limit=1&cursor=${cursor}`,
+      headers: agentKeyHeaders(),
+    });
+    expect(same.response.status).toBe(200);
+  });
+
+  test("?q= and ?featured=true compose (AND of search OR-clause + featured)", async () => {
+    await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zxq Combined Featured",
+        prompt: "p",
+        slug: "lss-combo-1",
+        description: "zxqcombomarker",
+        featured: true,
+      },
+    });
+    await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zxq Combined Plain",
+        prompt: "p",
+        slug: "lss-combo-2",
+        description: "zxqcombomarker",
+        featured: false,
+      },
+    });
+
+    // q matches both rows...
+    const both = await listTemplates({
+      baseURL,
+      query: "?q=zxqcombomarker&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(both.body.data.length).toBe(2);
+
+    // ...featured=true narrows to the one featured match.
+    const featuredOnly = await listTemplates({
+      baseURL,
+      query: "?q=zxqcombomarker&featured=true&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(featuredOnly.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zxq Combined Featured",
+    ]);
   });
 
   // ── Counts ──

--- a/tests/agent-templates.list-search-sort.test.ts
+++ b/tests/agent-templates.list-search-sort.test.ts
@@ -1,0 +1,230 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  agentKeyHeaders,
+  createTemplate,
+  listTemplates,
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+
+// Covers the list-API additions: free-text `q`, `sort`/`order` (incl. keyset
+// cursor under a non-default sort), and the `/counts` aggregate endpoint.
+// Tokens are globally unique so search/sort assertions are unaffected by any
+// other rows in the test DB; counts assertions are delta-based for the same
+// reason.
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const cleanup = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      OR: [
+        { slug: { startsWith: "lss-" } },
+        { agentName: { startsWith: "Zxq" } },
+        { agentName: { startsWith: "Zsort" } },
+        { agentName: { startsWith: "Zcount" } },
+      ],
+    },
+  });
+
+const fetchCounts = async (headers: Record<string, string>) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-templates/counts`, {
+    headers,
+  });
+  const body = (await response.json()) as {
+    total: number;
+    byStatus: Record<string, number>;
+    byCategory: Record<string, number>;
+    featured: number;
+  };
+  return { response, body };
+};
+
+describe("Agent templates list — search / sort / counts", () => {
+  beforeAll(async () => {
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+    const server = await startAgentTemplatesServer(4093);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await closeServer();
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  // ── Free-text search ──
+  test("?q= matches agentName OR description, case-insensitively", async () => {
+    await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zxq One",
+        prompt: "p",
+        slug: "lss-q-1",
+        description: "a trip about zxqhikingtoken stuff",
+      },
+    });
+    await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zxq Two",
+        prompt: "p",
+        slug: "lss-q-2",
+        description: "about zxqcookingtoken",
+      },
+    });
+    await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zxq Three zxqhikingtoken",
+        prompt: "p",
+        slug: "lss-q-3",
+        description: "plain",
+      },
+    });
+
+    // description match (One) + agentName match (Three), not Two.
+    const hit = await listTemplates({
+      baseURL,
+      query: "?q=zxqhikingtoken&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(hit.response.status).toBe(200);
+    expect(hit.body.data.map((t) => t.agentName as string).sort()).toEqual([
+      "Zxq One",
+      "Zxq Three zxqhikingtoken",
+    ]);
+
+    // case-insensitive
+    const upper = await listTemplates({
+      baseURL,
+      query: "?q=ZXQHIKINGTOKEN&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(upper.body.data.length).toBe(2);
+
+    // distinct token isolates the other row
+    const cooking = await listTemplates({
+      baseURL,
+      query: "?q=zxqcookingtoken&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(cooking.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zxq Two",
+    ]);
+  });
+
+  // ── Sort + keyset cursor under a non-default sort ──
+  test("?sort=agentName&order=asc orders results and paginates by cursor", async () => {
+    for (const name of ["Zsort Charlie", "Zsort Alpha", "Zsort Bravo"]) {
+      await createTemplate({
+        baseURL,
+        headers: agentKeyHeaders(),
+        body: {
+          agentName: name,
+          prompt: "p",
+          slug: `lss-${name.toLowerCase().replace(/\s+/g, "-")}`,
+          description: "zsortmarker",
+        },
+      });
+    }
+
+    const sorted = await listTemplates({
+      baseURL,
+      query: "?q=zsortmarker&sort=agentName&order=asc&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(sorted.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zsort Alpha",
+      "Zsort Bravo",
+      "Zsort Charlie",
+    ]);
+
+    // keyset cursor walks the same order one page at a time
+    const page1 = await listTemplates({
+      baseURL,
+      query: "?q=zsortmarker&sort=agentName&order=asc&limit=1",
+      headers: agentKeyHeaders(),
+    });
+    expect(page1.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zsort Alpha",
+    ]);
+    expect(page1.body.hasMore).toBe(true);
+    expect(page1.body.nextCursor).toEqual(expect.any(String));
+
+    const page2 = await listTemplates({
+      baseURL,
+      query: `?q=zsortmarker&sort=agentName&order=asc&limit=1&cursor=${encodeURIComponent(
+        page1.body.nextCursor as string,
+      )}`,
+      headers: agentKeyHeaders(),
+    });
+    expect(page2.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zsort Bravo",
+    ]);
+  });
+
+  test("a cursor built for a different sort is rejected with 400", async () => {
+    const res = await fetch(
+      // a createdAt cursor shape used with sort=agentName → malformed
+      `${baseURL}/api/v2/agent-templates?sort=agentName&cursor=${Buffer.from(
+        JSON.stringify({
+          id: "x",
+          s: "createdAt",
+          v: new Date().toISOString(),
+        }),
+      ).toString("base64url")}`,
+      { headers: agentKeyHeaders() },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ── Counts ──
+  test("/counts returns visibility-scoped aggregates (delta-checked)", async () => {
+    const before = await fetchCounts(agentKeyHeaders());
+    expect(before.response.status).toBe(200);
+    for (const s of ["published", "draft", "unlisted", "archived"]) {
+      expect(typeof before.body.byStatus[s]).toBe("number");
+    }
+    expect(typeof before.body.total).toBe("number");
+    expect(typeof before.body.featured).toBe("number");
+    expect(typeof before.body.byCategory).toBe("object");
+
+    // New template is a featured draft → total +1, draft +1, featured +1.
+    await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zcount Featured",
+        prompt: "p",
+        slug: "lss-count-1",
+        featured: true,
+      },
+    });
+
+    const after = await fetchCounts(agentKeyHeaders());
+    expect(after.body.total).toBe(before.body.total + 1);
+    expect(after.body.byStatus.draft).toBe(before.body.byStatus.draft + 1);
+    expect(after.body.featured).toBe(before.body.featured + 1);
+  });
+});

--- a/tests/agent-templates.list.test.ts
+++ b/tests/agent-templates.list.test.ts
@@ -30,8 +30,14 @@ const cleanupTemplates = () =>
     where: { ownerAccountId: ADMIN_ACCOUNT_ID },
   });
 
-const encodeCursor = (cursor: { id: string; createdAt: string }) =>
-  Buffer.from(JSON.stringify(cursor)).toString("base64url");
+// Mirrors the handler's cursor payload: `s` = sort field, `o` = order, `v` =
+// the sort field's value on the last row (plus `id` as the tiebreaker).
+const encodeCursor = (cursor: {
+  id: string;
+  s: string;
+  o: "asc" | "desc";
+  v: string;
+}) => Buffer.from(JSON.stringify(cursor)).toString("base64url");
 
 // Use a distinct, non-admin account so visibility semantics match the
 // pre-auth-required tests: the caller is NOT the template owner, so they
@@ -352,9 +358,11 @@ describe("Agent template list endpoint", () => {
     };
     const decodedDefaultCursor = JSON.parse(
       Buffer.from(defaultPage.body.nextCursor ?? "", "base64url").toString(),
-    ) as { id: string; createdAt: string };
+    ) as { id: string; s: string; o: string; v: string };
     expect(decodedDefaultCursor.id).toBe(lastDefaultRow.id);
-    expect(decodedDefaultCursor.createdAt).toBe(lastDefaultRow.createdAt);
+    expect(decodedDefaultCursor.s).toBe("createdAt");
+    expect(decodedDefaultCursor.o).toBe("desc");
+    expect(decodedDefaultCursor.v).toBe(lastDefaultRow.createdAt);
 
     const clamped = await readList("/api/v2/agent-templates?limit=200");
     expect(clamped.body.data).toHaveLength(100);
@@ -453,7 +461,9 @@ describe("Agent template list endpoint", () => {
 
     const pastEndCursor = encodeCursor({
       id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
-      createdAt: "1970-01-01T00:00:00.000Z",
+      s: "createdAt",
+      o: "desc",
+      v: "1970-01-01T00:00:00.000Z",
     });
     const pastEnd = await readList(
       `/api/v2/agent-templates?cursor=${pastEndCursor}`,


### PR DESCRIPTION
## Summary
Implements **items 1–3** of #268 — the list-API gaps the admin Templates dashboard (convos-assistants) needs to scale to thousands of templates:

1. **Free-text search** — `GET /api/v2/agent-templates?q=` (case-insensitive `contains` on `agentName` OR `description`), ANDed with the existing visibility / status / category / owner filters.
2. **Server-side sort** — `?sort=createdAt|updatedAt|agentName` + `?order=asc|desc`. The keyset cursor is generalized over the active sort column (it now encodes `{id, sort, value}`); a cursor built for a *different* sort returns 400 so a client that switches sort restarts cleanly. **Default stays `createdAt desc`**, so existing callers are unaffected.
3. **Counts endpoint** — `GET /api/v2/agent-templates/counts` → `{ total, byStatus, byCategory, featured }` over the caller's visible set (admin key → everything; anonymous → published; user → published + own), for the rail facet counts. Visibility logic is shared with the list handler via `lib/visibility.ts`.

## Tests
`tests/agent-templates.list-search-sort.test.ts` covers: `q` (name/description match, case-insensitivity, globally-unique-token isolation), `sort=agentName&order=asc` ordering + keyset cursor pagination, the cross-sort cursor 400, and delta-checked `/counts`. Typecheck / eslint / prettier are green locally; the DB-backed tests run in CI.

Addresses #268 (items 1–3). Items 4–6 (serialize `updatedAt`, provenance `source`, bulk endpoints) remain open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782952735&installation_id=128169237&pr_number=270&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F270&signature=7cf39fade5dd9349de15bfbefd4d5d2416d5d80f4a1fafdc808dac7cf984a690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add search, sort/order, and `/counts` endpoint to agent templates list API
> - Adds `?q=` free-text search across `agentName` and `description` (case-insensitive, max 200 chars) in [list.ts](https://github.com/ephemeraHQ/convos-backend/pull/270/files#diff-372e04aa0ec018e58c44cddb25f12ac7fd5ebc5f690597487f0ce81ee7b3fe47)
> - Adds `?sort` (createdAt, updatedAt, agentName) and `?order` (asc/desc) query params with keyset pagination cursors that encode sort/order and are rejected with 400 on mismatch
> - Adds a new `GET /api/v2/agent-templates/counts` endpoint in [list-counts.ts](https://github.com/ephemeraHQ/convos-backend/pull/270/files#diff-585cb5a371b8d96caa4cefa35ed28ef4d980609f10f6f7f0b130aeda9d443a6b) returning visibility-scoped aggregates: `total`, `byStatus`, `byCategory`, and `featured`
> - Extracts shared visibility scoping logic into [visibility.ts](https://github.com/ephemeraHQ/convos-backend/pull/270/files#diff-5dc06c5a34bf9cbd887569502280bf6e1e720ee844e1627f5762a444cb9fcc07)
> - Risk: existing pagination cursors are incompatible with the new cursor payload format `{id, s, o, v}`; stale cursors will be rejected with 400
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5441cf7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Free-text search across template name and description.
  * Keyset pagination and sortable listings (createdAt, updatedAt, agentName) with stable cursors that encode sort, order, and value.
  * New counts endpoint showing total, breakdowns by status and category (uncategorized included), and featured count; results respect caller access level.

* **Bug Fixes**
  * Improved cursor validation to reject malformed or mismatched cursors.

* **Tests**
  * Expanded coverage for search, sort/pagination, cursor validation, counts, and feature+filter composability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->