### PR TITLE
notifications: webhook `accountId` guard + orphan `ClientIdentifier` cleanup

### DIFF
--- a/prisma/migrations/20260601000000_add_client_identifier_account_id/migration.sql
+++ b/prisma/migrations/20260601000000_add_client_identifier_account_id/migration.sql
@@ -1,0 +1,31 @@
+-- Add ClientIdentifier.accountId for the webhook delivery account check.
+--
+-- The webhook handler refuses push delivery when client.accountId does not
+-- match the joined DeviceRegistration.accountId. A device can have many
+-- historical ClientIdentifier rows (one per account that ever signed in on
+-- the device); without the account check, an orphan from a previous account
+-- can still trigger pushes that wake the current account's device.
+
+-- AlterTable: add accountId to ClientIdentifier
+ALTER TABLE "ClientIdentifier" ADD COLUMN "accountId" UUID;
+
+-- Backfill ClientIdentifier.accountId for the most recent row per deviceId.
+-- Stamping all historical rows with the device's current accountId would
+-- let stale rows from previous accounts pass the webhook delivery guard
+-- (client.accountId == device.accountId) instead of being treated as
+-- untrusted ghosts. Older rows stay NULL until a fresh subscribe rewrites
+-- the correct account on the live row; the orphan ClientIdentifier cleanup
+-- migration handles long-tail churn separately. Rows where
+-- DeviceRegistration.accountId is NULL also stay NULL.
+WITH latest_client_per_device AS (
+    SELECT DISTINCT ON ("deviceId") "id", "deviceId"
+    FROM "ClientIdentifier"
+    ORDER BY "deviceId", "updatedAt" DESC, "addedAt" DESC, "id"
+)
+UPDATE "ClientIdentifier" ci
+SET "accountId" = dr."accountId"
+FROM "DeviceRegistration" dr,
+     latest_client_per_device lcpd
+WHERE ci."id" = lcpd."id"
+  AND ci."deviceId" = dr."deviceId"
+  AND dr."accountId" IS NOT NULL;

--- a/prisma/migrations/20260601000001_orphan_client_identifier_cleanup/migration.sql
+++ b/prisma/migrations/20260601000001_orphan_client_identifier_cleanup/migration.sql
@@ -1,0 +1,41 @@
+-- One-time orphan ClientIdentifier cleanup.
+--
+-- Production validation on a real broken phone (2026-05-29) found 24 stale
+-- ClientIdentifier rows pointing at one device, accumulated over ~4 months
+-- via repeated identity rotations. The XMTP notifications server keeps
+-- webhooking us for those orphans; the iOS NSE cannot decode them, which
+-- presents to the user as "push arrived in APNS but no banner".
+--
+-- The webhook accountId check shipped in the same PR as this migration
+-- already drops orphans at the delivery boundary going forward. This
+-- migration cleans up the historical data.
+--
+-- Policy: keep the most-recently-touched ClientIdentifier row per device;
+-- delete same-device rows that are both NOT the most recent AND older than
+-- 7 days. The "older than 7 days" guard avoids a foot-gun on devices that
+-- recently churned through multiple identities legitimately (developer
+-- account switching, fresh install + signin within the same day).
+
+-- ORDER BY must match the backfill migration's tiebreak chain
+-- ("updatedAt" DESC, "addedAt" DESC, "id"). If timestamps tie, an
+-- inconsistent tiebreak would let cleanup delete the same row the
+-- backfill stamped with accountId, leaving a NULL-accountId orphan as
+-- the surviving "latest" row.
+WITH ranked AS (
+  SELECT
+    "id",
+    "deviceId",
+    "updatedAt",
+    ROW_NUMBER() OVER (
+      PARTITION BY "deviceId"
+      ORDER BY "updatedAt" DESC, "addedAt" DESC, "id"
+    ) AS rn
+  FROM "ClientIdentifier"
+)
+DELETE FROM "ClientIdentifier"
+WHERE "id" IN (
+  SELECT "id"
+  FROM ranked
+  WHERE rn > 1
+    AND "updatedAt" < NOW() - INTERVAL '7 days'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,11 @@ model ClientIdentifier {
   id        String             @id
   deviceId  String
   device    DeviceRegistration @relation(fields: [deviceId], references: [deviceId], onDelete: Cascade)
+  /// Set from JWT on subscribe. The webhook handler refuses push delivery
+  /// when this value does not match DeviceRegistration.accountId so a stale
+  /// ClientIdentifier from a previous account on the same device cannot
+  /// wake the current account's device.
+  accountId String?            @db.Uuid
   addedAt   DateTime           @default(now())
   updatedAt DateTime           @updatedAt
 

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -134,16 +134,26 @@ export async function subscribe(
       }
     }
 
-    // Create or update client identifier record
+    // Create or update client identifier record. accountId is sourced
+    // from the JWT and is what the webhook delivery guard compares
+    // against the joined DeviceRegistration.accountId before sending a
+    // push. Older iOS builds that authenticate without SIWE produce a
+    // JWT with no accountId; leave the field untouched in that case so
+    // the migration backfill value (or a prior accountId from a SIWE
+    // authentication on the same row) is not clobbered.
+    const accountId = res.locals.accountId;
     try {
       await prisma.clientIdentifier.upsert({
         where: { id: body.clientId },
         create: {
           id: body.clientId,
           deviceId: body.deviceId,
+          accountId,
         },
-        // Refresh updatedAt by updating deviceId
-        update: { deviceId: body.deviceId },
+        update: {
+          deviceId: body.deviceId,
+          ...(accountId !== undefined ? { accountId } : {}),
+        },
       });
     } catch (dbErr) {
       // Compensate: delete installation to maintain consistency (only if we created one)

--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -39,6 +39,10 @@ export async function subscribe(
     req.log.info(
       {
         accountId: res.locals.accountId,
+        // Explicit boolean so Datadog can count legacy-JWT subscribes
+        // without depending on whether the logger drops or renders null
+        // for an undefined accountId field.
+        hasAccountId: res.locals.accountId !== undefined,
         deviceId: body.deviceId,
         clientId: body.clientId,
         topicCount: body.topics.length,

--- a/src/api/v2/notifications/handlers/webhook.ts
+++ b/src/api/v2/notifications/handlers/webhook.ts
@@ -41,6 +41,53 @@ function isWelcomeMessage(args: {
 }
 
 /**
+ * Refuses to deliver a push when the ClientIdentifier belongs to a different
+ * account than the DeviceRegistration. Same-device account switches accumulate
+ * orphan ClientIdentifier rows pointing at the device's deviceId (validated in
+ * production: 24 such rows on one device, ~4-month accumulation). The XMTP
+ * notifications server keeps webhooking us for those orphans; this check drops
+ * the delivery before it leaves our boundary.
+ *
+ * NULL on either side is treated as "untrusted" - the webhook drops it. This
+ * intentionally catches historical rows backfilled with NULL accountId and any
+ * future rows where account membership can't be established. The orphan
+ * ClientIdentifier cleanup migration sweeps the historical garbage out
+ * separately.
+ *
+ * Exported for direct unit testing of the guard contract; the wider webhook
+ * handler covers it implicitly via integration tests.
+ */
+export function isAccountIdMismatch(args: {
+  client: ClientIdentifier & { device: DeviceRegistration };
+  notification: WebhookNotificationBody;
+  req: Request;
+}): boolean {
+  const { client, notification, req } = args;
+  const clientAccountId = client.accountId;
+  const deviceAccountId = client.device.accountId;
+  if (
+    clientAccountId === null ||
+    deviceAccountId === null ||
+    clientAccountId !== deviceAccountId
+  ) {
+    req.log.warn(
+      {
+        event: "client_account_mismatch",
+        clientId: notification.installation.id,
+        deviceId: client.deviceId,
+        clientAccountId,
+        deviceAccountId,
+        contentTopic: notification.message.content_topic,
+        messageType: notification.message_context.message_type,
+      },
+      "Dropping push: ClientIdentifier.accountId does not match DeviceRegistration.accountId",
+    );
+    return true;
+  }
+  return false;
+}
+
+/**
  * Notifications webhook handler
  *
  * Authentication is handled by webhookAuthMiddleware which validates the
@@ -82,6 +129,11 @@ export async function handleXmtpNotification(req: Request, res: Response) {
     });
 
     if (v2Client) {
+      if (isAccountIdMismatch({ client: v2Client, notification, req })) {
+        res.status(200).end();
+        return;
+      }
+
       const pushType = v2Client.device.pushTokenType; // 'fcm' | 'apns'
       const tag = pushType === "fcm" ? "[FCM]" : "[APNS]";
       req.log.info(

--- a/tests/notifications-payload-guard.test.ts
+++ b/tests/notifications-payload-guard.test.ts
@@ -188,6 +188,7 @@ function makeClient(pushType: "apns" | "fcm"): ClientIdentifier & {
   return {
     id: "client-1",
     deviceId: "dev-1",
+    accountId: null,
     addedAt: new Date(),
     updatedAt: new Date(),
     device: {

--- a/tests/notifications-webhook-account-guard.test.ts
+++ b/tests/notifications-webhook-account-guard.test.ts
@@ -1,0 +1,142 @@
+import type { ClientIdentifier, DeviceRegistration } from "@prisma/client";
+import type { Request } from "express";
+import { describe, expect, test, vi } from "vitest";
+import { isAccountIdMismatch } from "@/api/v2/notifications/handlers/webhook";
+import type { WebhookNotificationBody } from "@/notifications/client";
+
+// Pure-function unit tests for the webhook account-id guard. The full webhook
+// handler is exercised by integration tests elsewhere; this file pins the
+// drop/pass contract on every NULL / mismatch / match permutation so a future
+// refactor cannot regress the same-device cross-account push scenario.
+
+const ACCOUNT_A = "00000000-0000-0000-0000-0000000000aa";
+const ACCOUNT_B = "00000000-0000-0000-0000-0000000000bb";
+
+function makeClient(args: {
+  clientAccountId: string | null;
+  deviceAccountId: string | null;
+}): ClientIdentifier & { device: DeviceRegistration } {
+  const device: DeviceRegistration = {
+    deviceId: "dev-1",
+    accountId: args.deviceAccountId,
+    pushToken: "tok",
+    pushTokenType: "apns",
+    apnsEnv: "sandbox",
+    disabled: false,
+    pushFailures: 0,
+    lastFailureAt: null,
+    lastSentAt: null,
+    addedAt: new Date(),
+    updatedAt: new Date(),
+  };
+  return {
+    id: "client-1",
+    deviceId: "dev-1",
+    accountId: args.clientAccountId,
+    addedAt: new Date(),
+    updatedAt: new Date(),
+    device,
+  };
+}
+
+function makeNotification(): WebhookNotificationBody {
+  return {
+    installation: { id: "client-1" },
+    message: {
+      content_topic: "/xmtp/mls/1/g-test/proto",
+      message: "encrypted-bytes",
+      timestamp_ns: "1717200000000000000",
+    },
+    message_context: {
+      message_type: "v3-application",
+      should_push: true,
+      is_sender: false,
+      has_hmac_key: false,
+    },
+  } as unknown as WebhookNotificationBody;
+}
+
+function makeReq(): {
+  req: Request;
+  warn: ReturnType<typeof vi.fn>;
+} {
+  const warn = vi.fn();
+  const req = {
+    log: {
+      warn,
+      info: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as Request;
+  return { req, warn };
+}
+
+describe("isAccountIdMismatch", () => {
+  test("both account IDs null -> drop", () => {
+    const { req, warn } = makeReq();
+    const result = isAccountIdMismatch({
+      client: makeClient({ clientAccountId: null, deviceAccountId: null }),
+      notification: makeNotification(),
+      req,
+    });
+    expect(result).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [logFields] = warn.mock.calls[0] as [Record<string, unknown>];
+    expect(logFields.event).toBe("client_account_mismatch");
+    expect(logFields.clientAccountId).toBeNull();
+    expect(logFields.deviceAccountId).toBeNull();
+  });
+
+  test("client null, device set -> drop", () => {
+    const { req, warn } = makeReq();
+    const result = isAccountIdMismatch({
+      client: makeClient({ clientAccountId: null, deviceAccountId: ACCOUNT_A }),
+      notification: makeNotification(),
+      req,
+    });
+    expect(result).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("device null, client set -> drop", () => {
+    const { req, warn } = makeReq();
+    const result = isAccountIdMismatch({
+      client: makeClient({ clientAccountId: ACCOUNT_A, deviceAccountId: null }),
+      notification: makeNotification(),
+      req,
+    });
+    expect(result).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("mismatched non-null -> drop", () => {
+    const { req, warn } = makeReq();
+    const result = isAccountIdMismatch({
+      client: makeClient({
+        clientAccountId: ACCOUNT_A,
+        deviceAccountId: ACCOUNT_B,
+      }),
+      notification: makeNotification(),
+      req,
+    });
+    expect(result).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [logFields] = warn.mock.calls[0] as [Record<string, unknown>];
+    expect(logFields.clientAccountId).toBe(ACCOUNT_A);
+    expect(logFields.deviceAccountId).toBe(ACCOUNT_B);
+  });
+
+  test("matching non-null -> pass through", () => {
+    const { req, warn } = makeReq();
+    const result = isAccountIdMismatch({
+      client: makeClient({
+        clientAccountId: ACCOUNT_A,
+        deviceAccountId: ACCOUNT_A,
+      }),
+      notification: makeNotification(),
+      req,
+    });
+    expect(result).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Slim subset of the larger Stack 2 backend work, isolated to the production-critical hardening that was validated against a real broken phone (24 stale ClientIdentifier rows on one device accumulated over ~4 months of identity rotation).

What's in:
- ClientIdentifier.accountId column, backfilled for the most recent row per deviceId only. Older rows stay NULL so stale identifiers from previous accounts on the same device do not pass the webhook guard.
- /v2/notifications/webhook refuses push delivery when ClientIdentifier.accountId is NULL on either side or does not match the joined DeviceRegistration.accountId.
- /v2/notifications/subscribe writes accountId from the JWT into the ClientIdentifier upsert so newly-issued installations are guarded immediately. Legacy JWTs without accountId leave the field untouched.
- One-time orphan cleanup migration: deletes same-device ClientIdentifier rows older than 7 days that are not the most recent row for their device.

What's deferred:
- NotificationSubscriptionSnapshot table + idempotent subscribe path.
- /v2/notifications/debug/status endpoint.
- remoteApplied response contract on /v2/notifications/subscribe.
- NSE unregister middleware with the reduced-privilege allowlist.

What's intentionally NOT here (so review bots stop oscillating):
- No `@@index([accountId])` on `ClientIdentifier`. The slim PR's only queries on this table are `findUnique`/`upsert` keyed by `id` (primary key); `accountId` is read after the lookup and compared in memory in the webhook guard. The backfill migration's `JOIN` filters on `deviceId` which is already indexed. Adding the index now would buy nothing at query time AND require a `CREATE INDEX CONCURRENTLY` split-migration dance to avoid the write-blocking lock. When a real query (e.g. "list all clients for account X") needs it, add the index in a focused follow-up migration.

The subscribe response shape is unchanged (200 with empty body), so the production iOS client continues to work without any paired iOS change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Slim subset of the larger Stack 2 backend work, isolated to the production-critical hardening that was validated against a real broken phone (24 stale ClientIdentifier rows on one device accumulated over ~4 months of identity rotation).
>
> What's in:
> - ClientIdentifier.accountId column, backfilled for the most recent row per deviceId only. Older rows stay NULL so stale identifiers from previous accounts on the same device do not pass the webhook guard.
> - /v2/notifications/webhook refuses push delivery when ClientIdentifier.accountId is NULL on either side or does not match the joined DeviceRegistration.accountId.
> - /v2/notifications/subscribe writes accountId from the JWT into the ClientIdentifier upsert so newly-issued installations are guarded immediately. Legacy JWTs without accountId leave the field untouched.
> - One-time orphan cleanup migration: deletes same-device ClientIdentifier rows older than 7 days that are not the most recent row for their device.
>
> What's deferred:
> - NotificationSubscriptionSnapshot table + idempotent subscribe path.
> - /v2/notifications/debug/status endpoint.
> - remoteApplied response contract on /v2/notifications/subscribe.
> - NSE unregister middleware with the reduced-privilege allowlist.
>
> What's intentionally NOT here (so review bots stop oscillating):
> - No `@@index([accountId])` on `ClientIdentifier`. The slim PR's only queries on this table are `findUnique`/`upsert` keyed by `id` (primary key); `accountId` is read after the lookup and compared in memory in the webhook guard. The backfill migration's `JOIN` filters on `deviceId` which is already indexed. Adding the index now would buy nothing at query time AND require a `CREATE INDEX CONCURRENTLY` split-migration dance to avoid the write-blocking lock. When a real query (e.g. "list all clients for account X") needs it, add the index in a focused follow-up migration.
>
> The subscribe response shape is unchanged (200 with empty body), so the production iOS client continues to work without any paired iOS change.
> <!-- Macroscope's changelog starts here -->
> #### Changes since #272 opened
>
> - Added `hasAccountId` boolean field to structured log context in subscription request handler [74149b7]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent stale device identifiers from processing notifications intended for other accounts.

* **Chores**
  * Cleaned up orphaned client identifier records accumulated from identity rotations.
  * Enhanced logging to improve notification delivery diagnostics.

* **Tests**
  * Added comprehensive test coverage for account identifier mismatch detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->