### PR TITLE
test(subscriptions): fix wall-clock time-bomb in credits/subscription fixtures

### DIFF
--- a/tests/subscriptions/account-credits.test.ts
+++ b/tests/subscriptions/account-credits.test.ts
@@ -19,6 +19,25 @@ vi.mock("firebase-admin/app");
 vi.mock("firebase-admin/app-check");
 vi.mock("firebase-admin/messaging");
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const flooredToSecond = (ms: number): Date => {
+  const d = new Date(ms);
+  d.setUTCMilliseconds(0);
+  return d;
+};
+const NOW_MS = Date.now();
+const PERIOD_START = flooredToSecond(NOW_MS - 5 * DAY_MS);
+const PERIOD_END = flooredToSecond(NOW_MS + 25 * DAY_MS);
+const PLUS_ANNUAL_END = flooredToSecond(NOW_MS + 395 * DAY_MS);
+const WITHIN_PERIOD_A = flooredToSecond(NOW_MS - 1 * DAY_MS);
+const WITHIN_PERIOD_B = flooredToSecond(NOW_MS - 2 * DAY_MS);
+const BEFORE_PERIOD = flooredToSecond(NOW_MS - 10 * DAY_MS);
+const PERIOD_LABEL = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+}).format(PERIOD_START);
+
 const makeApp = () => {
   const app = express();
   app.use(pinoMiddleware);
@@ -74,9 +93,9 @@ const seedPlusMonthly = async (accountId: string) =>
     status: SubscriptionStatus.active,
     originalTransactionId: `otid-${accountId}`,
     transactionId: `tx-${accountId}`,
-    startedAt: new Date("2026-05-01T00:00:00.000Z"),
-    currentPeriodStart: new Date("2026-05-01T00:00:00.000Z"),
-    currentPeriodEnd: new Date("2026-06-01T00:00:00.000Z"),
+    startedAt: PERIOD_START,
+    currentPeriodStart: PERIOD_START,
+    currentPeriodEnd: PERIOD_END,
     willRenew: true,
     isInTrial: false,
     environment: AppleEnv.sandbox,
@@ -153,8 +172,8 @@ describe("GET /v2/accounts/me/credits", () => {
     expect(body.monthlyGrant).toBe(2500);
     expect(body.monthlyGrantUsed).toBe(0);
     expect(body.balance).toBe(2500);
-    expect(body.nextRefreshAt).toBe("2026-06-01T00:00:00.000Z");
-    expect(body.periodLabel).toBe("May 2026");
+    expect(body.nextRefreshAt).toBe(PERIOD_END.toISOString());
+    expect(body.periodLabel).toBe(PERIOD_LABEL);
   });
 
   // Expired and past-ended subscriptions now fall through to the free-tier
@@ -228,18 +247,8 @@ describe("GET /v2/accounts/me/credits", () => {
   test("consumes within current period count against monthlyGrantUsed", async () => {
     const accountId = await newAccount();
     await seedPlusMonthly(accountId);
-    await writeConsume(
-      accountId,
-      300,
-      new Date("2026-05-10T00:00:00.000Z"),
-      "c1",
-    );
-    await writeConsume(
-      accountId,
-      200,
-      new Date("2026-05-20T00:00:00.000Z"),
-      "c2",
-    );
+    await writeConsume(accountId, 300, WITHIN_PERIOD_A, "c1");
+    await writeConsume(accountId, 200, WITHIN_PERIOD_B, "c2");
     const token = await tokenFor(accountId);
     const res = await request(makeApp())
       .get("/v2/accounts/me/credits")
@@ -253,12 +262,7 @@ describe("GET /v2/accounts/me/credits", () => {
     const accountId = await newAccount();
     await seedPlusMonthly(accountId);
     // Burn in the prior period — should not affect this period's display.
-    await writeConsume(
-      accountId,
-      9999,
-      new Date("2026-04-15T00:00:00.000Z"),
-      "previous-period",
-    );
+    await writeConsume(accountId, 9999, BEFORE_PERIOD, "previous-period");
     const token = await tokenFor(accountId);
     const res = await request(makeApp())
       .get("/v2/accounts/me/credits")
@@ -271,12 +275,7 @@ describe("GET /v2/accounts/me/credits", () => {
   test("monthlyGrantUsed is capped at monthlyGrant (over-burn doesn't go negative)", async () => {
     const accountId = await newAccount();
     await seedPlusMonthly(accountId);
-    await writeConsume(
-      accountId,
-      9999,
-      new Date("2026-05-15T00:00:00.000Z"),
-      "huge",
-    );
+    await writeConsume(accountId, 9999, WITHIN_PERIOD_A, "huge");
     const token = await tokenFor(accountId);
     const res = await request(makeApp())
       .get("/v2/accounts/me/credits")
@@ -297,9 +296,9 @@ describe("GET /v2/accounts/me/credits", () => {
       status: SubscriptionStatus.active,
       originalTransactionId: "otid-plus-annual",
       transactionId: "tx-plus-annual",
-      startedAt: new Date("2026-05-01T00:00:00.000Z"),
-      currentPeriodStart: new Date("2026-05-01T00:00:00.000Z"),
-      currentPeriodEnd: new Date("2027-05-01T00:00:00.000Z"),
+      startedAt: PERIOD_START,
+      currentPeriodStart: PERIOD_START,
+      currentPeriodEnd: PLUS_ANNUAL_END,
       willRenew: true,
       isInTrial: false,
       environment: AppleEnv.sandbox,
@@ -312,7 +311,7 @@ describe("GET /v2/accounts/me/credits", () => {
     const body = res.body as BalanceBody;
     expect(body.monthlyGrant).toBe(2500 * 12);
     expect(body.balance).toBe(2500 * 12);
-    expect(body.nextRefreshAt).toBe("2027-05-01T00:00:00.000Z");
+    expect(body.nextRefreshAt).toBe(PLUS_ANNUAL_END.toISOString());
   });
 });
 

--- a/tests/subscriptions/account-subscription.test.ts
+++ b/tests/subscriptions/account-subscription.test.ts
@@ -23,6 +23,13 @@ vi.mock("firebase-admin/messaging");
 
 const TEST_BUNDLE_ID = "app.convos.test";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const FUTURE_EXPIRES = (() => {
+  const d = new Date(Date.now() + 30 * DAY_MS);
+  d.setUTCMilliseconds(0);
+  return d;
+})();
+
 const makeApp = () => {
   const app = express();
   app.use(pinoMiddleware);
@@ -102,7 +109,7 @@ const signTransaction = async (overrides: Record<string, unknown>) => {
     productId: "app.convos.subs.monthly",
     purchaseDate: new Date("2026-05-01T00:00:00.000Z").getTime(),
     originalPurchaseDate: new Date("2026-05-01T00:00:00.000Z").getTime(),
-    expiresDate: new Date("2026-06-01T00:00:00.000Z").getTime(),
+    expiresDate: FUTURE_EXPIRES.getTime(),
     type: "Auto-Renewable Subscription",
     appAccountToken: "11111111-2222-3333-4444-555555555555",
     inAppOwnershipType: "PURCHASED",
@@ -157,7 +164,7 @@ describe("GET /v2/accounts/me/subscription", () => {
       period: "monthly",
       status: "active",
       productId: "app.convos.subs.monthly",
-      currentPeriodEnd: "2026-06-01T00:00:00.000Z",
+      currentPeriodEnd: FUTURE_EXPIRES.toISOString(),
       willRenew: true,
       isInTrial: false,
     });
@@ -264,7 +271,7 @@ describe("POST /v2/accounts/me/subscription/verify", () => {
       period: "annual",
       status: "active",
       productId: "app.convos.subs.annual",
-      currentPeriodEnd: "2026-06-01T00:00:00.000Z",
+      currentPeriodEnd: FUTURE_EXPIRES.toISOString(),
       willRenew: true,
       isInTrial: false,
     });


### PR DESCRIPTION
## Problem

`tests/subscriptions/account-credits.test.ts` and `account-subscription.test.ts` hardcoded an "active" subscription period of **2026-05-01 → 2026-06-01**. The `GET /v2/accounts/me/credits` and `POST /v2/accounts/me/subscription/verify` handlers evaluate entitlement against the real wall clock (`isEntitledSubscription` / `deriveSubscriptionStatusFromTransaction` default `now = new Date()`).

Once real time passed `currentPeriodEnd` (2026-06-01), the fixtures evaluated as **expired**:

- `GET /me/credits` fell through to the free-tier branch → `balance: 100` (daily cap) instead of the tier grant `2500`.
- `verify` persisted `status: expired` instead of `active` / `trial`.

**7 tests started failing on 2026-06-01**, reddening `Validate code quality` CI for `otr-dev` and every branch stacked on it. This was the only failure on the base.

## Fix (test-only, 2 files)

- Anchor the **currently-active** fixtures (`seedBuilderMonthly`, the pro-annual sub, `signTransaction` `expiresDate`) to `now ± N days`.
- Derive `periodLabel`, `nextRefreshAt`, and `currentPeriodEnd` assertions from the same dynamic dates (same `Intl` formatter / `.toISOString()` the handler uses → guaranteed match, no calendar-boundary fragility).
- Consume-ledger fixture dates moved to `within` / `before` period offsets relative to `now`.
- Left intentionally-expired / past fixtures as absolute dates (`status: expired` is date-stable, not a time-bomb).
- Relativized the pro-annual fixture too — it wasn't failing yet (ended 2027-05-01) but was a latent time-bomb.

Grant math (`2500` / `500` / `0` / `120000`) is still asserted, so the tests still catch real handler regressions — they're now-anchored, not made trivially green.

## Test plan

- [x] `pnpm exec vitest run --dir tests/subscriptions` → **99/99 pass** (was 7 failing)
- [x] `pnpm typecheck` clean
- [x] `pnpm exec prettier --check` + `eslint` clean on both files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783003625&installation_id=128169237&pr_number=273&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F273&signature=147ff68e57f33a01695942b6a9f2d54609ba7ba017b500837e8962106fdda65c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix wall-clock time-bombs in subscription and credits test fixtures
> Hard-coded dates (e.g. May/June 2026) in subscription and credits tests would cause failures once those dates passed. Replaces all fixed timestamps with runtime-computed constants (e.g. `NOW_MS`, `PERIOD_START`, `PERIOD_END`, `FUTURE_EXPIRES`) derived from the current time with UTC milliseconds zeroed to avoid flakiness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b257861.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated account subscription and credit tests to dynamically calculate date boundaries relative to current time, replacing hard-coded dates and improving test resilience and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->