### PR TITLE
subscriptions: pin test clock so fixture dates stop bit-rotting

### DIFF
--- a/tests/subscriptions/account-credits.test.ts
+++ b/tests/subscriptions/account-credits.test.ts
@@ -1,7 +1,15 @@
 import { LedgerReason } from "@prisma/client";
 import express from "express";
 import request from "supertest";
-import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { accountsMeRouter } from "@/api/v2/accounts/accountsMeRouter";
 import { authMiddleware } from "@/middleware/auth";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -56,8 +64,22 @@ const wipe = async () => {
   createdAccountIds.length = 0;
 };
 
+// Seeded subscriptions pin currentPeriodEnd to 2026-06-01T00:00:00.000Z.
+// Once real wall-clock time crosses that fixture date the seeded
+// subscription flips to "expired", the entitled-tier resolver falls back
+// to free, and every "active builder = 2500 credit grant" assertion in
+// this file fails. Pin the clock to a known point before the fixture so
+// the assertions stay stable on every CI run.
+const FROZEN_NOW = new Date("2026-05-30T12:00:00.000Z");
+
 beforeAll(async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(FROZEN_NOW);
   await validateJWTKeys();
+});
+
+afterAll(() => {
+  vi.useRealTimers();
 });
 
 afterEach(async () => {

--- a/tests/subscriptions/account-subscription.test.ts
+++ b/tests/subscriptions/account-subscription.test.ts
@@ -6,7 +6,15 @@ import {
 import express, { json } from "express";
 import { importPKCS8, SignJWT } from "jose";
 import request from "supertest";
-import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { accountsMeRouter } from "@/api/v2/accounts/accountsMeRouter";
 import { authMiddleware } from "@/middleware/auth";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -66,7 +74,16 @@ const wipe = async () => {
   createdAccountIds.length = 0;
 };
 
+// The subscription fixtures throughout this file pin currentPeriodEnd /
+// expiresDate to 2026-06-01T00:00:00.000Z. Without a frozen system clock
+// every test silently flips from "active" to "expired" once real wall-clock
+// time crosses that fixture date. Pin the clock to a known point safely
+// before it so the assertions stay stable on every CI run.
+const FROZEN_NOW = new Date("2026-05-30T12:00:00.000Z");
+
 beforeAll(async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(FROZEN_NOW);
   await validateJWTKeys();
   const { privateKey } = generateKeyPairSync("ec", {
     namedCurve: "prime256v1",
@@ -74,6 +91,10 @@ beforeAll(async () => {
     publicKeyEncoding: { type: "spki", format: "pem" },
   });
   signingPrivateKey = privateKey;
+});
+
+afterAll(() => {
+  vi.useRealTimers();
 });
 
 afterEach(async () => {


### PR DESCRIPTION
## Summary

Two subscription test files seed a subscription with `currentPeriodEnd: 2026-06-01T00:00:00.000Z`. Once real wall-clock time crossed that fixture date on **2026-06-01**, the seeded subscription started flipping to `expired`, the entitled-tier resolver fell back to free, and every "active builder = 2500 credit grant" / "status active" assertion in those files started failing.

CI on **#263** stayed green only because its last test run happened on 2026-05-29 (before the cliff). CI on **#272** (slim notifications PR) and any other PR re-running CI today will hit the same red.

Fix: pin the system clock via `vi.useFakeTimers` + `vi.setSystemTime(FROZEN_NOW)` to `2026-05-30T12:00:00.000Z` in both files. `shouldAdvanceTime: true` so async / timer-driven helpers (JWT signing, await chains) still progress normally; only the wall clock that subscription-status logic reads through `new Date()` is frozen.

## Files

- `tests/subscriptions/account-subscription.test.ts`
- `tests/subscriptions/account-credits.test.ts`

`tests/subscriptions/status.test.ts` is unaffected — it already passes an explicit `now` argument through the function under test.

## Test plan

- [x] Local typecheck + lint clean
- [ ] CI runs the previously-failing 7 tests green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004009&installation_id=128169237&pr_number=274&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F274&signature=18e3f0f09aa45cb8264b649b657421ef1e72f217abf567beb136dd5f854eebf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin test clock to 2026-05-30 in subscription test suites to prevent fixture date rot
> Subscription tests were using real wall-clock time, causing date-dependent fixtures to fail as time passed. Both [account-credits.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/274/files#diff-2f736181e686dfa2528043ed50d2f76a37133501fdc4efa08fc040e35c2b2f6c) and [account-subscription.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/274/files#diff-70fc7b633ae8b52e4970be7e5107ca8666efe4583412ab356c1f5aed815bd127) now freeze the system clock to `2026-05-30T12:00:00.000Z` via `vi.useFakeTimers` in `beforeAll`, and restore real timers in `afterAll`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8631d75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability for subscription and account credit-related tests through deterministic time handling in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->