### PR TITLE
feat(credits): wire signup bonus on first account creation

### DIFF
--- a/prisma/migrations/20260602120000_signup_bonus_account_creation/migration.sql
+++ b/prisma/migrations/20260602120000_signup_bonus_account_creation/migration.sql
@@ -1,0 +1,7 @@
+-- Correct the signup_bonus grant-kind description. The original seed
+-- (20260515120000_payments_credits_foundation) said "Granted once on first
+-- agent creation", which was never wired. The bonus is granted once on first
+-- account creation (SIWE upgrade on POST /v2/auth/token).
+UPDATE "GrantKind"
+SET "description" = 'Granted once when an account is first created (SIWE upgrade)'
+WHERE "id" = 'signup_bonus';

--- a/src/accounts/repository.ts
+++ b/src/accounts/repository.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/utils/prisma";
 export async function upsertAuthMethodAndAccount(args: {
   type: AuthMethodType;
   externalKey: string;
-}): Promise<{ accountId: string }> {
+}): Promise<{ accountId: string; created: boolean }> {
   const findOrInsert = () =>
     prisma.$transaction(async (tx) => {
       const existing = await tx.authMethod.findUnique({
@@ -13,7 +13,7 @@ export async function upsertAuthMethodAndAccount(args: {
           type_externalKey: { type: args.type, externalKey: args.externalKey },
         },
       });
-      if (existing) return { accountId: existing.accountId };
+      if (existing) return { accountId: existing.accountId, created: false };
 
       const account = await tx.account.create({ data: {} });
       await tx.authMethod.create({
@@ -23,7 +23,7 @@ export async function upsertAuthMethodAndAccount(args: {
           externalKey: args.externalKey,
         },
       });
-      return { accountId: account.id };
+      return { accountId: account.id, created: true };
     });
 
   try {

--- a/src/accounts/repository.ts
+++ b/src/accounts/repository.ts
@@ -5,6 +5,10 @@ import { prisma } from "@/utils/prisma";
 export async function upsertAuthMethodAndAccount(args: {
   type: AuthMethodType;
   externalKey: string;
+  onCreate?: (
+    tx: Prisma.TransactionClient,
+    accountId: string,
+  ) => Promise<unknown>;
 }): Promise<{ accountId: string; created: boolean }> {
   const findOrInsert = () =>
     prisma.$transaction(async (tx) => {
@@ -23,6 +27,7 @@ export async function upsertAuthMethodAndAccount(args: {
           externalKey: args.externalKey,
         },
       });
+      if (args.onCreate) await args.onCreate(tx, account.id);
       return { accountId: account.id, created: true };
     });
 

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -164,7 +164,7 @@ export async function generateToken(
         await grant({
           accountId,
           credits: config.signupBonusCredits,
-          idempotencyKey: `signup_bonus:${accountId}`,
+          idempotencyKey: `signup_bonus_${accountId}`,
           kind: "signup_bonus",
           note: "Signup bonus",
         });

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -8,8 +8,8 @@ import {
   NONCE_COOKIE_NAME,
   readNonceFromCookie,
 } from "@/api/v2/auth/nonce-cookie";
-import { grant } from "@/payments";
 import { config } from "@/payments/credits/config";
+import { grantSignupBonusWithTx } from "@/payments/signup-bonus";
 import { deviceIdSchema } from "@/utils/device-id";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
@@ -101,11 +101,30 @@ export async function generateToken(
       throw err;
     }
 
-    // 3d. Upsert Account + AuthMethod
-    const upserted = await upsertAuthMethodAndAccount({
-      type: "SIWE",
-      externalKey: address,
-    });
+    // 3d. Upsert Account + AuthMethod. On first creation, grant the signup
+    // bonus inside the same transaction (atomic) so a new account can never
+    // exist without its bonus. A failure rolls the account back and surfaces
+    // as a retryable 500 rather than silently dropping the bonus.
+    let upserted: { accountId: string; created: boolean };
+    try {
+      upserted = await upsertAuthMethodAndAccount({
+        type: "SIWE",
+        externalKey: address,
+        onCreate:
+          config.signupBonusCredits > 0
+            ? (tx, newAccountId) =>
+                grantSignupBonusWithTx(
+                  tx,
+                  newAccountId,
+                  config.signupBonusCredits,
+                )
+            : undefined,
+      });
+    } catch (err) {
+      req.log.error({ err }, "auth.account.create_failed");
+      res.status(500).json({ error: "Failed to create account" });
+      return;
+    }
     accountId = upserted.accountId;
 
     // Best-effort backfill of DeviceRegistration.accountId.
@@ -157,21 +176,6 @@ export async function generateToken(
         { err, deviceId: body.deviceId, accountId },
         "auth.device.account_backfill_failed",
       );
-    }
-
-    if (upserted.created && config.signupBonusCredits > 0) {
-      try {
-        await grant({
-          accountId,
-          credits: config.signupBonusCredits,
-          idempotencyKey: `signup_bonus_${accountId}`,
-          kind: "signup_bonus",
-          note: "Signup bonus",
-        });
-        req.log.info({ accountId }, "auth.account.signup_bonus_granted");
-      } catch (err) {
-        req.log.warn({ err, accountId }, "auth.account.signup_bonus_failed");
-      }
     }
   }
 

--- a/src/api/v2/auth/handlers/generate-token.ts
+++ b/src/api/v2/auth/handlers/generate-token.ts
@@ -8,6 +8,8 @@ import {
   NONCE_COOKIE_NAME,
   readNonceFromCookie,
 } from "@/api/v2/auth/nonce-cookie";
+import { grant } from "@/payments";
+import { config } from "@/payments/credits/config";
 import { deviceIdSchema } from "@/utils/device-id";
 import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
@@ -155,6 +157,21 @@ export async function generateToken(
         { err, deviceId: body.deviceId, accountId },
         "auth.device.account_backfill_failed",
       );
+    }
+
+    if (upserted.created && config.signupBonusCredits > 0) {
+      try {
+        await grant({
+          accountId,
+          credits: config.signupBonusCredits,
+          idempotencyKey: `signup_bonus:${accountId}`,
+          kind: "signup_bonus",
+          note: "Signup bonus",
+        });
+        req.log.info({ accountId }, "auth.account.signup_bonus_granted");
+      } catch (err) {
+        req.log.warn({ err, accountId }, "auth.account.signup_bonus_failed");
+      }
     }
   }
 

--- a/src/payments/credits/config.ts
+++ b/src/payments/credits/config.ts
@@ -7,6 +7,7 @@ export interface PaymentsConfig {
   reservedMaxTurnCredits: bigint;
   minBalance: bigint;
   freeTierDailyCapCredits: number;
+  signupBonusCredits: number;
 }
 
 const requireFloat = (key: string, raw: string | undefined): number => {
@@ -127,12 +128,35 @@ export const loadFreeTierDailyCapCredits = (): number => {
   return Number(big);
 };
 
+// PAYMENTS_SIGNUP_BONUS_CREDITS
+//   One-time bonus granted on first account creation (SIWE upgrade).
+//   OPTIONAL by design: unset/empty/"0" => 0 => feature disabled (kill-switch).
+//   Any other value must be a non-negative safe integer. Do NOT convert this
+//   to a require* loader; "unset = off" is the intended contract.
+export const loadSignupBonusCredits = (): number => {
+  const raw = process.env.PAYMENTS_SIGNUP_BONUS_CREDITS;
+  if (raw === undefined || raw.trim() === "") {
+    return 0;
+  }
+  const trimmed = raw.trim();
+  if (
+    !/^\d+$/.test(trimmed) ||
+    BigInt(trimmed) > BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    throw new ValidationError(
+      `PAYMENTS_SIGNUP_BONUS_CREDITS must be a non-negative safe integer, got: ${raw}`,
+    );
+  }
+  return Number(trimmed);
+};
+
 export const loadConfig = (): PaymentsConfig => ({
   ...loadMarkupRate(),
   creditsPerDollar: loadCreditsPerUsd(),
   reservedMaxTurnCredits: loadReservedMaxTurnCredits(),
   minBalance: loadMinBalanceCredits(),
   freeTierDailyCapCredits: loadFreeTierDailyCapCredits(),
+  signupBonusCredits: loadSignupBonusCredits(),
 });
 
 export const config: PaymentsConfig = loadConfig();

--- a/src/payments/signup-bonus.ts
+++ b/src/payments/signup-bonus.ts
@@ -1,0 +1,17 @@
+import { LedgerReason, type Prisma } from "@prisma/client";
+import { applyDeltaWithTx } from "./ledger/repository";
+
+export const grantSignupBonusWithTx = (
+  tx: Prisma.TransactionClient,
+  accountId: string,
+  credits: number,
+) =>
+  applyDeltaWithTx(tx, {
+    accountId,
+    delta: BigInt(credits),
+    reason: LedgerReason.grant,
+    idempotencyKey: `signup_bonus_${accountId}`,
+    scope: "grant",
+    grantKindId: "signup_bonus",
+    note: "Signup bonus",
+  });

--- a/tests/auth-account-repository.test.ts
+++ b/tests/auth-account-repository.test.ts
@@ -39,20 +39,6 @@ describe("upsertAuthMethodAndAccount", () => {
     expect(method?.externalKey).toBe(ADDR_A);
   });
 
-  test("second login same wallet: created=false", async () => {
-    const first = await upsertAuthMethodAndAccount({
-      type: "SIWE",
-      externalKey: ADDR_A,
-    });
-    expect(first.created).toBe(true);
-    const second = await upsertAuthMethodAndAccount({
-      type: "SIWE",
-      externalKey: ADDR_A,
-    });
-    expect(second.created).toBe(false);
-    expect(second.accountId).toBe(first.accountId);
-  });
-
   test("second login same wallet: returns same accountId, does not insert", async () => {
     const first = await upsertAuthMethodAndAccount({
       type: "SIWE",
@@ -62,6 +48,8 @@ describe("upsertAuthMethodAndAccount", () => {
       type: "SIWE",
       externalKey: ADDR_A,
     });
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
     expect(second.accountId).toBe(first.accountId);
     const accounts = await prisma.account.count({
       where: nonAdminAccountFilter,
@@ -99,6 +87,7 @@ describe("upsertAuthMethodAndAccount", () => {
       }),
     ]);
     expect(a.accountId).toBe(b.accountId);
+    expect([a.created, b.created].filter(Boolean).length).toBe(1);
     expect(await prisma.account.count({ where: nonAdminAccountFilter })).toBe(
       1,
     );

--- a/tests/auth-account-repository.test.ts
+++ b/tests/auth-account-repository.test.ts
@@ -24,10 +24,11 @@ describe("upsertAuthMethodAndAccount", () => {
   afterEach(reset);
 
   test("first login: creates Account + AuthMethod, returns accountId", async () => {
-    const { accountId } = await upsertAuthMethodAndAccount({
+    const { accountId, created } = await upsertAuthMethodAndAccount({
       type: "SIWE",
       externalKey: ADDR_A,
     });
+    expect(created).toBe(true);
     const account = await prisma.account.findUnique({
       where: { id: accountId },
     });
@@ -36,6 +37,20 @@ describe("upsertAuthMethodAndAccount", () => {
       where: { accountId, type: "SIWE" },
     });
     expect(method?.externalKey).toBe(ADDR_A);
+  });
+
+  test("second login same wallet: created=false", async () => {
+    const first = await upsertAuthMethodAndAccount({
+      type: "SIWE",
+      externalKey: ADDR_A,
+    });
+    expect(first.created).toBe(true);
+    const second = await upsertAuthMethodAndAccount({
+      type: "SIWE",
+      externalKey: ADDR_A,
+    });
+    expect(second.created).toBe(false);
+    expect(second.accountId).toBe(first.accountId);
   });
 
   test("second login same wallet: returns same accountId, does not insert", async () => {

--- a/tests/auth-account-repository.test.ts
+++ b/tests/auth-account-repository.test.ts
@@ -1,3 +1,4 @@
+import { LedgerReason } from "@prisma/client";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
 import { upsertAuthMethodAndAccount } from "@/accounts/repository";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
@@ -88,6 +89,77 @@ describe("upsertAuthMethodAndAccount", () => {
     ]);
     expect(a.accountId).toBe(b.accountId);
     expect([a.created, b.created].filter(Boolean).length).toBe(1);
+    expect(await prisma.account.count({ where: nonAdminAccountFilter })).toBe(
+      1,
+    );
+    expect(await prisma.authMethod.count()).toBe(1);
+  });
+
+  test("onCreate side-effect commits atomically with the account", async () => {
+    let seenAccountId: string | undefined;
+    const { accountId, created } = await upsertAuthMethodAndAccount({
+      type: "SIWE",
+      externalKey: ADDR_A,
+      onCreate: async (tx, id) => {
+        seenAccountId = id;
+        await tx.creditLedger.create({
+          data: {
+            accountId: id,
+            delta: 0n,
+            reason: LedgerReason.adjust,
+            idempotencyKey: `hook_${id}`,
+            scope: "grant",
+            balanceAfter: 0n,
+          },
+        });
+      },
+    });
+    expect(created).toBe(true);
+    expect(seenAccountId).toBe(accountId);
+    const rows = await prisma.creditLedger.findMany({ where: { accountId } });
+    expect(rows.length).toBe(1);
+  });
+
+  test("onCreate throws → atomic rollback, no account/authMethod committed", async () => {
+    await expect(
+      upsertAuthMethodAndAccount({
+        type: "SIWE",
+        externalKey: ADDR_A,
+        onCreate: () => Promise.reject(new Error("boom")),
+      }),
+    ).rejects.toThrow("boom");
+    expect(await prisma.account.count({ where: nonAdminAccountFilter })).toBe(
+      0,
+    );
+    expect(await prisma.authMethod.count()).toBe(0);
+  });
+
+  test("onCreate throws once then heals on retry (same wallet)", async () => {
+    let calls = 0;
+    const onCreate = () => {
+      calls++;
+      return calls === 1
+        ? Promise.reject(new Error("transient"))
+        : Promise.resolve();
+    };
+    await expect(
+      upsertAuthMethodAndAccount({
+        type: "SIWE",
+        externalKey: ADDR_A,
+        onCreate,
+      }),
+    ).rejects.toThrow("transient");
+    expect(await prisma.account.count({ where: nonAdminAccountFilter })).toBe(
+      0,
+    );
+    expect(await prisma.authMethod.count()).toBe(0);
+
+    const healed = await upsertAuthMethodAndAccount({
+      type: "SIWE",
+      externalKey: ADDR_A,
+      onCreate,
+    });
+    expect(healed.created).toBe(true);
     expect(await prisma.account.count({ where: nonAdminAccountFilter })).toBe(
       1,
     );

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -1,3 +1,4 @@
+import { LedgerReason } from "@prisma/client";
 import cookieParser from "cookie-parser";
 import { Wallet } from "ethers";
 import express from "express";
@@ -11,7 +12,6 @@ import { config } from "@/payments/credits/config";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { verifyJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
-import { LedgerReason } from "@prisma/client";
 import { buildSiweMessage } from "./helpers/siwe";
 
 vi.mock("firebase-admin/app");

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -49,13 +49,6 @@ async function reset() {
   // Preserve the admin account seeded by migration; only wipe test-created rows.
   await prisma.account.deleteMany({ where: { id: { not: ADMIN_ACCOUNT_ID } } });
   await prisma.authNonce.deleteMany();
-  // The best-effort grant-failure test deactivates the signup_bonus GrantKind.
-  // GrantKind is migration-seeded (not wiped here), so restore active=true to
-  // self-heal: a hard-killed run can't leave the shared test DB poisoned.
-  await prisma.grantKind.update({
-    where: { id: "signup_bonus" },
-    data: { active: true },
-  });
 }
 
 describe("POST /auth/token (legacy + SIWE)", () => {
@@ -459,32 +452,5 @@ describe("POST /auth/token signup bonus", () => {
       where: { accountId: method!.accountId, grantKindId: "signup_bonus" },
     });
     expect(rows.length).toBe(1);
-  });
-
-  test("grant failure does not block token mint (best-effort)", async () => {
-    await prisma.grantKind.update({
-      where: { id: "signup_bonus" },
-      data: { active: false },
-    });
-    try {
-      const { res, address } = await signupViaSiwe("dev-bonus-3");
-      expect(res.status).toBe(200);
-      const body = res.body as { token: string };
-      const payload = await verifyJwtToken({ token: body.token });
-      expect(payload.accountId).toBeTruthy();
-
-      const method = await prisma.authMethod.findFirst({
-        where: { externalKey: address },
-      });
-      const rows = await prisma.creditLedger.findMany({
-        where: { accountId: method!.accountId, grantKindId: "signup_bonus" },
-      });
-      expect(rows.length).toBe(0);
-    } finally {
-      await prisma.grantKind.update({
-        where: { id: "signup_bonus" },
-        data: { active: true },
-      });
-    }
   });
 });

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -48,6 +48,13 @@ async function reset() {
   // Preserve the admin account seeded by migration; only wipe test-created rows.
   await prisma.account.deleteMany({ where: { id: { not: ADMIN_ACCOUNT_ID } } });
   await prisma.authNonce.deleteMany();
+  // The best-effort grant-failure test deactivates the signup_bonus GrantKind.
+  // GrantKind is migration-seeded (not wiped here), so restore active=true to
+  // self-heal: a hard-killed run can't leave the shared test DB poisoned.
+  await prisma.grantKind.update({
+    where: { id: "signup_bonus" },
+    data: { active: true },
+  });
 }
 
 describe("POST /auth/token (legacy + SIWE)", () => {

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -4,6 +4,7 @@ import { Wallet } from "ethers";
 import express from "express";
 import request from "supertest";
 import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { idempotencyKeySchema } from "@/api/v2/accounts/schemas/shared";
 import { issueNonce } from "@/api/v2/auth/auth-nonce.repository";
 import { authRouter } from "@/api/v2/auth/auth.router";
 import { NONCE_COOKIE_NAME, signNonce } from "@/api/v2/auth/nonce-cookie";
@@ -439,7 +440,10 @@ describe("POST /auth/token signup bonus", () => {
     expect(rows.length).toBe(1);
     expect(rows[0].reason).toBe(LedgerReason.grant);
     expect(rows[0].delta).toBe(BigInt(config.signupBonusCredits));
-    expect(rows[0].idempotencyKey).toBe(`signup_bonus:${method!.accountId}`);
+    expect(rows[0].idempotencyKey).toBe(`signup_bonus_${method!.accountId}`);
+    expect(idempotencyKeySchema.safeParse(rows[0].idempotencyKey).success).toBe(
+      true,
+    );
   });
 
   test("second login same wallet → no second bonus", async () => {

--- a/tests/auth-token-siwe.test.ts
+++ b/tests/auth-token-siwe.test.ts
@@ -7,9 +7,11 @@ import { issueNonce } from "@/api/v2/auth/auth-nonce.repository";
 import { authRouter } from "@/api/v2/auth/auth.router";
 import { NONCE_COOKIE_NAME, signNonce } from "@/api/v2/auth/nonce-cookie";
 import { pinoMiddleware } from "@/middleware/pino";
+import { config } from "@/payments/credits/config";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { verifyJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
+import { LedgerReason } from "@prisma/client";
 import { buildSiweMessage } from "./helpers/siwe";
 
 vi.mock("firebase-admin/app");
@@ -393,5 +395,85 @@ describe("POST /auth/token (legacy + SIWE)", () => {
       where: { deviceId },
     });
     expect(after?.accountId ?? null).toBe(seeded?.accountId ?? null);
+  });
+});
+
+describe("POST /auth/token signup bonus", () => {
+  beforeAll(reset);
+  afterEach(reset);
+
+  async function signupViaSiwe(deviceId: string, signerKey?: string) {
+    const nonce = await issueNonce();
+    const cookieValue = signNonce(nonce);
+    const { messageStr, signature, address } = await buildSiweMessage({
+      deviceId,
+      nonce,
+      signerKey,
+    });
+    const res = await request(makeApp())
+      .post("/auth/token")
+      .set(...APPCHECK)
+      .set("Cookie", `${NONCE_COOKIE_NAME}=${cookieValue}`)
+      .send({ deviceId, siwe: { message: messageStr, signature } });
+    return { res, address };
+  }
+
+  test("new account → one signup_bonus grant of configured amount", async () => {
+    expect(config.signupBonusCredits).toBeGreaterThan(0);
+    const { res, address } = await signupViaSiwe("dev-bonus-1");
+    expect(res.status).toBe(200);
+
+    const method = await prisma.authMethod.findFirst({
+      where: { externalKey: address },
+    });
+    const rows = await prisma.creditLedger.findMany({
+      where: { accountId: method!.accountId, grantKindId: "signup_bonus" },
+    });
+    expect(rows.length).toBe(1);
+    expect(rows[0].reason).toBe(LedgerReason.grant);
+    expect(rows[0].delta).toBe(BigInt(config.signupBonusCredits));
+    expect(rows[0].idempotencyKey).toBe(`signup_bonus:${method!.accountId}`);
+  });
+
+  test("second login same wallet → no second bonus", async () => {
+    const first = await signupViaSiwe("dev-bonus-2");
+    expect(first.res.status).toBe(200);
+    const second = await signupViaSiwe("dev-bonus-2");
+    expect(second.res.status).toBe(200);
+
+    const method = await prisma.authMethod.findFirst({
+      where: { externalKey: first.address },
+    });
+    const rows = await prisma.creditLedger.findMany({
+      where: { accountId: method!.accountId, grantKindId: "signup_bonus" },
+    });
+    expect(rows.length).toBe(1);
+  });
+
+  test("grant failure does not block token mint (best-effort)", async () => {
+    await prisma.grantKind.update({
+      where: { id: "signup_bonus" },
+      data: { active: false },
+    });
+    try {
+      const { res, address } = await signupViaSiwe("dev-bonus-3");
+      expect(res.status).toBe(200);
+      const body = res.body as { token: string };
+      const payload = await verifyJwtToken({ token: body.token });
+      expect(payload.accountId).toBeTruthy();
+
+      const method = await prisma.authMethod.findFirst({
+        where: { externalKey: address },
+      });
+      const rows = await prisma.creditLedger.findMany({
+        where: { accountId: method!.accountId, grantKindId: "signup_bonus" },
+      });
+      expect(rows.length).toBe(0);
+    } finally {
+      await prisma.grantKind.update({
+        where: { id: "signup_bonus" },
+        data: { active: true },
+      });
+    }
   });
 });

--- a/tests/payments/signup-bonus-config.unit.test.ts
+++ b/tests/payments/signup-bonus-config.unit.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+describe("PAYMENTS_SIGNUP_BONUS_CREDITS", () => {
+  const original = process.env.PAYMENTS_SIGNUP_BONUS_CREDITS;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.PAYMENTS_SIGNUP_BONUS_CREDITS;
+    } else {
+      process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = original;
+    }
+  });
+
+  test("unset → 0 (disabled)", async () => {
+    delete process.env.PAYMENTS_SIGNUP_BONUS_CREDITS;
+    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    expect(loadSignupBonusCredits()).toBe(0);
+  });
+
+  test("empty string → 0 (disabled)", async () => {
+    process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "";
+    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    expect(loadSignupBonusCredits()).toBe(0);
+  });
+
+  test('"0" → 0 (disabled)', async () => {
+    process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "0";
+    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    expect(loadSignupBonusCredits()).toBe(0);
+  });
+
+  test("positive int → value", async () => {
+    process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "5000";
+    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    expect(loadSignupBonusCredits()).toBe(5000);
+  });
+
+  test("rejects negative", async () => {
+    process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "-1";
+    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    expect(() => loadSignupBonusCredits()).toThrow(
+      /must be a non-negative safe integer/,
+    );
+  });
+
+  test("rejects non-integer", async () => {
+    process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "1.5";
+    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    expect(() => loadSignupBonusCredits()).toThrow(
+      /must be a non-negative safe integer/,
+    );
+  });
+
+  test("rejects alpha", async () => {
+    process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "abc";
+    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    expect(() => loadSignupBonusCredits()).toThrow(
+      /must be a non-negative safe integer/,
+    );
+  });
+});

--- a/tests/payments/signup-bonus-config.unit.test.ts
+++ b/tests/payments/signup-bonus-config.unit.test.ts
@@ -13,31 +13,36 @@ describe("PAYMENTS_SIGNUP_BONUS_CREDITS", () => {
 
   test("unset → 0 (disabled)", async () => {
     delete process.env.PAYMENTS_SIGNUP_BONUS_CREDITS;
-    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    const { loadSignupBonusCredits } =
+      await import("@/payments/credits/config");
     expect(loadSignupBonusCredits()).toBe(0);
   });
 
   test("empty string → 0 (disabled)", async () => {
     process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "";
-    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    const { loadSignupBonusCredits } =
+      await import("@/payments/credits/config");
     expect(loadSignupBonusCredits()).toBe(0);
   });
 
   test('"0" → 0 (disabled)', async () => {
     process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "0";
-    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    const { loadSignupBonusCredits } =
+      await import("@/payments/credits/config");
     expect(loadSignupBonusCredits()).toBe(0);
   });
 
   test("positive int → value", async () => {
     process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "5000";
-    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    const { loadSignupBonusCredits } =
+      await import("@/payments/credits/config");
     expect(loadSignupBonusCredits()).toBe(5000);
   });
 
   test("rejects negative", async () => {
     process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "-1";
-    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    const { loadSignupBonusCredits } =
+      await import("@/payments/credits/config");
     expect(() => loadSignupBonusCredits()).toThrow(
       /must be a non-negative safe integer/,
     );
@@ -45,7 +50,8 @@ describe("PAYMENTS_SIGNUP_BONUS_CREDITS", () => {
 
   test("rejects non-integer", async () => {
     process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "1.5";
-    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    const { loadSignupBonusCredits } =
+      await import("@/payments/credits/config");
     expect(() => loadSignupBonusCredits()).toThrow(
       /must be a non-negative safe integer/,
     );
@@ -53,7 +59,8 @@ describe("PAYMENTS_SIGNUP_BONUS_CREDITS", () => {
 
   test("rejects alpha", async () => {
     process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "abc";
-    const { loadSignupBonusCredits } = await import("@/payments/credits/config");
+    const { loadSignupBonusCredits } =
+      await import("@/payments/credits/config");
     expect(() => loadSignupBonusCredits()).toThrow(
       /must be a non-negative safe integer/,
     );

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -56,6 +56,7 @@ process.env.PAYMENTS_CREDITS_PER_USD = "1000";
 process.env.PAYMENTS_RESERVED_MAX_TURN_CREDITS = "1";
 process.env.PAYMENTS_MIN_BALANCE_CREDITS = "-1000";
 process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "100";
+process.env.PAYMENTS_SIGNUP_BONUS_CREDITS = "5000";
 process.env.PAYMENTS_CRON_API_KEY =
   process.env.PAYMENTS_CRON_API_KEY ||
   "test-cron-api-key-that-is-at-least-32-characters-long";


### PR DESCRIPTION
## Summary

Wires the previously-dead `signup_bonus` GrantKind so it is granted exactly once when a new `accountId` is first created (the SIWE upgrade on `POST /v2/auth/token`).

- **Grant kind**: corrected the stale seed description ("first agent creation" — never wired) via a data migration. `id` (`signup_bonus`) and `name` unchanged.
- **Config**: new env var `PAYMENTS_SIGNUP_BONUS_CREDITS`. Unlike the other `PAYMENTS_*` vars, this one is **optional**: `0`/unset disables the grant (kill-switch). Ships OFF until ops sets a value.
- **Atomic grant**: the bonus ledger write happens **inside the same transaction** as `account.create` + `authMethod.create`, via an injectable `onCreate` hook on `upsertAuthMethodAndAccount` (+ a `grantSignupBonusWithTx` helper). Account + bonus commit or roll back together.
- **Idempotency**: key `signup_bonus_<accountId>` (matches the canonical `idempotencyKeySchema` charset `^[A-Za-z0-9_-]{1,255}$` — no `:`), with a test asserting conformance.

### Durability (addresses review feedback)
The earlier best-effort approach gated the grant on `created` and swallowed failures — a transient grant failure (or a process death between the account-create commit and the grant) would leave `created === false` forever, permanently suppressing the bonus.

The atomic approach removes that window entirely **without** a tracking column or a per-login check:
- A new account can never exist without its bonus — they share one transaction.
- A transient ledger failure rolls the account back and surfaces as a **retryable 500**, not a silent loss. The next login retries and self-heals.
- Only touches the rare first-SIWE path; zero lock contention (fresh account), zero cost on repeat logins.

### Invariant (per-account, not per-person)
A user who loses their wallet and signs in with a new wallet gets a new account + a fresh bonus — intended. A **future** account-recovery flow (Apple/Google subscription key) MUST reuse the existing `accountId`; reusing it yields `created === false`, suppressing a second bonus. Per-person dedup is a separate future slice.

### Follow-up (not in this PR)
- Sibling Terraform PR adds `PAYMENTS_SIGNUP_BONUS_CREDITS` to the ECS task definition. Dormant in prod until applied.
- Separate PR: enforce the idempotency-key charset on internal keys + migrate the deployed `daily_refill:` key format to `_` (forward-only; the daily rate-limit keys off `grantKindId`+date, not the key).

## Test Plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors on touched files
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 806 passed, 1 skipped (1 unrelated pre-existing wall-clock flake in agent-templates executor, passes on isolated re-run)
- Coverage: config loader; repo `created` flag + race winner; **atomic rollback + throw-once-then-heal (self-heal)**; handler integration (new account → one `signup_bonus` grant of configured amount + key-charset assert; relogin → no second bonus)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant signup bonus credits on first SIWE account creation
> - On first-time SIWE login, `grantSignupBonusWithTx` is called atomically within the account creation transaction, crediting `signupBonusCredits` to the new account with idempotency key `signup_bonus_{accountId}`.
> - `upsertAuthMethodAndAccount` in [repository.ts](https://github.com/ephemeraHQ/convos-backend/pull/275/files#diff-0ff968ca7965fe91033bcae8ae9ed9d246368ecd4821897c03c72f0e39427b4a) now returns `{ accountId, created }` and accepts an optional `onCreate` callback executed inside the same transaction.
> - Signup bonus amount is configured via `PAYMENTS_SIGNUP_BONUS_CREDITS` env var (defaults to 0); invalid values throw at config load time.
> - Risk: if the bonus grant fails, the entire account creation rolls back and the request returns HTTP 500.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ae0420.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->