### PR TITLE
feat(agent-templates): optional builder-prompt override on generations (persists as draft)

### DIFF
--- a/prisma/migrations/20260602130000_add_generation_builder_prompt/migration.sql
+++ b/prisma/migrations/20260602130000_add_generation_builder_prompt/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+-- Optional caller-supplied builder/system prompt override (admin dashboard).
+-- Privileged (agent-API-key only) and fed to the generator by the executor;
+-- null for ordinary generations, where the canonical prompt is used.
+ALTER TABLE "AgentTemplateGeneration"
+  ADD COLUMN "builderPrompt" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,6 +173,9 @@ model AgentTemplateGeneration {
   // Stored on the row because the executor is fire-and-forget and re-reads
   // the row; this is the simplest handoff channel.
   prefill         Json?
+  // Optional caller-supplied builder/system prompt override (admin dashboard);
+  // privileged (agent-API-key only) and fed to the generator by the executor.
+  builderPrompt   String?          @db.Text
   templateId      String?          @db.Uuid
   publishStatus   PublishStatus    @default(draft)
   reply           String?          @db.Text

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -236,14 +236,10 @@ export type TemplatePrefill = z.infer<typeof TemplatePrefillSchema>;
 
 type CoalescedInput =
   | { kind: "text"; text: string }
-  | { kind: "pdfBase64"; pdfBase64: string }
-  | { kind: "imageBase64"; imageBase64: string };
+  | { kind: "pdfBase64"; pdfBase64: string; text?: string }
+  | { kind: "imageBase64"; imageBase64: string; text?: string };
 
 function coalesceInputs(inputs: Inputs): CoalescedInput | null {
-  if (inputs.pdfBase64)
-    return { kind: "pdfBase64", pdfBase64: inputs.pdfBase64 };
-  if (inputs.imageBase64)
-    return { kind: "imageBase64", imageBase64: inputs.imageBase64 };
   // Pick the first text-bearing field whose content is non-whitespace.
   // A naive `||` chain short-circuits on truthy-but-whitespace values
   // (`"   "` is truthy in JS), so a payload like
@@ -253,6 +249,21 @@ function coalesceInputs(inputs: Inputs): CoalescedInput | null {
     (value): value is string =>
       typeof value === "string" && value.trim().length > 0,
   );
+  // The text rides along on file paths too — it's the user's directive for the
+  // attached file — so carry it through for length validation, mirroring the
+  // executor's coalescing.
+  if (inputs.pdfBase64)
+    return {
+      kind: "pdfBase64",
+      pdfBase64: inputs.pdfBase64,
+      ...(text ? { text } : {}),
+    };
+  if (inputs.imageBase64)
+    return {
+      kind: "imageBase64",
+      imageBase64: inputs.imageBase64,
+      ...(text ? { text } : {}),
+    };
   if (text) return { kind: "text", text };
   return null;
 }
@@ -649,7 +660,9 @@ export async function generationsPostHandler(req: Request, res: Response) {
   }
 
   // 4. Length limits
-  if (coalesced.kind === "text" && coalesced.text.length > MAX_TEXT_LEN) {
+  // `coalesced.text` is set on the text path AND on file paths that carry an
+  // intent directive, so cap it regardless of kind.
+  if (coalesced.text !== undefined && coalesced.text.length > MAX_TEXT_LEN) {
     res.status(400).json({
       error: `Text exceeds maximum length of ${MAX_TEXT_LEN} characters`,
     });

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -60,6 +60,9 @@ import { prisma } from "@/utils/prisma";
 
 const MAX_TEXT_LEN = 50_000;
 const MAX_BASE64_LEN = 35_000_000;
+// Builder/system prompt override cap — generous (the canonical file prompt is
+// ~12k tokens) but bounds an obviously-abusive body.
+const MAX_BUILDER_PROMPT_LEN = 100_000;
 const MAX_BODY_BYTES = 40 * 1024 * 1024;
 const MAX_WAIT_MS = 45_000;
 const DEFAULT_SSE_KEEPALIVE_MS = 15_000;
@@ -210,6 +213,12 @@ const bodySchema = z
     prefill: TemplatePrefillSchema.optional().transform((v) =>
       v && Object.keys(v).length > 0 ? v : undefined,
     ),
+    // Custom builder/system prompt that overrides the canonical template-
+    // generator prompt for this generation. Privileged — gated to agent-API-key
+    // callers below (like twitterContext) — and persisted on the row so the
+    // fire-and-forget executor can feed it to the generator. The produced
+    // template still lands as a draft via the normal pipeline.
+    builderPrompt: z.string().min(1).max(MAX_BUILDER_PROMPT_LEN).optional(),
     // Asserted owner — honoured only when the caller is agent-key-auth'd;
     // ignored for JWT (JWT account always wins) and anonymous (falls
     // back to ADMIN). See the owner-resolution block below.
@@ -478,6 +487,7 @@ interface DedupeRow extends GenerationRow {
   inputs: unknown;
   twitterContext: unknown;
   prefill: unknown;
+  builderPrompt: string | null;
 }
 
 const dedupeSelect = {
@@ -486,6 +496,7 @@ const dedupeSelect = {
   inputs: true,
   twitterContext: true,
   prefill: true,
+  builderPrompt: true,
   status: true,
   templateId: true,
   reply: true,
@@ -506,12 +517,14 @@ function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
       inputs: existing.inputs,
       twitterContext: existing.twitterContext,
       prefill: existing.prefill,
+      builderPrompt: existing.builderPrompt,
     },
     {
       source: body.source,
       inputs: body.inputs,
       twitterContext: body.twitterContext ?? null,
       prefill: body.prefill ?? null,
+      builderPrompt: body.builderPrompt ?? null,
     },
   );
 }
@@ -714,6 +727,17 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
+  // 5c. builderPrompt overrides the canonical generator system prompt — an
+  //     abuse-prone surface (a free general-purpose LLM, or a way to strip the
+  //     design/moderation guardrails baked into the canonical prompt), so it's
+  //     restricted to agent-API-key callers (the admin dashboard).
+  if (body.builderPrompt && !isApiKeyListener) {
+    res.status(403).json({
+      error: "builderPrompt requires agent API key authentication",
+    });
+    return;
+  }
+
   // 6. Idempotency-Key required and MUST be a UUID (any RFC 4122 version).
   //    Both the agent API key path and anonymous submissions are owned by
   //    `ADMIN_ACCOUNT_ID`, so they share an idempotency namespace; using
@@ -837,6 +861,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
         prefill: body.prefill
           ? (body.prefill as Prisma.InputJsonValue)
           : Prisma.JsonNull,
+        builderPrompt: body.builderPrompt ?? null,
         publishStatus: body.publishStatus,
         status: "pending",
       },

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -481,6 +481,10 @@ async function _runPipeline(
   // onto the metadata at persist below.
   const prefill = generation.prefill as TemplatePrefill | null;
 
+  // Optional caller-supplied builder/system prompt override (admin dashboard).
+  // null for ordinary generations, where the canonical prompt is used.
+  const builderPrompt = generation.builderPrompt;
+
   // Actor-attribution fields shared by every capture site below, plus the
   // PostHog LLM Analytics trace id so the product event joins to the
   // `$ai_generation` spans the OpenRouter calls emit. Built once: the trace's
@@ -510,6 +514,7 @@ async function _runPipeline(
       signal,
       prefill,
       trace,
+      builderPrompt,
     );
   } catch (err) {
     // Meter error path

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -208,21 +208,31 @@ function postHogBase(args: {
 function coalesceInputs(
   inputs: GenerationInputs,
 ): GenerateTemplateInput | null {
+  // The user's typed text is their intent/directive for an attached file —
+  // generateTemplate appends it as "User's intent: …" on the pdf/image paths —
+  // so it must survive coalescing there too, not just on the text-only path.
+  // `.find` (not a `||` chain) so a truthy-but-whitespace field can't mask a
+  // real one behind it.
+  const text = [inputs.text, inputs.idea, inputs.content, inputs.url].find(
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0,
+  );
   if (inputs.pdfBase64) {
     return {
       pdfBase64: inputs.pdfBase64,
       mimeType: inputs.mimeType || "application/pdf",
       filename: inputs.filename || "document.pdf",
+      ...(text ? { text } : {}),
     };
   }
   if (inputs.imageBase64) {
     return {
       imageBase64: inputs.imageBase64,
       mimeType: inputs.mimeType || "image/png",
+      ...(text ? { text } : {}),
     };
   }
-  const text = inputs.text || inputs.idea || inputs.content || inputs.url;
-  if (text && text.trim().length > 0) return { text };
+  if (text) return { text };
   return null;
 }
 
@@ -469,12 +479,15 @@ async function _runPipeline(
       "No usable input — provide one of text, idea, content, url, pdfBase64, or imageBase64",
     );
   }
+  // File presence determines the input type. `text` may now ALSO be present on
+  // the pdf/image paths (the user's intent directive), so it's checked LAST — a
+  // bare text submission is the only shape with no pdf/image key.
   const inputType: "text" | "pdfBase64" | "imageBase64" =
-    "text" in coalesced
-      ? "text"
-      : "pdfBase64" in coalesced
-        ? "pdfBase64"
-        : "imageBase64";
+    "pdfBase64" in coalesced
+      ? "pdfBase64"
+      : "imageBase64" in coalesced
+        ? "imageBase64"
+        : "text";
 
   // Caller-pinned prefill is read up front so it can be fed INTO the generator
   // (so the produced prompt + welcome use the pinned name), not just overlaid

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -1240,6 +1240,7 @@ export async function generateTemplate(
   externalSignal?: AbortSignal,
   prefill?: GenerationPrefill | null,
   trace?: TraceContext,
+  systemPromptOverride?: string | null,
 ): Promise<GenerationResult> {
   // Backward compat: string input = text
   const opts: GenerateTemplateInput =
@@ -1249,7 +1250,12 @@ export async function generateTemplate(
   if (!apiKey) {
     throw new Error("BUILDER_OPENROUTER_API_KEY not configured");
   }
-  const systemPrompt = getSystemPrompt();
+  // A per-request override (the admin preview tool A/B-ing a builder prompt)
+  // wins over the file/test-seam prompt; an empty/whitespace value falls
+  // through to the canonical prompt.
+  const systemPrompt = systemPromptOverride?.trim()
+    ? systemPromptOverride
+    : getSystemPrompt();
   if (!systemPrompt) {
     throw new Error("Template generator system prompt not loaded");
   }
@@ -1400,9 +1406,12 @@ export async function generateTemplate(
       // 1.25x); reads are 0.1x either way. Net cheaper + faster whenever two
       // generations land within an hour. Supported per-block on Bedrock.
       //
-      // `systemPrompt` (not the raw SYSTEM_PROMPT import) so the eval harness's
-      // __setSystemPromptOverrideForTests seam still applies; in production
-      // there's no override, so the text stays byte-identical and caches.
+      // `systemPrompt` (not the raw SYSTEM_PROMPT import) so both the eval
+      // harness's __setSystemPromptOverrideForTests seam AND a per-request
+      // `systemPromptOverride` (the admin preview tool) still apply. In
+      // production neither is set, so the text stays byte-identical and
+      // caches; a preview override is intentionally a cache miss (low volume,
+      // dev/admin-only).
       {
         role: "system",
         content: [
@@ -1584,6 +1593,7 @@ let _generateTemplateOverride:
       signal?: AbortSignal,
       prefill?: GenerationPrefill | null,
       trace?: TraceContext,
+      systemPromptOverride?: string | null,
     ) => Promise<GenerationResult>)
   | null = null;
 
@@ -1595,6 +1605,7 @@ export function __resetGenerateTemplateForTests(
         signal?: AbortSignal,
         prefill?: GenerationPrefill | null,
         trace?: TraceContext,
+        systemPromptOverride?: string | null,
       ) => Promise<GenerationResult>)
     | null,
 ) {
@@ -1608,17 +1619,28 @@ export function __resetGenerateTemplateForTests(
  * Optional `signal` aborts the in-flight OpenRouter fetches, so a caller
  * (e.g. the generation executor's per-pipeline timeout) can cancel work
  * mid-LLM-call and avoid paying tokens for a result it would discard.
+ *
+ * Optional `systemPromptOverride` lets a trusted caller (the admin preview
+ * tool) swap the builder system prompt for a single request without
+ * persisting anything; omitted on the production generation path.
  */
 export async function callGenerateTemplate(
   input: GenerateTemplateInput | string,
   signal?: AbortSignal,
   prefill?: GenerationPrefill | null,
   trace?: TraceContext,
+  systemPromptOverride?: string | null,
 ): Promise<GenerationResult> {
   if (_generateTemplateOverride) {
-    return _generateTemplateOverride(input, signal, prefill, trace);
+    return _generateTemplateOverride(
+      input,
+      signal,
+      prefill,
+      trace,
+      systemPromptOverride,
+    );
   }
-  return generateTemplate(input, signal, prefill, trace);
+  return generateTemplate(input, signal, prefill, trace, systemPromptOverride);
 }
 
 export { BREVITY_RAIL };

--- a/tests/agent-templates.executor.test.ts
+++ b/tests/agent-templates.executor.test.ts
@@ -147,6 +147,56 @@ describe("generation-executor", () => {
     expect(template?.firstPublishedAt).toBeNull();
   });
 
+  test("threads the row's builderPrompt to the generator as the system-prompt override", async () => {
+    let capturedOverride: string | null | undefined;
+    __resetGenerateTemplateForTests(
+      (_input, _signal, _prefill, _trace, systemPromptOverride) => {
+        capturedOverride = systemPromptOverride;
+        return Promise.resolve({
+          template: fakeTemplate,
+          metrics: DEFAULT_TEST_METRICS,
+        });
+      },
+    );
+    const builderPrompt = "You are a custom builder. Always make pirates.";
+    const gen = await prisma.agentTemplateGeneration.create({
+      data: {
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+        source: TEST_SOURCE,
+        idempotencyKey: "builder-prompt-threading",
+        inputs: { text: "a trivia agent" },
+        builderPrompt,
+        status: "pending",
+      },
+    });
+
+    await executeGeneration(gen.id);
+
+    const final = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: gen.id },
+    });
+    expect(final?.status).toBe("done");
+    expect(capturedOverride).toBe(builderPrompt);
+  });
+
+  test("ordinary generation (no builderPrompt) passes no override", async () => {
+    let capturedOverride: string | null | undefined = "SENTINEL";
+    __resetGenerateTemplateForTests(
+      (_input, _signal, _prefill, _trace, systemPromptOverride) => {
+        capturedOverride = systemPromptOverride ?? null;
+        return Promise.resolve({
+          template: fakeTemplate,
+          metrics: DEFAULT_TEST_METRICS,
+        });
+      },
+    );
+    const gen = await createPendingGeneration("no-builder-prompt");
+
+    await executeGeneration(gen.id);
+
+    expect(capturedOverride).toBeNull();
+  });
+
   test("non-sluggable agentName falls back to a safe default slug", async () => {
     // deriveBaseSlug("🤖 ✨ 🚀") strips to "" — validateSlug rejects it, so
     // persistTemplate must fall back to a valid slug rather than persist an

--- a/tests/agent-templates.executor.test.ts
+++ b/tests/agent-templates.executor.test.ts
@@ -197,6 +197,47 @@ describe("generation-executor", () => {
     expect(capturedOverride).toBeNull();
   });
 
+  test("preserves the user's text intent alongside an attached file", async () => {
+    let capturedInput: unknown;
+    let capturedProps: PostHogCaptureProperties | undefined;
+    __resetGenerateTemplateForTests((input) => {
+      capturedInput = input;
+      return Promise.resolve({
+        template: fakeTemplate,
+        metrics: DEFAULT_TEST_METRICS,
+      });
+    });
+    __resetPostHogForTests((props) => {
+      capturedProps = props;
+    });
+    const gen = await prisma.agentTemplateGeneration.create({
+      data: {
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+        source: TEST_SOURCE,
+        idempotencyKey: "file-plus-intent",
+        inputs: {
+          imageBase64: "AAAA",
+          mimeType: "image/png",
+          text: "make a cooking agent",
+        },
+        status: "pending",
+      },
+    });
+
+    await executeGeneration(gen.id);
+    __resetPostHogForTests(() => {}); // restore the no-op for later tests
+
+    // The directive must survive coalescing — generateTemplate uses it as the
+    // file's "User's intent:" rather than dropping it.
+    expect(capturedInput).toMatchObject({
+      imageBase64: "AAAA",
+      text: "make a cooking agent",
+    });
+    // ...and `text` now riding on the object must NOT flip the analytics
+    // classification: a file is still reported as imageBase64, not "text".
+    expect(capturedProps?.inputType).toBe("imageBase64");
+  });
+
   test("non-sluggable agentName falls back to a safe default slug", async () => {
     // deriveBaseSlug("🤖 ✨ 🚀") strips to "" — validateSlug rejects it, so
     // persistTemplate must fall back to a valid slug rather than persist an

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -389,6 +389,54 @@ describe("POST /generations — idempotency", () => {
   });
 });
 
+describe("POST /generations — builderPrompt (privileged override)", () => {
+  test("anonymous caller + builderPrompt → 403", async () => {
+    // builderPrompt overrides the canonical generator prompt, so like
+    // twitterContext it's restricted to agent-API-key callers.
+    const res = await post(
+      { ...sampleBody, builderPrompt: "You are a custom builder." },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": stableUuid("builder-anon"),
+        },
+      },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("agent-key + builderPrompt → 202 and persists on the row", async () => {
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const res = await post(
+      { ...sampleBody, builderPrompt: "You are a custom builder." },
+      { headers: withKey("builder-ok") },
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { generationId: string };
+    const row = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: body.generationId },
+    });
+    expect(row?.builderPrompt).toBe("You are a custom builder.");
+  });
+
+  test("same key + different builderPrompt → 409", async () => {
+    // builderPrompt influences the generator's output, so it's part of the
+    // idempotent contract — a reused key with a different prompt must 409.
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const first = await post(
+      { ...sampleBody, builderPrompt: "Prompt A" },
+      { headers: withKey("idem-builder-diff") },
+    );
+    expect(first.status).toBe(202);
+
+    const second = await post(
+      { ...sampleBody, builderPrompt: "Prompt B" },
+      { headers: withKey("idem-builder-diff") },
+    );
+    expect(second.status).toBe(409);
+  });
+});
+
 describe("POST /generations — SSE mode", () => {
   test("Accept: text/event-stream emits terminal result frame", async () => {
     const res = await fetch(`${baseURL}/api/v2/agent-templates/generations`, {

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -181,6 +181,17 @@ describe("POST /generations — validation", () => {
     expect(res.status).toBe(400);
   });
 
+  test("intent text exceeds 50_000 chars on a file path → 400", async () => {
+    // The intent text rides along with an attached file (the generator uses it
+    // as the file's directive), so it's length-capped on the file path too.
+    const tooLong = "a".repeat(50_001);
+    const res = await post(
+      { source: TEST_SOURCE, inputs: { imageBase64: "AAAA", text: tooLong } },
+      { headers: withKey("v4-file-intent") },
+    );
+    expect(res.status).toBe(400);
+  });
+
   test("missing Idempotency-Key → 400", async () => {
     const res = await post(sampleBody, { headers: baseHeaders() });
     expect(res.status).toBe(400);

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -122,6 +122,8 @@ afterAll(async () => {
   __resetGenerateTemplateForTests(null);
   __resetPostHogForTests(null);
   __resetModerationForTests(null);
+  // Restore the singleton agent-key override so it can't leak into other suites.
+  __setAgentAssetsApiKeyOverrideForTests(undefined);
   await prisma.account
     .delete({ where: { id: ASSERTED_ACCOUNT_ID } })
     .catch(() => {


### PR DESCRIPTION
## Summary

Adds an optional `builderPrompt` to `POST /api/v2/agent-templates/generations`. An agent-API-key caller (the admin dashboard) can supply a custom system prompt that overrides the canonical template generator (`data/template-generator-prompt.txt`) for a single generation. The override is persisted on the generation row and fed to the generator by the fire-and-forget executor; the produced template lands as a **draft** via the normal pipeline.

## How it works

- **`generateTemplate` / `callGenerateTemplate` / the `_generateTemplateOverride` test seam** take an optional `systemPromptOverride`. A per-request override wins over the file/test-seam prompt; empty/whitespace falls back to the canonical prompt. Output shape is unchanged (`response_format` untouched).
- **`generations-post.ts`** — `builderPrompt` (max 100k chars) added to the request schema, gated to agent-API-key callers (`isApiKeyListener`, the same gating as `twitterContext`), included in the idempotency dedupe contract, and stored on the row.
- **`AgentTemplateGeneration.builderPrompt`** — new nullable `TEXT` column (+ migration).
- **`generation-executor.ts`** — threads the row's `builderPrompt` to the generator.

**Why gated:** a builder-prompt override is abuse-prone (a free general-purpose LLM, or a way to strip the design/moderation guardrails baked into the canonical prompt), so it's never honored on the public/anonymous path.

## Also: preserve text intent on file inputs

Fixes a pre-existing bug in the same code path. `coalesceInputs` dropped the user's `text`/intent whenever a PDF or image was attached, but `generateTemplate` uses that text as the file's directive (`"User's intent: …"`) — so "use this PDF to make a cooking agent" lost the directive. The intent text is now carried through on the file paths (executor) and length-capped on every path (validator).

## Tests

- **`agent-templates.executor.test.ts`** — `builderPrompt` threads to the generator; no override when absent; the user's text intent survives alongside an attached file.
- **`agent-templates.generations-post.test.ts`** — anonymous + `builderPrompt` → 403; agent-key persists it on the row; same key + different `builderPrompt` → 409; over-long intent text on a file path → 400.

`tsc` / `eslint` / `prettier` clean; integration tests run in CI (they need `DATABASE_URL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional builder/system prompt override for template generation (restricted to agent API key callers).
  * POST endpoint accepts and persists a builderPrompt; user text is preserved when sent alongside file uploads.

* **Bug Fixes**
  * Idempotency/dedup now considers builderPrompt, preventing mismatches on retries.

* **Tests**
  * Added tests for builderPrompt authorization, idempotency, text-preservation with files, and long-text validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional `builderPrompt` override to agent template generations, persisted as draft
> - Adds a `builderPrompt` field to `AgentTemplateGeneration` (new nullable `TEXT` column via migration) that lets privileged callers supply a system prompt override at generation time.
> - Only agent-API-key authenticated callers may set `builderPrompt`; anonymous or non-agent callers receive a 403.
> - The executor reads `builderPrompt` from the generation row and passes it to `callGenerateTemplate` as a system prompt override, falling back to the canonical prompt when absent.
> - Deduplication/idempotency checks now include `builderPrompt`, so mismatched values for the same idempotency key return 409.
> - Also fixes intent text being dropped when a file (PDF/image) input is present, and extends the text-length validation to cover file+text requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 812b9ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
