### PR TITLE
feat(agent-templates): contract rail re-asserts field quality for custom builder prompts

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -177,6 +177,25 @@ const BREVITY_RAIL = `## Runtime Reminder
 
 Chat replies appear as push notifications on members' phones. Hard cap: 3 sentences, plain text — no markdown, bullets, headers, or links. When the answer is reference-worthy (plan, guide, comparison, itinerary, summary, rundown, breakdown), write a file to your workspace and send it with MEDIA:./filename.html — Convos artifacts are HTML, never .md, and you must run the \`artifact\` skill before writing any .html file (it owns the design system: DESIGN.md, Note vs Table, head-meta, light/dark). The 3-sentence cap applies to the short chat message next to the artifact, not the file itself. Default to a single short paragraph. If two thoughts truly need to land apart, separate them with a **blank line** (double line break, \`\\n\\n\`) — a single newline glues them into one bubble, which is almost never what you want.`;
 
+// Appended to a custom builder-prompt override (the admin tool) — never to the
+// canonical prompt, which already carries this guidance. The JSON *shape* is
+// enforced by the response schema regardless, so this rail only re-asserts the
+// field *quality* the schema can't check (a real name/emoji, no empties) — the
+// part a custom prompt is most likely to drop. Goes LAST so a long custom
+// prompt can't bury it (mirrors BREVITY_RAIL on the agent prompt).
+const BUILDER_CONTRACT_RAIL = `## Field Requirements (non-negotiable)
+
+The builder instructions above design the agent, and the output JSON shape is
+already enforced by the response schema. Regardless of those instructions, fill
+every field with a real, fitting value — never blank, placeholder, or "TODO":
+
+- agentName — a memorable 1–3 word handle that fits the agent's vibe. Never "Assistant", "Bot", "Helper", or a descriptive title.
+- emoji — exactly one glyph that fits the agent. Never blank.
+- description — one line (≤140 chars) on what the agent is for.
+- category — one sensible category.
+- tools — only the tools the agent actually needs.
+- prompt — the agent's full instructions; never empty.`;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -1250,11 +1269,14 @@ export async function generateTemplate(
   if (!apiKey) {
     throw new Error("BUILDER_OPENROUTER_API_KEY not configured");
   }
-  // A per-request override (the admin preview tool A/B-ing a builder prompt)
-  // wins over the file/test-seam prompt; an empty/whitespace value falls
-  // through to the canonical prompt.
-  const systemPrompt = systemPromptOverride?.trim()
-    ? systemPromptOverride
+  // A per-request override (the admin tool's custom builder prompt) wins over
+  // the file/test-seam prompt; an empty/whitespace value falls through to the
+  // canonical prompt. The override replaces the canonical prompt's field-quality
+  // guidance, so append BUILDER_CONTRACT_RAIL to re-assert it (the response
+  // schema still enforces the JSON shape either way).
+  const trimmedOverride = systemPromptOverride?.trim();
+  const systemPrompt = trimmedOverride
+    ? `${trimmedOverride}\n\n---\n\n${BUILDER_CONTRACT_RAIL}`
     : getSystemPrompt();
   if (!systemPrompt) {
     throw new Error("Template generator system prompt not loaded");
@@ -1643,4 +1665,4 @@ export async function callGenerateTemplate(
   return generateTemplate(input, signal, prefill, trace, systemPromptOverride);
 }
 
-export { BREVITY_RAIL };
+export { BREVITY_RAIL, BUILDER_CONTRACT_RAIL };

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -212,6 +212,41 @@ describe("templateGen service — OpenRouter integration", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Builder-prompt override + contract rail
+  // -----------------------------------------------------------------------
+  test("a builder-prompt override is sent verbatim with the contract rail appended", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    const customPrompt = "You are a pirate-themed agent builder. Arr.";
+    await generateTemplate(
+      { text: "a trivia agent" },
+      undefined,
+      null,
+      undefined,
+      customPrompt,
+    );
+
+    const req = getLastOpenRouterRequest();
+    const systemMsg = req.body.messages[0].content[0].text as string;
+    // Override first (verbatim), rail appended last so a long custom prompt
+    // can't bury the field-quality requirements.
+    expect(systemMsg.startsWith(customPrompt)).toBe(true);
+    expect(systemMsg).toContain(mod.BUILDER_CONTRACT_RAIL);
+  });
+
+  test("no override → canonical prompt, contract rail NOT appended", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    await generateTemplate({ text: "a trivia agent" });
+
+    const req = getLastOpenRouterRequest();
+    const systemMsg = req.body.messages[0].content[0].text as string;
+    expect(systemMsg).not.toContain(mod.BUILDER_CONTRACT_RAIL);
+  });
+
+  // -----------------------------------------------------------------------
   // Model defaults to anthropic/claude-opus-4.7
   // -----------------------------------------------------------------------
   test("model defaults to anthropic/claude-opus-4.7", async () => {


### PR DESCRIPTION
## Summary

A custom `builderPrompt` (`POST /generations`, admin-only — #276) replaces the canonical template-generator system prompt, including its field-quality guidance ("agentName 1–3 words, no descriptive titles", a fitting emoji, etc.). The strict `response_format` schema still forces the JSON **shape**, but not **quality** or non-emptiness — so a custom prompt that ignores naming could yield a weak name or a blank emoji.

This appends a fixed `BUILDER_CONTRACT_RAIL` to the override (only on the override path — the canonical prompt already carries this). It re-asserts the per-field quality bar the schema can't enforce, and goes **last** so a long custom prompt can't bury it — mirroring how `BREVITY_RAIL` is appended to the generated agent prompt. It deliberately does **not** restate the JSON shape; that's owned by the strict response schema.

## Tests

`template-gen.service.test.ts`:
- a builder-prompt override is sent verbatim with the rail appended last;
- the canonical (no-override) path has no rail.

`tsc` / `eslint` / `prettier` clean; the service test passes locally (it mocks `fetch`, no DB needed).

Follow-up to #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783049602&installation_id=128169237&pr_number=277&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F277&signature=579907ac00116cc9144b16b264ca63c068066adcea5b0adfa6650e1406af7527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Append field-quality contract rail to custom builder prompts in `generateTemplate`
> When a non-empty `systemPromptOverride` is provided to `generateTemplate`, the new `BUILDER_CONTRACT_RAIL` constant is appended after the custom prompt to enforce field-quality requirements (e.g. all JSON fields populated, `agentName` as a 1–3 word handle, exactly one emoji glyph). When no override is given, behavior is unchanged and the rail is not included.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d407eb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom builder prompts now include enhanced field validation and stricter quality enforcement to ensure consistent response schema requirements.

* **Tests**
  * Added coverage for custom builder prompt override behavior and validation enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->