### PR TITLE
feat(agent-templates): enum-constrain generated template tools

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -46,6 +46,18 @@ import {
 // ---------------------------------------------------------------------------
 
 const MAX_CONTENT_LENGTH = 10_000;
+
+/** The only tool values a generated template may use. Mirrors the SUPERPOWERS
+ *  table + field requirements in `data/template-generator-prompt.txt`; the
+ *  json_schema enum on the generate call enforces it at decode time so a custom
+ *  builder prompt can't emit an unmappable tool. */
+export const TEMPLATE_TOOLS = [
+  "Search",
+  "Browse",
+  "Email",
+  "Schedule",
+] as const;
+
 // Concrete OpenRouter model id (not an OpenRouter `@preset/...` alias) so
 // PostHog LLM Analytics can price `$ai_generation` events — `$ai_total_cost_usd`
 // resolves automatically. Override per-environment with `BUILDER_MODEL`.
@@ -1466,7 +1478,10 @@ export async function generateTemplate(
             emoji: { type: "string" },
             description: { type: "string" },
             category: { type: "string" },
-            tools: { type: "array", items: { type: "string" } },
+            tools: {
+              type: "array",
+              items: { type: "string", enum: [...TEMPLATE_TOOLS] },
+            },
           },
           required: [
             "prompt",

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -390,6 +390,16 @@ describe("templateGen service — OpenRouter integration", () => {
         "tools",
       ].sort(),
     );
+
+    // `tools` is enum-constrained so a custom builder prompt can't emit an
+    // unmappable tool — enforced at decode time, not just by the prompt.
+    expect(schema.properties.tools.items.enum).toEqual([...mod.TEMPLATE_TOOLS]);
+    expect([...mod.TEMPLATE_TOOLS]).toEqual([
+      "Search",
+      "Browse",
+      "Email",
+      "Schedule",
+    ]);
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The generator's `response_format` json_schema declared `tools` as `array<string>` with no `enum`, and there's no server-side allowlist — so whatever the model emits is persisted verbatim. The canonical prompt constrains it ("tools — Only from: Search, Browse, Email, Schedule"), but a **custom `builderPrompt`** replaces that guidance, so a custom prompt could emit unmappable tool names.

This adds an `enum` to the `tools` items in the strict json_schema, so the provider enforces the four canonical values **at decode time** — prompt-independent. Fixes the custom-prompt path and hardens the canonical one. A shared `TEMPLATE_TOOLS` constant ties the schema to the canonical set (and the test).

## Tests

`template-gen.service.test.ts`: the strict-schema test now also asserts `tools.items.enum` equals `TEMPLATE_TOOLS` (Search / Browse / Email / Schedule).

`tsc` / `eslint` / `prettier` clean; service test passes (200/200, mocks fetch — no DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783059207&installation_id=128169237&pr_number=278&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F278&signature=7a131fcfdafe1ddda95cd9da1fc0389181dbcfe457b91bdb46b26ee1bc45c197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enum-constrain `tools` field in agent template generation to allowed values
> Restricts the `tools` property in the `generateTemplate` response schema to an enum of `["Search", "Browse", "Email", "Schedule"]` via a new exported `TEMPLATE_TOOLS` constant in [templateGen.ts](https://github.com/ephemeraHQ/convos-backend/pull/278/files#diff-d151881c4ab5cd2005df4016ac6a564fb6094e4ce06b69fbf9529fb70e59148a). The enum is applied to the OpenRouter `response_format` JSON schema with `strict: true`, constraining the model's output at decode time. Tests in [template-gen.service.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/278/files#diff-66e49a396e95bc85161de2c4ab2110569c5666fb2350cd6eca5d8458cbc38b19) assert the enum matches `TEMPLATE_TOOLS` exactly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea12e6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Agent template generation now includes enhanced validation for template tools. Templates are now restricted to use only the following supported tools: Search, Browse, Email, and Schedule. This prevents invalid tool configurations and ensures consistency and reliability across generated templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->