### PR TITLE
feat(agent-templates): enum-constrain generated template category

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -58,6 +58,27 @@ export const TEMPLATE_TOOLS = [
   "Schedule",
 ] as const;
 
+/** The category taxonomy a generated template may use. Single in-repo source for
+ *  the json_schema enum below and the selector/classifier sub-stage prompts (and
+ *  it mirrors the field-requirements line in `data/template-generator-prompt.txt`);
+ *  the enum on the generate call enforces it at decode time so a custom builder
+ *  prompt — or temperature drift — can't invent an off-taxonomy category. */
+export const TEMPLATE_CATEGORIES = [
+  "Sports & Rec",
+  "Travel & Adventures",
+  "Food & Dining",
+  "Events & Occasions",
+  "Hobbies & Interests",
+  "Entertainment & Culture",
+  "Music & Creative",
+  "Kids & Family",
+  "Wellness & Fitness",
+  "Money & Investing",
+  "Work",
+  "Local",
+  "Superpowers",
+] as const;
+
 // Concrete OpenRouter model id (not an OpenRouter `@preset/...` alias) so
 // PostHog LLM Analytics can price `$ai_generation` events — `$ai_total_cost_usd`
 // resolves automatically. Override per-environment with `BUILDER_MODEL`.
@@ -698,7 +719,7 @@ If you find either kind, also produce metadata based on the README + repo:
 - agentName: a creative memorable name derived from the repo (e.g. "garrytan/gbrain" → "GBrain 🧠" style)
 - emoji: single emoji that fits
 - description: 1-2 sentence third-person description
-- category: one of: Sports & Rec, Travel & Adventures, Food & Dining, Events & Occasions, Hobbies & Interests, Entertainment & Culture, Music & Creative, Kids & Family, Wellness & Fitness, Money & Investing, Work, Local, Superpowers
+- category: one of: ${TEMPLATE_CATEGORIES.join(", ")}
 
 Respond with ONLY a JSON object (no markdown fences, no explanation):
 
@@ -1118,7 +1139,7 @@ If passthrough, also produce metadata:
 - agentName: memorable name derived from the content
 - emoji: single emoji that fits
 - description: 1-2 sentence third-person description
-- category: one of: Sports & Rec, Travel & Adventures, Food & Dining, Events & Occasions, Hobbies & Interests, Entertainment & Culture, Music & Creative, Kids & Family, Wellness & Fitness, Money & Investing, Work, Local, Superpowers
+- category: one of: ${TEMPLATE_CATEGORIES.join(", ")}
 
 Respond with ONLY a JSON object (no markdown fences, no explanation):
 
@@ -1477,7 +1498,7 @@ export async function generateTemplate(
             agentName: { type: "string" },
             emoji: { type: "string" },
             description: { type: "string" },
-            category: { type: "string" },
+            category: { type: "string", enum: [...TEMPLATE_CATEGORIES] },
             tools: {
               type: "array",
               items: { type: "string", enum: [...TEMPLATE_TOOLS] },

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -400,6 +400,27 @@ describe("templateGen service — OpenRouter integration", () => {
       "Email",
       "Schedule",
     ]);
+
+    // `category` is likewise enum-constrained so a custom builder prompt (or
+    // temperature drift) can't invent an off-taxonomy category.
+    expect(schema.properties.category.enum).toEqual([
+      ...mod.TEMPLATE_CATEGORIES,
+    ]);
+    expect([...mod.TEMPLATE_CATEGORIES]).toEqual([
+      "Sports & Rec",
+      "Travel & Adventures",
+      "Food & Dining",
+      "Events & Occasions",
+      "Hobbies & Interests",
+      "Entertainment & Culture",
+      "Music & Creative",
+      "Kids & Family",
+      "Wellness & Fitness",
+      "Money & Investing",
+      "Work",
+      "Local",
+      "Superpowers",
+    ]);
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sibling fix to #278 (tools enum) for the `category` field.

The generate `json_schema` left `category: { type: "string" }` freeform while `tools` is enum-constrained. Because a custom `builderPrompt` **replaces** the default system prompt — the only place the category taxonomy is spelled out — the generator invented off-taxonomy categories (observed `Lifestyle & Community` in a custom-prompt run, right alongside the freeform tools #278 fixed).

- **`TEMPLATE_CATEGORIES`** — single in-repo source for the taxonomy.
- **Schema enum** on the generate `category` field — decode-time enforcement a custom prompt or temperature drift can't bypass.
- **Interpolated** the const into the selector + classifier sub-stage prompts so their prose can't drift from the enum.
- Test asserts `schema.properties.category.enum === TEMPLATE_CATEGORIES`, mirroring the tools assertion.

The prose copy in `data/template-generator-prompt.txt` stays (static asset, now advisory since the schema enforces). Governs **new** generations only — existing off-taxonomy rows are separate data cleanup.

typecheck + prettier + eslint clean; service test 46/46.

## Direction

Interim step. The end state is **template categories as a first-class DB entity with proper CRUD** — editable without a code change, and the single source both the generator (this enum) and the dashboard (facet rail + editor datalist) read. The in-code `TEMPLATE_CATEGORIES` const + schema enum is the cheap, decode-safe stopgap until that lands; once categories live in a table, the enum and the worker's list both derive from it instead of a hand-maintained const.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783062996&installation_id=128169237&pr_number=279&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F279&signature=9b4797b3efbf7083bbecdbee2d5dfbc8ec72ba8a2ccc882c372202e2b2abc01e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enum-constrain the `category` field in agent template generation
> Adds a `TEMPLATE_CATEGORIES` constant in [templateGen.ts](https://github.com/ephemeraHQ/convos-backend/pull/279/files#diff-d151881c4ab5cd2005df4016ac6a564fb6094e4ce06b69fbf9529fb70e59148a) listing 13 allowed category strings. The JSON schema sent to OpenRouter now includes an `enum` constraint on the `category` field, so any off-taxonomy value is rejected at decode time. Builder prompt text is also updated to interpolate from this constant, keeping prompts and schema in sync.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4292667.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to template category management for better code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
