### PR TITLE
feat(payments): enforce idempotency-key charset on every ledger write

### DIFF
--- a/src/api/v2/accounts/schemas/shared.ts
+++ b/src/api/v2/accounts/schemas/shared.ts
@@ -1,16 +1,13 @@
 import { z } from "zod";
 
+export { idempotencyKeySchema } from "@/payments/ledger/idempotency-key";
+
 // Per-call cost cap. $1000/call in USD micros. Preserved from the original
 // credits.router.ts schemas to keep request-size sanity bounds in place.
 export const MAX_USD_COST_MICROS = 1_000_000_000n;
 
 // Per-grant credits cap. 1B credits. Fits comfortably under Number.MAX_SAFE_INTEGER.
 export const MAX_GRANT_CREDITS = 1_000_000_000;
-
-// Stripe-style idempotency key: ASCII alphanumeric + dash/underscore, 1-255 chars.
-export const idempotencyKeySchema = z.string().regex(/^[A-Za-z0-9_-]{1,255}$/, {
-  message: "invalid_idempotency_key",
-});
 
 // BigInt-safe integer parser: accepts string or number, returns bigint.
 export const bigintStringOrNumber = z

--- a/src/payments/daily-refill/service.ts
+++ b/src/payments/daily-refill/service.ts
@@ -98,7 +98,7 @@ export async function runDailyRefill(opts?: {
         accountId,
         delta: BigInt(delta),
         reason: LedgerReason.grant,
-        idempotencyKey: `daily_refill:${accountId}:${dayKey}`,
+        idempotencyKey: `daily_refill_${accountId}_${dayKey}`,
         scope: "daily_refill",
         grantKindId: "daily_refill",
         note: `Daily refill to cap ${cap}`,

--- a/src/payments/errors.ts
+++ b/src/payments/errors.ts
@@ -4,7 +4,6 @@ export class GrantKindNotFoundError extends AppError {
   constructor(kind: string) {
     super(404, `Grant kind "${kind}" not found or inactive`, { kind });
     this.name = "GrantKindNotFoundError";
-    Object.setPrototypeOf(this, GrantKindNotFoundError.prototype);
   }
 }
 
@@ -26,7 +25,6 @@ export class InsufficientBalanceError extends AppError {
       },
     );
     this.name = "InsufficientBalanceError";
-    Object.setPrototypeOf(this, InsufficientBalanceError.prototype);
   }
 }
 
@@ -48,6 +46,5 @@ export class IdempotencyMismatchError extends AppError {
       },
     );
     this.name = "IdempotencyMismatchError";
-    Object.setPrototypeOf(this, IdempotencyMismatchError.prototype);
   }
 }

--- a/src/payments/ledger/idempotency-key.ts
+++ b/src/payments/ledger/idempotency-key.ts
@@ -10,6 +10,9 @@ export const idempotencyKeySchema = z.string().regex(IDEMPOTENCY_KEY_REGEX, {
 
 export const assertIdempotencyKey = (key: string): void => {
   if (!IDEMPOTENCY_KEY_REGEX.test(key)) {
-    throw new ValidationError(`invalid_idempotency_key: ${key}`);
+    throw new ValidationError("invalid_idempotency_key", {
+      keyLength: key.length,
+      disallowedChars: [...new Set(key.replace(/[A-Za-z0-9_-]/g, ""))],
+    });
   }
 };

--- a/src/payments/ledger/idempotency-key.ts
+++ b/src/payments/ledger/idempotency-key.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { ValidationError } from "@/utils/errors";
+
+// Stripe-style idempotency key: ASCII alphanumeric + dash/underscore, 1-255 chars.
+export const IDEMPOTENCY_KEY_REGEX = /^[A-Za-z0-9_-]{1,255}$/;
+
+export const idempotencyKeySchema = z.string().regex(IDEMPOTENCY_KEY_REGEX, {
+  message: "invalid_idempotency_key",
+});
+
+export const assertIdempotencyKey = (key: string): void => {
+  if (!IDEMPOTENCY_KEY_REGEX.test(key)) {
+    throw new ValidationError(`invalid_idempotency_key: ${key}`);
+  }
+};

--- a/src/payments/ledger/repository.ts
+++ b/src/payments/ledger/repository.ts
@@ -2,6 +2,7 @@ import { Prisma, type CreditLedger, type LedgerReason } from "@prisma/client";
 import { prisma } from "@/utils/prisma";
 import { IdempotencyMismatchError } from "../errors";
 import type { GrantKindId, HistoryCursor, LedgerScope } from "../types";
+import { assertIdempotencyKey } from "./idempotency-key";
 
 export interface ApplyDeltaInput {
   accountId: string;
@@ -169,6 +170,7 @@ export const applyDeltaWithTx = async (
   tx: TxClient,
   input: ApplyDeltaInput,
 ): Promise<ApplyDeltaResult> => {
+  assertIdempotencyKey(input.idempotencyKey);
   const before = await lockOrCreateBalance(tx, input.accountId);
   const after = before + input.delta;
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -6,7 +6,7 @@ export class AppError extends Error {
   ) {
     super(message);
     this.name = "AppError";
-    Object.setPrototypeOf(this, AppError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { getBalance } from "@/payments";
 import { runDailyRefill } from "@/payments/daily-refill/service";
 import { ymdUtc } from "@/payments/daily-refill/utc";
+import { idempotencyKeySchema } from "@/payments/ledger/idempotency-key";
 import { applyDelta } from "@/payments/ledger/repository";
 import { prisma } from "@/utils/prisma";
 
@@ -80,7 +81,7 @@ async function seedRateLimitAnchor(
       accountId,
       delta: 100n,
       reason: LedgerReason.grant,
-      idempotencyKey: `daily_refill:${accountId}:${ymdUtc(createdAt)}-seed`,
+      idempotencyKey: `daily_refill_${accountId}_${ymdUtc(createdAt)}-seed`,
       grantKindId: "daily_refill",
       createdAt,
     },
@@ -165,7 +166,7 @@ describe("runDailyRefill — top-up math", () => {
     await applyDelta({
       accountId,
       delta: 40n,
-      idempotencyKey: `seed-40:${accountId}`,
+      idempotencyKey: `seed-40_${accountId}`,
       reason: LedgerReason.adjust,
       scope: "grant",
     });
@@ -177,12 +178,34 @@ describe("runDailyRefill — top-up math", () => {
     expect(entry!.newBalance).toBe(100n);
   });
 
+  test("emitted daily_refill key conforms to the idempotency charset", async () => {
+    const accountId = await seedAccount();
+    await applyDelta({
+      accountId,
+      delta: 40n,
+      idempotencyKey: `seed-conform_${accountId}`,
+      reason: LedgerReason.adjust,
+      scope: "grant",
+    });
+    await runDailyRefill({ now: NOW });
+    const row = await prisma.creditLedger.findFirst({
+      where: { accountId, grantKindId: "daily_refill" },
+    });
+    expect(row).not.toBeNull();
+    expect(row!.idempotencyKey).toBe(
+      `daily_refill_${accountId}_${ymdUtc(NOW)}`,
+    );
+    expect(idempotencyKeySchema.safeParse(row!.idempotencyKey).success).toBe(
+      true,
+    );
+  });
+
   test("balance at cap → noOp (no ledger row added)", async () => {
     const accountId = await seedAccount();
     await applyDelta({
       accountId,
       delta: 100n,
-      idempotencyKey: `seed-100:${accountId}`,
+      idempotencyKey: `seed-100_${accountId}`,
       reason: LedgerReason.adjust,
       scope: "grant",
     });
@@ -198,7 +221,7 @@ describe("runDailyRefill — top-up math", () => {
     await applyDelta({
       accountId,
       delta: 150n,
-      idempotencyKey: `seed-150:${accountId}`,
+      idempotencyKey: `seed-150_${accountId}`,
       reason: LedgerReason.adjust,
       scope: "grant",
     });
@@ -215,14 +238,14 @@ describe("runDailyRefill — top-up math", () => {
     await applyDelta({
       accountId,
       delta: 10n,
-      idempotencyKey: `seed-pos:${accountId}`,
+      idempotencyKey: `seed-pos_${accountId}`,
       reason: LedgerReason.adjust,
       scope: "grant",
     });
     await applyDelta({
       accountId,
       delta: -50n,
-      idempotencyKey: `seed-neg:${accountId}`,
+      idempotencyKey: `seed-neg_${accountId}`,
       reason: LedgerReason.adjust,
       scope: "grant",
     });
@@ -308,7 +331,7 @@ describe("runDailyRefill — idempotency", () => {
     await applyDelta({
       accountId,
       delta: -60n,
-      idempotencyKey: `drain:${accountId}`,
+      idempotencyKey: `drain_${accountId}`,
       reason: LedgerReason.adjust,
       scope: "grant",
     });
@@ -324,7 +347,7 @@ describe("runDailyRefill — idempotency", () => {
     });
 
     // Second run: sees balance=40n, headroom=60, calls
-    //   grant({ credits: 60, idempotencyKey: "daily_refill:<accountId>:2026-05-15" })
+    //   grant({ credits: 60, idempotencyKey: "daily_refill_<accountId>_2026-05-15" })
     // The stored row has delta=100 (from the first run). The mismatch between
     // requested delta (60) and stored delta (100) triggers IdempotencyMismatchError,
     // which the service catches and logs in errors[]. Balance stays at 40n.
@@ -355,10 +378,10 @@ describe("runDailyRefill — failure isolation", () => {
     // IMPORTANT: createdAt is set to yesterday so the global rate-limit
     // query (MAX createdAt WHERE grantKindId='daily_refill' >= startOfTodayUtc(NOW))
     // does NOT short-circuit the batch. The date-keyed idempotency key
-    // ('daily_refill:<accountId>:2026-05-15') still collides with what the
+    // ('daily_refill_<accountId>_2026-05-15') still collides with what the
     // service generates for today, triggering the mismatch error.
     const dayKey = ymdUtc(NOW);
-    const collidingKey = `daily_refill:${collidingAccountId}:${dayKey}`;
+    const collidingKey = `daily_refill_${collidingAccountId}_${dayKey}`;
     await prisma.creditLedger.create({
       data: {
         accountId: collidingAccountId,

--- a/tests/payments/idempotency-enforcement.integration.test.ts
+++ b/tests/payments/idempotency-enforcement.integration.test.ts
@@ -35,6 +35,10 @@ describe("idempotency-key enforcement at applyDelta", () => {
     ).rejects.toThrow(ValidationError);
     const rows = await prisma.creditLedger.findMany({ where: { accountId } });
     expect(rows.length).toBe(0);
+    const balanceRow = await prisma.userCredits.findUnique({
+      where: { accountId },
+    });
+    expect(balanceRow).toBeNull();
   });
 
   test("an underscore key writes successfully", async () => {

--- a/tests/payments/idempotency-enforcement.integration.test.ts
+++ b/tests/payments/idempotency-enforcement.integration.test.ts
@@ -1,0 +1,53 @@
+import { LedgerReason } from "@prisma/client";
+import { afterEach, describe, expect, test } from "vitest";
+import { applyDelta } from "@/payments/ledger/repository";
+import { ValidationError } from "@/utils/errors";
+import { prisma } from "@/utils/prisma";
+
+const tracker: string[] = [];
+
+afterEach(async () => {
+  for (const accountId of tracker) {
+    await prisma.creditLedger.deleteMany({ where: { accountId } });
+    await prisma.userCredits.deleteMany({ where: { accountId } });
+    await prisma.account.deleteMany({ where: { id: accountId } });
+  }
+  tracker.length = 0;
+});
+
+async function seedAccount(): Promise<string> {
+  const acct = await prisma.account.create({ data: {} });
+  tracker.push(acct.id);
+  return acct.id;
+}
+
+describe("idempotency-key enforcement at applyDelta", () => {
+  test("a colon key throws ValidationError and writes no ledger row", async () => {
+    const accountId = await seedAccount();
+    await expect(
+      applyDelta({
+        accountId,
+        delta: 10n,
+        idempotencyKey: `bad:${accountId}:key`,
+        reason: LedgerReason.adjust,
+        scope: "grant",
+      }),
+    ).rejects.toThrow(ValidationError);
+    const rows = await prisma.creditLedger.findMany({ where: { accountId } });
+    expect(rows.length).toBe(0);
+  });
+
+  test("an underscore key writes successfully", async () => {
+    const accountId = await seedAccount();
+    const result = await applyDelta({
+      accountId,
+      delta: 10n,
+      idempotencyKey: `good_${accountId}_key`,
+      reason: LedgerReason.adjust,
+      scope: "grant",
+    });
+    expect(result.replayed).toBe(false);
+    const rows = await prisma.creditLedger.findMany({ where: { accountId } });
+    expect(rows.length).toBe(1);
+  });
+});

--- a/tests/payments/idempotency-key.unit.test.ts
+++ b/tests/payments/idempotency-key.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import {
+  assertIdempotencyKey,
+  idempotencyKeySchema,
+} from "@/payments/ledger/idempotency-key";
+import { ValidationError } from "@/utils/errors";
+
+const VALID = [
+  "a_b-C9",
+  "61ceb68c-465b-4b1b-8da4-cefc74bc21cf",
+  "signup_bonus_61ceb68c-465b-4b1b-8da4-cefc74bc21cf",
+  "daily_refill_61ceb68c-465b-4b1b-8da4-cefc74bc21cf_2024-01-15",
+  "a".repeat(255),
+];
+
+const INVALID = [
+  "daily_refill:acct:2026-06-03",
+  "has space",
+  "key.dot",
+  "key/slash",
+  "",
+  "a".repeat(256),
+];
+
+describe("idempotency key charset", () => {
+  test.each(VALID)("accepts %s", (key) => {
+    expect(() => {
+      assertIdempotencyKey(key);
+    }).not.toThrow();
+    expect(idempotencyKeySchema.safeParse(key).success).toBe(true);
+  });
+
+  test.each(INVALID)("rejects %s", (key) => {
+    expect(() => {
+      assertIdempotencyKey(key);
+    }).toThrow(ValidationError);
+    expect(idempotencyKeySchema.safeParse(key).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the "Item 1" follow-up from #275: the canonical idempotency-key charset (`^[A-Za-z0-9_-]{1,255}$`) was only validated on externally-supplied HTTP `Idempotency-Key` headers. Internally-constructed keys bypassed it — the daily-refill job emitted `daily_refill:${acct}:${day}` (a `:`, outside the charset). This enforces the charset on every CreditLedger write and fixes the one offending emitter.

- **Canonical home** — new `src/payments/ledger/idempotency-key.ts` (`IDEMPOTENCY_KEY_REGEX`, `idempotencyKeySchema`, `assertIdempotencyKey`). `schemas/shared.ts` re-exports the schema (removes the `payments → api` layering inversion; the two HTTP handlers keep working unchanged).
- **Enforcement** — `assertIdempotencyKey(input.idempotencyKey)` as the first statement of `applyDeltaWithTx`, the single choke point all writes flow through (`grant`/`consume`/`adjust`/daily-refill). A bad key throws `ValidationError` before any DB work — no partial state. DRY: one guard, not duplicated.
- **daily_refill key** — `daily_refill:…:…` → `daily_refill_…_…`. **Forward-only**: the daily rate-limit keys off `grantKindId`+`createdAt`, not the key, so historical `:` rows and new `_` rows coexist with no double-grant. No backfill.
- **Drive-by fix** — uncovered a latent base-class bug: `AppError`'s constructor did `Object.setPrototypeOf(this, AppError.prototype)`, which clobbered every subclass's prototype so `instanceof <Subclass>` was always false. Changed to `new.target.prototype` (fixes `ValidationError` + the 3 payments error subclasses); `instanceof AppError` still holds at all ~8 production sites. Removed the now-redundant per-subclass `setPrototypeOf` calls. The two direct-`Error` subclasses (`LedgerFloorBreachError`, `SubscriptionAccountMismatchError`) correctly keep theirs.

### Scope / safety
- Untouched: `AgentTemplateGeneration` UUID keys (`IDEMPOTENCY_KEY_UUID_RE`), AppleReceipt keys — separate key families.
- Independent of #275; that branch's `signup_bonus_<accountId>` already conforms, so merge order doesn't matter.

## Test Plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors on touched files
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 808 passed, 1 skipped (the 1 failure is a pre-existing unrelated wall-clock flake in `agent-templates.executor.test.ts` "timeout race" — passes 16/16 on isolated re-run)
- Coverage: charset accept/reject unit (`idempotency-key.unit.test.ts`); emitted-key conformance (daily-refill integration); enforcement throws + writes no row (`idempotency-enforcement.integration.test.ts`); `errors.unit.test.ts` proves the AppError hierarchy intact

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783067186&installation_id=128169237&pr_number=280&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F280&signature=d7e585b3d1f8ad82045ca9c7f838e2f2efb7a59023d5f9070a6ceaf3850582d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce ASCII alphanumeric/dash/underscore charset on idempotency keys for all ledger writes
> - Adds [`idempotency-key.ts`](https://github.com/ephemeraHQ/convos-backend/pull/280/files#diff-664be1d611998d302bcc18aa47a17058316c208050117ebcc50bff6094db7c74) defining `IDEMPOTENCY_KEY_REGEX`, `idempotencyKeySchema`, and `assertIdempotencyKey()` which throws `ValidationError` for keys outside the allowed charset (ASCII alphanumeric, `-`, `_`, 1–255 chars).
> - Calls `assertIdempotencyKey()` at the start of `applyDeltaWithTx` in [`ledger/repository.ts`](https://github.com/ephemeraHQ/convos-backend/pull/280/files#diff-69d0da1657814118e710df59d6d2f101ee40ca5c083afe604005bc9e5c630522), rejecting invalid keys before any balance lock or DB write.
> - Changes daily-refill idempotency key format in [`daily-refill/service.ts`](https://github.com/ephemeraHQ/convos-backend/pull/280/files#diff-8679ceae2d84b5f2aa35c463964294c46686a1bd13f295d85b31e27ffcfb2f77) from colon-separated (`daily_refill:<accountId>:<dayKey>`) to underscore-separated (`daily_refill_<accountId>_<dayKey>`) to comply with the new charset.
> - Fixes `AppError` prototype assignment to use `new.target.prototype`, correcting `instanceof` checks for error subclasses.
> - Risk: any existing caller passing colon-containing or otherwise non-conforming idempotency keys will now receive a `ValidationError` instead of silently writing to the ledger.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b667cdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced stricter idempotency key validation across payment flows, preventing malformed keys and rejected or duplicated operations.
  * Applied validation earlier in ledger processing and adjusted daily-refill idempotency key handling to match the new allowed format.
  * Improved error subclassing so payment errors report more consistent behavior.

* **Tests**
  * Added unit and integration tests covering idempotency-key validation and daily-refill idempotency behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmtplabs/convos-backend/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->