### PR TITLE
fix(subscriptions): ship Apple root CA certs in the bundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { pinoMiddleware } from "./middleware/pino";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
 import healthcheckRouter from "./routes/healthcheck";
 import { wellKnownRouter } from "./routes/well-known";
+import { assertAppleRootCertsPresent } from "./subscriptions/jws-verifier";
 import { validateJWTKeys } from "./utils/jwt";
 import logger from "./utils/logger";
 
@@ -66,6 +67,22 @@ app.use(noRouteMiddleware);
 app.use(errorHandlerMiddleware);
 
 const port = process.env.PORT || 4000;
+
+// Fail fast at boot if the Apple root CA certs didn't ship with the bundle.
+// These are read from dist/certs at runtime (copied there by tsup's onSuccess
+// hook). If the asset pipeline regresses, refuse to start rather than coming
+// up "healthy" and 500ing lazily on the first Apple verify / S2S request —
+// which is what previously masked a missing-cert bug as a signature error.
+try {
+  assertAppleRootCertsPresent();
+  logger.info("Apple root CA certs present");
+} catch (error) {
+  logger.error(
+    { error },
+    "Apple root CA certs missing from bundle — refusing to start",
+  );
+  process.exit(1);
+}
 
 // Validate JWT keys at startup before starting the server
 validateJWTKeys()

--- a/src/subscriptions/jws-verifier.ts
+++ b/src/subscriptions/jws-verifier.ts
@@ -32,7 +32,7 @@ const loadAppleRootCert = (file: string): Buffer => {
     // missing the verifier can't be built at all — fail loud with a config error
     // instead of letting a raw ENOENT surface as a generic "Invalid signed
     // transaction" 400, which is what masked this as a signature bug for weeks.
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       throw new AppError(
         500,
         `Apple root CA cert missing from bundle: ${path.join(CERT_DIR, file)}`,

--- a/src/subscriptions/jws-verifier.ts
+++ b/src/subscriptions/jws-verifier.ts
@@ -22,10 +22,27 @@ const CERT_DIR = path.join(
   "certs",
 );
 
-const loadAppleRootCerts = () => [
-  readFileSync(path.join(CERT_DIR, "AppleRootCA-G2.cer")),
-  readFileSync(path.join(CERT_DIR, "AppleRootCA-G3.cer")),
-];
+const CERT_FILES = ["AppleRootCA-G2.cer", "AppleRootCA-G3.cer"] as const;
+
+const loadAppleRootCert = (file: string): Buffer => {
+  try {
+    return readFileSync(path.join(CERT_DIR, file));
+  } catch (err) {
+    // The certs are copied into the bundle by tsup's onSuccess hook. If they're
+    // missing the verifier can't be built at all — fail loud with a config error
+    // instead of letting a raw ENOENT surface as a generic "Invalid signed
+    // transaction" 400, which is what masked this as a signature bug for weeks.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      throw new AppError(
+        500,
+        `Apple root CA cert missing from bundle: ${path.join(CERT_DIR, file)}`,
+      );
+    }
+    throw err;
+  }
+};
+
+const loadAppleRootCerts = () => CERT_FILES.map(loadAppleRootCert);
 
 const resolveEnvironment = () => {
   const raw = process.env.APPLE_ENV?.trim();

--- a/src/subscriptions/jws-verifier.ts
+++ b/src/subscriptions/jws-verifier.ts
@@ -44,6 +44,18 @@ const loadAppleRootCert = (file: string): Buffer => {
 
 const loadAppleRootCerts = () => CERT_FILES.map(loadAppleRootCert);
 
+/**
+ * Boot-time assertion that the Apple root CA certs shipped with the bundle.
+ * Called from startup so a broken asset pipeline (certs not copied into
+ * dist/certs) crashes the process before it accepts traffic — rather than
+ * letting the API come up "healthy" and 500 lazily on the first Apple verify
+ * / S2S request. Independent of Apple env config (bundle id etc.): this only
+ * checks the bundled assets, so it runs and means the same thing everywhere.
+ */
+export const assertAppleRootCertsPresent = (): void => {
+  loadAppleRootCerts();
+};
+
 const resolveEnvironment = () => {
   const raw = process.env.APPLE_ENV?.trim();
   const isProd = isProductionEnv();

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,3 +1,4 @@
+import { cp } from "node:fs/promises";
 import { tsconfigPathsPlugin } from "esbuild-plugin-tsconfig-paths";
 import { defineConfig } from "tsup";
 
@@ -19,4 +20,12 @@ export default defineConfig({
   // Resolve tsconfig path aliases (@/ and @prisma-zod/*) so they are inlined
   // into the bundle rather than left as unresolvable bare specifiers at runtime.
   esbuildPlugins: [tsconfigPathsPlugin()],
+  // Copy the Apple root CA certs into the bundle. The JWS verifier resolves them
+  // relative to `import.meta.url`, which in the bundle is `dist/index.js` → it
+  // reads `dist/certs/`. tsup only emits JS, so without this step the deployed
+  // image is missing the certs and every Apple verify / S2S notification fails
+  // with `ENOENT: .../dist/certs/AppleRootCA-G2.cer`.
+  async onSuccess() {
+    await cp("src/subscriptions/certs", "dist/certs", { recursive: true });
+  },
 });


### PR DESCRIPTION
## Problem

Backend logs (otr-dev) on the Apple S2S webhook:

```
Apple S2S notification JWS verification failed
ENOENT: no such file or directory, open '/app/dist/certs/AppleRootCA-G2.cer'
```

The JWS verifier (`src/subscriptions/jws-verifier.ts`) resolves `CERT_DIR` relative to `import.meta.url` and `readFileSync`s the two `.cer` files at verifier init. In the tsup bundle `import.meta.url` is `dist/index.js`, so it reads `dist/certs/` — but tsup only emits JS and never copies the certs, and the Dockerfile ships `dist/` verbatim. Result: the deployed image is missing the certs.

This kills **both** Apple write paths, since they share `getVerifier()`:
- iOS `POST /api/v2/accounts/.../subscription/verify` (primary write on first purchase)
- Apple S2S webhook `POST /api/v2/webhooks/apple/ssn` (renewals, cancellations, refunds)

It was invisible in dev because `tsx watch` resolves `import.meta.url` to `src/subscriptions/jws-verifier.ts`, so `CERT_DIR` → `src/subscriptions/certs`, which exists. The gap is **dist-only**.

## Fix

Copy `src/subscriptions/certs` → `dist/certs` in tsup's `onSuccess` hook so the certs ship with the bundle. Keeps the asset step in the build config and leaves the security-critical verifier code untouched.

## Verification

`pnpm build` now emits:

```
dist/certs/AppleRootCA-G2.cer   (1430 B)
dist/certs/AppleRootCA-G3.cer   (583 B)
```

Ordering holds: `clean: true` wipes `dist`, tsup emits JS, then `onSuccess` re-copies the certs.

## Notes / follow-ups (not in this PR)

- **Regression?** Since dev always worked via the `src/` path, the likely truth is server-side Apple verify has *never* succeeded in a deployed env — an original gap, not a regression. Worth confirming if needed.
- Optional: make `loadAppleRootCerts()` surface `ENOENT` distinctly instead of a generic 400 "Invalid signed transaction", so a future missing-asset failure reads as a config error rather than a bad signature.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783083212&installation_id=128169237&pr_number=281&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F281&signature=9e575429da0a3a02ef1e2d228270d0877204192892607e3fe6073d74f460b063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship Apple root CA certs in the bundle and verify their presence at startup
> - Copies `src/subscriptions/certs` to `dist/certs` during the build step via a new `onSuccess` hook in [tsup.config.ts](https://github.com/ephemeraHQ/convos-backend/pull/281/files#diff-8fed899bdbc24789a7bb4973574e624ed6207c6ce572338bc3c3e117672b2a20).
> - Adds `assertAppleRootCertsPresent` in [jws-verifier.ts](https://github.com/ephemeraHQ/convos-backend/pull/281/files#diff-ba97d161a549202f2ef5b83e8e3e3f1980e1df19c6f017e5ba3c62cef68e4115), called at boot time; the process exits with code 1 if certs are missing.
> - `loadAppleRootCert` now throws an `AppError(500)` on `ENOENT` instead of surfacing a raw file-system error.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #281 opened
>
> - Relaxed TypeScript type assertion in error handling for `loadAppleRootCert` utility [0e226e0]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06614c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing Apple root certificates, with clearer error messages and proper HTTP status codes. Missing certificate files now provide specific diagnostic information instead of generic verification failures.

* **Chores**
  * Build process updated to automatically copy required root certificates into distribution packages, ensuring certificate files are available at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->