### PR TITLE
fix(subscriptions): verify Apple receipts against both environments (Production + Sandbox)

### DIFF
--- a/src/subscriptions/jws-verifier.ts
+++ b/src/subscriptions/jws-verifier.ts
@@ -4,10 +4,13 @@ import { fileURLToPath } from "node:url";
 import {
   Environment,
   SignedDataVerifier,
+  VerificationException,
+  VerificationStatus,
   type JWSTransactionDecodedPayload,
   type ResponseBodyV2DecodedPayload,
 } from "@apple/app-store-server-library";
 import { AppError } from "@/utils/errors";
+import logger from "@/utils/logger";
 
 // Read NODE_ENV dynamically (not from the cached `isProductionEnv()` config
 // constant) so the prod-only guard below stays testable. NODE_ENV doesn't
@@ -120,47 +123,109 @@ export type VerifierConfig = {
   appAppleId?: number;
 };
 
-export const buildVerifierConfig = (): VerifierConfig => {
-  const environment = resolveEnvironment();
-  return {
-    rootCertificates: loadAppleRootCerts(),
-    enableOnlineChecks: environment === Environment.PRODUCTION,
-    environment,
-    bundleId: resolveBundleId(),
-    appAppleId:
-      environment === Environment.SANDBOX ? undefined : resolveAppAppleId(),
-  };
-};
+const buildVerifierConfigForEnvironment = (
+  environment: Environment,
+): VerifierConfig => ({
+  rootCertificates: loadAppleRootCerts(),
+  // Online OCSP revocation checks only for Production. Sandbox/LocalTesting
+  // verify the chain offline against the signed date — Apple's sandbox OCSP
+  // responders are unreliable, and TestFlight receipts must verify without
+  // depending on them.
+  enableOnlineChecks: environment === Environment.PRODUCTION,
+  environment,
+  bundleId: resolveBundleId(),
+  // appAppleId is required to verify Production receipts but must be omitted
+  // for Sandbox (the library rejects a Sandbox receipt that carries one).
+  appAppleId:
+    environment === Environment.SANDBOX ? undefined : resolveAppAppleId(),
+});
 
-let cachedVerifier: SignedDataVerifier | null = null;
+export const buildVerifierConfig = (): VerifierConfig =>
+  buildVerifierConfigForEnvironment(resolveEnvironment());
 
-export const getVerifier = () => {
-  if (cachedVerifier) return cachedVerifier;
-  const cfg = buildVerifierConfig();
-  cachedVerifier = new SignedDataVerifier(
+// One cached verifier per Apple environment. We may need both: the configured
+// primary plus the opposite one for the fallback below.
+const verifierCache = new Map<Environment, SignedDataVerifier>();
+
+// Test override. When set, it's used directly with no environment fallback —
+// tests inject a single LOCAL_TESTING verifier and assert exact-environment
+// behavior, which the fallback would otherwise mask.
+let testVerifier: SignedDataVerifier | null = null;
+
+const getVerifierForEnvironment = (
+  environment: Environment,
+): SignedDataVerifier => {
+  const cached = verifierCache.get(environment);
+  if (cached) return cached;
+  const cfg = buildVerifierConfigForEnvironment(environment);
+  const verifier = new SignedDataVerifier(
     cfg.rootCertificates,
     cfg.enableOnlineChecks,
     cfg.environment,
     cfg.bundleId,
     cfg.appAppleId,
   );
-  return cachedVerifier;
+  verifierCache.set(environment, verifier);
+  return verifier;
 };
 
+export const getVerifier = (): SignedDataVerifier =>
+  testVerifier ?? getVerifierForEnvironment(resolveEnvironment());
+
 export const resetVerifierForTests = () => {
-  cachedVerifier = null;
+  testVerifier = null;
+  verifierCache.clear();
 };
 
 export const setVerifierForTests = (verifier: SignedDataVerifier) => {
-  cachedVerifier = verifier;
+  testVerifier = verifier;
 };
 
-export const verifyAndDecodeNotification = async (
+// Production receipts and Sandbox (TestFlight) receipts can both reach the same
+// backend: a real purchase is Production-signed, a TestFlight purchase is
+// Sandbox-signed. A verifier configured for one rejects the other with
+// INVALID_ENVIRONMENT *after* the cert chain verifies. So we try the configured
+// environment first and, only on INVALID_ENVIRONMENT, retry against the other —
+// Apple's recommended "verify with production, retry with sandbox" pattern.
+const FALLBACK_ENVIRONMENT: Partial<Record<Environment, Environment>> = {
+  [Environment.PRODUCTION]: Environment.SANDBOX,
+  [Environment.SANDBOX]: Environment.PRODUCTION,
+};
+
+const isInvalidEnvironment = (err: unknown): boolean =>
+  err instanceof VerificationException &&
+  err.status === VerificationStatus.INVALID_ENVIRONMENT;
+
+const verifyWithEnvironmentFallback = async <T>(
+  op: (verifier: SignedDataVerifier) => Promise<T>,
+): Promise<T> => {
+  // A test-injected verifier is an explicit override — no fallback.
+  if (testVerifier) return op(testVerifier);
+
+  const primary = resolveEnvironment();
+  try {
+    return await op(getVerifierForEnvironment(primary));
+  } catch (err) {
+    const alternate = FALLBACK_ENVIRONMENT[primary];
+    if (!alternate || !isInvalidEnvironment(err)) throw err;
+    logger.info(
+      { primary, alternate },
+      "apple.verify.environment_fallback — receipt signed for the alternate environment; retrying",
+    );
+    return op(getVerifierForEnvironment(alternate));
+  }
+};
+
+export const verifyAndDecodeNotification = (
   signedPayload: string,
 ): Promise<ResponseBodyV2DecodedPayload> =>
-  getVerifier().verifyAndDecodeNotification(signedPayload);
+  verifyWithEnvironmentFallback((verifier) =>
+    verifier.verifyAndDecodeNotification(signedPayload),
+  );
 
-export const verifyAndDecodeTransaction = async (
+export const verifyAndDecodeTransaction = (
   signedTransactionInfo: string,
 ): Promise<JWSTransactionDecodedPayload> =>
-  getVerifier().verifyAndDecodeTransaction(signedTransactionInfo);
+  verifyWithEnvironmentFallback((verifier) =>
+    verifier.verifyAndDecodeTransaction(signedTransactionInfo),
+  );

--- a/tests/subscriptions/jws-verifier-fallback.test.ts
+++ b/tests/subscriptions/jws-verifier-fallback.test.ts
@@ -1,0 +1,102 @@
+import type { Environment } from "@apple/app-store-server-library";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+// Replace the Apple SignedDataVerifier with a stub whose behavior depends on
+// the environment it was constructed for: a Production-configured verifier
+// rejects with INVALID_ENVIRONMENT (as it would for a Sandbox/TestFlight
+// receipt), while a Sandbox-configured verifier accepts. This lets us exercise
+// the environment-fallback path without real Apple-signed receipts. The real
+// Environment / VerificationException / VerificationStatus exports are kept.
+vi.mock("@apple/app-store-server-library", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const { Environment, VerificationException, VerificationStatus } = actual as {
+    Environment: { PRODUCTION: Environment };
+    VerificationException: new (status: number) => Error;
+    VerificationStatus: { INVALID_ENVIRONMENT: number };
+  };
+
+  class FakeSignedDataVerifier {
+    constructor(
+      _certs: unknown,
+      _online: boolean,
+      readonly environment: Environment,
+    ) {}
+
+    private decode(signed: string, kind: "tx" | "notif") {
+      if (this.environment === Environment.PRODUCTION) {
+        // Chain verified, but the receipt was signed for another environment.
+        throw new VerificationException(VerificationStatus.INVALID_ENVIRONMENT);
+      }
+      return kind === "tx"
+        ? { transactionId: signed, environment: "Sandbox" }
+        : { notificationUUID: signed, data: { environment: "Sandbox" } };
+    }
+
+    verifyAndDecodeTransaction(signed: string) {
+      return Promise.resolve(this.decode(signed, "tx"));
+    }
+
+    verifyAndDecodeNotification(signed: string) {
+      return Promise.resolve(this.decode(signed, "notif"));
+    }
+  }
+
+  return { ...actual, SignedDataVerifier: FakeSignedDataVerifier };
+});
+
+// Imported after the mock is registered (vi.mock is hoisted).
+const { resetVerifierForTests, verifyAndDecodeTransaction } =
+  await import("@/subscriptions/jws-verifier");
+
+type EnvSnapshot = Record<
+  "APPLE_ENV" | "APPLE_BUNDLE_ID" | "APPLE_APP_APPLE_ID" | "NODE_ENV",
+  string | undefined
+>;
+
+const snapshot = (): EnvSnapshot => ({
+  APPLE_ENV: process.env.APPLE_ENV,
+  APPLE_BUNDLE_ID: process.env.APPLE_BUNDLE_ID,
+  APPLE_APP_APPLE_ID: process.env.APPLE_APP_APPLE_ID,
+  NODE_ENV: process.env.NODE_ENV,
+});
+
+const restore = (snap: EnvSnapshot) => {
+  for (const [k, v] of Object.entries(snap)) {
+    if (v === undefined) Reflect.deleteProperty(process.env, k);
+    else process.env[k] = v;
+  }
+};
+
+describe("verifyAndDecodeTransaction — environment fallback", () => {
+  let snap: EnvSnapshot;
+
+  beforeEach(() => {
+    snap = snapshot();
+    process.env.APPLE_BUNDLE_ID = "app.convos.test";
+    process.env.APPLE_APP_APPLE_ID = "6747291340";
+    resetVerifierForTests();
+  });
+
+  afterEach(() => {
+    restore(snap);
+    resetVerifierForTests();
+  });
+
+  test("Production primary falls back to Sandbox on INVALID_ENVIRONMENT", async () => {
+    process.env.APPLE_ENV = "production";
+    // Production verifier throws INVALID_ENVIRONMENT; fallback to Sandbox wins.
+    const decoded = await verifyAndDecodeTransaction("sandbox.receipt");
+    expect(decoded.transactionId).toBe("sandbox.receipt");
+    expect(decoded.environment).toBe("Sandbox");
+  });
+
+  test("Sandbox primary verifies directly with no fallback", async () => {
+    process.env.APPLE_ENV = "sandbox";
+    const decoded = await verifyAndDecodeTransaction("sandbox.receipt");
+    expect(decoded.transactionId).toBe("sandbox.receipt");
+  });
+});


### PR DESCRIPTION
## Problem

After the cert fix (#281), otr-prod still 400s every verify with:

```
JWS transaction verification failed
errName: VerificationException
errStatus: 4   // = INVALID_ENVIRONMENT
pathname: /api/v2/accounts/me/subscription/verify
```

`errStatus: 4` is `INVALID_ENVIRONMENT` (confirmed against the installed lib, `jws_verification.js:409`) — **not** a cert/signature problem. The chain verifies fine; the receipt was just signed for a *different Apple environment* than the verifier is configured for.

- **otr-dev** → `APPLE_ENV=sandbox` → SANDBOX verifier. TestFlight purchases are Sandbox-signed → ✅
- **otr-prod** → `NODE_ENV=production`, `APPLE_ENV` unset/`production` → PRODUCTION verifier. But pre-launch testing is via **TestFlight, which Apple signs as Sandbox** → Sandbox receipt vs PRODUCTION verifier → `INVALID_ENVIRONMENT` → ❌

This isn't just a pre-launch quirk: at GA, real App Store purchases are **Production**-signed and TestFlight testers stay **Sandbox**-signed, and both reach the same backend. A single fixed environment can't serve both.

## Fix

Apple's recommended pattern — *"verify with production, retry with sandbox."* Cache a verifier per environment; try the configured (`APPLE_ENV`) environment first, and **only on `INVALID_ENVIRONMENT`** retry against the other (Production↔Sandbox).

- `APPLE_ENV` stays the **preferred/primary** environment — the fallback only kicks in for a genuine cross-environment receipt, so there's no behavior change for correctly-signed receipts.
- `enableOnlineChecks` stays per-environment (OCSP for Production, offline for Sandbox) — each cached verifier keeps its correct config.
- `LOCAL_TESTING` has no Production/Sandbox counterpart → never falls back.
- A test-injected verifier (`setVerifierForTests`) bypasses the fallback entirely, preserving the existing exact-environment assertions.
- Logs `apple.verify.environment_fallback` (info) when the fallback fires — useful signal that prod is serving cross-env receipts.

## Result

otr-prod can verify TestFlight (Sandbox) receipts **and** real (Production) purchases on the same deploy, through launch and after.

## Tests

- New `tests/subscriptions/jws-verifier-fallback.test.ts` — mocks the Apple verifier to prove: Production-primary falls back to Sandbox on `INVALID_ENVIRONMENT`; Sandbox-primary verifies directly with no fallback.
- Existing 17 verifier tests + full subscriptions suite (100 tests) green; `pnpm check` clean.

## Note
No env-var change required to fix prod — but you can drop the otr-prod `APPLE_ENV=sandbox` crutch (if it was set) since the backend now handles both regardless.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783098196&installation_id=128169237&pr_number=282&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F282&signature=03c3026e4bd00a7f6e2cc89c13124ea31a4735c8c99ef9383cb706d46edf3291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry Apple receipt verification against the alternate environment on `INVALID_ENVIRONMENT`
> - Adds `verifyWithEnvironmentFallback` in [jws-verifier.ts](https://github.com/ephemeraHQ/convos-backend/pull/282/files#diff-ba97d161a549202f2ef5b83e8e3e3f1980e1df19c6f017e5ba3c62cef68e4115) that retries `verifyAndDecodeNotification` and `verifyAndDecodeTransaction` against the opposite Apple environment (Production↔Sandbox) when the primary verification fails with `INVALID_ENVIRONMENT`.
> - Replaces the single cached `SignedDataVerifier` with a `Map<Environment, SignedDataVerifier>` so both environments can be cached independently.
> - Adds a test-only `testVerifier` override that bypasses the fallback path, and updates `resetVerifierForTests` to clear both the override and the full cache.
> - Behavioral Change: receipts issued in Sandbox will now succeed even when the configured environment is Production (and vice versa), whereas previously they would throw.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d49acb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction and notification verification now includes automatic fallback to alternate environment when initial verification fails due to environment mismatch.

* **Tests**
  * Added comprehensive test coverage for environment-fallback verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->