### PR TITLE
fix(agent-templates): serve router + run generation sweep in production

### DIFF
--- a/src/api/v2/agent-templates/handlers/generations-get.ts
+++ b/src/api/v2/agent-templates/handlers/generations-get.ts
@@ -19,7 +19,6 @@
  *
  * Auth: optionalAuthOrAgentApiKeyAuth. Anonymous reads are permitted; the
  * generation ID is treated as a bearer secret.
- * Production guard: XMTP_ENV !== "production" (in v2/index.ts).
  */
 
 import type { Request, Response } from "express";

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -35,7 +35,6 @@
  * Auth: optionalAuthOrAgentApiKeyAuth. Anonymous submissions are accepted
  * and owned by ADMIN_ACCOUNT_ID; authenticated submissions are owned by
  * the JWT/API-key account.
- * Production guard: XMTP_ENV !== "production" (in v2/index.ts).
  * Body size: 40 MB (route-specific middleware).
  */
 

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -42,10 +42,12 @@ import { appleWebhookRouter } from "./subscriptions/apple-webhook.router";
 
 const v2Router = Router();
 
+// /dev is a non-production test surface; keep it gated.
 if (process.env.XMTP_ENV !== "production") {
   v2Router.use("/dev", devAuthMiddleware, devRouter);
-  v2Router.use("/agent-templates", agentTemplatesRouter);
 }
+
+v2Router.use("/agent-templates", agentTemplatesRouter);
 
 v2Router.use("/invites", invitesV2Router);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   stopTtlSweep as stopGenerationTtlSweep,
 } from "@/api/v2/agent-templates/services/ttl-sweep";
 import apiRouter from "./api";
-import { IS_DEVELOPMENT, XMTP_ENV } from "./config";
+import { IS_DEVELOPMENT } from "./config";
 import { errorHandlerMiddleware } from "./middleware/errorHandler";
 import { jsonMiddleware } from "./middleware/json";
 import { noRouteMiddleware } from "./middleware/noRoute";
@@ -100,11 +100,9 @@ validateJWTKeys()
         });
       }
 
-      // Generation pipeline sweep — only when the agent-templates router is
-      // mounted (gated on XMTP_ENV !== "production"; see src/api/v2/index.ts).
-      if (XMTP_ENV !== "production") {
-        startGenerationTtlSweep();
-      }
+      // Generation pipeline sweep — expires stale generation rows. Runs in
+      // every env now that the agent-templates router is mounted everywhere.
+      startGenerationTtlSweep();
     });
 
     // Wrap the async drain steps in a void-IIFE so the SIGTERM listener
@@ -116,7 +114,7 @@ validateJWTKeys()
         logger.info("SIGTERM signal received: closing Convos API service");
         // Stop the generation TTL sweep so its setInterval doesn't keep
         // dispatching DB queries against a closing pool during the drain
-        // window. No-op if the sweep was never started (production gate).
+        // window. No-op if the sweep was never started.
         stopGenerationTtlSweep();
         // Flush buffered PostHog events before the process exits. The SDK
         // buffers up to flushAt (default 20) or flushInterval (default 10s)


### PR DESCRIPTION
## Summary

The `/api/v2/agent-templates` router — catalog reads, template detail, and the generation create/status API — was gated behind `XMTP_ENV !== "production"` in `src/api/v2/index.ts`. On the production backend (`api.prod.convos.xyz`, `XMTP_ENV=production`) the router was never mounted, so every `/api/v2/agent-templates*` path returned a bare `404`.

The assistants site (`agents-production.convos.org`) calls `POST {CONVOS_BACKEND_URL}/api/v2/agent-templates/generations` from its `/api/create/start` route. That route converts a non-JSON backend response into a `502`, so the empty 404 surfaced to users as `502 Bad Gateway` on create.

This change:
- Mounts `/agent-templates` in **every** environment (`src/api/v2/index.ts`).
- Keeps `/dev` gated to non-production (it's a test-only surface).
- Runs the generation TTL sweep unconditionally (`src/index.ts`), since it must run wherever the router runs; drops the now-unused `XMTP_ENV` import and refreshes two stale "production gate" comments.

## Before this is useful in prod, the prod environment must have

- **OpenRouter** API key + a credit balance — generation execution calls OpenRouter.
- **`AgentTemplate` / `AgentTemplateGeneration` migrations** applied to the prod DB.
- **`BUILDER_REVALIDATE_SECRET`** matching the prod website (optional — without it, dashboard cache busting falls back to the 60s TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783104455&installation_id=128169237&pr_number=283&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F283&signature=314cbf290f8ad7d119acb439e9e41e3e240342a3841816757295175247d9a6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated environment-based routing configuration to restrict non-production features accordingly.
  * Improved generation pipeline TTL sweep initialization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable agent-templates router and generation TTL sweep in production
> - Moves the `agentTemplatesRouter` mount in [v2/index.ts](https://github.com/ephemeraHQ/convos-backend/pull/283/files#diff-2027b6d52fe007c8b0c1dd4b9196c1d432b42462c0efaa178004eca83ef794eb) out of the non-production gate so `/api/v2/agent-templates` routes are served in all environments; `/api/v2/dev` remains gated.
> - Removes the `XMTP_ENV !== 'production'` guard in [index.ts](https://github.com/ephemeraHQ/convos-backend/pull/283/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) so the generation TTL sweep starts unconditionally at server startup.
> - Removes now-stale comments referencing the production guard from the generations handlers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f297875.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->