### PR TITLE
Promote otr-dev → otr-prod

### DIFF
--- a/src/api/v2/agent-templates/handlers/generations-get.ts
+++ b/src/api/v2/agent-templates/handlers/generations-get.ts
@@ -19,7 +19,6 @@
  *
  * Auth: optionalAuthOrAgentApiKeyAuth. Anonymous reads are permitted; the
  * generation ID is treated as a bearer secret.
- * Production guard: XMTP_ENV !== "production" (in v2/index.ts).
  */
 
 import type { Request, Response } from "express";

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -35,7 +35,6 @@
  * Auth: optionalAuthOrAgentApiKeyAuth. Anonymous submissions are accepted
  * and owned by ADMIN_ACCOUNT_ID; authenticated submissions are owned by
  * the JWT/API-key account.
- * Production guard: XMTP_ENV !== "production" (in v2/index.ts).
  * Body size: 40 MB (route-specific middleware).
  */
 

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -42,10 +42,12 @@ import { appleWebhookRouter } from "./subscriptions/apple-webhook.router";
 
 const v2Router = Router();
 
+// /dev is a non-production test surface; keep it gated.
 if (process.env.XMTP_ENV !== "production") {
   v2Router.use("/dev", devAuthMiddleware, devRouter);
-  v2Router.use("/agent-templates", agentTemplatesRouter);
 }
+
+v2Router.use("/agent-templates", agentTemplatesRouter);
 
 v2Router.use("/invites", invitesV2Router);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   stopTtlSweep as stopGenerationTtlSweep,
 } from "@/api/v2/agent-templates/services/ttl-sweep";
 import apiRouter from "./api";
-import { IS_DEVELOPMENT, XMTP_ENV } from "./config";
+import { IS_DEVELOPMENT } from "./config";
 import { errorHandlerMiddleware } from "./middleware/errorHandler";
 import { jsonMiddleware } from "./middleware/json";
 import { noRouteMiddleware } from "./middleware/noRoute";
@@ -100,11 +100,9 @@ validateJWTKeys()
         });
       }
 
-      // Generation pipeline sweep — only when the agent-templates router is
-      // mounted (gated on XMTP_ENV !== "production"; see src/api/v2/index.ts).
-      if (XMTP_ENV !== "production") {
-        startGenerationTtlSweep();
-      }
+      // Generation pipeline sweep — expires stale generation rows. Runs in
+      // every env now that the agent-templates router is mounted everywhere.
+      startGenerationTtlSweep();
     });
 
     // Wrap the async drain steps in a void-IIFE so the SIGTERM listener
@@ -116,7 +114,7 @@ validateJWTKeys()
         logger.info("SIGTERM signal received: closing Convos API service");
         // Stop the generation TTL sweep so its setInterval doesn't keep
         // dispatching DB queries against a closing pool during the drain
-        // window. No-op if the sweep was never started (production gate).
+        // window. No-op if the sweep was never started.
         stopGenerationTtlSweep();
         // Flush buffered PostHog events before the process exits. The SDK
         // buffers up to flushAt (default 20) or flushInterval (default 10s)

--- a/src/subscriptions/jws-verifier.ts
+++ b/src/subscriptions/jws-verifier.ts
@@ -4,10 +4,13 @@ import { fileURLToPath } from "node:url";
 import {
   Environment,
   SignedDataVerifier,
+  VerificationException,
+  VerificationStatus,
   type JWSTransactionDecodedPayload,
   type ResponseBodyV2DecodedPayload,
 } from "@apple/app-store-server-library";
 import { AppError } from "@/utils/errors";
+import logger from "@/utils/logger";
 
 // Read NODE_ENV dynamically (not from the cached `isProductionEnv()` config
 // constant) so the prod-only guard below stays testable. NODE_ENV doesn't
@@ -120,47 +123,109 @@ export type VerifierConfig = {
   appAppleId?: number;
 };
 
-export const buildVerifierConfig = (): VerifierConfig => {
-  const environment = resolveEnvironment();
-  return {
-    rootCertificates: loadAppleRootCerts(),
-    enableOnlineChecks: environment === Environment.PRODUCTION,
-    environment,
-    bundleId: resolveBundleId(),
-    appAppleId:
-      environment === Environment.SANDBOX ? undefined : resolveAppAppleId(),
-  };
-};
+const buildVerifierConfigForEnvironment = (
+  environment: Environment,
+): VerifierConfig => ({
+  rootCertificates: loadAppleRootCerts(),
+  // Online OCSP revocation checks only for Production. Sandbox/LocalTesting
+  // verify the chain offline against the signed date — Apple's sandbox OCSP
+  // responders are unreliable, and TestFlight receipts must verify without
+  // depending on them.
+  enableOnlineChecks: environment === Environment.PRODUCTION,
+  environment,
+  bundleId: resolveBundleId(),
+  // appAppleId is required to verify Production receipts but must be omitted
+  // for Sandbox (the library rejects a Sandbox receipt that carries one).
+  appAppleId:
+    environment === Environment.SANDBOX ? undefined : resolveAppAppleId(),
+});
 
-let cachedVerifier: SignedDataVerifier | null = null;
+export const buildVerifierConfig = (): VerifierConfig =>
+  buildVerifierConfigForEnvironment(resolveEnvironment());
 
-export const getVerifier = () => {
-  if (cachedVerifier) return cachedVerifier;
-  const cfg = buildVerifierConfig();
-  cachedVerifier = new SignedDataVerifier(
+// One cached verifier per Apple environment. We may need both: the configured
+// primary plus the opposite one for the fallback below.
+const verifierCache = new Map<Environment, SignedDataVerifier>();
+
+// Test override. When set, it's used directly with no environment fallback —
+// tests inject a single LOCAL_TESTING verifier and assert exact-environment
+// behavior, which the fallback would otherwise mask.
+let testVerifier: SignedDataVerifier | null = null;
+
+const getVerifierForEnvironment = (
+  environment: Environment,
+): SignedDataVerifier => {
+  const cached = verifierCache.get(environment);
+  if (cached) return cached;
+  const cfg = buildVerifierConfigForEnvironment(environment);
+  const verifier = new SignedDataVerifier(
     cfg.rootCertificates,
     cfg.enableOnlineChecks,
     cfg.environment,
     cfg.bundleId,
     cfg.appAppleId,
   );
-  return cachedVerifier;
+  verifierCache.set(environment, verifier);
+  return verifier;
 };
 
+export const getVerifier = (): SignedDataVerifier =>
+  testVerifier ?? getVerifierForEnvironment(resolveEnvironment());
+
 export const resetVerifierForTests = () => {
-  cachedVerifier = null;
+  testVerifier = null;
+  verifierCache.clear();
 };
 
 export const setVerifierForTests = (verifier: SignedDataVerifier) => {
-  cachedVerifier = verifier;
+  testVerifier = verifier;
 };
 
-export const verifyAndDecodeNotification = async (
+// Production receipts and Sandbox (TestFlight) receipts can both reach the same
+// backend: a real purchase is Production-signed, a TestFlight purchase is
+// Sandbox-signed. A verifier configured for one rejects the other with
+// INVALID_ENVIRONMENT *after* the cert chain verifies. So we try the configured
+// environment first and, only on INVALID_ENVIRONMENT, retry against the other —
+// Apple's recommended "verify with production, retry with sandbox" pattern.
+const FALLBACK_ENVIRONMENT: Partial<Record<Environment, Environment>> = {
+  [Environment.PRODUCTION]: Environment.SANDBOX,
+  [Environment.SANDBOX]: Environment.PRODUCTION,
+};
+
+const isInvalidEnvironment = (err: unknown): boolean =>
+  err instanceof VerificationException &&
+  err.status === VerificationStatus.INVALID_ENVIRONMENT;
+
+const verifyWithEnvironmentFallback = async <T>(
+  op: (verifier: SignedDataVerifier) => Promise<T>,
+): Promise<T> => {
+  // A test-injected verifier is an explicit override — no fallback.
+  if (testVerifier) return op(testVerifier);
+
+  const primary = resolveEnvironment();
+  try {
+    return await op(getVerifierForEnvironment(primary));
+  } catch (err) {
+    const alternate = FALLBACK_ENVIRONMENT[primary];
+    if (!alternate || !isInvalidEnvironment(err)) throw err;
+    logger.info(
+      { primary, alternate },
+      "apple.verify.environment_fallback — receipt signed for the alternate environment; retrying",
+    );
+    return op(getVerifierForEnvironment(alternate));
+  }
+};
+
+export const verifyAndDecodeNotification = (
   signedPayload: string,
 ): Promise<ResponseBodyV2DecodedPayload> =>
-  getVerifier().verifyAndDecodeNotification(signedPayload);
+  verifyWithEnvironmentFallback((verifier) =>
+    verifier.verifyAndDecodeNotification(signedPayload),
+  );
 
-export const verifyAndDecodeTransaction = async (
+export const verifyAndDecodeTransaction = (
   signedTransactionInfo: string,
 ): Promise<JWSTransactionDecodedPayload> =>
-  getVerifier().verifyAndDecodeTransaction(signedTransactionInfo);
+  verifyWithEnvironmentFallback((verifier) =>
+    verifier.verifyAndDecodeTransaction(signedTransactionInfo),
+  );

--- a/tests/subscriptions/jws-verifier-fallback.test.ts
+++ b/tests/subscriptions/jws-verifier-fallback.test.ts
@@ -1,0 +1,102 @@
+import type { Environment } from "@apple/app-store-server-library";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+// Replace the Apple SignedDataVerifier with a stub whose behavior depends on
+// the environment it was constructed for: a Production-configured verifier
+// rejects with INVALID_ENVIRONMENT (as it would for a Sandbox/TestFlight
+// receipt), while a Sandbox-configured verifier accepts. This lets us exercise
+// the environment-fallback path without real Apple-signed receipts. The real
+// Environment / VerificationException / VerificationStatus exports are kept.
+vi.mock("@apple/app-store-server-library", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const { Environment, VerificationException, VerificationStatus } = actual as {
+    Environment: { PRODUCTION: Environment };
+    VerificationException: new (status: number) => Error;
+    VerificationStatus: { INVALID_ENVIRONMENT: number };
+  };
+
+  class FakeSignedDataVerifier {
+    constructor(
+      _certs: unknown,
+      _online: boolean,
+      readonly environment: Environment,
+    ) {}
+
+    private decode(signed: string, kind: "tx" | "notif") {
+      if (this.environment === Environment.PRODUCTION) {
+        // Chain verified, but the receipt was signed for another environment.
+        throw new VerificationException(VerificationStatus.INVALID_ENVIRONMENT);
+      }
+      return kind === "tx"
+        ? { transactionId: signed, environment: "Sandbox" }
+        : { notificationUUID: signed, data: { environment: "Sandbox" } };
+    }
+
+    verifyAndDecodeTransaction(signed: string) {
+      return Promise.resolve(this.decode(signed, "tx"));
+    }
+
+    verifyAndDecodeNotification(signed: string) {
+      return Promise.resolve(this.decode(signed, "notif"));
+    }
+  }
+
+  return { ...actual, SignedDataVerifier: FakeSignedDataVerifier };
+});
+
+// Imported after the mock is registered (vi.mock is hoisted).
+const { resetVerifierForTests, verifyAndDecodeTransaction } =
+  await import("@/subscriptions/jws-verifier");
+
+type EnvSnapshot = Record<
+  "APPLE_ENV" | "APPLE_BUNDLE_ID" | "APPLE_APP_APPLE_ID" | "NODE_ENV",
+  string | undefined
+>;
+
+const snapshot = (): EnvSnapshot => ({
+  APPLE_ENV: process.env.APPLE_ENV,
+  APPLE_BUNDLE_ID: process.env.APPLE_BUNDLE_ID,
+  APPLE_APP_APPLE_ID: process.env.APPLE_APP_APPLE_ID,
+  NODE_ENV: process.env.NODE_ENV,
+});
+
+const restore = (snap: EnvSnapshot) => {
+  for (const [k, v] of Object.entries(snap)) {
+    if (v === undefined) Reflect.deleteProperty(process.env, k);
+    else process.env[k] = v;
+  }
+};
+
+describe("verifyAndDecodeTransaction — environment fallback", () => {
+  let snap: EnvSnapshot;
+
+  beforeEach(() => {
+    snap = snapshot();
+    process.env.APPLE_BUNDLE_ID = "app.convos.test";
+    process.env.APPLE_APP_APPLE_ID = "6747291340";
+    resetVerifierForTests();
+  });
+
+  afterEach(() => {
+    restore(snap);
+    resetVerifierForTests();
+  });
+
+  test("Production primary falls back to Sandbox on INVALID_ENVIRONMENT", async () => {
+    process.env.APPLE_ENV = "production";
+    // Production verifier throws INVALID_ENVIRONMENT; fallback to Sandbox wins.
+    const decoded = await verifyAndDecodeTransaction("sandbox.receipt");
+    expect(decoded.transactionId).toBe("sandbox.receipt");
+    expect(decoded.environment).toBe("Sandbox");
+  });
+
+  test("Sandbox primary verifies directly with no fallback", async () => {
+    process.env.APPLE_ENV = "sandbox";
+    const decoded = await verifyAndDecodeTransaction("sandbox.receipt");
+    expect(decoded.transactionId).toBe("sandbox.receipt");
+  });
+});


### PR DESCRIPTION
Promotes **all of `otr-dev`** to `otr-prod` (full branch, not a cherry-pick). `otr-prod` has no commits of its own ahead of `otr-dev`, so this is a clean fast-forward.

## Commits being promoted
- `584723e` fix(agent-templates): serve router + run generation sweep in production (#283)
- `5a6996c` fix(subscriptions): verify Apple receipts against both environments (Production + Sandbox) (#282)

## Before/after merging — prod env must have (for #283 to function)
- **OpenRouter** API key + credit balance (generation execution calls OpenRouter)
- **`AgentTemplate` / `AgentTemplateGeneration` migrations** applied to the prod DB, and the `ADMIN_ACCOUNT_ID` (`48a05ef4-…`) account row present (owns anonymous create submissions)
- **`BUILDER_REVALIDATE_SECRET`** matching the assistants website (optional; otherwise 60s cache TTL)
- After deploy: set `CONVOS_BACKEND_URL=https://api.prod.convos.xyz` on the website (Vercel prod) and redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783106180&installation_id=128169237&pr_number=284&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F284&signature=3557f7d98645780fadf2c57c039fc6ea869fc38b13e6fe69459c48b753860be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Promote agent-templates routes and generation TTL sweep to production with Apple environment fallback in JWS verification
> - Mounts `agentTemplatesRouter` in all environments by removing it from the `XMTP_ENV !== 'production'` guard in [v2/index.ts](https://github.com/ephemeraHQ/convos-backend/pull/284/files#diff-2027b6d52fe007c8b0c1dd4b9196c1d432b42462c0efaa178004eca83ef794eb); `/dev` routes remain gated.
> - Starts the generation TTL sweep unconditionally on server listen in [src/index.ts](https://github.com/ephemeraHQ/convos-backend/pull/284/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), removing the non-production guard.
> - Adds `verifyWithEnvironmentFallback` in [jws-verifier.ts](https://github.com/ephemeraHQ/convos-backend/pull/284/files#diff-ba97d161a549202f2ef5b83e8e3e3f1980e1df19c6f017e5ba3c62cef68e4115): on `INVALID_ENVIRONMENT` errors, Apple JWS verification retries with the alternate environment (Production↔Sandbox) before surfacing a failure.
> - Refactors the verifier cache to be per-environment using a `Map`, replacing the single global cached instance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 584723e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->