### PR TITLE
fix(subscriptions): accept legacy builder/pro productIds (map to plus)

### DIFF
--- a/src/subscriptions/product-mapping.ts
+++ b/src/subscriptions/product-mapping.ts
@@ -15,11 +15,21 @@ export type ProductMapping = {
 //   - "app.convos.subs.<period>" (dev/preview ASC bundles — unprefixed,
 //     locked in because ASC product IDs are globally unique per
 //     developer account and prod claimed the `plus.*` ID)
+//   - "app.convos.subs.(builder|pro).<period>" (LEGACY) — the original
+//     two-tier SKUs. Apple bakes the productId into the signed JWS at the
+//     original purchase and keeps returning it on every renewal/upgrade for
+//     the life of that subscription, so existing subscribers (incl. early
+//     TestFlight / App Store testers) still send these. We dropped the
+//     Builder/Pro tiers in #263 and backfilled all rows to `plus`; we must
+//     keep *recognizing* these IDs or those subscribers' verify 400s forever
+//     (CON-386). iOS can't rewrite them client-side — that would break Apple's
+//     signature.
 // period is always monthly|annual. Anchored so trailing junk fails fast.
 //
-// We ship a single tier (Plus). Everything matched here decodes to
-// SUBSCRIPTION_TIER_PLUS.
-const PRODUCT_ID_PATTERN = /^app\.convos\.subs\.(?:plus\.)?(monthly|annual)$/;
+// We ship a single tier (Plus). Everything matched here — including the legacy
+// builder/pro SKUs — decodes to SUBSCRIPTION_TIER_PLUS.
+const PRODUCT_ID_PATTERN =
+  /^app\.convos\.subs\.(?:(?:builder|pro|plus)\.)?(monthly|annual)$/;
 
 /**
  * Decode a StoreKit product identifier into its tier + period.
@@ -34,7 +44,7 @@ export const productMapping = (productId: string): ProductMapping => {
   if (!match) {
     throw new AppError(
       400,
-      `Unrecognized productId: "${productId}". Expected app.convos.subs.<monthly|annual> (dev) or app.convos.subs.plus.<monthly|annual> (prod)`,
+      `Unrecognized productId: "${productId}". Expected app.convos.subs[.(builder|pro|plus)].<monthly|annual> — builder/pro are legacy SKUs mapped to plus`,
     );
   }
   const [, periodRaw] = match;

--- a/tests/subscriptions/product-mapping.test.ts
+++ b/tests/subscriptions/product-mapping.test.ts
@@ -1,0 +1,59 @@
+import { SubscriptionPeriod } from "@prisma/client";
+import { describe, expect, test } from "vitest";
+import { productMapping } from "@/subscriptions/product-mapping";
+import { SUBSCRIPTION_TIER_PLUS } from "@/subscriptions/tiers";
+
+describe("productMapping", () => {
+  test("maps current prod SKUs (plus.<period>) to plus", () => {
+    expect(productMapping("app.convos.subs.plus.monthly")).toEqual({
+      tier: SUBSCRIPTION_TIER_PLUS,
+      period: SubscriptionPeriod.monthly,
+    });
+    expect(productMapping("app.convos.subs.plus.annual")).toEqual({
+      tier: SUBSCRIPTION_TIER_PLUS,
+      period: SubscriptionPeriod.annual,
+    });
+  });
+
+  test("maps unprefixed dev SKUs (<period>) to plus", () => {
+    expect(productMapping("app.convos.subs.monthly").period).toBe(
+      SubscriptionPeriod.monthly,
+    );
+    expect(productMapping("app.convos.subs.annual").period).toBe(
+      SubscriptionPeriod.annual,
+    );
+  });
+
+  // Apple keeps returning the original productId on renewals/upgrades for the
+  // life of a subscription, so legacy builder/pro subs must still verify. All
+  // tiers collapsed to plus in #263 — see CON-386.
+  test("maps legacy builder/pro SKUs to plus", () => {
+    expect(productMapping("app.convos.subs.builder.monthly")).toEqual({
+      tier: SUBSCRIPTION_TIER_PLUS,
+      period: SubscriptionPeriod.monthly,
+    });
+    expect(productMapping("app.convos.subs.builder.annual").tier).toBe(
+      SUBSCRIPTION_TIER_PLUS,
+    );
+    expect(productMapping("app.convos.subs.pro.monthly").tier).toBe(
+      SUBSCRIPTION_TIER_PLUS,
+    );
+    expect(productMapping("app.convos.subs.pro.annual")).toEqual({
+      tier: SUBSCRIPTION_TIER_PLUS,
+      period: SubscriptionPeriod.annual,
+    });
+  });
+
+  test("rejects unknown tier prefixes, wrong periods, and trailing junk", () => {
+    for (const bad of [
+      "app.convos.subs.enterprise.monthly", // unknown tier
+      "app.convos.subs.plus.weekly", // unknown period
+      "app.convos.subs.monthly.extra", // trailing junk
+      "app.convos.subs.builder", // missing period
+      "com.someone.else.monthly", // foreign namespace
+      "", // empty
+    ]) {
+      expect(() => productMapping(bad)).toThrow(/Unrecognized productId/);
+    }
+  });
+});


### PR DESCRIPTION
## Problem (CON-386, the actual root cause for upgrades)

Tapping **Upgrade** on a device with an existing sandbox sub still 400s — but now *past* the cert (#281) and environment (#282) fixes. Smoking-gun log:

```
Backend verify failed for transaction 2000001182085041:
  "Unrecognized productId: \"app.convos.subs.builder.monthly\"."
```

Apple bakes the productId into the **signed JWS at original purchase** and keeps returning it on every renewal/upgrade for the life of that subscription. Subscriptions created on the old two-tier SKUs (`app.convos.subs.builder|pro.<period>`) therefore keep sending those IDs. But `#263` tightened `PRODUCT_ID_PATTERN` to plus-only, so for any legacy subscriber:

1. JWS verifies fine (chain + environment OK)
2. `productMapping()` 400s with "Unrecognized productId"
3. no `Subscription` row written → `/credits` returns free-tier → UI shows Basic

**iOS can't fix this client-side** — rewriting the productId before forwarding would break Apple's signature.

## Why it surfaced now (the three stacked gates on `/subscription/verify`)

| Gate | Failure | Fix |
|---|---|---|
| 1. JWS signature/chain | `Invalid signed transaction` (cert ENOENT) | #281 |
| 2. Environment match | `INVALID_ENVIRONMENT` (status 4) | #282 |
| 3. **productId mapping** | **`Unrecognized productId`** | **this PR** |

Each fix unmasked the next. A legacy sub now sails through gates 1–2 and dies at gate 3 — so this is the last blocker for legacy subscribers.

## Fix

Broaden the regex to accept `builder|pro|plus` and map all of them to `plus` (the single tier we ship; `#263` already backfilled every row to `plus`):

```js
/^app\.convos\.subs\.(?:(?:builder|pro|plus)\.)?(monthly|annual)$/
```

`productMapping()` already returns `SUBSCRIPTION_TIER_PLUS` unconditionally, so this is purely about *recognition* — no tier logic changes. It's the single chokepoint for both `/subscription/verify` and the S2S notification path, so both are covered.

## Tests

New `tests/subscriptions/product-mapping.test.ts`: current (`plus.*`, unprefixed) and legacy (`builder.*`, `pro.*`) SKUs map to plus with the right period; unknown tiers / bad periods / trailing junk / foreign namespaces still 400. Full subscriptions suite + `pnpm check` green.

## Note
This is the third of three stacked verify fixes (#281 cert, #282 env, this). With all three deployed to otr-dev, a legacy-sub Upgrade should finally write the `Subscription` row.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783107502&installation_id=128169237&pr_number=285&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F285&signature=cc771208a8ce0809b9a86db20b6bfeb2d3a3db660217be7eb5281cac5921f0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept legacy builder/pro product IDs by mapping them to the Plus tier
> Updates `PRODUCT_ID_PATTERN` in [product-mapping.ts](https://github.com/ephemeraHQ/convos-backend/pull/285/files#diff-3f9e05ce855082a5d1546a57be0dbf18ba990072397e87e3a40daf16e8f96096) to accept `builder` and `pro` tier prefixes in addition to `plus`, treating all three as valid and mapping them to the Plus tier. Previously, product IDs with these legacy prefixes failed validation. Adds a Vitest suite covering current, unprefixed dev, and legacy SKUs, as well as rejection of invalid inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76264df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for legacy iOS App Store product identifier formats to prevent unrecognized product errors

* **Tests**
  * Added comprehensive test suite for subscription tier mapping, including legacy product formats and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->