### PR TITLE
docs: Composio security model 1-pager

### DIFF
--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -6,7 +6,7 @@
 
 ## TL;DR
 
-Convos Backend owns all Composio connections and exposes a narrow per-call API to agents. Retire the per-assistant Composio projects in the Assistants pool config. Per-user projects can come in v2; not blocking MVP.
+Convos Backend owns all Composio connections and exposes a narrow per-call API to agents. **The load-bearing security invariant: the agent must never hold the Composio project API key.** One project is safe as long as exactly one keyholder exists. Retire the per-assistant Composio projects in the Assistants pool config. Per-user projects can come in v2; not blocking MVP.
 
 ## The bug today
 
@@ -28,15 +28,46 @@ Agent → Backend.exec(user, toolkit, action, args)
 
 Per-call scope is `(user, toolkit, action, connectionId)` — the same tuple iOS already gates via the picker. Backend re-checks the capability grant before forwarding (defense-in-depth: a misbehaving agent can't escalate verbs).
 
+### Clipped-client model: what the agent has vs doesn't have
+
+What the agent holds:
+- Its own JWT (proves *which* agent it is).
+- `inboxId` of the conversation sender (already in the XMTP envelope).
+- Toolkit name, action name, args.
+
+What the agent does **not** hold:
+- The Composio project API key.
+- Any user's `userId` / `accountId` / `connectionId`.
+- Any other user's `inboxId`.
+
+A fully compromised agent can therefore only act on the inboxId it's in conversation with, only call actions the user actually granted, and only via Backend. There is no `userId` it can lie about because it never sees one.
+
+### Defense in depth
+
+Three layers stack inside the one-project model:
+
+1. **Backend grant re-check (must-have).** Every `exec` call looks up the iOS-issued capability grant for `(asker_inboxId, conversationId, provider, capability)`. No grant → 403.
+2. **Action-level allowlist on Backend.** Backend.exec only forwards action slugs explicitly mapped from a published bundle config. A new Composio action lands disabled-by-default until added to a bundle. Mitigates "agent discovers a powerful action you didn't realize the toolkit had."
+3. **Per-call scoped sessions (MVP-2).** When Composio's `tool_router/sessions` API matures, Backend issues a short-lived session token scoped to `(userId, toolkit, action)` and hands *that* to the agent for one call. Composio enforces per-call scope itself; Backend's hot-path cost drops.
+
 ## Phasing
 
 | Phase | Scope | Effort |
 |---|---|---|
-| **MVP-1** | Convos Backend exposes `POST /v2/composio/exec` (thin proxy for `tools/execute`) **plus identifier alignment** (see below). Agent call stack becomes `connections.mjs exec → Backend → Composio`. **Per-assistant Composio projects retired** — that's the source of the current bug. | one sprint |
+| **MVP-1** | Convos Backend exposes `POST /v2/composio/exec` with grant re-check, action allowlist, and identifier alignment (see below). Agent call stack becomes `connections.mjs exec → Backend → Composio`. **Per-assistant Composio projects retired** — that's the source of the current bug. | one sprint |
 | **MVP-2** | Replace proxy with Composio `tool_router/sessions` or scoped MCP URLs. Same agent contract, lower Backend hot-path cost. | when session APIs prove out |
 | **v2** | Project-per-user on Backend for stronger blast-radius isolation. | not blocking |
 
 The agent contract stays the same across phases — only Backend internals change.
+
+## Work breakdown by repo
+
+| Repo | Change | Notes |
+|---|---|---|
+| `convos-backend` | New `POST /v2/composio/exec` handler: grant lookup, action allowlist, `inboxId → accountId` resolution, Composio proxy. | All net-new code. |
+| `convos-assistants` | Swap `runtime/convos-platform/skills/connections/scripts/connections.mjs:544` Composio direct call → `Backend.exec` HTTP call. | Two runtimes to update: `convos-platform` and the mirrored `runtime/hermes/.hermes-dev/home/skills/connections/scripts/connections.mjs`. Easy to miss. |
+| `convos-assistants` | Retire per-assistant Composio project keys from the Assistants pool config. | Config-only change once `exec` is live. |
+| `convos-ios` | None. The picker UI, grant codecs, capability resolution, and `connection_event.revoked` flow are all framework-agnostic. | — |
 
 ## Identifier alignment (the missing link)
 
@@ -82,7 +113,7 @@ Both should land. They don't conflict.
 
 - **Single shared project, no Backend layer (status quo with the iOS-side bug):** every agent shares one project key. No isolation between agents at the Composio layer, and the OAuth-vs-execution split is exactly the bug we have today.
 - **Project per assistant (current Assistants pool config):** breaks sign-in-once. User would re-OAuth Google Calendar for every assistant they interact with. Product spec rules this out.
-- **Project per user:** needs an *org-level* key on Backend to programmatically create projects — back to "one key with the keys to the kingdom." Plus likely per-project Composio billing. Push to v2.
+- **Project per user:** needs an *org-level* key on Backend to programmatically create projects — back to "one key with the keys to the kingdom." Plus likely per-project Composio billing. Push to v2. MVP-1 closes the *agent-side* leak completely; v2 addresses *Backend-side* key exfiltration (one stolen Composio key → all users leak). Different threat, different cost.
 
 ## Open questions
 
@@ -96,7 +127,8 @@ Both should land. They don't conflict.
 
 1. Approve the Backend-mediated direction above.
 2. Approve retiring the per-assistant Composio projects in Assistants pool config.
-3. Assign owner for the MVP-1 Backend `exec` endpoint.
+3. Assign owner for the MVP-1 Backend `exec` endpoint (`convos-backend`).
+4. Assign owner for the agent-side swap to `Backend.exec` (`convos-assistants`, both runtimes).
 
 ## Why this aligns with what we already shipped
 

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -2,7 +2,7 @@
 
 **Author:** Louis
 **Audience:** Fabri, Nick, Mike
-**Status:** Implemented — on `louis/composio-exec` → `louis/connections-bundles` (backend), `louis/composio-backend-exec` (assistants), `louis/connections-picker-bundles` (iOS); in review, not yet merged to `dev`. The original decision record (fork X/Y, sign-off questions) lives in this PR's history.
+**Status:** Implemented — in review as backend #303 (stacked on #294), assistants #2112, iOS #1047/#1048/#1049; not yet merged to `dev`. The original decision record (fork X/Y, sign-off questions) lives in this PR's history.
 
 ## TL;DR
 
@@ -52,7 +52,7 @@ Clients have no Composio action slugs, so action-level consent is expressed as b
 
 - The catalog (`src/api/v2/connections/bundles.config.ts`) maps `service → bundle → action slugs` and is served via **`GET /v2/connections/services`** (JWT-only) **with slugs stripped** — no Composio slug ever reaches a client.
 - Grants carry `{toolkit, serviceVersion, bundleIds}`; the device persists only bundle ids. The backend resolves bundles → actions **at exec time against the current catalog**, so re-mapping actions needs no app release.
-- **Fail closed everywhere:** unknown bundle ids are rejected at grant time (400 `unknown_bundle`); a grant whose bundles resolve to nothing (stale/unknown) authorizes nothing at exec (403 `no_grant`) — it never falls back to whole-toolkit. A read-only bundle (`calendar.events.read`) exists precisely to prove a read grant can never write (regression-tested).
+- **Fail closed everywhere:** unknown bundle ids are rejected at grant time (400 `unknown_bundle`); a grant whose bundles resolve to nothing (stale/unknown) authorizes nothing at exec (403 `no_grant`) — it never falls back to whole-toolkit. The catalog ships a single calendar bundle, "Events" (view + edit); the legacy read-only bundle (`calendar.events.read`) is deprecated but still resolvable, and proves a read grant can never write (regression-tested).
 - **Transition-only exception:** a legacy grant with _both_ `actions` and `bundleIds` empty still means whole-toolkit (logged). Flipping this to fail-closed is Phase C, once iOS + Android always send `bundleIds` — see "In progress."
 
 ## Grant lifecycle

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -67,27 +67,28 @@ Two trusted anchors the agent **cannot forge** make this enforceable:
 
 The trusted layer resolves the connection only from the set of `accountId`s belonging to *this instance's* conversation members (Anchor 1 + the conversation-scoped Herald key, `/v1/conversation/{heraldConversationId}/profiles`). The agent names no connection.
 
-- **Multi-inbox per user.** Users will have multiple inboxes (work/personal, etc.); their connections shouldn't fragment across inboxes.
-- **Auth-method federation.** A Composio connection isn't tied to whichever auth method the user happened to sign in with.
-- **Multi-device for free.** Same human on two devices = one Composio user. The latent multi-device bug iOS has today goes away by construction.
+- **DM (the common case): exact per-user isolation** — one member, one possible connection, nothing to spoof.
+- **Group: blast radius bounded to conversation members** — never a stranger in another chat.
 
-Concretely:
-- Backend uses `accountId` (read from the JWT) as Composio's `userId` for all new OAuth flows.
-- Backend's `exec` endpoint accepts `inboxId` from the agent — same identifier the agent already has from the XMTP envelope — then resolves `inboxId → accountId` via `XmtpInbox` before forwarding to Composio. Agent contract stays simple ("here's whose inbox I'm acting on behalf of"), Backend does the resolution.
-- For existing connections keyed on `deviceId` in Composio, Backend falls back to `deviceId` lookup if `accountId` returns no result. Users migrate naturally on re-OAuth, no forced action.
+This closes the cross-conversation leak ("User A asks for User B" where A and B are in different chats) completely, with **no new trusted infrastructure** beyond the grant store.
 
-**Sequencing:** Composio MVP-1 should land **after** (or alongside) the new auth API, not before. Otherwise we'd cut over from `deviceId` to `inboxId` in MVP-1 and then to `accountId` once auth ships — two migrations for nothing. Gate MVP-1 on `accountId` being in JWTs first.
+### Tier 2 — per-sender isolation (closes intra-group escalation)
 
-**Open question for the auth API:** the agent → Backend.exec call hits `XmtpInbox` resolution on every invocation. Worth confirming that proof-of-ownership lookup is cheap per-call (or cacheable per-conversation).
+**This is the "group limit."** Under Tier 1, any member's connection is reachable during *any* turn — so in a group, member B can drive the agent into member A's calendar. The boundary is the conversation, not the person. Closing it needs the connection resolved from the **verified sender's `accountId`** (Anchor 2), default-denying every other member's connection. **Shared grants** (the existing `isShared` path) remain the explicit opt-in when A *wants* the group to use their calendar.
 
-**Alternative considered:** a `deviceId ↔ inboxId` mapping table on the Backend without going through `accountId`. Cheaper short-term but doesn't solve inbox recovery, multi-inbox, federation, or multi-device. The auth API gives us the right structural answer once.
+The hard part — and the real reason this is MVP-2: one agent instance serves the whole group with **interleaved** messages, so a mutable "current sender" flag is racy. The robust form is a **per-delivery capability**, not shared state:
 
-## Orthogonal: per-agent grant scoping ([convos-ios#812](https://github.com/xmtplabs/convos-ios/pull/812))
+- **(a) Per-delivery binding.** The worker resolves the connection for that delivery's verified `senderInboxId → accountId` and binds it to that delivery's work. New plumbing: today's egress context is static at init.
+- **(b) Composio scoped sessions** (`tool_router/sessions` / scoped MCP URLs). The worker mints a short-lived session for the verified sender per message; Composio enforces scope and the proxy stops being security-critical. Cleanest **if** sessions support action-level scope (open Decision Q).
 
-Per-agent gating lives at the messaging layer keyed on agent `inboxId` (which agent owns the grant in this conversation). Composio's `userId` is the data owner (`accountId`). Two independent axes:
+**Same rule on the OAuth `connect` path.** The `entity_id`/`accountId` at connect time must be the verified sender, not the trigger-file value — otherwise a malicious agent attaches a victim's connection under the wrong account.
 
-- **#812** — iOS resolver enforces "agent X's grant ≠ agent Y's grant" via `grantedToInboxId` on `CapabilityResolution`, `ConnectionEnablement`, `CloudConnectionGrant`, plus `askerInboxId` on `CapabilityRequest`.
-- **This doc** — Backend's `exec` endpoint forwards to Composio with `userId: accountId`, where `accountId` is the data owner.
+### Open fork: where the grant store + the Composio call live
+
+Two secrets, and they need not co-locate: the **Composio project key** (one global secret) and the **per-user `connected_account_id`s** (your backend grant store keyed by `accountId`). But *who calls Composio* is a real decision:
+
+- **(X) Proxy-resolves.** The `outbound.ts` proxy holds the project key (Nick's model) and, per call, resolves the connection from the backend grant store using the verified sender's `accountId`, then calls Composio. Keeps key custody in assistants; adds a backend lookup on the hot path.
+- **(Y) Backend-mediates.** Backend holds the key *and* the grants and makes the Composio call itself — the agent calls `Backend.exec(toolkit, action, args)` with no connection identifier. Simplest isolation story (the bearer capability never leaves backend), but it's the mediation layer Nick pushed back on for key custody.
 
 Both should land. They don't conflict.
 

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -24,33 +24,30 @@ Two premises in the first draft were wrong. The code:
 
 ### Composio terminology + two API facts (the security model hinges on these)
 
-What the agent holds:
-- Its own JWT (proves *which* agent it is).
-- `inboxId` of the conversation sender (already in the XMTP envelope).
-- Toolkit name, action name, args.
+- **`user_id` is Composio's request field, not a Convos identifier.** Today Convos puts the **`inboxId`** in it; the target (per the auth API) is **`accountId`**. Don't read `user_id` as a Convos concept — it's just Composio's parameter name.
+- **`connected_account_id` is a bearer capability.** Composio does **not** cross-check that `connected_account_id` belongs to `user_id` (confirmed by Louis). So whoever passes a `connected_account_id` can use that connection *regardless of `user_id`*. Constraining the account identifier alone is **not** sufficient — the `connected_account_id` itself must never reach the agent.
+- **Does `tools/execute` resolve a connection from `user_id` + toolkit alone (no `connected_account_id`)?** Open — needed to confirm the agent can omit `connected_account_id` entirely (Decision Q).
 
-What the agent does **not** hold:
-- The Composio project API key.
-- Any user's `userId` / `accountId` / `connectionId`.
-- Any other user's `inboxId`.
+## The bug today
 
-A fully compromised agent can therefore only act on the inboxId it's in conversation with, only call actions the user actually granted, and only via Backend. There is no `userId` it can lie about because it never sees one.
+For OAuth toolkits the agent runs both `connect` and `execute` through the same global key, so those work. The break is on the **iOS-capability** path (calendar, fitness, etc., the `IOS_CAPABILITY_SERVICES` set): iOS creates the connection in *its* Composio project, drops a `connectionId` into profile metadata, and the agent then tries to execute against the *global agent* key — different project, connection not found.
 
-### Defense in depth
+The consent layer ([convos-ios#796](https://github.com/xmtplabs/convos-ios/pull/796)/[#797](https://github.com/xmtplabs/convos-ios/pull/797), [convos-assistants#1484](https://github.com/xmtplabs/convos-assistants/pull/1484)) is correct under any model below. The break is purely **which project the connection lives in vs. where the agent executes** — i.e. a key-custody/consolidation problem, which the proxy below also fixes by giving us one mediated path.
 
-Three layers stack inside the one-project model:
+## Recommendation 1 (key custody): proxy Composio in `outbound.ts`
 
-1. **Backend grant re-check (must-have).** Every `exec` call looks up the iOS-issued capability grant for `(asker_inboxId, conversationId, provider, capability)`. No grant → 403.
-2. **Action-level allowlist on Backend.** Backend.exec only forwards action slugs explicitly mapped from a published bundle config. A new Composio action lands disabled-by-default until added to a bundle. Mitigates "agent discovers a powerful action you didn't realize the toolkit had."
-3. **Per-call scoped sessions (MVP-2).** When Composio's `tool_router/sessions` API matures, Backend issues a short-lived session token scoped to `(userId, toolkit, action)` and hands *that* to the agent for one call. Composio enforces per-call scope itself; Backend's hot-path cost drops.
+Agents call `http://composio.internal/api/v3/...`; the outbound handler injects the key and forwards to `backend.composio.dev`. The agent never holds the key, and direct egress to Composio is blocked the same way `openrouter.ai` is.
 
-## Phasing
+This is the existing pattern, applied verbatim:
 
-| Phase | Scope | Effort |
+| Step | Change | Precedent |
 |---|---|---|
-| **MVP-1** | Convos Backend exposes `POST /v2/composio/exec` with grant re-check, action allowlist, and identifier alignment (see below). Agent call stack becomes `connections.mjs exec → Backend → Composio`. **Per-assistant Composio projects retired** — that's the source of the current bug. | one sprint |
-| **MVP-2** | Replace proxy with Composio `tool_router/sessions` or scoped MCP URLs. Same agent contract, lower Backend hot-path cost. | when session APIs prove out |
-| **v2** | Project-per-user on Backend for stronger blast-radius isolation. | not blocking |
+| 1 | Add `composioApiKey` to `CredentialsSchema` (`schemas.ts:182`). | `heraldApiKey` |
+| 2 | Define `COMPOSIO_OUTBOUND_HOST = "composio.internal"`. | `HERALD_OUTBOUND_HOST` |
+| 3 | Add `proxyComposio()` handler: inject `x-api-key`, forward to upstream. | `proxyHerald` |
+| 4 | Wire it in `buildOutboundOverrides` + `outboundByHost`, and add `"backend.composio.dev" → denyDirectEgress`. | OpenRouter + `denyDirectEgress` |
+| 5 | Stop forwarding the real key to the container in `buildHermesEnv` (set a placeholder); point `COMPOSIO_BASE_URL` at `http://composio.internal`. | OpenRouter key handling |
+| 6 | Swap the agent's `composio()` base URL to the internal host. Two runtimes: `convos-platform` and the mirrored `runtime/hermes/.hermes-dev/...`. | — |
 
 The agent contract stays the same across phases — only Backend internals change.
 

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -14,7 +14,7 @@ iOS authorizes Google Calendar via Convos Backend's Composio project. The connec
 
 The capability-request consent layer ([convos-ios#796](https://github.com/xmtplabs/convos-ios/pull/796) / [#797](https://github.com/xmtplabs/convos-ios/pull/797), [convos-assistants#1484](https://github.com/xmtplabs/convos-assistants/pull/1484)) is correct under any security model below. The break is purely **where the agent invokes the toolkit**.
 
-## Recommendation: Backend mints scoped invocations
+## Recommendation: Backend mediates Composio access
 
 Agents call **Convos Backend → Composio**, never Composio directly. Backend already holds the only Composio project key; we keep it that way and expose a narrow API to agents.
 

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -49,32 +49,23 @@ This is the existing pattern, applied verbatim:
 | 5 | Stop forwarding the real key to the container in `buildHermesEnv` (set a placeholder); point `COMPOSIO_BASE_URL` at `http://composio.internal`. | OpenRouter key handling |
 | 6 | Swap the agent's `composio()` base URL to the internal host. Two runtimes: `convos-platform` and the mirrored `runtime/hermes/.hermes-dev/...`. | — |
 
-The agent contract stays the same across phases — only Backend internals change.
+**What this buys:** the load-bearing key-custody invariant, with code that already exists, in one repo, with zero backend dependency and no hot-path round trip. Ship this now.
 
-## Work breakdown by repo
+## Recommendation 2 (isolation): constrain `user_id` in the proxy, in two tiers
 
-| Repo | Change | Notes |
-|---|---|---|
-| `convos-backend` | New `POST /v2/composio/exec` handler: grant lookup, action allowlist, `inboxId → accountId` resolution, Composio proxy. | All net-new code. |
-| `convos-assistants` | Swap `runtime/convos-platform/skills/connections/scripts/connections.mjs:544` Composio direct call → `Backend.exec` HTTP call. | Two runtimes to update: `convos-platform` and the mirrored `runtime/hermes/.hermes-dev/home/skills/connections/scripts/connections.mjs`. Easy to miss. |
-| `convos-assistants` | Retire per-assistant Composio project keys from the Assistants pool config. | Config-only change once `exec` is live. |
-| `convos-ios` | None. The picker UI, grant codecs, capability resolution, and `connection_event.revoked` flow are all framework-agnostic. | — |
+The threat in one line: **`connected_account_id` is a bearer capability** (Composio doesn't check it against the account identifier), and the agent fills it in today. So the invariant isn't "constrain the identifier" — it's:
 
-## Identifier alignment (the missing link)
+> **The agent must never hold or name a `connected_account_id`.** A trusted layer resolves the connection from a trusted identity (the verified sender's `accountId`) via a grant store keyed by `accountId`, and injects it. The agent sends only `{ toolkit, action, args }`.
 
-Today there are four silos with no link between them:
-- **device/auth:** `deviceId` (iOS `identifierForVendor`, encoded in the JWT).
-- **messaging:** `inboxId` (XMTP — sender of conversations).
-- **Composio API:** `userId`, populated today with `deviceId`.
-- **payments foundations:** `inboxId`.
+Two trusted anchors the agent **cannot forge** make this enforceable:
 
-The agent only ever has `inboxId` (from the XMTP envelope sender); the Backend only ever has `deviceId` (from the JWT). There's no mapping anywhere — JWT has no inboxId field, no Backend table reconciles them. Today this works only because iOS handles both sides of its own flow; the moment an agent is the caller, the link breaks.
+**Anchor 1 — the conversation is pinned at init.** `Credentials.heraldConversationId` is set when the instance is created (`create-assistant-workflow.ts:539`) and is never agent-supplied.
 
-**Recommended fix: switch Composio's `userId` to `accountId` from the new auth API.**
+**Anchor 2 — Herald hands the worker an authentic per-message sender.** The Herald webhook carries `senderInboxId` as a top-level field in the **HMAC-signed** body — `herald.ts:94` verifies the signature, `operations.ts:356` already parses it, envelope shape at `deliver-notify-workflow.test.ts:53`. Herald decrypts XMTP server-side, so this sender is authentic; the worker just doesn't read the field yet. (Contrast `.convos-current-trigger.json`, which a compromised agent **can** forge — `connections.mjs:109`.)
 
-The new auth API ([Borja's design](https://xmtp-labs.slack.com/archives/C0ASWCMS0N9/), summarized below) introduces `accountId` as the unifying identifier across device/auth, messaging, payments, and Composio. SIWE / Google / Apple / X / mail auth methods all federate to one `accountId`; one `accountId` maps to N `inboxId` via an `XmtpInbox` object that proves ownership.
+### Tier 1 — conversation-boundary isolation (ship with the proxy)
 
-Why `accountId` beats the simpler "use `inboxId`" cut:
+The trusted layer resolves the connection only from the set of `accountId`s belonging to *this instance's* conversation members (Anchor 1 + the conversation-scoped Herald key, `/v1/conversation/{heraldConversationId}/profiles`). The agent names no connection.
 
 - **Multi-inbox per user.** Users will have multiple inboxes (work/personal, etc.); their connections shouldn't fragment across inboxes.
 - **Auth-method federation.** A Composio connection isn't tied to whichever auth method the user happened to sign in with.

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -85,6 +85,11 @@ The hard part — and the real reason this is MVP-2: one agent instance serves t
 
 ### Open fork: where the grant store + the Composio call live
 
+> **Decided (2026-06-09): fork (Y) backend-mediates.** The backend holds the key and the
+> grants and makes the Composio call; the agent calls `Backend.exec(toolkit, action, args)`
+> with no connection identifier, so the bearer capability never leaves the backend. Backend
+> implementation plan: [`docs/plans/composio-exec-grant-mediation.md`](../plans/composio-exec-grant-mediation.md).
+
 Two secrets, and they need not co-locate: the **Composio project key** (one global secret) and the **per-user `connected_account_id`s** (your backend grant store keyed by `accountId`). But *who calls Composio* is a real decision:
 
 - **(X) Proxy-resolves.** The `outbound.ts` proxy holds the project key (Nick's model) and, per call, resolves the connection from the backend grant store using the verified sender's `accountId`, then calls Composio. Keeps key custody in assistants; adds a backend lookup on the hot path.
@@ -110,7 +115,7 @@ Unchanged from the first draft and still composes cleanly. Per-agent gating live
 
 ## Decision needed
 
-1. **Pick the call path — fork (X) proxy-resolves vs (Y) backend-mediates** (see Recommendation 2). This decides which repo owns the Composio call and whether key custody stays in the proxy. Everything else follows from it.
+1. **Decided (2026-06-09): fork (Y) backend-mediates.** The backend owns the Composio call and holds both the key and the grants; the agent calls `Backend.exec(toolkit, action, args)`. Consequence: this supersedes **Recommendation 1** (key custody in `outbound.ts`) — under (Y) the agent never calls Composio directly, so there is no key to inject in the proxy, and MVP-1 *does* carry backend work (contrast the "no backend changes" note below, written for the (X) path). Reconfirm with Nick, who preferred (X) to avoid a backend mediation hop.
 2. Approve **Tier 1 conversation-boundary isolation** as the MVP (closes the cross-conversation leak; DMs get exact per-user isolation). Owner for the grant store keyed by `accountId` + the agent contract (`{toolkit, action, args}`, no `connected_account_id`).
 3. **Resolved (Louis):** Composio does **not** cross-validate `connected_account_id` against the account — so it's a bearer capability and must never reach the agent. The agent contract carries no connection identifier regardless of fork.
 4. **Still open — for Nick:**

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -1,138 +1,88 @@
-# Composio Security Model — MVP
+# Composio Security Model — 1-Pager
 
 **Author:** Louis
 **Audience:** Fabri, Nick, Mike
-**Status:** Draft for sign-off (revised after Nick's review)
+**Status:** Implemented — on `louis/composio-exec` → `louis/connections-bundles` (backend), `louis/composio-backend-exec` (assistants), `louis/connections-picker-bundles` (iOS); in review, not yet merged to `dev`. The original decision record (fork X/Y, sign-off questions) lives in this PR's history.
 
 ## TL;DR
 
-There are **two** problems hiding under "Composio security," and the first draft of this doc conflated them:
+Two problems hide under "Composio security," and **backend-mediated execution** closes both:
 
-1. **Key custody** — the agent must never hold the Composio API key.
-2. **User scoping** — a compromised agent must not be able to act on another user's connection.
+1. **Key custody** — the agent must never hold a Composio key. It now holds none: `COMPOSIO_API_KEY` lives only in convos-backend, the agent container gets placeholder creds, and the legacy direct-Composio path in the agent runtime is deleted.
+2. **User scoping** — a compromised (prompt-injected) agent must not act on another user's connection, nor exceed what the user consented to. The agent sends only `{toolkit, action, args}` (plus an optional `onBehalfOf` *selector*); identity is stamped by trusted infrastructure, consent is re-checked per call against the grant store, and actions are scoped by **permission bundles**.
 
-**Key custody belongs in the Assistants outbound proxy, not the backend.** `workers/assistant/.../outbound.ts` already injects credentials for OpenRouter, Herald, the private bucket, and the runtime, and already hard-blocks direct egress (`denyDirectEgress`). Adding a `composio.internal` handler is ~6 mechanical steps in one repo — no new backend endpoint, no extra HTTP hop. Nick is right; this is the cheap, correct home for it.
+## Threat model (the two facts everything rests on)
 
-**OAuth-account isolation is a separate problem that proxying does not solve — in either repo.** The global Composio key is omnipotent across every user in the project, and `user_id` is just the sender's `inboxId`, which is **not a secret**. A prompt-injected agent sends a victim's `inboxId` and the global key acts on their calendar. Injecting the *key* doesn't touch this — the agent still fills in `user_id`/`connected_account_id`. Isolation requires the trusted layer to supply the identity and leave the agent **no field to name another account**. The good news: the trusted anchors to do this already exist (the instance is pinned to one conversation; Herald hands the worker an authentic per-message sender). See Recommendation 2.
+- **`user_id` is not a secret.** It's Composio's request field; a prompt-injected agent can name any value. Identity must therefore come from a layer the agent cannot influence.
+- **`connected_account_id` is a bearer capability.** Composio does not cross-check it against `user_id` — possession is access. It must never reach, or be accepted from, any client or agent.
 
-## Correcting the record
+> Invariant: **the agent never holds a key, never holds or names a connection, and cannot name another account.** Identity comes from the trusted worker; consent comes from the JWT-authenticated grant store; custody (the Composio key + bearer ids) stays in the backend.
 
-Two premises in the first draft were wrong. The code:
+## How a tool call flows
 
-- **There is no per-assistant Composio project pool.** `COMPOSIO_API_KEY` is a **single global worker env var**, forwarded straight into the agent container (`hermes-env.ts:190-204`). The agent reads `process.env.COMPOSIO_API_KEY` and calls `https://backend.composio.dev` directly (`connections.mjs` `composio()` helper). So "retire per-assistant Composio projects" was retiring something that doesn't exist — and Nick's "Composio creds live in the agent container" is the accurate description of today.
-- **The agent already uses `inboxId`, not `deviceId`.** Execution sends `user_id: grant.composioEntityId`, where `composioEntityId = senderId` (the XMTP envelope sender's inboxId, optionally `:label`). The "identifier alignment / switch off deviceId" section of the first draft was solving a break that isn't in this code path.
+```
+agent container (untrusted)
+  → POST http://composio.internal/exec        { toolkit, action, args, onBehalfOf? }
+trusted assistants worker (Cloudflare DO) — proxyComposioExec
+  → builds a FRESH request: container headers dropped, body whitelisted
+  → POST {backend}/api/v2/composio/exec
+      X-Composio-Exec-Key:       dedicated secret (COMPOSIO_EXEC_API_KEY)
+      x-convos-conversation-id:  pinned at instance creation — worker state
+      x-convos-agent-inbox-id:   the instance's own inbox — worker state
+convos-backend — execHandler
+  1. composioExecAuth — dedicated key, constant-time compare
+  2. resolveTrustedCaller — identity headers absent/oversized → 403 (fail closed)
+  3. grant lookup (granteeInboxId, conversationId, toolkit; live, unexpired)
+  4. action ∈ union(grant.actions, bundle-resolved actions) — else 403 no_grant
+  5. >1 matching owner and no onBehalfOf → 409 ambiguous_grant (fail closed)
+  6. connection resolved SERVER-SIDE from (ownerAccountId, toolkit) — never client input
+  7. toolkit version pinned; unresolvable → 502 (fail closed)
+  8. composio.tools.execute(action, { userId: ownerAccountId, connectedAccountId, version })
+```
 
-### Composio terminology + two API facts (the security model hinges on these)
+Defense around the path:
 
-- **`user_id` is Composio's request field, not a Convos identifier.** Today Convos puts the **`inboxId`** in it; the target (per the auth API) is **`accountId`**. Don't read `user_id` as a Convos concept — it's just Composio's parameter name.
-- **`connected_account_id` is a bearer capability.** Composio does **not** cross-check that `connected_account_id` belongs to `user_id` (confirmed by Louis). So whoever passes a `connected_account_id` can use that connection *regardless of `user_id`*. Constraining the account identifier alone is **not** sufficient — the `connected_account_id` itself must never reach the agent.
-- **Does `tools/execute` resolve a connection from `user_id` + toolkit alone (no `connected_account_id`)?** Open — needed to confirm the agent can omit `connected_account_id` entirely (Decision Q).
+- **Dedicated exec key, not the agent key.** The worker's generic `convos.internal` proxy injects the agent API key for arbitrary backend paths — reusing that key for exec would let a container smuggle an exec call with forged identity headers through the generic proxy. So exec authenticates with a separate secret (`COMPOSIO_EXEC_API_KEY`) that only `proxyComposioExec` sets, and the generic proxy additionally **denies `/api/v2/composio/*`** and **strips `x-convos-*` headers**.
+- **Direct egress denied.** `backend.composio.dev` → `denyDirectEgress` in the worker, same as `openrouter.ai`.
+- **`onBehalfOf` is a selector, not authority.** It picks among the agent's *already-authorized* grants ("query Alice's calendar" in a group); naming a member who never granted yields `no_grant` — it cannot widen access.
 
-## The bug today
+## Permission bundles (least privilege)
 
-For OAuth toolkits the agent runs both `connect` and `execute` through the same global key, so those work. The break is on the **iOS-capability** path (calendar, fitness, etc., the `IOS_CAPABILITY_SERVICES` set): iOS creates the connection in *its* Composio project, drops a `connectionId` into profile metadata, and the agent then tries to execute against the *global agent* key — different project, connection not found.
+Clients have no Composio action slugs, so action-level consent is expressed as backend-owned **bundles** (human intents like "Events"):
 
-The consent layer ([convos-ios#796](https://github.com/xmtplabs/convos-ios/pull/796)/[#797](https://github.com/xmtplabs/convos-ios/pull/797), [convos-assistants#1484](https://github.com/xmtplabs/convos-assistants/pull/1484)) is correct under any model below. The break is purely **which project the connection lives in vs. where the agent executes** — i.e. a key-custody/consolidation problem, which the proxy below also fixes by giving us one mediated path.
+- The catalog (`src/api/v2/connections/bundles.config.ts`) maps `service → bundle → action slugs` and is served via **`GET /v2/connections/services`** (JWT-only) **with slugs stripped** — no Composio slug ever reaches a client.
+- Grants carry `{toolkit, serviceVersion, bundleIds}`; the device persists only bundle ids. The backend resolves bundles → actions **at exec time against the current catalog**, so re-mapping actions needs no app release.
+- **Fail closed everywhere:** unknown bundle ids are rejected at grant time (400 `unknown_bundle`); a grant whose bundles resolve to nothing (stale/unknown) authorizes nothing at exec (403 `no_grant`) — it never falls back to whole-toolkit. A read-only bundle (`calendar.events.read`) exists precisely to prove a read grant can never write (regression-tested).
+- **Transition-only exception:** a legacy grant with *both* `actions` and `bundleIds` empty still means whole-toolkit (logged). Flipping this to fail-closed is Phase C, once iOS + Android always send `bundleIds` — see "In progress."
 
-## Recommendation 1 (key custody): proxy Composio in `outbound.ts`
+## Grant lifecycle
 
-Agents call `http://composio.internal/api/v3/...`; the outbound handler injects the key and forwards to `backend.composio.dev`. The agent never holds the key, and direct egress to Composio is blocked the same way `openrouter.ai` is.
+- **Issue:** `POST /v2/connections/grants` (SIWE JWT) — the owner is taken from the JWT, never the body; a caller can only grant access to their own connections. Any `connectionId` in the body is **ignored by design** (bearer capability — accepting one would let a caller pin a victim's connection). One grant per `(owner, grantee, conversation, toolkit)`; grants fan out per agent (iOS #812).
+- **Check:** per exec call, live-only (`revokedAt` null, unexpired) — revocation is immediate.
+- **Revoke:** by **natural key** (`POST /v2/connections/grants/revoke` with `toolkit [+ conversationId] [+ granteeInboxId]`), so revocation works even when the client lost the grant id; plus `DELETE /grants/:id`. Owner scoped from the JWT.
 
-This is the existing pattern, applied verbatim:
+## Safety properties
 
-| Step | Change | Precedent |
-|---|---|---|
-| 1 | Add `composioApiKey` to `CredentialsSchema` (`schemas.ts:182`). | `heraldApiKey` |
-| 2 | Define `COMPOSIO_OUTBOUND_HOST = "composio.internal"`. | `HERALD_OUTBOUND_HOST` |
-| 3 | Add `proxyComposio()` handler: inject `x-api-key`, forward to upstream. | `proxyHerald` |
-| 4 | Wire it in `buildOutboundOverrides` + `outboundByHost`, and add `"backend.composio.dev" → denyDirectEgress`. | OpenRouter + `denyDirectEgress` |
-| 5 | Stop forwarding the real key to the container in `buildHermesEnv` (set a placeholder); point `COMPOSIO_BASE_URL` at `http://composio.internal`. | OpenRouter key handling |
-| 6 | Swap the agent's `composio()` base URL to the internal host. Two runtimes: `convos-platform` and the mirrored `runtime/hermes/.hermes-dev/...`. | — |
+| Attack | Outcome |
+|---|---|
+| Stranger outside the conversation | No grant row → 403 before any Composio call |
+| Container forges identity headers | Worker builds a fresh request; generic proxy strips `x-convos-*` and denies `/api/v2/composio/*`; exec key never in the container |
+| Agent impersonates another agent | `granteeInboxId` comes from worker state, not the container |
+| Client/agent supplies a `connectionId` | No API accepts one; resolution is server-side from the owner's own account |
+| Verb escalation (read grant tries a write) | Action must be in the bundle-resolved union → 403 `no_grant` |
+| Stale/unknown bundle ids | 400 `unknown_bundle` at grant; resolve-to-nothing at exec → 403 `no_grant` |
+| Revoked grant | Re-checked per call; natural-key revoke needs no stored id |
+| Two members granted the same toolkit | 409 `ambiguous_grant` unless `onBehalfOf` names one |
 
-**What this buys:** the load-bearing key-custody invariant, with code that already exists, in one repo, with zero backend dependency and no hot-path round trip. Ship this now.
+## Known limits & in progress
 
-## Recommendation 2 (isolation): constrain `user_id` in the proxy, in two tiers
+- **Tier-1 boundary (honest limit):** within one conversation, any member can drive the agent into a granted toolkit — the blast radius is the conversation, matching the iOS consent semantics. **Tier 2 per-sender isolation** (worker stamps the HMAC-verified Herald sender per delivery; backend matches it against `ownerInboxId` unless the grant is explicitly shared) is designed but **not built**.
+- **PR #294 — Composio connections scoped to `accountId`** (+ one-time move migration): **in progress** (open). Exec already keys Composio's `user_id` to the stable `ownerAccountId`.
+- **Phase C — fail-closed flip for legacy grants** (drop the whole-toolkit default for empty/empty grants): **in progress**, gated on iOS + Android always sending `bundleIds`.
+- **Toolkit version pinning** currently pins the newest published version at call time (fail-closed when unresolvable); pinning to a vetted version is being refined: **in progress**.
+- **`accountId` federation** (multi-inbox/multi-device) stays gated on the new auth API — unchanged, v2.
 
-The threat in one line: **`connected_account_id` is a bearer capability** (Composio doesn't check it against the account identifier), and the agent fills it in today. So the invariant isn't "constrain the identifier" — it's:
+## Pointers
 
-> **The agent must never hold or name a `connected_account_id`.** A trusted layer resolves the connection from a trusted identity (the verified sender's `accountId`) via a grant store keyed by `accountId`, and injects it. The agent sends only `{ toolkit, action, args }`.
-
-Two trusted anchors the agent **cannot forge** make this enforceable:
-
-**Anchor 1 — the conversation is pinned at init.** `Credentials.heraldConversationId` is set when the instance is created (`create-assistant-workflow.ts:539`) and is never agent-supplied.
-
-**Anchor 2 — Herald hands the worker an authentic per-message sender.** The Herald webhook carries `senderInboxId` as a top-level field in the **HMAC-signed** body — `herald.ts:94` verifies the signature, `operations.ts:356` already parses it, envelope shape at `deliver-notify-workflow.test.ts:53`. Herald decrypts XMTP server-side, so this sender is authentic; the worker just doesn't read the field yet. (Contrast `.convos-current-trigger.json`, which a compromised agent **can** forge — `connections.mjs:109`.)
-
-### Tier 1 — conversation-boundary isolation (ship with the proxy)
-
-The trusted layer resolves the connection only from the set of `accountId`s belonging to *this instance's* conversation members (Anchor 1 + the conversation-scoped Herald key, `/v1/conversation/{heraldConversationId}/profiles`). The agent names no connection.
-
-- **DM (the common case): exact per-user isolation** — one member, one possible connection, nothing to spoof.
-- **Group: blast radius bounded to conversation members** — never a stranger in another chat.
-
-This closes the cross-conversation leak ("User A asks for User B" where A and B are in different chats) completely, with **no new trusted infrastructure** beyond the grant store.
-
-### Tier 2 — per-sender isolation (closes intra-group escalation)
-
-**This is the "group limit."** Under Tier 1, any member's connection is reachable during *any* turn — so in a group, member B can drive the agent into member A's calendar. The boundary is the conversation, not the person. Closing it needs the connection resolved from the **verified sender's `accountId`** (Anchor 2), default-denying every other member's connection. **Shared grants** (the existing `isShared` path) remain the explicit opt-in when A *wants* the group to use their calendar.
-
-The hard part — and the real reason this is MVP-2: one agent instance serves the whole group with **interleaved** messages, so a mutable "current sender" flag is racy. The robust form is a **per-delivery capability**, not shared state:
-
-- **(a) Per-delivery binding.** The worker resolves the connection for that delivery's verified `senderInboxId → accountId` and binds it to that delivery's work. New plumbing: today's egress context is static at init.
-- **(b) Composio scoped sessions** (`tool_router/sessions` / scoped MCP URLs). The worker mints a short-lived session for the verified sender per message; Composio enforces scope and the proxy stops being security-critical. Cleanest **if** sessions support action-level scope (open Decision Q).
-
-**Same rule on the OAuth `connect` path.** The `entity_id`/`accountId` at connect time must be the verified sender, not the trigger-file value — otherwise a malicious agent attaches a victim's connection under the wrong account.
-
-### Open fork: where the grant store + the Composio call live
-
-> **Decided (2026-06-09): fork (Y) backend-mediates.** The backend holds the key and the
-> grants and makes the Composio call; the agent calls `Backend.exec(toolkit, action, args)`
-> with no connection identifier, so the bearer capability never leaves the backend. Backend
-> implementation plan: [`docs/plans/composio-exec-grant-mediation.md`](../plans/composio-exec-grant-mediation.md).
->
-> **Refined (2026-06-10): (Y) composes with Rec 1's proxy, it doesn't replace it.** The
-> `composio.internal` outbound handler still ships — it just forwards to the backend's
-> `/v2/composio/exec` instead of `backend.composio.dev`, injecting the worker's
-> `X-Agent-API-Key` plus identity headers (`X-Convos-Conversation-Id`,
-> `X-Convos-Agent-Inbox-Id`) stamped from instance state. The backend trusts those headers
-> exactly as it already trusts the worker's credits calls on the same key: the container
-> never holds it. This resolves Tier 1's trusted-identity source with no new auth scheme;
-> Anchor 2 (per-delivery verified sender) remains the Tier 2 mechanism.
-
-Two secrets, and they need not co-locate: the **Composio project key** (one global secret) and the **per-user `connected_account_id`s** (your backend grant store keyed by `accountId`). But *who calls Composio* is a real decision:
-
-- **(X) Proxy-resolves.** The `outbound.ts` proxy holds the project key (Nick's model) and, per call, resolves the connection from the backend grant store using the verified sender's `accountId`, then calls Composio. Keeps key custody in assistants; adds a backend lookup on the hot path.
-- **(Y) Backend-mediates.** Backend holds the key *and* the grants and makes the Composio call itself — the agent calls `Backend.exec(toolkit, action, args)` with no connection identifier. Simplest isolation story (the bearer capability never leaves backend), but it's the mediation layer Nick pushed back on for key custody.
-
-Louis's "store credentials in convos-backend" leans (Y); the earlier "OK for key custody in the proxy" leans (X). **Pick one** — it changes which repo owns the Composio call. Note both keep `connected_account_id` out of the agent; they differ only on where the key lives.
-
-## Identifier alignment / `accountId` — demoted to v2
-
-Because the agent already uses `inboxId` as `user_id`, there's no `deviceId → inboxId` break to fix for MVP. The `accountId` federation story (multi-inbox per user, multi-device, auth-method federation) from Borja's new auth API is still the right long-term unifier, but it's **gated on that API shipping and is not blocking** this work. Moved to v2: when auth lands, switch Composio's `user_id` from `inboxId` to `accountId` and resolve `inboxId → accountId` at the proxy.
-
-## Orthogonal: per-agent grant scoping ([convos-ios#812](https://github.com/xmtplabs/convos-ios/pull/812))
-
-Unchanged from the first draft and still composes cleanly. Per-agent gating lives at the messaging layer keyed on agent `inboxId` (`grantedToInboxId`/`askerInboxId`); the runtime already drops `connection_event`s scoped to another agent (`sdk-client.ts`). That's a different axis from key custody and user scoping; all three land independently.
-
-## Phasing
-
-| Phase | Scope | Effort |
-|---|---|---|
-| **MVP-1** | `composio.internal` proxy (Rec 1) **+ Tier 1 conversation-boundary isolation** (Rec 2). Key leaves the container; global key becomes per-conversation-scoped; cross-conversation leak closed; DMs get exact per-user isolation. Agent sends only `{toolkit, action, args}`. | one repo, ~one sprint |
-| **MVP-2** | **Tier 2 per-sender isolation** (Rec 2, option a or b) — closes intra-group escalation using the worker's verified `senderInboxId`. | scoped after Composio session Q |
-| **v2** | `accountId` federation, gated on the new auth API. | not blocking |
-
-## Decision needed
-
-1. **Decided (2026-06-09, refined 2026-06-10): fork (Y) backend-mediates, via Rec 1's proxy as the courier.** The backend owns the Composio call and holds both the key and the grants; the agent calls `composio.internal/exec` with `{toolkit, action, args}` and the `outbound.ts` handler forwards to the backend's `/v2/composio/exec`, injecting `X-Agent-API-Key` + identity headers from instance state (same worker→backend trust the credits flow already uses). So Rec 1's mechanism is *reused* — pointed at our backend instead of Composio — and `COMPOSIO_API_KEY` stops being forwarded into the container (today it is: `hermes-env.ts:190-204`). MVP-1 *does* carry backend work (contrast the "no backend changes" note below, written for the (X) path). Reconfirm with Nick: the consent re-check can't live in the proxy (no grant store there), and the extra hop buys exactly that.
-2. Approve **Tier 1 conversation-boundary isolation** as the MVP (closes the cross-conversation leak; DMs get exact per-user isolation). Owner for the grant store keyed by `accountId` + the agent contract (`{toolkit, action, args}`, no `connected_account_id`).
-3. **Resolved (Louis):** Composio does **not** cross-validate `connected_account_id` against the account — so it's a bearer capability and must never reach the agent. The agent contract carries no connection identifier regardless of fork.
-4. **Still open — for Nick:**
-   - Can `tools/execute` resolve the connection from the account identifier + toolkit alone (so we omit `connected_account_id` entirely)?
-   - Do `tool_router/sessions` / scoped MCP URLs support **action-level** scope (`GOOGLECALENDAR_EVENTS_LIST`, not the whole toolkit)? Decides Tier 2 option (a) vs (b).
-
-## Why this aligns with what we already shipped
-
-- iOS PRs (`#796`, `#797`) issue grants tagged `(provider, capability, conversationId)` and post `connection_event` revocations; the runtime already relays revocations into the model (`#1484`). The consent semantics are framework-agnostic and survive this change.
-- iOS `#812` (per-agent grant scoping) is an independent axis and lands alongside.
-- **No iOS or backend changes for MVP-1.** This is the correction from the first draft: the work is entirely in `convos-assistants`, reusing a proxy pattern that already ships in production for four other upstreams.
+- Bundles contract + catalog decisions: `docs/plans/connections-bundles-backend.md` (on `louis/connections-bundles`, with JSON Schemas under `docs/schemas/`).
+- Implementation plan (historical, see its status banner for corrections): [`docs/plans/composio-exec-grant-mediation.md`](../plans/composio-exec-grant-mediation.md).

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -1,0 +1,84 @@
+# Composio Security Model — MVP
+
+**Author:** Louis
+**Audience:** Fabri, Nick, Mike
+**Status:** Draft for sign-off
+
+## TL;DR
+
+Convos Backend owns all Composio connections and exposes a narrow per-call API to agents. Retire the per-assistant Composio projects in the Assistants pool config. Per-user projects can come in v2; not blocking MVP.
+
+## The bug today
+
+iOS authorizes Google Calendar via Convos Backend's Composio project. The connection lands there. The user's profile metadata gets a `connectionId`. The agent then tries to invoke the action via *its own* per-assistant Composio project — and finds nothing, because the connection lives in a different project.
+
+The capability-request consent layer ([convos-ios#796](https://github.com/xmtplabs/convos-ios/pull/796) / [#797](https://github.com/xmtplabs/convos-ios/pull/797), [convos-assistants#1484](https://github.com/xmtplabs/convos-assistants/pull/1484)) is correct under any security model below. The break is purely **where the agent invokes the toolkit**.
+
+## Recommendation: Backend mints scoped invocations
+
+Agents call **Convos Backend → Composio**, never Composio directly. Backend already holds the only Composio project key; we keep it that way and expose a narrow API to agents.
+
+```
+iOS  → Backend.connect(toolkit)              # OAuth, stores connectionId in profile metadata
+                ↓
+Agent → Backend.exec(user, toolkit, action, args)
+                ↓ (re-validates the iOS-issued capability grant)
+        Backend → Composio
+```
+
+Per-call scope is `(user, toolkit, action, connectionId)` — the same tuple iOS already gates via the picker. Backend re-checks the capability grant before forwarding (defense-in-depth: a misbehaving agent can't escalate verbs).
+
+## Phasing
+
+| Phase | Scope | Effort |
+|---|---|---|
+| **MVP-1** | Convos Backend exposes `POST /v2/composio/exec` (thin proxy for `tools/execute`) **plus identifier alignment** (see below). Agent call stack becomes `connections.mjs exec → Backend → Composio`. **Per-assistant Composio projects retired** — that's the source of the current bug. | one sprint |
+| **MVP-2** | Replace proxy with Composio `tool_router/sessions` or scoped MCP URLs. Same agent contract, lower Backend hot-path cost. | when session APIs prove out |
+| **v2** | Project-per-user on Backend for stronger blast-radius isolation. | not blocking |
+
+The agent contract stays the same across phases — only Backend internals change.
+
+## Identifier alignment (the missing link)
+
+Today there's no link between a Convos user's grants and Composio's connections:
+- iOS ↔ Backend uses `deviceId` (iOS `identifierForVendor`, encoded in the JWT).
+- Backend ↔ Composio passes `deviceId` verbatim as Composio's `userId`.
+- Conversation ↔ agent uses XMTP `inboxId` — the sender of `capability_request_result`.
+
+The agent only ever has `inboxId`; the Backend only ever has `deviceId`. There's no mapping anywhere — JWT has no inboxId field, no Backend table reconciles them. Today this works only because iOS handles both sides of its own flow; the moment an agent is the caller, the link breaks.
+
+**Recommended fix: switch Composio's `userId` to `inboxId`, with a fallback window.**
+
+- iOS sends `inboxId` to the Backend on connection calls (header or JWT metadata).
+- Backend uses `inboxId` as Composio's `userId` for all *new* OAuth flows.
+- Backend's `exec` endpoint accepts `inboxId` from the agent — same identifier the agent already has from the XMTP message sender.
+- For existing connections (keyed under `deviceId` in Composio), Backend falls back to `deviceId` lookup if `inboxId` returns no result. Users naturally migrate when they re-OAuth, no forced action.
+- Side benefit: incidentally fixes a latent multi-device bug. Today, the same user on two devices = two Composio "users" and two separate OAuths.
+
+**Alternative considered:** a `deviceId ↔ inboxId` mapping table on the Backend. Avoids any Composio-side migration but adds a schema model, a registration step, and 1:N ambiguity for users with multiple installs. The fallback-window approach gets us the same end state without those costs.
+
+## Why not the alternatives
+
+- **Single shared project, no Backend layer (status quo with the iOS-side bug):** every agent shares one project key. No isolation between agents at the Composio layer, and the OAuth-vs-execution split is exactly the bug we have today.
+- **Project per assistant (current Assistants pool config):** breaks sign-in-once. User would re-OAuth Google Calendar for every assistant they interact with. Product spec rules this out.
+- **Project per user:** needs an *org-level* key on Backend to programmatically create projects — back to "one key with the keys to the kingdom." Plus likely per-project Composio billing. Push to v2.
+
+## Open questions
+
+@Nick
+
+1. Does Composio's `tool_router/sessions` or scoped MCP URLs accept **action-level** scope (`GOOGLECALENDAR_EVENTS_LIST` only, not the whole toolkit)? If toolkit-only, MVP-1's proxy stays the long-term path.
+2. Session TTL semantics — short-lived (minutes) preferred. Longer-lived would need revocation hooks tied to the iOS `connection_event.revoked` we already plumb.
+3. Pricing — does the single-project model with high call volume cost less than project-per-user?
+
+## Decision needed
+
+1. Approve the Backend-mediated direction above.
+2. Approve retiring the per-assistant Composio projects in Assistants pool config.
+3. Assign owner for the MVP-1 Backend `exec` endpoint.
+
+## Why this aligns with what we already shipped
+
+- iOS PRs (`#796`, `#797`) already issue grants tagged with `(provider, capability, conversationId)` and post `connection_event` revocations. These are the inputs the Backend re-checks before any tool execution.
+- `convos-assistants#1484` already relays `connection_event.revoked` into the model as a system message. When the Backend rejects an `exec` because a grant was just revoked, the model already has the context to explain why.
+- No iOS changes needed regardless of the model chosen. The picker UI and the consent semantics are framework-agnostic.

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -9,7 +9,7 @@
 Two problems hide under "Composio security," and **backend-mediated execution** closes both:
 
 1. **Key custody** — the agent must never hold a Composio key. It now holds none: `COMPOSIO_API_KEY` lives only in convos-backend, the agent container gets placeholder creds, and the legacy direct-Composio path in the agent runtime is deleted.
-2. **User scoping** — a compromised (prompt-injected) agent must not act on another user's connection, nor exceed what the user consented to. The agent sends only `{toolkit, action, args}` (plus an optional `onBehalfOf` *selector*); identity is stamped by trusted infrastructure, consent is re-checked per call against the grant store, and actions are scoped by **permission bundles**.
+2. **User scoping** — a compromised (prompt-injected) agent must not act on another user's connection, nor exceed what the user consented to. The agent sends only `{toolkit, action, args}` (plus an optional `onBehalfOf` _selector_); identity is stamped by trusted infrastructure, consent is re-checked per call against the grant store, and actions are scoped by **permission bundles**.
 
 ## Threat model (the two facts everything rests on)
 
@@ -44,7 +44,7 @@ Defense around the path:
 
 - **Dedicated exec key, not the agent key.** The worker's generic `convos.internal` proxy injects the agent API key for arbitrary backend paths — reusing that key for exec would let a container smuggle an exec call with forged identity headers through the generic proxy. So exec authenticates with a separate secret (`COMPOSIO_EXEC_API_KEY`) that only `proxyComposioExec` sets, and the generic proxy additionally **denies `/api/v2/composio/*`** and **strips `x-convos-*` headers**.
 - **Direct egress denied.** `backend.composio.dev` → `denyDirectEgress` in the worker, same as `openrouter.ai`.
-- **`onBehalfOf` is a selector, not authority.** It picks among the agent's *already-authorized* grants ("query Alice's calendar" in a group); naming a member who never granted yields `no_grant` — it cannot widen access.
+- **`onBehalfOf` is a selector, not authority.** It picks among the agent's _already-authorized_ grants ("query Alice's calendar" in a group); naming a member who never granted yields `no_grant` — it cannot widen access.
 
 ## Permission bundles (least privilege)
 
@@ -53,7 +53,7 @@ Clients have no Composio action slugs, so action-level consent is expressed as b
 - The catalog (`src/api/v2/connections/bundles.config.ts`) maps `service → bundle → action slugs` and is served via **`GET /v2/connections/services`** (JWT-only) **with slugs stripped** — no Composio slug ever reaches a client.
 - Grants carry `{toolkit, serviceVersion, bundleIds}`; the device persists only bundle ids. The backend resolves bundles → actions **at exec time against the current catalog**, so re-mapping actions needs no app release.
 - **Fail closed everywhere:** unknown bundle ids are rejected at grant time (400 `unknown_bundle`); a grant whose bundles resolve to nothing (stale/unknown) authorizes nothing at exec (403 `no_grant`) — it never falls back to whole-toolkit. A read-only bundle (`calendar.events.read`) exists precisely to prove a read grant can never write (regression-tested).
-- **Transition-only exception:** a legacy grant with *both* `actions` and `bundleIds` empty still means whole-toolkit (logged). Flipping this to fail-closed is Phase C, once iOS + Android always send `bundleIds` — see "In progress."
+- **Transition-only exception:** a legacy grant with _both_ `actions` and `bundleIds` empty still means whole-toolkit (logged). Flipping this to fail-closed is Phase C, once iOS + Android always send `bundleIds` — see "In progress."
 
 ## Grant lifecycle
 
@@ -63,16 +63,16 @@ Clients have no Composio action slugs, so action-level consent is expressed as b
 
 ## Safety properties
 
-| Attack | Outcome |
-|---|---|
-| Stranger outside the conversation | No grant row → 403 before any Composio call |
-| Container forges identity headers | Worker builds a fresh request; generic proxy strips `x-convos-*` and denies `/api/v2/composio/*`; exec key never in the container |
-| Agent impersonates another agent | `granteeInboxId` comes from worker state, not the container |
-| Client/agent supplies a `connectionId` | No API accepts one; resolution is server-side from the owner's own account |
-| Verb escalation (read grant tries a write) | Action must be in the bundle-resolved union → 403 `no_grant` |
-| Stale/unknown bundle ids | 400 `unknown_bundle` at grant; resolve-to-nothing at exec → 403 `no_grant` |
-| Revoked grant | Re-checked per call; natural-key revoke needs no stored id |
-| Two members granted the same toolkit | 409 `ambiguous_grant` unless `onBehalfOf` names one |
+| Attack                                     | Outcome                                                                                                                           |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Stranger outside the conversation          | No grant row → 403 before any Composio call                                                                                       |
+| Container forges identity headers          | Worker builds a fresh request; generic proxy strips `x-convos-*` and denies `/api/v2/composio/*`; exec key never in the container |
+| Agent impersonates another agent           | `granteeInboxId` comes from worker state, not the container                                                                       |
+| Client/agent supplies a `connectionId`     | No API accepts one; resolution is server-side from the owner's own account                                                        |
+| Verb escalation (read grant tries a write) | Action must be in the bundle-resolved union → 403 `no_grant`                                                                      |
+| Stale/unknown bundle ids                   | 400 `unknown_bundle` at grant; resolve-to-nothing at exec → 403 `no_grant`                                                        |
+| Revoked grant                              | Re-checked per call; natural-key revoke needs no stored id                                                                        |
+| Two members granted the same toolkit       | 409 `ambiguous_grant` unless `onBehalfOf` names one                                                                               |
 
 ## Known limits & in progress
 

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -90,32 +90,35 @@ Two secrets, and they need not co-locate: the **Composio project key** (one glob
 - **(X) Proxy-resolves.** The `outbound.ts` proxy holds the project key (Nick's model) and, per call, resolves the connection from the backend grant store using the verified sender's `accountId`, then calls Composio. Keeps key custody in assistants; adds a backend lookup on the hot path.
 - **(Y) Backend-mediates.** Backend holds the key *and* the grants and makes the Composio call itself — the agent calls `Backend.exec(toolkit, action, args)` with no connection identifier. Simplest isolation story (the bearer capability never leaves backend), but it's the mediation layer Nick pushed back on for key custody.
 
-Both should land. They don't conflict.
+Louis's "store credentials in convos-backend" leans (Y); the earlier "OK for key custody in the proxy" leans (X). **Pick one** — it changes which repo owns the Composio call. Note both keep `connected_account_id` out of the agent; they differ only on where the key lives.
 
-## Why not the alternatives
+## Identifier alignment / `accountId` — demoted to v2
 
-- **Single shared project, no Backend layer (status quo with the iOS-side bug):** every agent shares one project key. No isolation between agents at the Composio layer, and the OAuth-vs-execution split is exactly the bug we have today.
-- **Project per assistant (current Assistants pool config):** breaks sign-in-once. User would re-OAuth Google Calendar for every assistant they interact with. Product spec rules this out.
-- **Project per user:** needs an *org-level* key on Backend to programmatically create projects — back to "one key with the keys to the kingdom." Plus likely per-project Composio billing. Push to v2. MVP-1 closes the *agent-side* leak completely; v2 addresses *Backend-side* key exfiltration (one stolen Composio key → all users leak). Different threat, different cost.
+Because the agent already uses `inboxId` as `user_id`, there's no `deviceId → inboxId` break to fix for MVP. The `accountId` federation story (multi-inbox per user, multi-device, auth-method federation) from Borja's new auth API is still the right long-term unifier, but it's **gated on that API shipping and is not blocking** this work. Moved to v2: when auth lands, switch Composio's `user_id` from `inboxId` to `accountId` and resolve `inboxId → accountId` at the proxy.
 
-## Open questions
+## Orthogonal: per-agent grant scoping ([convos-ios#812](https://github.com/xmtplabs/convos-ios/pull/812))
 
-@Nick
+Unchanged from the first draft and still composes cleanly. Per-agent gating lives at the messaging layer keyed on agent `inboxId` (`grantedToInboxId`/`askerInboxId`); the runtime already drops `connection_event`s scoped to another agent (`sdk-client.ts`). That's a different axis from key custody and user scoping; all three land independently.
 
-1. Does Composio's `tool_router/sessions` or scoped MCP URLs accept **action-level** scope (`GOOGLECALENDAR_EVENTS_LIST` only, not the whole toolkit)? If toolkit-only, MVP-1's proxy stays the long-term path.
-2. Session TTL semantics — short-lived (minutes) preferred. Longer-lived would need revocation hooks tied to the iOS `connection_event.revoked` we already plumb.
-3. Pricing — does the single-project model with high call volume cost less than project-per-user?
+## Phasing
+
+| Phase | Scope | Effort |
+|---|---|---|
+| **MVP-1** | `composio.internal` proxy (Rec 1) **+ Tier 1 conversation-boundary isolation** (Rec 2). Key leaves the container; global key becomes per-conversation-scoped; cross-conversation leak closed; DMs get exact per-user isolation. Agent sends only `{toolkit, action, args}`. | one repo, ~one sprint |
+| **MVP-2** | **Tier 2 per-sender isolation** (Rec 2, option a or b) — closes intra-group escalation using the worker's verified `senderInboxId`. | scoped after Composio session Q |
+| **v2** | `accountId` federation, gated on the new auth API. | not blocking |
 
 ## Decision needed
 
-1. Approve the Backend-mediated direction above.
-2. Approve retiring the per-assistant Composio projects in Assistants pool config.
-3. Assign owner for the MVP-1 Backend `exec` endpoint (`convos-backend`).
-4. Assign owner for the agent-side swap to `Backend.exec` (`convos-assistants`, both runtimes).
+1. **Pick the call path — fork (X) proxy-resolves vs (Y) backend-mediates** (see Recommendation 2). This decides which repo owns the Composio call and whether key custody stays in the proxy. Everything else follows from it.
+2. Approve **Tier 1 conversation-boundary isolation** as the MVP (closes the cross-conversation leak; DMs get exact per-user isolation). Owner for the grant store keyed by `accountId` + the agent contract (`{toolkit, action, args}`, no `connected_account_id`).
+3. **Resolved (Louis):** Composio does **not** cross-validate `connected_account_id` against the account — so it's a bearer capability and must never reach the agent. The agent contract carries no connection identifier regardless of fork.
+4. **Still open — for Nick:**
+   - Can `tools/execute` resolve the connection from the account identifier + toolkit alone (so we omit `connected_account_id` entirely)?
+   - Do `tool_router/sessions` / scoped MCP URLs support **action-level** scope (`GOOGLECALENDAR_EVENTS_LIST`, not the whole toolkit)? Decides Tier 2 option (a) vs (b).
 
 ## Why this aligns with what we already shipped
 
-- iOS PRs (`#796`, `#797`) already issue grants tagged with `(provider, capability, conversationId)` and post `connection_event` revocations. These are the inputs the Backend re-checks before any tool execution.
-- iOS PR `#812` adds per-agent grant scoping (`grantedToInboxId`, `askerInboxId`). Composes naturally with this doc: per-agent gating at the messaging layer, per-account data scoping at Composio.
-- `convos-assistants#1484` already relays `connection_event.revoked` into the model as a system message. When the Backend rejects an `exec` because a grant was just revoked, the model already has the context to explain why.
-- No iOS changes needed regardless of the model chosen. The picker UI and the consent semantics are framework-agnostic.
+- iOS PRs (`#796`, `#797`) issue grants tagged `(provider, capability, conversationId)` and post `connection_event` revocations; the runtime already relays revocations into the model (`#1484`). The consent semantics are framework-agnostic and survive this change.
+- iOS `#812` (per-agent grant scoping) is an independent axis and lands alongside.
+- **No iOS or backend changes for MVP-1.** This is the correction from the first draft: the work is entirely in `convos-assistants`, reusing a proxy pattern that already ships in production for four other upstreams.

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -54,7 +54,6 @@ The new auth API ([Borja's design](https://xmtp-labs.slack.com/archives/C0ASWCMS
 
 Why `accountId` beats the simpler "use `inboxId`" cut:
 
-- **Inbox recovery survives.** `inboxId` changes on key rotation / lost device; `accountId` persists. Composio connections shouldn't churn on inbox changes.
 - **Multi-inbox per user.** Users will have multiple inboxes (work/personal, etc.); their connections shouldn't fragment across inboxes.
 - **Auth-method federation.** A Composio connection isn't tied to whichever auth method the user happened to sign in with.
 - **Multi-device for free.** Same human on two devices = one Composio user. The latent multi-device bug iOS has today goes away by construction.

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -2,33 +2,27 @@
 
 **Author:** Louis
 **Audience:** Fabri, Nick, Mike
-**Status:** Draft for sign-off
+**Status:** Draft for sign-off (revised after Nick's review)
 
 ## TL;DR
 
-Convos Backend owns all Composio connections and exposes a narrow per-call API to agents. **The load-bearing security invariant: the agent must never hold the Composio project API key.** One project is safe as long as exactly one keyholder exists. Retire the per-assistant Composio projects in the Assistants pool config. Per-user projects can come in v2; not blocking MVP.
+There are **two** problems hiding under "Composio security," and the first draft of this doc conflated them:
 
-## The bug today
+1. **Key custody** — the agent must never hold the Composio API key.
+2. **User scoping** — a compromised agent must not be able to act on another user's connection.
 
-iOS authorizes Google Calendar via Convos Backend's Composio project. The connection lands there. The user's profile metadata gets a `connectionId`. The agent then tries to invoke the action via *its own* per-assistant Composio project — and finds nothing, because the connection lives in a different project.
+**Key custody belongs in the Assistants outbound proxy, not the backend.** `workers/assistant/.../outbound.ts` already injects credentials for OpenRouter, Herald, the private bucket, and the runtime, and already hard-blocks direct egress (`denyDirectEgress`). Adding a `composio.internal` handler is ~6 mechanical steps in one repo — no new backend endpoint, no extra HTTP hop. Nick is right; this is the cheap, correct home for it.
 
-The capability-request consent layer ([convos-ios#796](https://github.com/xmtplabs/convos-ios/pull/796) / [#797](https://github.com/xmtplabs/convos-ios/pull/797), [convos-assistants#1484](https://github.com/xmtplabs/convos-assistants/pull/1484)) is correct under any security model below. The break is purely **where the agent invokes the toolkit**.
+**OAuth-account isolation is a separate problem that proxying does not solve — in either repo.** The global Composio key is omnipotent across every user in the project, and `user_id` is just the sender's `inboxId`, which is **not a secret**. A prompt-injected agent sends a victim's `inboxId` and the global key acts on their calendar. Injecting the *key* doesn't touch this — the agent still fills in `user_id`/`connected_account_id`. Isolation requires the trusted layer to supply the identity and leave the agent **no field to name another account**. The good news: the trusted anchors to do this already exist (the instance is pinned to one conversation; Herald hands the worker an authentic per-message sender). See Recommendation 2.
 
-## Recommendation: Backend mediates Composio access
+## Correcting the record
 
-Agents call **Convos Backend → Composio**, never Composio directly. Backend already holds the only Composio project key; we keep it that way and expose a narrow API to agents.
+Two premises in the first draft were wrong. The code:
 
-```
-iOS  → Backend.connect(toolkit)              # OAuth, stores connectionId in profile metadata
-                ↓
-Agent → Backend.exec(user, toolkit, action, args)
-                ↓ (re-validates the iOS-issued capability grant)
-        Backend → Composio
-```
+- **There is no per-assistant Composio project pool.** `COMPOSIO_API_KEY` is a **single global worker env var**, forwarded straight into the agent container (`hermes-env.ts:190-204`). The agent reads `process.env.COMPOSIO_API_KEY` and calls `https://backend.composio.dev` directly (`connections.mjs` `composio()` helper). So "retire per-assistant Composio projects" was retiring something that doesn't exist — and Nick's "Composio creds live in the agent container" is the accurate description of today.
+- **The agent already uses `inboxId`, not `deviceId`.** Execution sends `user_id: grant.composioEntityId`, where `composioEntityId = senderId` (the XMTP envelope sender's inboxId, optionally `:label`). The "identifier alignment / switch off deviceId" section of the first draft was solving a break that isn't in this code path.
 
-Per-call scope is `(user, toolkit, action, connectionId)` — the same tuple iOS already gates via the picker. Backend re-checks the capability grant before forwarding (defense-in-depth: a misbehaving agent can't escalate verbs).
-
-### Clipped-client model: what the agent has vs doesn't have
+### Composio terminology + two API facts (the security model hinges on these)
 
 What the agent holds:
 - Its own JWT (proves *which* agent it is).

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -40,22 +40,44 @@ The agent contract stays the same across phases — only Backend internals chang
 
 ## Identifier alignment (the missing link)
 
-Today there's no link between a Convos user's grants and Composio's connections:
-- iOS ↔ Backend uses `deviceId` (iOS `identifierForVendor`, encoded in the JWT).
-- Backend ↔ Composio passes `deviceId` verbatim as Composio's `userId`.
-- Conversation ↔ agent uses XMTP `inboxId` — the sender of `capability_request_result`.
+Today there are four silos with no link between them:
+- **device/auth:** `deviceId` (iOS `identifierForVendor`, encoded in the JWT).
+- **messaging:** `inboxId` (XMTP — sender of conversations).
+- **Composio API:** `userId`, populated today with `deviceId`.
+- **payments foundations:** `inboxId`.
 
-The agent only ever has `inboxId`; the Backend only ever has `deviceId`. There's no mapping anywhere — JWT has no inboxId field, no Backend table reconciles them. Today this works only because iOS handles both sides of its own flow; the moment an agent is the caller, the link breaks.
+The agent only ever has `inboxId` (from the XMTP envelope sender); the Backend only ever has `deviceId` (from the JWT). There's no mapping anywhere — JWT has no inboxId field, no Backend table reconciles them. Today this works only because iOS handles both sides of its own flow; the moment an agent is the caller, the link breaks.
 
-**Recommended fix: switch Composio's `userId` to `inboxId`, with a fallback window.**
+**Recommended fix: switch Composio's `userId` to `accountId` from the new auth API.**
 
-- iOS sends `inboxId` to the Backend on connection calls (header or JWT metadata).
-- Backend uses `inboxId` as Composio's `userId` for all *new* OAuth flows.
-- Backend's `exec` endpoint accepts `inboxId` from the agent — same identifier the agent already has from the XMTP message sender.
-- For existing connections (keyed under `deviceId` in Composio), Backend falls back to `deviceId` lookup if `inboxId` returns no result. Users naturally migrate when they re-OAuth, no forced action.
-- Side benefit: incidentally fixes a latent multi-device bug. Today, the same user on two devices = two Composio "users" and two separate OAuths.
+The new auth API ([Borja's design](https://xmtp-labs.slack.com/archives/C0ASWCMS0N9/), summarized below) introduces `accountId` as the unifying identifier across device/auth, messaging, payments, and Composio. SIWE / Google / Apple / X / mail auth methods all federate to one `accountId`; one `accountId` maps to N `inboxId` via an `XmtpInbox` object that proves ownership.
 
-**Alternative considered:** a `deviceId ↔ inboxId` mapping table on the Backend. Avoids any Composio-side migration but adds a schema model, a registration step, and 1:N ambiguity for users with multiple installs. The fallback-window approach gets us the same end state without those costs.
+Why `accountId` beats the simpler "use `inboxId`" cut:
+
+- **Inbox recovery survives.** `inboxId` changes on key rotation / lost device; `accountId` persists. Composio connections shouldn't churn on inbox changes.
+- **Multi-inbox per user.** Users will have multiple inboxes (work/personal, etc.); their connections shouldn't fragment across inboxes.
+- **Auth-method federation.** A Composio connection isn't tied to whichever auth method the user happened to sign in with.
+- **Multi-device for free.** Same human on two devices = one Composio user. The latent multi-device bug iOS has today goes away by construction.
+
+Concretely:
+- Backend uses `accountId` (read from the JWT) as Composio's `userId` for all new OAuth flows.
+- Backend's `exec` endpoint accepts `inboxId` from the agent — same identifier the agent already has from the XMTP envelope — then resolves `inboxId → accountId` via `XmtpInbox` before forwarding to Composio. Agent contract stays simple ("here's whose inbox I'm acting on behalf of"), Backend does the resolution.
+- For existing connections keyed on `deviceId` in Composio, Backend falls back to `deviceId` lookup if `accountId` returns no result. Users migrate naturally on re-OAuth, no forced action.
+
+**Sequencing:** Composio MVP-1 should land **after** (or alongside) the new auth API, not before. Otherwise we'd cut over from `deviceId` to `inboxId` in MVP-1 and then to `accountId` once auth ships — two migrations for nothing. Gate MVP-1 on `accountId` being in JWTs first.
+
+**Open question for the auth API:** the agent → Backend.exec call hits `XmtpInbox` resolution on every invocation. Worth confirming that proof-of-ownership lookup is cheap per-call (or cacheable per-conversation).
+
+**Alternative considered:** a `deviceId ↔ inboxId` mapping table on the Backend without going through `accountId`. Cheaper short-term but doesn't solve inbox recovery, multi-inbox, federation, or multi-device. The auth API gives us the right structural answer once.
+
+## Orthogonal: per-agent grant scoping ([convos-ios#812](https://github.com/xmtplabs/convos-ios/pull/812))
+
+Per-agent gating lives at the messaging layer keyed on agent `inboxId` (which agent owns the grant in this conversation). Composio's `userId` is the data owner (`accountId`). Two independent axes:
+
+- **#812** — iOS resolver enforces "agent X's grant ≠ agent Y's grant" via `grantedToInboxId` on `CapabilityResolution`, `ConnectionEnablement`, `CloudConnectionGrant`, plus `askerInboxId` on `CapabilityRequest`.
+- **This doc** — Backend's `exec` endpoint forwards to Composio with `userId: accountId`, where `accountId` is the data owner.
+
+Both should land. They don't conflict.
 
 ## Why not the alternatives
 
@@ -80,5 +102,6 @@ The agent only ever has `inboxId`; the Backend only ever has `deviceId`. There's
 ## Why this aligns with what we already shipped
 
 - iOS PRs (`#796`, `#797`) already issue grants tagged with `(provider, capability, conversationId)` and post `connection_event` revocations. These are the inputs the Backend re-checks before any tool execution.
+- iOS PR `#812` adds per-agent grant scoping (`grantedToInboxId`, `askerInboxId`). Composes naturally with this doc: per-agent gating at the messaging layer, per-account data scoping at Composio.
 - `convos-assistants#1484` already relays `connection_event.revoked` into the model as a system message. When the Backend rejects an `exec` because a grant was just revoked, the model already has the context to explain why.
 - No iOS changes needed regardless of the model chosen. The picker UI and the consent semantics are framework-agnostic.

--- a/docs/architecture/composio-security-1pager.md
+++ b/docs/architecture/composio-security-1pager.md
@@ -89,6 +89,15 @@ The hard part — and the real reason this is MVP-2: one agent instance serves t
 > grants and makes the Composio call; the agent calls `Backend.exec(toolkit, action, args)`
 > with no connection identifier, so the bearer capability never leaves the backend. Backend
 > implementation plan: [`docs/plans/composio-exec-grant-mediation.md`](../plans/composio-exec-grant-mediation.md).
+>
+> **Refined (2026-06-10): (Y) composes with Rec 1's proxy, it doesn't replace it.** The
+> `composio.internal` outbound handler still ships — it just forwards to the backend's
+> `/v2/composio/exec` instead of `backend.composio.dev`, injecting the worker's
+> `X-Agent-API-Key` plus identity headers (`X-Convos-Conversation-Id`,
+> `X-Convos-Agent-Inbox-Id`) stamped from instance state. The backend trusts those headers
+> exactly as it already trusts the worker's credits calls on the same key: the container
+> never holds it. This resolves Tier 1's trusted-identity source with no new auth scheme;
+> Anchor 2 (per-delivery verified sender) remains the Tier 2 mechanism.
 
 Two secrets, and they need not co-locate: the **Composio project key** (one global secret) and the **per-user `connected_account_id`s** (your backend grant store keyed by `accountId`). But *who calls Composio* is a real decision:
 
@@ -115,7 +124,7 @@ Unchanged from the first draft and still composes cleanly. Per-agent gating live
 
 ## Decision needed
 
-1. **Decided (2026-06-09): fork (Y) backend-mediates.** The backend owns the Composio call and holds both the key and the grants; the agent calls `Backend.exec(toolkit, action, args)`. Consequence: this supersedes **Recommendation 1** (key custody in `outbound.ts`) — under (Y) the agent never calls Composio directly, so there is no key to inject in the proxy, and MVP-1 *does* carry backend work (contrast the "no backend changes" note below, written for the (X) path). Reconfirm with Nick, who preferred (X) to avoid a backend mediation hop.
+1. **Decided (2026-06-09, refined 2026-06-10): fork (Y) backend-mediates, via Rec 1's proxy as the courier.** The backend owns the Composio call and holds both the key and the grants; the agent calls `composio.internal/exec` with `{toolkit, action, args}` and the `outbound.ts` handler forwards to the backend's `/v2/composio/exec`, injecting `X-Agent-API-Key` + identity headers from instance state (same worker→backend trust the credits flow already uses). So Rec 1's mechanism is *reused* — pointed at our backend instead of Composio — and `COMPOSIO_API_KEY` stops being forwarded into the container (today it is: `hermes-env.ts:190-204`). MVP-1 *does* carry backend work (contrast the "no backend changes" note below, written for the (X) path). Reconfirm with Nick: the consent re-check can't live in the proxy (no grant store there), and the extra hop buys exactly that.
 2. Approve **Tier 1 conversation-boundary isolation** as the MVP (closes the cross-conversation leak; DMs get exact per-user isolation). Owner for the grant store keyed by `accountId` + the agent contract (`{toolkit, action, args}`, no `connected_account_id`).
 3. **Resolved (Louis):** Composio does **not** cross-validate `connected_account_id` against the account — so it's a bearer capability and must never reach the agent. The agent contract carries no connection identifier regardless of fork.
 4. **Still open — for Nick:**

--- a/docs/plans/composio-exec-grant-mediation.md
+++ b/docs/plans/composio-exec-grant-mediation.md
@@ -1,0 +1,137 @@
+# Composio exec — Backend-mediated tool execution (fork Y)
+
+> **Status**: Draft for discussion
+> **Canonical security doc**: [`docs/architecture/composio-security-1pager.md`](../architecture/composio-security-1pager.md) (PR #286, revised after Nick's review)
+> **Decision recorded**: fork **(Y) backend-mediates** (2026-06-09)
+> **Builds on**: PR #294 — backend Composio OAuth flow keyed on `accountId`
+> **Created**: 2026-06-08 · **Reframed**: 2026-06-09
+
+## What this is
+
+The security one-pager leaves one load-bearing decision open: **who calls Composio** —
+(X) the Assistants `outbound.ts` proxy resolves the connection and calls Composio, or
+(Y) the **backend** holds the key *and* the grants and makes the call itself, with the agent
+calling `Backend.exec(toolkit, action, args)` and naming no connection. **We picked (Y).**
+This doc is the backend implementation plan for that path. Everything here defers to the
+one-pager for the threat model; it does not restate or contradict it.
+
+## Threat model (from the one-pager — do not weaken)
+
+Two facts make naive designs unsafe, and they hold under either fork:
+
+1. **`user_id` is not a secret.** It's the sender's `inboxId` today (`accountId` long-term).
+   A prompt-injected agent can name any value.
+2. **`connected_account_id` is a bearer capability.** Composio does **not** cross-check it
+   against `user_id` (confirmed by Louis). Whoever passes a `connected_account_id` can use
+   that connection regardless of `user_id`.
+
+Therefore the invariant is **not** "verify the connection belongs to the account" — an
+ownership check like `getIfOwned` is *insufficient*, because possession of the id *is* the
+capability. The invariant is:
+
+> **The agent must never hold or name a `connected_account_id`, and must not be able to name
+> another account.** A trusted layer resolves the connection from a trusted identity and
+> injects it. The agent sends only `{ toolkit, action, args }`.
+
+> ⚠️ This supersedes the earlier draft of this plan, which used
+> `getIfOwned(connectionId, accountId)` as the gate and had the agent pass `ownerInboxId` /
+> `connectionId`. Both are unsafe under fact #2 and have been removed.
+
+## Why (Y) is clean
+
+Under (Y) the bearer capability **never leaves the backend**. The backend already holds the
+single global Composio key, already creates the connections (OAuth flow, keyed on `accountId`
+per #294), and can hold the `accountId → connected_account_id` grant store. The agent contract
+is the smallest possible: `Backend.exec(toolkit, action, args)`. The cost (Nick's pushback) is
+a backend hop on the tool hot path — accepted as the price of keeping the bearer capability
+server-side.
+
+## The crux: where the backend gets a *trusted* identity
+
+`Backend.exec` is called by the Assistants worker, authenticated with the shared agent key.
+That key is global — it proves "an agent is calling," not "for whom." So the backend cannot
+trust an account/sender field the caller simply puts in the body; that is exactly the spoof
+fact #1 describes. The trusted identity must come from a signal the agent cannot forge. Two
+tiers, matching the one-pager:
+
+### Tier 1 — conversation-boundary (MVP-1)
+
+The call is bound to the **pinned `conversationId`** (set at instance creation, never
+agent-supplied). The backend resolves the connection only among the `accountId`s of *that
+conversation's members*, sourced from a trusted membership lookup (Herald conversation
+profiles, or the backend's own conversation record), and never from an agent-named field.
+
+- **DM:** one member → exact per-user isolation, nothing to spoof.
+- **Group:** blast radius bounded to conversation members — never a stranger in another chat.
+
+Closes the cross-conversation leak (A asks for B, different chats) completely. The agent names
+no connection. This is the shippable MVP.
+
+### Tier 2 — per-sender (MVP-2)
+
+Closes intra-group escalation (member B steering the agent into member A's connection). Needs
+the connection resolved from the **verified sender's** `accountId`. The trusted sender signal
+is Herald's HMAC-signed `senderInboxId` (one-pager Anchor 2). **Open sub-question for (Y):**
+how that signal reaches the backend trustworthily — the realistic options are
+
+- **(a)** the worker forwards Herald's HMAC-signed envelope and the **backend re-verifies the
+  HMAC** itself (stateless, backend trusts the sender cryptographically, not the caller); or
+- **(b)** a short-lived **per-delivery capability** the trusted runtime mints per message; or
+- **(c)** Composio **scoped sessions** minted per verified sender, if they support action-level
+  scope (one-pager Decision Q).
+
+Tier 2 is explicitly out of MVP-1 scope; MVP-1 must not pretend per-sender isolation.
+
+## Where identifiers stand (no new dependency for MVP-1)
+
+- #294 already keys the backend's Composio **OAuth** flow on `accountId`; the grant store is
+  keyed by `accountId`.
+- The **agent execution** path today sends `user_id = inboxId` (the one-pager's "agent already
+  uses inboxId" correction). Tier 1 resolves membership → `accountId` via Herald profiles
+  (which carry both), so MVP-1 needs **no** `inboxId → accountId` table.
+- The `XmtpInbox` / auth-API `accountId` federation is the long-term unifier but stays **v2**,
+  gated on Borja's auth API — not blocking MVP-1.
+
+## Consent vs. identity (two different gates)
+
+Resolving *whose* connection (above) is identity. *Whether this agent may use it* is consent —
+the iOS capability grants (`#796`/`#797`, per-agent scoping `#812`). Under (Y) the backend makes
+the call, so the backend must check consent too. Whether it does so from grant records iOS
+**pushes to the backend**, or by reading the messaging-layer scoping relayed via Herald, is a
+secondary decision to settle during MVP-1 design — it does not change the identity model above.
+
+## Backend surface (MVP-1, Tier 1)
+
+- `POST /v2/composio/exec` — agent-key auth. Body: `{ conversationId, toolkit, action, args }`.
+  **No connection id, no account id from the agent.**
+  1. Resolve conversation membership → candidate `accountId`s (trusted lookup).
+  2. Resolve the connection for `(toolkit, candidate accountIds)` from the grant store; in a DM
+     this is unique. Group disambiguation beyond membership is Tier 2.
+  3. Check consent (grant exists for this agent/capability/conversation).
+  4. `composio.tools.execute(action, { userId: accountId, arguments: args, connectedAccountId })`
+     — `connectedAccountId` injected server-side, never returned to the agent.
+- Grant store: `accountId → connected_account_id` per toolkit (the backend already mints these
+  in the OAuth flow; surface them to exec without ever returning the id to the agent).
+
+`composio.tools.execute(slug, { userId, arguments, connectedAccountId? })` confirmed against
+`@composio/core` `ToolExecuteParamsSchema`.
+
+## Sequencing
+
+1. Confirm the Tier-1 membership source (Herald profiles vs backend conversation record).
+2. exec endpoint + grant-store read path, Tier 1 only, behind a flag. Tests assert: agent
+   cannot name a connection; cross-conversation request → denied; DM → resolves uniquely.
+3. Settle the consent source (iOS push vs Herald relay) and wire the consent check.
+4. Assistants worker swaps direct Composio calls for `Backend.exec`.
+5. MVP-2: Tier-2 trusted-sender mechanism (sub-question a/b/c above).
+
+MVP-1 fail-closes: with no resolvable membership/connection, exec returns 403 before any
+Composio call.
+
+## Removed from the earlier draft (kept here so the change is auditable)
+
+- `getIfOwned`-as-authorization — unsafe under the bearer-capability fact.
+- Agent passing `ownerInboxId` / `connectionId` — the agent must name no connection.
+- "Retire per-assistant Composio projects" — there is no per-assistant pool (single global key).
+- Identifier alignment (deviceId→accountId) as MVP-1 work — the agent path already uses
+  `inboxId`; #294 handled the backend OAuth path; `accountId` federation is v2.

--- a/docs/plans/composio-exec-grant-mediation.md
+++ b/docs/plans/composio-exec-grant-mediation.md
@@ -20,7 +20,7 @@ The plan below predates the build-out; where it disagrees with the code, the cod
 2. **Action scope is bundle-based.** "actions empty ⇒ whole toolkit" is superseded by
    **permission bundles** (`docs/plans/connections-bundles-backend.md`): allowed set =
    union(`grant.actions`, bundle-resolved actions), fail-closed on unknown/unresolvable
-   bundles; whole-toolkit survives only for legacy grants with *both* fields empty
+   bundles; whole-toolkit survives only for legacy grants with _both_ fields empty
    (Phase C flips that to fail-closed).
 3. **`onBehalfOf` exists.** The 409 `ambiguous_grant` path is now resolvable by the agent
    passing `onBehalfOf` (a selector among already-authorized grants — cannot widen access).
@@ -149,7 +149,7 @@ connectedAccountId })`. The id is never returned to the agent.
 
 **Phase 0 — done**
 
-- #294: backend OAuth flow keyed on `accountId` (+ migration) — *PR still open/in-flight*.
+- #294: backend OAuth flow keyed on `accountId` (+ migration) — _PR still open/in-flight_.
 - `louis/composio-exec`: `ConnectionGrant` store + migration; grant CRUD under
   `/v2/connections/grants` (SIWE JWT + `requireAccount`; owner stamped from the JWT);
   `POST /v2/composio/exec` with the header-based trusted-caller resolver, fail-closed;

--- a/docs/plans/composio-exec-grant-mediation.md
+++ b/docs/plans/composio-exec-grant-mediation.md
@@ -8,11 +8,12 @@
 
 ## ⚠️ Corrections vs. the shipped implementation (2026-06-11)
 
-The plan below predates the build-out; where it disagrees with the code, the code (and the
-1-pager) wins:
+The plan below predates the build-out; where it disagreed with the code, the code (and the
+1-pager) wins. The wire contract and exec steps below were updated 2026-06-12 to match the
+shipped design; these items remain as the audit trail:
 
-1. **Exec auth is a dedicated secret, not the agent key.** The wire contract below says
-   `X-Agent-API-Key`; shipped exec authenticates with **`X-Composio-Exec-Key`**
+1. **Exec auth is a dedicated secret, not the agent key.** The wire contract below
+   originally said `X-Agent-API-Key`; shipped exec authenticates with **`X-Composio-Exec-Key`**
    (`COMPOSIO_EXEC_API_KEY`), deliberately distinct — the generic `convos.internal` proxy
    injects the agent key for arbitrary paths, so reusing it would let a container smuggle
    an exec call with forged identity headers. The generic proxy also denies
@@ -108,7 +109,7 @@ Worker → backend (fresh request — **never** forwards container headers):
 
 ```
 POST /v2/composio/exec
-  X-Agent-API-Key:           <CONVOS_API_KEY, worker-only>
+  X-Composio-Exec-Key:       <COMPOSIO_EXEC_API_KEY, worker-only>
   X-Convos-Conversation-Id:  <heraldConversationId pinned at instance creation>
   X-Convos-Agent-Inbox-Id:   <the instance's own inboxId, from worker state>
   body: { toolkit, action, args }
@@ -116,17 +117,20 @@ POST /v2/composio/exec
 
 Backend (`execHandler`):
 
-1. `agentApiKeyAuth` (worker authentication).
+1. `composioExecAuth` (dedicated `X-Composio-Exec-Key`, constant-time compare).
 2. `resolveTrustedCaller` reads the two identity headers; absent/oversized → **403
    `trusted_identity_unavailable`** (fail-closed).
 3. Grant lookup by `(granteeInboxId = agentInboxId, conversationId, toolkit)`, live only
-   (`revokedAt` null, not expired), action within `actions` (empty ⇒ whole toolkit) →
-   else **403 `no_grant`**.
-4. Multiple distinct owners matched → **409 `ambiguous_grant`** (Tier 2 territory; fail
-   closed rather than guess whose data).
-5. Resolve `connectedAccountId` (grant-pinned, else from `(ownerAccountId, toolkit)`),
+   (`revokedAt` null, not expired). Allowed actions = union(`grant.actions`,
+   bundle-resolved actions), fail-closed on unknown/unresolvable bundles; requested
+   action outside the union → **403 `no_grant`**. (Legacy-only: a grant with _both_
+   fields empty keeps whole-toolkit until Phase C flips it to fail-closed.)
+4. Multiple distinct owners matched and no `onBehalfOf` → **409 `ambiguous_grant`**
+   (fail closed rather than guess whose data).
+5. Resolve `connectedAccountId` **server-side** from `(ownerAccountId, toolkit)` — never
+   client-supplied or grant-pinned; pin the toolkit version (unresolvable → fail closed);
    call `composio.tools.execute(action, { userId: ownerAccountId, arguments,
-connectedAccountId })`. The id is never returned to the agent.
+connectedAccountId, version })`. The id is never returned to the agent.
 
 ## Safety properties
 
@@ -135,7 +139,8 @@ connectedAccountId })`. The id is never returned to the agent.
   worker stamps the _real_ conversation.
 - **Agent impersonating another agent**: `granteeInboxId` comes from worker state, not
   the container; grants are per-agent (iOS #812 fan-out).
-- **Verb escalation**: action checked against the granted `actions`.
+- **Verb escalation**: action checked against union(`grant.actions`, bundle-resolved
+  actions); fail-closed on unknown bundles.
 - **Revocation**: checked per call; immediate.
 - **Known Tier-1 limit (honest)**: within one conversation, any member can drive the
   agent into a granted toolkit — blast radius is the conversation, matching today's iOS

--- a/docs/plans/composio-exec-grant-mediation.md
+++ b/docs/plans/composio-exec-grant-mediation.md
@@ -1,137 +1,183 @@
-# Composio exec — Backend-mediated tool execution (fork Y)
+# Composio exec — Backend-mediated tool execution (fork Y, worker-courier model)
 
-> **Status**: Draft for discussion
-> **Canonical security doc**: [`docs/architecture/composio-security-1pager.md`](../architecture/composio-security-1pager.md) (PR #286, revised after Nick's review)
-> **Decision recorded**: fork **(Y) backend-mediates** (2026-06-09)
+> **Status**: Active — backend backbone implemented on `louis/composio-exec`
+> **Canonical security doc**: [`docs/architecture/composio-security-1pager.md`](../architecture/composio-security-1pager.md) (PR #286)
+> **Decision recorded**: fork **(Y) backend-mediates**, identity via **worker-stamped headers** (2026-06-10)
 > **Builds on**: PR #294 — backend Composio OAuth flow keyed on `accountId`
-> **Created**: 2026-06-08 · **Reframed**: 2026-06-09
+> **Created**: 2026-06-08 · **Reframed for fork Y**: 2026-06-09 · **Grounded in repo facts**: 2026-06-10
 
-## What this is
+## The model in one paragraph
 
-The security one-pager leaves one load-bearing decision open: **who calls Composio** —
-(X) the Assistants `outbound.ts` proxy resolves the connection and calls Composio, or
-(Y) the **backend** holds the key *and* the grants and makes the call itself, with the agent
-calling `Backend.exec(toolkit, action, args)` and naming no connection. **We picked (Y).**
-This doc is the backend implementation plan for that path. Everything here defers to the
-one-pager for the threat model; it does not restate or contradict it.
+The agent container is untrusted; the assistants **worker** (Cloudflare DO running the
+outbound proxy) is trusted infrastructure and already holds the only agent API key for
+convos-backend (`CONVOS_API_KEY` / `X-Agent-API-Key` — used in production for credits;
+the container gets placeholder creds). The agent calls `composio.internal/exec` with only
+`{toolkit, action, args}`; the worker builds a **fresh** request to the backend's
+`POST /v2/composio/exec`, attaching the key plus identity headers from its **own state**
+(never container input). The backend authorizes against the iOS-pushed grant store,
+resolves the Composio `connected_account_id` server-side, and makes the Composio call.
+The bearer capability and the Composio key never touch the untrusted container; the agent
+has no field with which to name another account.
 
-## Threat model (from the one-pager — do not weaken)
+## Ground truth this rests on (verified 2026-06-10)
 
-Two facts make naive designs unsafe, and they hold under either fork:
+**convos-assistants**
 
-1. **`user_id` is not a secret.** It's the sender's `inboxId` today (`accountId` long-term).
-   A prompt-injected agent can name any value.
-2. **`connected_account_id` is a bearer capability.** Composio does **not** cross-check it
-   against `user_id` (confirmed by Louis). Whoever passes a `connected_account_id` can use
-   that connection regardless of `user_id`.
+- The worker proxies all container egress (`outbound.ts`): OpenRouter, Herald, Runtime,
+  Browser, private bucket — placeholder creds in the container, injection at the proxy,
+  `denyDirectEgress` for bypass attempts. Composio is **today's outlier**: the real
+  `COMPOSIO_API_KEY` is forwarded into the container (`hermes-env.ts:191-204`) and
+  `connections.mjs` calls `backend.composio.dev` directly with
+  `user_id: grant.composioEntityId`, `connected_account_id: grant.composioConnectionId`.
+- The worker already authenticates to convos-backend with `X-Agent-API-Key` for the
+  credits flow (`convos-backend-client.ts`); **the container never holds that key.**
+- Herald webhooks are HMAC-verified by the worker (`herald.ts:31-51`, timing-safe);
+  `senderInboxId`/`conversationId` arrive inside the signed body. The instance's
+  `heraldConversationId` is pinned at creation and is not agent-supplied.
+- `.convos-current-trigger.json` (where `connections.mjs` reads sender/conversation
+  today) is **agent-writable → spoofable**. Under this model it stops being
+  security-relevant: identity comes from the worker.
 
-Therefore the invariant is **not** "verify the connection belongs to the account" — an
-ownership check like `getIfOwned` is *insufficient*, because possession of the id *is* the
-capability. The invariant is:
+**convos-ios**
 
-> **The agent must never hold or name a `connected_account_id`, and must not be able to name
-> another account.** A trusted layer resolves the connection from a trusted identity and
-> injects it. The agent sends only `{ toolkit, action, args }`.
+- At grant time iOS holds everything the grant store needs:
+  `(senderId, grantedToInboxId, conversationId, service, composioConnectionId,
+composioEntityId)` — and it already **fans out one grant per agent** in the
+  conversation (`CloudConnectionGrantRequestSheet.swift:77-97`), matching the
+  per-`granteeInboxId` rows exactly.
+- iOS already calls `/v2/connections/*` with the SIWE-derived JWT
+  (`ConvosAPIClient.swift:790-828`); `POST /v2/connections/grants` slots in beside them,
+  called from `CloudConnectionGrantWriter.grantConnection()`.
+- Revocation: `CloudConnectionManager.disconnect()` → `ConnectionEventWriter.sendRevoked()`
+  is the hook for `DELETE /v2/connections/grants/:id`.
 
-> ⚠️ This supersedes the earlier draft of this plan, which used
-> `getIfOwned(connectionId, accountId)` as the gate and had the agent pass `ownerInboxId` /
-> `connectionId`. Both are unsafe under fact #2 and have been removed.
+## Threat model (unchanged — do not weaken)
 
-## Why (Y) is clean
+1. **`user_id` is not a secret** — a prompt-injected agent can name any value.
+2. **`connected_account_id` is a bearer capability** — Composio does not cross-check it
+   against `user_id`. Possession is access, so ownership checks are insufficient and the
+   id must never reach the agent.
 
-Under (Y) the bearer capability **never leaves the backend**. The backend already holds the
-single global Composio key, already creates the connections (OAuth flow, keyed on `accountId`
-per #294), and can hold the `accountId → connected_account_id` grant store. The agent contract
-is the smallest possible: `Backend.exec(toolkit, action, args)`. The cost (Nick's pushback) is
-a backend hop on the tool hot path — accepted as the price of keeping the bearer capability
-server-side.
+Invariant: **the agent never holds or names a connection, and cannot name another
+account.** Identity comes from the trusted worker; consent comes from the SIWE-issued
+grant store; custody (Composio key + bearer ids) stays in the backend.
 
-## The crux: where the backend gets a *trusted* identity
+## Why the worker-courier resolves the old open question
 
-`Backend.exec` is called by the Assistants worker, authenticated with the shared agent key.
-That key is global — it proves "an agent is calling," not "for whom." So the backend cannot
-trust an account/sender field the caller simply puts in the body; that is exactly the spoof
-fact #1 describes. The trusted identity must come from a signal the agent cannot forge. Two
-tiers, matching the one-pager:
+Earlier drafts asked how a trusted `(conversationId, agentInboxId)` reaches the backend
+(forward Herald's HMAC for re-verification? per-delivery tokens?). Ground truth makes
+this simple: the backend already trusts worker-stamped data on this key for **credits**
+(the worker debits specific accountIds). Identity headers are the same trust, same key,
+same pattern — no new auth scheme, no HMAC forwarding. Trusting the worker is not an
+added assumption: it already runs the proxy and holds every other credential.
 
-### Tier 1 — conversation-boundary (MVP-1)
+## Wire contract
 
-The call is bound to the **pinned `conversationId`** (set at instance creation, never
-agent-supplied). The backend resolves the connection only among the `accountId`s of *that
-conversation's members*, sourced from a trusted membership lookup (Herald conversation
-profiles, or the backend's own conversation record), and never from an agent-named field.
+Agent container → worker (`composio.internal`):
 
-- **DM:** one member → exact per-user isolation, nothing to spoof.
-- **Group:** blast radius bounded to conversation members — never a stranger in another chat.
+```
+POST /exec        { toolkit, action, args }
+```
 
-Closes the cross-conversation leak (A asks for B, different chats) completely. The agent names
-no connection. This is the shippable MVP.
+Worker → backend (fresh request — **never** forwards container headers):
 
-### Tier 2 — per-sender (MVP-2)
+```
+POST /v2/composio/exec
+  X-Agent-API-Key:           <CONVOS_API_KEY, worker-only>
+  X-Convos-Conversation-Id:  <heraldConversationId pinned at instance creation>
+  X-Convos-Agent-Inbox-Id:   <the instance's own inboxId, from worker state>
+  body: { toolkit, action, args }
+```
 
-Closes intra-group escalation (member B steering the agent into member A's connection). Needs
-the connection resolved from the **verified sender's** `accountId`. The trusted sender signal
-is Herald's HMAC-signed `senderInboxId` (one-pager Anchor 2). **Open sub-question for (Y):**
-how that signal reaches the backend trustworthily — the realistic options are
+Backend (`execHandler`):
 
-- **(a)** the worker forwards Herald's HMAC-signed envelope and the **backend re-verifies the
-  HMAC** itself (stateless, backend trusts the sender cryptographically, not the caller); or
-- **(b)** a short-lived **per-delivery capability** the trusted runtime mints per message; or
-- **(c)** Composio **scoped sessions** minted per verified sender, if they support action-level
-  scope (one-pager Decision Q).
+1. `agentApiKeyAuth` (worker authentication).
+2. `resolveTrustedCaller` reads the two identity headers; absent/oversized → **403
+   `trusted_identity_unavailable`** (fail-closed).
+3. Grant lookup by `(granteeInboxId = agentInboxId, conversationId, toolkit)`, live only
+   (`revokedAt` null, not expired), action within `actions` (empty ⇒ whole toolkit) →
+   else **403 `no_grant`**.
+4. Multiple distinct owners matched → **409 `ambiguous_grant`** (Tier 2 territory; fail
+   closed rather than guess whose data).
+5. Resolve `connectedAccountId` (grant-pinned, else from `(ownerAccountId, toolkit)`),
+   call `composio.tools.execute(action, { userId: ownerAccountId, arguments,
+connectedAccountId })`. The id is never returned to the agent.
 
-Tier 2 is explicitly out of MVP-1 scope; MVP-1 must not pretend per-sender isolation.
+## Safety properties
 
-## Where identifiers stand (no new dependency for MVP-1)
+- **Stranger outside the conversation**: no grant row for that conversation → 403 before
+  any Composio call. Holding the agent key (i.e., being our worker) doesn't help — the
+  worker stamps the _real_ conversation.
+- **Agent impersonating another agent**: `granteeInboxId` comes from worker state, not
+  the container; grants are per-agent (iOS #812 fan-out).
+- **Verb escalation**: action checked against the granted `actions`.
+- **Revocation**: checked per call; immediate.
+- **Known Tier-1 limit (honest)**: within one conversation, any member can drive the
+  agent into a granted toolkit — blast radius is the conversation, matching today's iOS
+  semantics (grants fan out to all agents per conversation). Per-sender isolation is
+  Tier 2: the worker additionally stamps `X-Convos-Sender-Inbox-Id` from the
+  HMAC-verified Herald delivery (needs per-delivery binding — interleaving makes a
+  mutable "current sender" racy), and the backend matches it against `ownerInboxId`
+  unless the grant is explicitly shared.
 
-- #294 already keys the backend's Composio **OAuth** flow on `accountId`; the grant store is
-  keyed by `accountId`.
-- The **agent execution** path today sends `user_id = inboxId` (the one-pager's "agent already
-  uses inboxId" correction). Tier 1 resolves membership → `accountId` via Herald profiles
-  (which carry both), so MVP-1 needs **no** `inboxId → accountId` table.
-- The `XmtpInbox` / auth-API `accountId` federation is the long-term unifier but stays **v2**,
-  gated on Borja's auth API — not blocking MVP-1.
+## Work plan
 
-## Consent vs. identity (two different gates)
+**Phase 0 — done**
 
-Resolving *whose* connection (above) is identity. *Whether this agent may use it* is consent —
-the iOS capability grants (`#796`/`#797`, per-agent scoping `#812`). Under (Y) the backend makes
-the call, so the backend must check consent too. Whether it does so from grant records iOS
-**pushes to the backend**, or by reading the messaging-layer scoping relayed via Herald, is a
-secondary decision to settle during MVP-1 design — it does not change the identity model above.
+- #294: backend OAuth flow keyed on `accountId` (+ migration).
+- `louis/composio-exec`: `ConnectionGrant` store + migration; grant CRUD under
+  `/v2/connections/grants` (SIWE JWT + `requireAccount`; owner stamped from the JWT);
+  `POST /v2/composio/exec` with the header-based trusted-caller resolver, fail-closed;
+  `ComposioService.execute`/`resolveConnectionId`. Tests: no-DB security boundary
+  passing; DB-backed grant/exec cases written (`pnpm test:local`).
 
-## Backend surface (MVP-1, Tier 1)
+**Phase 1 — convos-ios (small)**
 
-- `POST /v2/composio/exec` — agent-key auth. Body: `{ conversationId, toolkit, action, args }`.
-  **No connection id, no account id from the agent.**
-  1. Resolve conversation membership → candidate `accountId`s (trusted lookup).
-  2. Resolve the connection for `(toolkit, candidate accountIds)` from the grant store; in a DM
-     this is unique. Group disambiguation beyond membership is Tier 2.
-  3. Check consent (grant exists for this agent/capability/conversation).
-  4. `composio.tools.execute(action, { userId: accountId, arguments: args, connectedAccountId })`
-     — `connectedAccountId` injected server-side, never returned to the agent.
-- Grant store: `accountId → connected_account_id` per toolkit (the backend already mints these
-  in the OAuth flow; surface them to exec without ever returning the id to the agent).
+- `ConvosAPIClient`: add `POST /v2/connections/grants` + `DELETE
+/v2/connections/grants/:id` beside the existing connections methods.
+- Call grant-create from `CloudConnectionGrantWriter.grantConnection()` (per agent, as
+  it already loops); call revoke from `CloudConnectionManager.disconnect()` /
+  `postRevocationSideEffects()`.
+- Keep publishing profile metadata for UX; **later** drop
+  `composioConnectionId`/`composioEntityId` from it (the agent no longer needs them —
+  removing the bearer id from the untrusted wire entirely).
 
-`composio.tools.execute(slug, { userId, arguments, connectedAccountId? })` confirmed against
-`@composio/core` `ToolExecuteParamsSchema`.
+**Phase 2 — convos-assistants (the cutover)**
 
-## Sequencing
+- `outbound.ts`: add `composio.internal` handler → rewrites to
+  `${CONVOS_API_BASE_URL}/v2/composio/exec`, attaches `X-Agent-API-Key` + the two
+  identity headers from instance state; **constructs a fresh request** (drop all
+  container headers); add `"backend.composio.dev" → denyDirectEgress`.
+- `hermes-env.ts`: stop forwarding `COMPOSIO_API_KEY` (placeholder, like OpenRouter).
+- `connections.mjs`: execution path calls `composio.internal/exec` with
+  `{toolkit, action, args}`; delete the `user_id`/`connected_account_id` plumbing and
+  the trigger-file identity dependency.
+- Verify the worker has the instance's `agentInboxId` in its own state (it pins
+  `heraldConversationId` at creation; confirm the inboxId is alongside or add it).
 
-1. Confirm the Tier-1 membership source (Herald profiles vs backend conversation record).
-2. exec endpoint + grant-store read path, Tier 1 only, behind a flag. Tests assert: agent
-   cannot name a connection; cross-conversation request → denied; DM → resolves uniquely.
-3. Settle the consent source (iOS push vs Herald relay) and wire the consent check.
-4. Assistants worker swaps direct Composio calls for `Backend.exec`.
-5. MVP-2: Tier-2 trusted-sender mechanism (sub-question a/b/c above).
+**Phase 3 — Tier 2 (per-sender isolation)**
 
-MVP-1 fail-closes: with no resolvable membership/connection, exec returns 403 before any
-Composio call.
+- Worker: per-delivery binding of the Herald-verified `senderInboxId` →
+  `X-Convos-Sender-Inbox-Id` (a per-delivery capability, not shared mutable state).
+- Backend: when present, require `sender == grant.ownerInboxId` or an explicitly shared
+  grant; this also resolves `ambiguous_grant` (pick the sender's own connection).
+- iOS: explicit shared/private choice on grants if product wants intra-group privacy.
 
-## Removed from the earlier draft (kept here so the change is auditable)
+**Open items**
+
+- Nick's sign-off on the backend hop (fork Y) — softened now: Rec 1's proxy pattern is
+  _reused_ (the `composio.internal` handler), it just points at our backend instead of
+  Composio, and the consent re-check can't live in the worker (it has no grant store).
+- Agent-driven OAuth `connect` for non-iOS toolkits: route through the same proxy later;
+  out of scope for exec MVP.
+- Run the DB-backed suite (`pnpm test:local`) before PR.
+
+## Removed/corrected along the way (audit trail)
 
 - `getIfOwned`-as-authorization — unsafe under the bearer-capability fact.
-- Agent passing `ownerInboxId` / `connectionId` — the agent must name no connection.
-- "Retire per-assistant Composio projects" — there is no per-assistant pool (single global key).
-- Identifier alignment (deviceId→accountId) as MVP-1 work — the agent path already uses
-  `inboxId`; #294 handled the backend OAuth path; `accountId` federation is v2.
+- Agent passing `ownerInboxId`/`connectionId`/`accountId` — agent names nothing.
+- "Retire per-assistant Composio projects" — no such pool exists (single global key).
+- deviceId→accountId "identifier alignment" as MVP work — agent path already used
+  `inboxId`; #294 fixed the backend OAuth path; `accountId` federation stays v2.
+- "Forward Herald HMAC to backend / per-delivery token / scoped sessions" as the Tier-1
+  identity mechanism — superseded by worker-stamped headers (same trust as credits).

--- a/docs/plans/composio-exec-grant-mediation.md
+++ b/docs/plans/composio-exec-grant-mediation.md
@@ -1,10 +1,35 @@
 # Composio exec — Backend-mediated tool execution (fork Y, worker-courier model)
 
-> **Status**: Active — backend backbone implemented on `louis/composio-exec`
+> **Status**: Implemented (historical plan) — backend on `louis/composio-exec` → `louis/connections-bundles`; assistants cutover on `louis/composio-backend-exec`; iOS grant push + picker on `louis/connection-grants-backend-push` → `louis/connections-picker-bundles`. In review, not yet on `dev`.
 > **Canonical security doc**: [`docs/architecture/composio-security-1pager.md`](../architecture/composio-security-1pager.md) (PR #286)
 > **Decision recorded**: fork **(Y) backend-mediates**, identity via **worker-stamped headers** (2026-06-10)
-> **Builds on**: PR #294 — backend Composio OAuth flow keyed on `accountId`
-> **Created**: 2026-06-08 · **Reframed for fork Y**: 2026-06-09 · **Grounded in repo facts**: 2026-06-10
+> **Builds on**: PR #294 — backend Composio OAuth flow keyed on `accountId` (**still open/in-flight**)
+> **Created**: 2026-06-08 · **Reframed for fork Y**: 2026-06-09 · **Grounded in repo facts**: 2026-06-10 · **Status corrections**: 2026-06-11
+
+## ⚠️ Corrections vs. the shipped implementation (2026-06-11)
+
+The plan below predates the build-out; where it disagrees with the code, the code (and the
+1-pager) wins:
+
+1. **Exec auth is a dedicated secret, not the agent key.** The wire contract below says
+   `X-Agent-API-Key`; shipped exec authenticates with **`X-Composio-Exec-Key`**
+   (`COMPOSIO_EXEC_API_KEY`), deliberately distinct — the generic `convos.internal` proxy
+   injects the agent key for arbitrary paths, so reusing it would let a container smuggle
+   an exec call with forged identity headers. The generic proxy also denies
+   `/api/v2/composio/*` and strips `x-convos-*` headers.
+2. **Action scope is bundle-based.** "actions empty ⇒ whole toolkit" is superseded by
+   **permission bundles** (`docs/plans/connections-bundles-backend.md`): allowed set =
+   union(`grant.actions`, bundle-resolved actions), fail-closed on unknown/unresolvable
+   bundles; whole-toolkit survives only for legacy grants with *both* fields empty
+   (Phase C flips that to fail-closed).
+3. **`onBehalfOf` exists.** The 409 `ambiguous_grant` path is now resolvable by the agent
+   passing `onBehalfOf` (a selector among already-authorized grants — cannot widen access).
+4. **No grant-pinned connection.** Step 5's "grant-pinned" connection resolution was
+   dropped; clients can never supply a `connectionId` (ignored at grant, no field at exec);
+   resolution is always server-side from `(ownerAccountId, toolkit)`. Exec also pins the
+   toolkit version (fail-closed when unresolvable).
+5. **Revocation is by natural key** (`POST /v2/connections/grants/revoke`), in addition to
+   `DELETE /grants/:id` — reliable even when the client lost the grant id.
 
 ## The model in one paragraph
 
@@ -124,7 +149,7 @@ connectedAccountId })`. The id is never returned to the agent.
 
 **Phase 0 — done**
 
-- #294: backend OAuth flow keyed on `accountId` (+ migration).
+- #294: backend OAuth flow keyed on `accountId` (+ migration) — *PR still open/in-flight*.
 - `louis/composio-exec`: `ConnectionGrant` store + migration; grant CRUD under
   `/v2/connections/grants` (SIWE JWT + `requireAccount`; owner stamped from the JWT);
   `POST /v2/composio/exec` with the header-based trusted-caller resolver, fail-closed;


### PR DESCRIPTION
## Summary

Documents the **Composio security model as implemented**: backend-mediated tool execution + permission bundles. Originally a decision draft; updated 2026-06-11 to match the shipped implementation (the decision record — fork X/Y, sign-off questions — remains in this PR's history). Implementation lives on `louis/composio-exec` → `louis/connections-bundles` (backend), `louis/composio-backend-exec` (assistants), `louis/connections-picker-bundles` (iOS); in review, not yet on `dev`.

## Highlights

- **Invariant up front**: the agent never holds a key, never holds or names a connection, and cannot name another account. `COMPOSIO_API_KEY` lives only in convos-backend; the container gets placeholder creds; the legacy direct-Composio agent path is deleted.
- **Exec flow**: agent → `composio.internal` (trusted worker courier, fresh request) → `POST /api/v2/composio/exec` with a **dedicated `X-Composio-Exec-Key`** (distinct from the agent key — closes the generic-proxy smuggling vector) + worker-stamped identity headers; fail-closed trusted-caller resolution; per-call grant re-check; **server-side connection resolution** (client/agent-supplied `connectionId` is never accepted anywhere); toolkit-version pinning (fail-closed).
- **Permission bundles** (least privilege): backend-owned catalog, `GET /v2/connections/services` (JWT-only, Composio slugs stripped); grants carry `{toolkit, serviceVersion, bundleIds}`; exec allowed-set = union(legacy `actions`, bundle-resolved actions); unknown bundles → 400 `unknown_bundle` at grant, unresolvable → 403 `no_grant` at exec; read-only `calendar.events.read` bundle proves read-can't-write.
- **Grant lifecycle**: owner always from the JWT, `onBehalfOf` is a selector (cannot widen access), revocation by **natural key** (works without a stored grant id) and re-checked per call.
- **Honest about what's in flight**: PR #294 (`accountId`-scoped Composio connections + migration), Phase C fail-closed flip for legacy whole-toolkit grants, Tier 2 per-sender isolation, toolkit-version pinning refinement.
- Companion plan doc (`composio-exec-grant-mediation.md`) kept as the historical implementation plan with a **corrections banner** (dedicated exec key, bundles supersede the empty⇒whole-toolkit rule, `onBehalfOf`, no grant-pinned connections, natural-key revoke).

## Test plan

- [ ] Doc review by Fabri, Nick, Mike

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115922&installation_id=128169237&pr_number=286&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F286&signature=822798941043a627529c0c9a922396d806182cdafee2ef15bfa92a603ad7697f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Composio security model architecture docs and implementation plan
> Adds two documentation files covering the Composio security model: a 1-pager ([composio-security-1pager.md](https://github.com/ephemeraHQ/convos-backend/pull/286/files#diff-4259df0ac3596d1738dfb4deee98142191f64486a97acddd045104770d1289fa)) and a historical implementation plan ([composio-exec-grant-mediation.md](https://github.com/ephemeraHQ/convos-backend/pull/286/files#diff-57defa81693e3a4515c774adf6a67563888466aa9b9a2f6fa4dc309eacb8671b)).
>
> - The 1-pager documents the backend-mediated execution model, including key custody, user scoping, trusted worker proxy flow, exec authentication via `X-Composio-Exec-Key`, grant lifecycle, and fail-closed error behaviors
> - The implementation plan records the worker-courier design, wire contract, backend exec steps, server-side connection/version resolution, and phased work across backend, iOS, and assistants
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e123d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security architecture and phased rollout plan for a proxy-style, backend-mediated Composio execution model that prevents agents from holding API keys or supplying sensitive connection identifiers.
  * Documented worker-mediated caller identity, server-side grant resolution with strict fail-closed enforcement, permission-bundle based action scoping, and grant lifecycle/revocation rules.
  * Defined isolation tiers, threat model, safety properties, and rollout checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
