### PR TITLE
feat(agent-templates): attribute OpenRouter builder calls to "Convos Agents" app

### DIFF
--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -46,6 +46,15 @@ const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 // the `upstream_provider` recorded on `builder.generation.llm_call`).
 const DEFAULT_PROVIDER_PREFERENCE = { order: ["amazon-bedrock"] };
 
+// OpenRouter app attribution — populates the "App" entry in the OpenRouter
+// dashboard. OpenRouter keys the app on HTTP-Referer and displays X-Title.
+// A distinct title keeps builder spend separate from the runtime's
+// "Hermes Agent" app (set by the Worker proxy in convos-assistants).
+const OPENROUTER_ATTRIBUTION_HEADERS = {
+  "HTTP-Referer": "https://agents.convos.org",
+  "X-Title": "Convos Agents",
+};
+
 /** PostHog event recording the upstream provider that served one LLM call.
  *  One per call, alongside the wrapper's `$ai_generation`. */
 export const LLM_CALL_EVENT = "builder.generation.llm_call";
@@ -80,6 +89,8 @@ function buildClient(apiKey: string): { client: OpenAI; wrapped: boolean } {
     // The raw-fetch code made a single attempt; keep that so error/timeout
     // tests don't see silent retries.
     maxRetries: 0,
+    // Attribute every builder call to the "Convos Agents" app in OpenRouter.
+    defaultHeaders: OPENROUTER_ATTRIBUTION_HEADERS,
     // Resolve the global fetch at call time so tests that reassign
     // `globalThis.fetch` still intercept the SDK's requests.
     fetch: (url: any, init?: any) => globalThis.fetch(url, init),

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -171,7 +171,7 @@ describe("templateGen service — OpenRouter integration", () => {
   // -----------------------------------------------------------------------
   // URL and Authorization header
   // -----------------------------------------------------------------------
-  test("production call uses literal OpenRouter URL with Bearer auth and Content-Type only", async () => {
+  test("production call uses literal OpenRouter URL with Bearer auth, Content-Type, and Convos app attribution headers", async () => {
     const mod = await import("@/api/v2/agent-templates/services/templateGen");
     generateTemplate = mod.generateTemplate;
 
@@ -201,9 +201,12 @@ describe("templateGen service — OpenRouter integration", () => {
     expect(req.headers["authorization"]).toBe(`Bearer ${TEST_API_KEY}`);
     expect(req.headers["content-type"]).toBe("application/json");
 
+    // App attribution: builder calls are attributed to the "Convos Agents"
+    // app in OpenRouter (OPENROUTER_ATTRIBUTION_HEADERS in openrouter-client).
+    expect(req.headers["http-referer"]).toBe("https://agents.convos.org");
+    expect(req.headers["x-title"]).toBe("Convos Agents");
+
     // Forbidden headers must NOT be present
-    expect(req.headers["http-referer"]).toBeUndefined();
-    expect(req.headers["x-title"]).toBeUndefined();
     expect(req.headers["openai-beta"]).toBeUndefined();
     // User-Agent should not be a custom Convos one (or absent entirely, which is fine)
     if (req.headers["user-agent"]) {


### PR DESCRIPTION
The agent-template prompt builder calls OpenRouter directly via the OpenAI SDK (`openrouter-client.ts`) and currently sends no attribution headers, so its spend shows up unattributed in the OpenRouter dashboard.

This sets `HTTP-Referer: https://agents.convos.org` and `X-Title: Convos Agents` as `defaultHeaders` on the shared SDK client, so every builder call is attributed to a dedicated **Convos Agents** app — keeping builder spend separate from the Hermes runtime's existing "Hermes Agent" app (which is set proxy-side in convos-assistants).

OpenRouter keys the app on `HTTP-Referer` and displays `X-Title`. The headers merge before the existing custom `fetch` / PostHog wrapper, so there is no change to request behavior, retries, or tracing. Applies to every builder stage (selector, classifier, generate, moderation, twitter-intent, compose-reply) via the shared client.

Verified with `tsc --noEmit`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783120004&installation_id=128169237&pr_number=287&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F287&signature=0661dc4e4569e3349b0c2ff2aa4eaec6f11e7f5ec2250723c3fa09fc20adf7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenRouter attribution headers to `buildClient` in agent-templates
> Adds `HTTP-Referer: https://agents.convos.org` and `X-Title: Convos Agents` as default headers on all OpenRouter API requests made via [openrouter-client.ts](https://github.com/ephemeraHQ/convos-backend/pull/287/files#diff-6350fa102ccf82d602fd5ecd832731a3c9feb5914c17a24758537d6e4e634626). Both the PostHog-wrapped and plain client paths are affected. The integration test in [template-gen.service.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/287/files#diff-66e49a396e95bc85161de2c4ab2110569c5666fb2350cd6eca5d8458cbc38b19) is updated to assert these header values are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 866610b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced OpenRouter integration with attribution headers for improved service tracking across all requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->