### PR TITLE
feat(agent-templates): ephemeral (non-persisting) generation endpoint

### DIFF
--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -7,6 +7,7 @@ import { requireAccount } from "@/middleware/auth";
 import { createHandler } from "./handlers/create";
 import { deleteHandler } from "./handlers/delete";
 import { detailHandler } from "./handlers/detail";
+import { generationsEphemeralPostHandler } from "./handlers/generations-ephemeral-post";
 import { generationsGetHandler } from "./handlers/generations-get";
 import { generationsPostHandler } from "./handlers/generations-post";
 import { listHandler } from "./handlers/list";
@@ -37,6 +38,14 @@ agentTemplatesRouter.post(
   "/generations",
   optionalAuthOrAgentApiKeyAuth,
   generationsPostHandler,
+);
+// Synchronous, non-persisting generation for the admin compare tool. Mounted
+// before /generations/:generationId so the wildcard doesn't capture
+// "ephemeral" as a generation id. Admin-only (enforced in the handler).
+agentTemplatesRouter.post(
+  "/generations/ephemeral",
+  optionalAuthOrAgentApiKeyAuth,
+  generationsEphemeralPostHandler,
 );
 agentTemplatesRouter.get(
   "/generations/:generationId",

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -24,6 +24,16 @@ import {
 
 // One synchronous generation, kept under typical edge/proxy request ceilings.
 const EPHEMERAL_TIMEOUT_MS = 90_000;
+
+// Test seam: shrink the timeout so the 504 path is exercisable without waiting.
+let _timeoutMsOverride: number | null = null;
+export function __setEphemeralTimeoutMsForTests(ms: number | null): void {
+  _timeoutMsOverride = ms;
+}
+function getTimeoutMs(): number {
+  return _timeoutMsOverride ?? EPHEMERAL_TIMEOUT_MS;
+}
+
 const MAX_TEXT_LEN = 50_000;
 const MAX_BASE64_LEN = 35_000_000;
 const MAX_BUILDER_PROMPT_LEN = 100_000;
@@ -129,7 +139,7 @@ export async function generationsEphemeralPostHandler(
 
   // Held in a variable so the catch can distinguish a timeout (signal.aborted)
   // from a generation error without parsing the wrapped error message.
-  const signal = AbortSignal.timeout(EPHEMERAL_TIMEOUT_MS);
+  const signal = AbortSignal.timeout(getTimeoutMs());
   try {
     const { template, metrics } = await callGenerateTemplate(
       coalesced,

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -1,0 +1,144 @@
+/**
+ * Handler for POST /api/v2/agent-templates/generations/ephemeral
+ *
+ * Synchronous, NON-persisting generation. Runs the real generator and returns
+ * the produced template inline — it never writes an AgentTemplate or an
+ * AgentTemplateGeneration row. Built for the admin compare tool, which generates
+ * throwaway candidates (with and without a builderPrompt override) purely to
+ * judge prompt quality across one or more ideas; nothing should land in the
+ * catalog until an admin explicitly keeps one (via the normal create endpoint).
+ *
+ * Admin-only: gated to agent-API-key callers (isApiKeyListener), like the
+ * privileged builderPrompt field on the async endpoint. Skips the async job
+ * machinery (idempotency, status row, TTL) and content moderation — the caller
+ * is trusted and nothing generated here is persisted or published.
+ */
+
+import type { Request, Response } from "express";
+import { z } from "zod";
+import {
+  callGenerateTemplate,
+  type GenerateTemplateInput,
+  type GenerationPrefill,
+} from "@/api/v2/agent-templates/services/templateGen";
+
+// One synchronous generation, kept under typical edge/proxy request ceilings.
+const EPHEMERAL_TIMEOUT_MS = 90_000;
+const MAX_TEXT_LEN = 50_000;
+const MAX_BASE64_LEN = 35_000_000;
+const MAX_BUILDER_PROMPT_LEN = 100_000;
+
+const inputsSchema = z
+  .object({
+    text: z.string().optional(),
+    idea: z.string().optional(),
+    content: z.string().optional(),
+    url: z.string().optional(),
+    pdfBase64: z.string().optional(),
+    mimeType: z.string().optional(),
+    filename: z.string().optional(),
+    imageBase64: z.string().optional(),
+  })
+  .strict();
+
+const prefillSchema = z
+  .object({
+    agentName: z.string().trim().min(1).max(256).optional(),
+    emoji: z.string().trim().min(1).max(64).optional(),
+    description: z.string().trim().min(1).max(1024).optional(),
+  })
+  .strict();
+
+const bodySchema = z
+  .object({
+    inputs: inputsSchema,
+    builderPrompt: z.string().min(1).max(MAX_BUILDER_PROMPT_LEN).optional(),
+    prefill: prefillSchema.optional(),
+  })
+  .strict();
+
+// Mirror the async endpoint's coalescing: pick the first non-whitespace
+// text-bearing field, and let a file (pdf/image) define the input type.
+function coalesce(
+  inputs: z.infer<typeof inputsSchema>,
+): GenerateTemplateInput | null {
+  const text = [inputs.text, inputs.idea, inputs.content, inputs.url].find(
+    (v): v is string => typeof v === "string" && v.trim().length > 0,
+  );
+  if (inputs.pdfBase64) {
+    return {
+      pdfBase64: inputs.pdfBase64,
+      mimeType: inputs.mimeType || "application/pdf",
+      filename: inputs.filename || "document.pdf",
+      ...(text ? { text } : {}),
+    };
+  }
+  if (inputs.imageBase64) {
+    return {
+      imageBase64: inputs.imageBase64,
+      mimeType: inputs.mimeType || "image/png",
+      ...(text ? { text } : {}),
+    };
+  }
+  if (text) return { text };
+  return null;
+}
+
+export async function generationsEphemeralPostHandler(
+  req: Request,
+  res: Response,
+) {
+  const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+  if (!isApiKeyListener) {
+    res
+      .status(403)
+      .json({ error: "ephemeral generation requires agent API key auth" });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ error: "Invalid request body", details: parsed.error.issues });
+    return;
+  }
+
+  const coalesced = coalesce(parsed.data.inputs);
+  if (!coalesced) {
+    res.status(400).json({
+      error:
+        "No usable input — provide one of text, idea, content, url, pdfBase64, or imageBase64",
+    });
+    return;
+  }
+  if (coalesced.text && coalesced.text.length > MAX_TEXT_LEN) {
+    res.status(400).json({ error: `text exceeds ${MAX_TEXT_LEN} characters` });
+    return;
+  }
+  if (
+    (coalesced.pdfBase64 && coalesced.pdfBase64.length > MAX_BASE64_LEN) ||
+    (coalesced.imageBase64 && coalesced.imageBase64.length > MAX_BASE64_LEN)
+  ) {
+    res.status(400).json({ error: "attached file exceeds the size limit" });
+    return;
+  }
+
+  const prefill: GenerationPrefill | null = parsed.data.prefill ?? null;
+  const builderPrompt = parsed.data.builderPrompt ?? null;
+
+  try {
+    const { template, metrics } = await callGenerateTemplate(
+      coalesced,
+      AbortSignal.timeout(EPHEMERAL_TIMEOUT_MS),
+      prefill,
+      undefined,
+      builderPrompt,
+    );
+    res.status(200).json({ template, metrics });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    req.log.error({ err }, "[ephemeral-generation] generation failed");
+    res.status(500).json({ error: `Generation failed: ${message}` });
+  }
+}

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -127,18 +127,29 @@ export async function generationsEphemeralPostHandler(
   const prefill: GenerationPrefill | null = parsed.data.prefill ?? null;
   const builderPrompt = parsed.data.builderPrompt ?? null;
 
+  // Held in a variable so the catch can distinguish a timeout (signal.aborted)
+  // from a generation error without parsing the wrapped error message.
+  const signal = AbortSignal.timeout(EPHEMERAL_TIMEOUT_MS);
   try {
     const { template, metrics } = await callGenerateTemplate(
       coalesced,
-      AbortSignal.timeout(EPHEMERAL_TIMEOUT_MS),
+      signal,
       prefill,
       undefined,
       builderPrompt,
     );
     res.status(200).json({ template, metrics });
+    return;
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    if (signal.aborted) {
+      req.log.warn({ err }, "[ephemeral-generation] generation timed out");
+      res.status(504).json({ error: "Generation timed out" });
+      return;
+    }
+    // Keep the specifics in logs; return a stable, generic message to the
+    // client (matches the other agent-templates handlers).
     req.log.error({ err }, "[ephemeral-generation] generation failed");
-    res.status(500).json({ error: `Generation failed: ${message}` });
+    res.status(500).json({ error: "Generation failed" });
+    return;
   }
 }

--- a/tests/agent-templates.generations-ephemeral.test.ts
+++ b/tests/agent-templates.generations-ephemeral.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for POST /api/v2/agent-templates/generations/ephemeral
+ *
+ * Covers:
+ *   - Auth: non-API-key caller                                  → 403
+ *   - Validation: missing/empty inputs                          → 400
+ *   - Happy path: returns { template } inline, builderPrompt
+ *     forwarded, and NOTHING persisted                          → 200
+ *   - Generator error: stable generic message (no leak)         → 500
+ *   - Timeout: AbortSignal fires                                → 504
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { __setEphemeralTimeoutMsForTests } from "@/api/v2/agent-templates/handlers/generations-ephemeral-post";
+import {
+  __resetGenerateTemplateForTests,
+  DEFAULT_TEST_METRICS,
+} from "@/api/v2/agent-templates/services/templateGen";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { prisma } from "@/utils/prisma";
+import {
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+import { makeFakeTemplate } from "./agent-templates.generation.helpers";
+
+const TEST_PORT = 4079;
+const fakeTemplate = makeFakeTemplate({
+  agentName: "Ephemeral Test Agent",
+  description: "desc",
+  prompt: "prompt",
+});
+
+const apiKeyHeaders = {
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+};
+const noKeyHeaders = { "Content-Type": "application/json" };
+
+// Records the args the generator was called with, so a test can assert the
+// builderPrompt override is forwarded (the 5th param, systemPromptOverride).
+let lastCall: { systemPromptOverride?: string | null } | null = null;
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const post = (body: unknown, headers: Record<string, string> = apiKeyHeaders) =>
+  fetch(`${baseURL}/api/v2/agent-templates/generations/ephemeral`, {
+    method: "POST",
+    headers,
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+
+beforeAll(async () => {
+  __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+  const server = await startAgentTemplatesServer(TEST_PORT);
+  baseURL = server.baseURL;
+  closeServer = server.close;
+});
+
+beforeEach(() => {
+  lastCall = null;
+  __setEphemeralTimeoutMsForTests(null);
+  // Default: a fast, successful generation that records its override arg.
+  __resetGenerateTemplateForTests(
+    (_input, _signal, _prefill, _trace, systemPromptOverride) => {
+      lastCall = { systemPromptOverride };
+      return Promise.resolve({
+        template: fakeTemplate,
+        metrics: DEFAULT_TEST_METRICS,
+      });
+    },
+  );
+});
+
+afterEach(() => {
+  __setEphemeralTimeoutMsForTests(null);
+});
+
+afterAll(async () => {
+  __resetGenerateTemplateForTests(null);
+  __setAgentAssetsApiKeyOverrideForTests(undefined);
+  await closeServer();
+});
+
+describe("POST /generations/ephemeral — auth", () => {
+  test("no agent API key → 403", async () => {
+    const res = await post(
+      { inputs: { idea: "a wine club sommelier" } },
+      noKeyHeaders,
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /generations/ephemeral — validation", () => {
+  test("missing inputs → 400", async () => {
+    const res = await post({});
+    expect(res.status).toBe(400);
+  });
+
+  test("empty inputs (no usable input) → 400", async () => {
+    const res = await post({ inputs: {} });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error.toLowerCase()).toContain("one of");
+  });
+});
+
+describe("POST /generations/ephemeral — happy path", () => {
+  test("returns the template inline, forwards builderPrompt, persists nothing", async () => {
+    const before = await prisma.agentTemplate.count({
+      where: { agentName: fakeTemplate.agentName },
+    });
+
+    const res = await post({
+      inputs: { idea: "a wine club sommelier" },
+      builderPrompt: "CUSTOM BUILDER PROMPT",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { template: { agentName: string } };
+    expect(body.template.agentName).toBe(fakeTemplate.agentName);
+
+    // The override (builderPrompt) reaches the generator as systemPromptOverride.
+    expect(lastCall?.systemPromptOverride).toBe("CUSTOM BUILDER PROMPT");
+
+    // Ephemeral: no AgentTemplate row created.
+    const after = await prisma.agentTemplate.count({
+      where: { agentName: fakeTemplate.agentName },
+    });
+    expect(after).toBe(before);
+  });
+});
+
+describe("POST /generations/ephemeral — error mapping", () => {
+  test("generator failure → 500 with a stable generic message (no leak)", async () => {
+    __resetGenerateTemplateForTests(() =>
+      Promise.reject(new Error("boom: internal secret detail")),
+    );
+    const res = await post({ inputs: { idea: "x" } });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Generation failed");
+    expect(body.error).not.toContain("secret");
+  });
+
+  test("timeout → 504", async () => {
+    __setEphemeralTimeoutMsForTests(20);
+    // Reject when the timeout signal aborts (mirrors a real aborted fetch).
+    __resetGenerateTemplateForTests(
+      (_input, signal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        }),
+    );
+    const res = await post({ inputs: { idea: "x" } });
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as { error: string };
+    expect(body.error.toLowerCase()).toContain("timed out");
+  });
+});


### PR DESCRIPTION
## What

Adds `POST /api/v2/agent-templates/generations/ephemeral` — a synchronous, **non-persisting** generation endpoint.

- Runs the real generator (`callGenerateTemplate`) and returns `{ template, metrics }` inline.
- **Never** writes an `AgentTemplate` or `AgentTemplateGeneration` row.
- Admin-only: gated to agent-API-key callers (`isApiKeyListener`), like the `builderPrompt` override on the async endpoint.
- Skips the async job machinery (idempotency, status row, TTL) and content moderation — the caller is trusted and nothing generated here is persisted or published.
- 90s request timeout; mirrors the async endpoint's input coalescing and length caps.

## Why

The admin templates tool's "Compare prompts" feature generates throwaway candidates (with and without a custom builder prompt) across one or more ideas purely to judge prompt quality. On the normal async endpoint each generation persists a draft, so a multi-idea sweep litters the catalog. This endpoint makes that generation ephemeral; the tool creates a draft (via the normal create endpoint) only from a result worth keeping.

## Notes

- Route registered before `/generations/:generationId` so the wildcard doesn't capture `ephemeral` as a generation id.
- No schema or migration changes.
- Consumed by the assistant worker proxy (`/api/admin/templates/ephemeral`) in convos-assistants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783297620&installation_id=128169237&pr_number=292&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F292&signature=82d2db31bce98d1a325eb1cc7ee171a67dbe98dca7cf6460bfd63442c492b479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ephemeral (non-persisting) POST `/api/v2/agent-templates/generations/ephemeral` endpoint
> - Adds a new synchronous endpoint that runs template generation and returns `{ template, metrics }` without persisting any records to the database.
> - Access is restricted to API key callers only (403 otherwise); request body is validated with Zod, enforcing text ≤50k chars and base64 files ≤35M chars.
> - Input fields (`text`, `idea`, `content`, `url`, `pdfBase64`, `imageBase64`) are coalesced into a single `GenerateTemplateInput`; an optional `builderPrompt` is forwarded as a system prompt override.
> - Times out after 90 seconds by default, returning 504 on timeout; other generator errors return a generic 500.
> - The route is mounted before `/generations/:generationId` to prevent the wildcard from capturing the literal path segment `ephemeral`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea7248a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New ephemeral template generation endpoint for synchronous, non-persistent template creation
  * Accepts multiple input types: text, URLs, and file uploads (PDF/image via base64)
  * Input validation with file/size limits and timeout protection
  * Returns generated template and performance metrics on success
* **Bug Fixes**
  * Ensures the new ephemeral route is handled without interfering with existing generation routes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->