### PR TITLE
feat(connections): scope Composio connections to accountId (+ one-time move migration)

### DIFF
--- a/dev/scripts/migrateComposioUserIds.ts
+++ b/dev/scripts/migrateComposioUserIds.ts
@@ -11,22 +11,47 @@
  * Usage (dry-run is the default — it mutates nothing):
  *   pnpm tsx --env-file=.env dev/scripts/migrateComposioUserIds.ts
  *   pnpm tsx --env-file=.env dev/scripts/migrateComposioUserIds.ts --apply
+ *   pnpm tsx --env-file=.env dev/scripts/migrateComposioUserIds.ts --apply --force
+ *
+ * --apply is a no-op if the environment's ledger already says "done"; pass
+ * --force to apply again anyway (the move stays idempotent). Dry-run always runs.
  */
-import { migrateComposioConnectionsToAccountId } from "@/api/v2/connections/migrate-user-ids";
+import {
+  COMPOSIO_USER_ID_MIGRATION_KEY,
+  migrateComposioConnectionsToAccountId,
+} from "@/api/v2/connections/migrate-user-ids";
 import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 
 const APPLY = process.argv.includes("--apply");
+const FORCE = process.argv.includes("--force");
 
-migrateComposioConnectionsToAccountId({ apply: APPLY, log: logger })
-  .then((counts) => {
-    logger.info({ counts }, "[composio-migration] CLI finished");
-    if (!APPLY) {
+async function main() {
+  if (APPLY && !FORCE) {
+    const marker = await prisma.runtimeConfig.findUnique({
+      where: { key: COMPOSIO_USER_ID_MIGRATION_KEY },
+    });
+    if (marker?.value === "done") {
       logger.info(
-        "[composio-migration] dry-run only — re-run with --apply to perform the move",
+        "[composio-migration] already marked done for this environment; pass --force to apply again (dry-run always runs)",
       );
+      return;
     }
-  })
+  }
+
+  const counts = await migrateComposioConnectionsToAccountId({
+    apply: APPLY,
+    log: logger,
+  });
+  logger.info({ counts }, "[composio-migration] CLI finished");
+  if (!APPLY) {
+    logger.info(
+      "[composio-migration] dry-run only — re-run with --apply to perform the move",
+    );
+  }
+}
+
+main()
   .catch((error: unknown) => {
     logger.error({ error }, "[composio-migration] CLI failed");
     process.exitCode = 1;

--- a/dev/scripts/migrateComposioUserIds.ts
+++ b/dev/scripts/migrateComposioUserIds.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env tsx
+
+/**
+ * ONE-TIME migration: move Composio connected accounts from being keyed by
+ * `deviceId` to being keyed by the stable `accountId`.
+ *
+ * Background: connections used to be created in Composio with the per-device
+ * `deviceId` as the Composio `user_id`. We now scope connections to the stable
+ * account `accountId`. Composio's `user_id` cannot be renamed in place, but a
+ * connection can be MOVED by re-creating it from its existing credentials under
+ * a new `user_id`, then deleting the original. This carries OAuth tokens over,
+ * so users do NOT have to re-authenticate.
+ *
+ * Per connection, classification is by DB membership (NOT by guessing UUID
+ * shape, since both deviceId and accountId can be UUIDs):
+ *   - user_id is a known Account.id          -> already migrated, skip
+ *   - user_id is a known DeviceRegistration  -> MOVE to that device's accountId
+ *   - neither                                -> orphan, log only (never touched)
+ *
+ * The move is retrieve -> create(under accountId, same state) -> delete(old).
+ * If credentials can't be carried over (tokens redacted on read, or Composio's
+ * legacy create endpoint is retired for this auth config), the original is left
+ * intact and recorded as "needs re-auth" (the user simply reconnects).
+ *
+ * Idempotent: after a successful --apply, moved connections are keyed by
+ * accountId (skipped on re-run) and originals are deleted, so re-running is a
+ * no-op. Safe to run once per environment.
+ *
+ * Usage (dry-run is the default — it mutates nothing):
+ *   pnpm tsx --env-file=.env dev/scripts/migrateComposioUserIds.ts
+ *   pnpm tsx --env-file=.env dev/scripts/migrateComposioUserIds.ts --apply
+ */
+import {
+  Composio,
+  ComposioLegacyConnectedAccountsEndpointRetiredError,
+} from "@composio/core";
+import { COMPOSIO_API_KEY } from "@/config";
+import { prisma } from "@/utils/prisma";
+
+const APPLY = process.argv.includes("--apply");
+const PAGE_LIMIT = 100;
+
+// Credential fields that indicate the move can actually carry auth over.
+const SECRET_KEYS = [
+  "access_token",
+  "refresh_token",
+  "token",
+  "bearer_token",
+  "api_key",
+  "generic_api_key",
+  "password",
+  "basic_encoded",
+  "private_key",
+  "credentials_json",
+];
+
+function presentSecretKeys(val: unknown): string[] {
+  if (typeof val !== "object" || val === null) return [];
+  const record = val as Record<string, unknown>;
+  return SECRET_KEYS.filter((key) => {
+    const value = record[key];
+    return typeof value === "string" && value.length > 0;
+  });
+}
+
+async function main() {
+  if (!COMPOSIO_API_KEY) {
+    throw new Error("COMPOSIO_API_KEY is not set; cannot run migration.");
+  }
+
+  console.log(
+    `[migrate] mode=${APPLY ? "APPLY (will mutate Composio)" : "DRY-RUN (no changes)"}`,
+  );
+
+  // 1. Build DB lookups.
+  const accounts = await prisma.account.findMany({ select: { id: true } });
+  const accountIds = new Set(accounts.map((a) => a.id));
+
+  const devices = await prisma.deviceRegistration.findMany({
+    select: { deviceId: true, accountId: true },
+  });
+  const deviceToAccount = new Map<string, string>();
+  for (const device of devices) {
+    if (device.accountId) {
+      deviceToAccount.set(device.deviceId, device.accountId);
+    }
+  }
+  console.log(
+    `[migrate] loaded ${accountIds.size} accounts, ${deviceToAccount.size} device->account mappings`,
+  );
+
+  const composio = new Composio({
+    apiKey: COMPOSIO_API_KEY,
+    allowTracking: false,
+  });
+  const client = composio.getClient();
+
+  const counts = {
+    scanned: 0,
+    alreadyMigrated: 0,
+    moved: 0,
+    needsReauth: 0,
+    orphaned: 0,
+    skippedNoAccount: 0,
+  };
+
+  // 2. Page through every connected account in the project.
+  let cursor: string | null | undefined;
+  do {
+    const page = await client.connectedAccounts.list({
+      cursor: cursor ?? null,
+      limit: PAGE_LIMIT,
+    });
+
+    for (const item of page.items) {
+      counts.scanned += 1;
+      // The migration is fundamentally about this field; reading it is the point.
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      const userId = item.user_id;
+      const label = `${item.id} (toolkit=${item.toolkit.slug}, status=${item.status})`;
+
+      // Already keyed by an accountId — nothing to do.
+      if (accountIds.has(userId)) {
+        counts.alreadyMigrated += 1;
+        continue;
+      }
+
+      // Not a known device either — leave it untouched.
+      const targetAccountId = deviceToAccount.get(userId);
+      if (!targetAccountId) {
+        if (devices.some((d) => d.deviceId === userId)) {
+          // Known device but no account bound — can't target an accountId.
+          counts.skippedNoAccount += 1;
+          console.log(
+            `[migrate] SKIP ${label}: device ${userId} has no accountId`,
+          );
+        } else {
+          counts.orphaned += 1;
+          console.log(
+            `[migrate] ORPHAN ${label}: user_id ${userId} is neither an account nor a known device`,
+          );
+        }
+        continue;
+      }
+
+      // It's a device-keyed connection we can move to targetAccountId.
+      try {
+        const detail = await client.connectedAccounts.retrieve(item.id);
+        const secrets = presentSecretKeys(detail.state.val);
+
+        if (secrets.length === 0) {
+          counts.needsReauth += 1;
+          console.log(
+            `[migrate] NEEDS-REAUTH ${label}: no credential values readable in state (redacted?) — user must reconnect`,
+          );
+          continue;
+        }
+
+        if (!APPLY) {
+          counts.moved += 1;
+          console.log(
+            `[migrate] WOULD MOVE ${label}: device ${userId} -> account ${targetAccountId} (credentials present: ${secrets.join(", ")})`,
+          );
+          continue;
+        }
+
+        const created = await client.connectedAccounts.create({
+          auth_config: { id: detail.auth_config.id },
+          connection: {
+            user_id: targetAccountId,
+            // Carry the existing credential state over verbatim.
+            state: detail.state,
+          },
+        });
+        await client.connectedAccounts.delete(item.id);
+        counts.moved += 1;
+        console.log(
+          `[migrate] MOVED ${label}: ${item.id} (device ${userId}) -> ${created.id} (account ${targetAccountId})`,
+        );
+      } catch (error) {
+        counts.needsReauth += 1;
+        if (
+          error instanceof ComposioLegacyConnectedAccountsEndpointRetiredError
+        ) {
+          console.log(
+            `[migrate] NEEDS-REAUTH ${label}: legacy create endpoint retired for this auth config — user must reconnect`,
+          );
+        } else {
+          console.error(`[migrate] NEEDS-REAUTH ${label}: move failed`, error);
+        }
+      }
+    }
+
+    cursor = page.next_cursor;
+  } while (cursor);
+
+  console.log("[migrate] summary:", JSON.stringify(counts, null, 2));
+  if (!APPLY) {
+    console.log(
+      "[migrate] DRY-RUN complete. Re-run with --apply to perform the move.",
+    );
+  }
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error("[migrate] fatal error", error);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/dev/scripts/migrateComposioUserIds.ts
+++ b/dev/scripts/migrateComposioUserIds.ts
@@ -1,210 +1,34 @@
 #!/usr/bin/env tsx
 
 /**
- * ONE-TIME migration: move Composio connected accounts from being keyed by
- * `deviceId` to being keyed by the stable `accountId`.
+ * Local CLI wrapper around the Composio deviceId -> accountId migration.
  *
- * Background: connections used to be created in Composio with the per-device
- * `deviceId` as the Composio `user_id`. We now scope connections to the stable
- * account `accountId`. Composio's `user_id` cannot be renamed in place, but a
- * connection can be MOVED by re-creating it from its existing credentials under
- * a new `user_id`, then deleting the original. This carries OAuth tokens over,
- * so users do NOT have to re-authenticate.
- *
- * Per connection, classification is by DB membership (NOT by guessing UUID
- * shape, since both deviceId and accountId can be UUIDs):
- *   - user_id is a known Account.id          -> already migrated, skip
- *   - user_id is a known DeviceRegistration  -> MOVE to that device's accountId
- *   - neither                                -> orphan, log only (never touched)
- *
- * The move is retrieve -> create(under accountId, same state) -> delete(old).
- * If credentials can't be carried over (tokens redacted on read, or Composio's
- * legacy create endpoint is retired for this auth config), the original is left
- * intact and recorded as "needs re-auth" (the user simply reconnects).
- *
- * Idempotent: after a successful --apply, moved connections are keyed by
- * accountId (skipped on re-run) and originals are deleted, so re-running is a
- * no-op. Safe to run once per environment.
+ * In deployed environments this runs automatically on boot (once per env, via
+ * `runComposioUserIdMigrationOnce` in src/index.ts). This script is for running
+ * it by hand — primarily the dry-run, to inspect what would happen and verify
+ * credentials are actually readable before any environment applies it.
  *
  * Usage (dry-run is the default — it mutates nothing):
  *   pnpm tsx --env-file=.env dev/scripts/migrateComposioUserIds.ts
  *   pnpm tsx --env-file=.env dev/scripts/migrateComposioUserIds.ts --apply
  */
-import {
-  Composio,
-  ComposioLegacyConnectedAccountsEndpointRetiredError,
-} from "@composio/core";
-import { COMPOSIO_API_KEY } from "@/config";
+import { migrateComposioConnectionsToAccountId } from "@/api/v2/connections/migrate-user-ids";
+import logger from "@/utils/logger";
 import { prisma } from "@/utils/prisma";
 
 const APPLY = process.argv.includes("--apply");
-const PAGE_LIMIT = 100;
 
-// Credential fields that indicate the move can actually carry auth over.
-const SECRET_KEYS = [
-  "access_token",
-  "refresh_token",
-  "token",
-  "bearer_token",
-  "api_key",
-  "generic_api_key",
-  "password",
-  "basic_encoded",
-  "private_key",
-  "credentials_json",
-];
-
-function presentSecretKeys(val: unknown): string[] {
-  if (typeof val !== "object" || val === null) return [];
-  const record = val as Record<string, unknown>;
-  return SECRET_KEYS.filter((key) => {
-    const value = record[key];
-    return typeof value === "string" && value.length > 0;
-  });
-}
-
-async function main() {
-  if (!COMPOSIO_API_KEY) {
-    throw new Error("COMPOSIO_API_KEY is not set; cannot run migration.");
-  }
-
-  console.log(
-    `[migrate] mode=${APPLY ? "APPLY (will mutate Composio)" : "DRY-RUN (no changes)"}`,
-  );
-
-  // 1. Build DB lookups.
-  const accounts = await prisma.account.findMany({ select: { id: true } });
-  const accountIds = new Set(accounts.map((a) => a.id));
-
-  const devices = await prisma.deviceRegistration.findMany({
-    select: { deviceId: true, accountId: true },
-  });
-  const deviceToAccount = new Map<string, string>();
-  for (const device of devices) {
-    if (device.accountId) {
-      deviceToAccount.set(device.deviceId, device.accountId);
+migrateComposioConnectionsToAccountId({ apply: APPLY, log: logger })
+  .then((counts) => {
+    logger.info({ counts }, "[composio-migration] CLI finished");
+    if (!APPLY) {
+      logger.info(
+        "[composio-migration] dry-run only — re-run with --apply to perform the move",
+      );
     }
-  }
-  console.log(
-    `[migrate] loaded ${accountIds.size} accounts, ${deviceToAccount.size} device->account mappings`,
-  );
-
-  const composio = new Composio({
-    apiKey: COMPOSIO_API_KEY,
-    allowTracking: false,
-  });
-  const client = composio.getClient();
-
-  const counts = {
-    scanned: 0,
-    alreadyMigrated: 0,
-    moved: 0,
-    needsReauth: 0,
-    orphaned: 0,
-    skippedNoAccount: 0,
-  };
-
-  // 2. Page through every connected account in the project.
-  let cursor: string | null | undefined;
-  do {
-    const page = await client.connectedAccounts.list({
-      cursor: cursor ?? null,
-      limit: PAGE_LIMIT,
-    });
-
-    for (const item of page.items) {
-      counts.scanned += 1;
-      // The migration is fundamentally about this field; reading it is the point.
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      const userId = item.user_id;
-      const label = `${item.id} (toolkit=${item.toolkit.slug}, status=${item.status})`;
-
-      // Already keyed by an accountId — nothing to do.
-      if (accountIds.has(userId)) {
-        counts.alreadyMigrated += 1;
-        continue;
-      }
-
-      // Not a known device either — leave it untouched.
-      const targetAccountId = deviceToAccount.get(userId);
-      if (!targetAccountId) {
-        if (devices.some((d) => d.deviceId === userId)) {
-          // Known device but no account bound — can't target an accountId.
-          counts.skippedNoAccount += 1;
-          console.log(
-            `[migrate] SKIP ${label}: device ${userId} has no accountId`,
-          );
-        } else {
-          counts.orphaned += 1;
-          console.log(
-            `[migrate] ORPHAN ${label}: user_id ${userId} is neither an account nor a known device`,
-          );
-        }
-        continue;
-      }
-
-      // It's a device-keyed connection we can move to targetAccountId.
-      try {
-        const detail = await client.connectedAccounts.retrieve(item.id);
-        const secrets = presentSecretKeys(detail.state.val);
-
-        if (secrets.length === 0) {
-          counts.needsReauth += 1;
-          console.log(
-            `[migrate] NEEDS-REAUTH ${label}: no credential values readable in state (redacted?) — user must reconnect`,
-          );
-          continue;
-        }
-
-        if (!APPLY) {
-          counts.moved += 1;
-          console.log(
-            `[migrate] WOULD MOVE ${label}: device ${userId} -> account ${targetAccountId} (credentials present: ${secrets.join(", ")})`,
-          );
-          continue;
-        }
-
-        const created = await client.connectedAccounts.create({
-          auth_config: { id: detail.auth_config.id },
-          connection: {
-            user_id: targetAccountId,
-            // Carry the existing credential state over verbatim.
-            state: detail.state,
-          },
-        });
-        await client.connectedAccounts.delete(item.id);
-        counts.moved += 1;
-        console.log(
-          `[migrate] MOVED ${label}: ${item.id} (device ${userId}) -> ${created.id} (account ${targetAccountId})`,
-        );
-      } catch (error) {
-        counts.needsReauth += 1;
-        if (
-          error instanceof ComposioLegacyConnectedAccountsEndpointRetiredError
-        ) {
-          console.log(
-            `[migrate] NEEDS-REAUTH ${label}: legacy create endpoint retired for this auth config — user must reconnect`,
-          );
-        } else {
-          console.error(`[migrate] NEEDS-REAUTH ${label}: move failed`, error);
-        }
-      }
-    }
-
-    cursor = page.next_cursor;
-  } while (cursor);
-
-  console.log("[migrate] summary:", JSON.stringify(counts, null, 2));
-  if (!APPLY) {
-    console.log(
-      "[migrate] DRY-RUN complete. Re-run with --apply to perform the move.",
-    );
-  }
-}
-
-main()
+  })
   .catch((error: unknown) => {
-    console.error("[migrate] fatal error", error);
+    logger.error({ error }, "[composio-migration] CLI failed");
     process.exitCode = 1;
   })
   .finally(() => {

--- a/src/api/v2/connections/composio.service.ts
+++ b/src/api/v2/connections/composio.service.ts
@@ -89,7 +89,8 @@ export class ComposioService {
    * Returns null if it doesn't exist or isn't owned by the caller.
    *
    * Composio's retrieve endpoint no longer returns userId on the response,
-   * so ownership is verified by listing the caller's accounts.
+   * so ownership is verified by listing the caller's accounts. The userId is
+   * the caller's stable accountId.
    */
   async getIfOwned(args: { connectionId: string; userId: string }) {
     const list = await this.composio.connectedAccounts.list({

--- a/src/api/v2/connections/handlers/complete.ts
+++ b/src/api/v2/connections/handlers/complete.ts
@@ -8,8 +8,8 @@ const bodySchema = z.object({
 });
 
 export async function completeHandler(req: Request, res: Response) {
-  const deviceId = res.locals.deviceId;
-  if (!deviceId) {
+  const accountId = res.locals.accountId;
+  if (!accountId) {
     res.status(401).json({ error: "Unauthorized" });
     return;
   }
@@ -18,7 +18,7 @@ export async function completeHandler(req: Request, res: Response) {
   if (!parsed.success) {
     req.log.warn(
       {
-        deviceId,
+        accountId,
         issues: parsed.error.issues,
         receivedBody: req.body as unknown,
         contentType: req.header("content-type"),
@@ -41,16 +41,16 @@ export async function completeHandler(req: Request, res: Response) {
   try {
     const owned = await service.getIfOwned({
       connectionId: parsed.data.connectionRequestId,
-      userId: deviceId,
+      userId: accountId,
     });
     if (!owned) {
-      res.status(403).json({ error: "Connection not owned by this device" });
+      res.status(403).json({ error: "Connection not owned by this account" });
       return;
     }
-    res.status(200).json(mapComposioToResponse(owned, deviceId));
+    res.status(200).json(mapComposioToResponse(owned, accountId));
     return;
   } catch (error) {
-    req.log.error({ error, deviceId }, "[Composio] complete failed");
+    req.log.error({ error, accountId }, "[Composio] complete failed");
     res.status(502).json({ error: "Failed to complete connection" });
     return;
   }

--- a/src/api/v2/connections/handlers/delete.ts
+++ b/src/api/v2/connections/handlers/delete.ts
@@ -5,8 +5,8 @@ export async function deleteHandler(
   req: Request<{ id: string }>,
   res: Response,
 ) {
-  const deviceId = res.locals.deviceId;
-  if (!deviceId) {
+  const accountId = res.locals.accountId;
+  if (!accountId) {
     res.status(401).json({ error: "Unauthorized" });
     return;
   }
@@ -26,10 +26,10 @@ export async function deleteHandler(
   try {
     const owned = await service.getIfOwned({
       connectionId,
-      userId: deviceId,
+      userId: accountId,
     });
     if (!owned) {
-      res.status(403).json({ error: "Connection not owned by this device" });
+      res.status(403).json({ error: "Connection not owned by this account" });
       return;
     }
     await service.delete(connectionId);
@@ -37,7 +37,7 @@ export async function deleteHandler(
     return;
   } catch (error) {
     req.log.error(
-      { error, deviceId, connectionId },
+      { error, accountId, connectionId },
       "[Composio] delete failed",
     );
     res.status(502).json({ error: "Failed to delete connection" });

--- a/src/api/v2/connections/handlers/initiate.ts
+++ b/src/api/v2/connections/handlers/initiate.ts
@@ -11,8 +11,10 @@ const bodySchema = z.object({
 });
 
 export async function initiateHandler(req: Request, res: Response) {
-  const deviceId = res.locals.deviceId;
-  if (!deviceId) {
+  // Connections are scoped to the stable accountId (requireAccount guarantees it
+  // is present). The 401 guard is defense-in-depth.
+  const accountId = res.locals.accountId;
+  if (!accountId) {
     res.status(401).json({ error: "Unauthorized" });
     return;
   }
@@ -21,7 +23,7 @@ export async function initiateHandler(req: Request, res: Response) {
   if (!parsed.success) {
     req.log.warn(
       {
-        deviceId,
+        accountId,
         issues: parsed.error.issues,
         receivedBody: req.body as unknown,
         contentType: req.header("content-type"),
@@ -47,7 +49,7 @@ export async function initiateHandler(req: Request, res: Response) {
     );
     if (!authConfigId) {
       req.log.warn(
-        { deviceId, serviceId: parsed.data.serviceId },
+        { accountId, serviceId: parsed.data.serviceId },
         "[Composio] no ENABLED auth config found for serviceId",
       );
       res.status(400).json({
@@ -58,7 +60,7 @@ export async function initiateHandler(req: Request, res: Response) {
     }
 
     const request = await service.initiate({
-      userId: deviceId,
+      userId: accountId,
       authConfigId,
       callbackUrl: parsed.data.redirectUri,
     });
@@ -68,7 +70,7 @@ export async function initiateHandler(req: Request, res: Response) {
     });
     return;
   } catch (error) {
-    req.log.error({ error, deviceId }, "[Composio] initiate failed");
+    req.log.error({ error, accountId }, "[Composio] initiate failed");
     res.status(502).json({ error: "Failed to initiate connection" });
     return;
   }

--- a/src/api/v2/connections/handlers/list.ts
+++ b/src/api/v2/connections/handlers/list.ts
@@ -4,8 +4,8 @@ import { createComposioService } from "../composio.service";
 import { mapComposioToResponse } from "../types";
 
 export async function listHandler(req: Request, res: Response) {
-  const deviceId = res.locals.deviceId;
-  if (!deviceId) {
+  const accountId = res.locals.accountId;
+  if (!accountId) {
     res.status(401).json({ error: "Unauthorized" });
     return;
   }
@@ -17,14 +17,14 @@ export async function listHandler(req: Request, res: Response) {
   }
 
   try {
-    const list = await service.listForUser(deviceId);
+    const list = await service.listForUser(accountId);
     const items: ConnectedAccountListResponseItem[] = list.items;
     res.status(200).json({
-      connections: items.map((item) => mapComposioToResponse(item, deviceId)),
+      connections: items.map((item) => mapComposioToResponse(item, accountId)),
     });
     return;
   } catch (error) {
-    req.log.error({ error, deviceId }, "[Composio] list failed");
+    req.log.error({ error, accountId }, "[Composio] list failed");
     res.status(502).json({ error: "Failed to list connections" });
     return;
   }

--- a/src/api/v2/connections/migrate-user-ids.ts
+++ b/src/api/v2/connections/migrate-user-ids.ts
@@ -1,7 +1,4 @@
-import {
-  Composio,
-  ComposioLegacyConnectedAccountsEndpointRetiredError,
-} from "@composio/core";
+import { Composio } from "@composio/core";
 import type { PrismaClient } from "@prisma/client";
 import type { Logger } from "pino";
 import { COMPOSIO_API_KEY } from "@/config";
@@ -37,7 +34,11 @@ export const COMPOSIO_USER_ID_MIGRATION_KEY = "composio_user_id_migration_v1";
 // instances booting at once can't both run it (and create duplicates).
 const ADVISORY_LOCK_KEY = 728_193_641;
 
-// Credential fields that indicate the move can actually carry auth over.
+// Credential fields whose presence means the move can actually carry auth over.
+// Best-effort list spanning Composio's auth schemes (OAuth2/OAuth1, API key,
+// basic, bearer, service account); presence of any one is enough. May need
+// extending if Composio introduces new credential field names — a connection
+// with none readable is treated as "needs re-auth" rather than silently dropped.
 const SECRET_KEYS = [
   "access_token",
   "refresh_token",
@@ -55,7 +56,12 @@ export type MigrationCounts = {
   scanned: number;
   alreadyMigrated: number;
   moved: number;
+  // Credentials unreadable (redacted/absent) or the legacy create endpoint is
+  // retired for the auth config — the user must reconnect. Not retryable.
   needsReauth: number;
+  // Transient API errors (retrieve/create/delete) — left in place, retried on
+  // the next run. Distinct from needsReauth so operators can tell them apart.
+  failed: number;
   orphaned: number;
   skippedNoAccount: number;
 };
@@ -81,7 +87,7 @@ export async function migrateComposioConnectionsToAccountId(opts: {
   apply: boolean;
   log: Logger;
   db?: MigrationDb;
-}): Promise<MigrationCounts> {
+}) {
   const { apply, log } = opts;
   const db = opts.db ?? prisma;
 
@@ -124,6 +130,7 @@ export async function migrateComposioConnectionsToAccountId(opts: {
     alreadyMigrated: 0,
     moved: 0,
     needsReauth: 0,
+    failed: 0,
     orphaned: 0,
     skippedNoAccount: 0,
   };
@@ -198,7 +205,43 @@ export async function migrateComposioConnectionsToAccountId(opts: {
             state: detail.state,
           },
         });
-        await client.connectedAccounts.delete(item.id);
+
+        // Create succeeded — now delete the original. If THIS fails we must roll
+        // back the new connection, otherwise a retry would skip the new one as
+        // alreadyMigrated, re-process the still-present old one, and create a
+        // duplicate (then a triplicate, ...).
+        try {
+          await client.connectedAccounts.delete(item.id);
+        } catch (deleteError) {
+          counts.failed += 1;
+          let rolledBack = false;
+          try {
+            await client.connectedAccounts.delete(created.id);
+            rolledBack = true;
+          } catch (rollbackError) {
+            // Both deletes failed: old + new now coexist. Flag loudly — a retry
+            // could duplicate again, so this needs manual cleanup in Composio.
+            log.error(
+              {
+                connection: label,
+                newConnection: created.id,
+                error: rollbackError,
+              },
+              "[composio-migration] CRITICAL: old delete failed AND new rollback failed; manual cleanup required (duplicate connection)",
+            );
+          }
+          log.error(
+            {
+              connection: label,
+              newConnection: created.id,
+              rolledBack,
+              error: deleteError,
+            },
+            "[composio-migration] delete of old connection failed; rolled back new to keep retry idempotent",
+          );
+          continue;
+        }
+
         counts.moved += 1;
         log.info(
           {
@@ -210,18 +253,25 @@ export async function migrateComposioConnectionsToAccountId(opts: {
           "[composio-migration] moved",
         );
       } catch (error) {
-        counts.needsReauth += 1;
-        if (
-          error instanceof ComposioLegacyConnectedAccountsEndpointRetiredError
-        ) {
+        // retrieve or create failed. Legacy-retired is a permanent re-auth case;
+        // anything else is a (possibly transient) API failure we can retry.
+        // Detect the legacy-retired error by name rather than importing the
+        // class, so this compiles across @composio/core versions regardless of
+        // whether they export it.
+        const isLegacyRetired =
+          error instanceof Error &&
+          error.name === "ComposioLegacyConnectedAccountsEndpointRetiredError";
+        if (isLegacyRetired) {
+          counts.needsReauth += 1;
           log.warn(
             { connection: label },
             "[composio-migration] needs-reauth: legacy create endpoint retired for this auth config",
           );
         } else {
+          counts.failed += 1;
           log.error(
             { connection: label, error },
-            "[composio-migration] needs-reauth: move failed",
+            "[composio-migration] failed: retrieve/create errored (retried next run)",
           );
         }
       }
@@ -244,7 +294,7 @@ export async function migrateComposioConnectionsToAccountId(opts: {
  *   - never throws — a failure just leaves the marker unset so the next boot
  *     retries.
  */
-export async function runComposioUserIdMigrationOnce(): Promise<void> {
+export async function runComposioUserIdMigrationOnce() {
   if (!COMPOSIO_API_KEY) return;
 
   try {

--- a/src/api/v2/connections/migrate-user-ids.ts
+++ b/src/api/v2/connections/migrate-user-ids.ts
@@ -1,0 +1,299 @@
+import {
+  Composio,
+  ComposioLegacyConnectedAccountsEndpointRetiredError,
+} from "@composio/core";
+import type { PrismaClient } from "@prisma/client";
+import type { Logger } from "pino";
+import { COMPOSIO_API_KEY } from "@/config";
+import logger from "@/utils/logger";
+import { prisma } from "@/utils/prisma";
+
+/**
+ * One-time data migration: move Composio connected accounts from being keyed by
+ * the per-device `deviceId` to the stable account `accountId`.
+ *
+ * Composio's `user_id` is immutable, but a connection can be MOVED by
+ * re-creating it from its existing credentials under a new `user_id`, then
+ * deleting the original — this carries OAuth tokens over so users do NOT have to
+ * re-authenticate. The move is retrieve -> create(under accountId) -> delete.
+ *
+ * Classification is by DB membership (NOT UUID shape, since both deviceId and
+ * accountId can be UUIDs):
+ *   - user_id is a known Account.id          -> already migrated, skip
+ *   - user_id is a known DeviceRegistration  -> MOVE to that device's accountId
+ *   - neither                                -> orphan, log only (never touched)
+ *
+ * The function is convergent/idempotent: a second pass finds migrated
+ * connections keyed by accountId (skipped) and moved originals deleted, so it is
+ * a no-op. {@link runComposioUserIdMigrationOnce} wraps it with a once-per-env
+ * guard so it runs automatically on deploy, exactly like a DB migration.
+ */
+
+// Marker row in RuntimeConfig — our migration ledger (cf. _prisma_migrations).
+// Bump the suffix if the migration ever needs to be re-run intentionally.
+export const COMPOSIO_USER_ID_MIGRATION_KEY = "composio_user_id_migration_v1";
+
+// Arbitrary constant identifying this migration's Postgres advisory lock, so two
+// instances booting at once can't both run it (and create duplicates).
+const ADVISORY_LOCK_KEY = 728_193_641;
+
+// Credential fields that indicate the move can actually carry auth over.
+const SECRET_KEYS = [
+  "access_token",
+  "refresh_token",
+  "token",
+  "bearer_token",
+  "api_key",
+  "generic_api_key",
+  "password",
+  "basic_encoded",
+  "private_key",
+  "credentials_json",
+];
+
+export type MigrationCounts = {
+  scanned: number;
+  alreadyMigrated: number;
+  moved: number;
+  needsReauth: number;
+  orphaned: number;
+  skippedNoAccount: number;
+};
+
+// Both PrismaClient and an interactive-transaction client satisfy this.
+type MigrationDb = Pick<PrismaClient, "account" | "deviceRegistration">;
+
+function presentSecretKeys(val: unknown): string[] {
+  if (typeof val !== "object" || val === null) return [];
+  const record = val as Record<string, unknown>;
+  return SECRET_KEYS.filter((key) => {
+    const value = record[key];
+    return typeof value === "string" && value.length > 0;
+  });
+}
+
+/**
+ * Core migration pass. With `apply: false` (the default for the CLI) it mutates
+ * nothing and reports what it would do, including whether credentials are
+ * actually readable (the redaction check).
+ */
+export async function migrateComposioConnectionsToAccountId(opts: {
+  apply: boolean;
+  log: Logger;
+  db?: MigrationDb;
+}): Promise<MigrationCounts> {
+  const { apply, log } = opts;
+  const db = opts.db ?? prisma;
+
+  if (!COMPOSIO_API_KEY) {
+    throw new Error("COMPOSIO_API_KEY is not set; cannot run migration.");
+  }
+
+  // 1. Build DB lookups.
+  const accounts = await db.account.findMany({ select: { id: true } });
+  const accountIds = new Set(accounts.map((a) => a.id));
+
+  const devices = await db.deviceRegistration.findMany({
+    select: { deviceId: true, accountId: true },
+  });
+  const deviceToAccount = new Map<string, string>();
+  const knownDeviceIds = new Set<string>();
+  for (const device of devices) {
+    knownDeviceIds.add(device.deviceId);
+    if (device.accountId) {
+      deviceToAccount.set(device.deviceId, device.accountId);
+    }
+  }
+  log.info(
+    {
+      accounts: accountIds.size,
+      deviceMappings: deviceToAccount.size,
+      mode: apply ? "apply" : "dry-run",
+    },
+    "[composio-migration] loaded DB lookups",
+  );
+
+  const composio = new Composio({
+    apiKey: COMPOSIO_API_KEY,
+    allowTracking: false,
+  });
+  const client = composio.getClient();
+
+  const counts: MigrationCounts = {
+    scanned: 0,
+    alreadyMigrated: 0,
+    moved: 0,
+    needsReauth: 0,
+    orphaned: 0,
+    skippedNoAccount: 0,
+  };
+
+  // 2. Page through every connected account in the project.
+  let cursor: string | null | undefined;
+  do {
+    const page = await client.connectedAccounts.list({
+      cursor: cursor ?? null,
+      limit: 100,
+    });
+
+    for (const item of page.items) {
+      counts.scanned += 1;
+      // Reading this field is the entire point of the migration.
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      const userId = item.user_id;
+      const label = `${item.id} (toolkit=${item.toolkit.slug}, status=${item.status})`;
+
+      // Already keyed by an accountId — nothing to do.
+      if (accountIds.has(userId)) {
+        counts.alreadyMigrated += 1;
+        continue;
+      }
+
+      const targetAccountId = deviceToAccount.get(userId);
+      if (!targetAccountId) {
+        if (knownDeviceIds.has(userId)) {
+          counts.skippedNoAccount += 1;
+          log.warn(
+            { connection: label, deviceId: userId },
+            "[composio-migration] skip: device has no accountId",
+          );
+        } else {
+          counts.orphaned += 1;
+          log.warn(
+            { connection: label, userId },
+            "[composio-migration] orphan: user_id is neither an account nor a known device",
+          );
+        }
+        continue;
+      }
+
+      // Device-keyed connection we can move to targetAccountId.
+      try {
+        const detail = await client.connectedAccounts.retrieve(item.id);
+        const secrets = presentSecretKeys(detail.state.val);
+
+        if (secrets.length === 0) {
+          counts.needsReauth += 1;
+          log.warn(
+            { connection: label },
+            "[composio-migration] needs-reauth: no credential values readable in state (redacted?)",
+          );
+          continue;
+        }
+
+        if (!apply) {
+          counts.moved += 1;
+          log.info(
+            { connection: label, from: userId, to: targetAccountId, secrets },
+            "[composio-migration] would move",
+          );
+          continue;
+        }
+
+        const created = await client.connectedAccounts.create({
+          auth_config: { id: detail.auth_config.id },
+          connection: {
+            user_id: targetAccountId,
+            // Carry the existing credential state over verbatim.
+            state: detail.state,
+          },
+        });
+        await client.connectedAccounts.delete(item.id);
+        counts.moved += 1;
+        log.info(
+          {
+            oldConnection: item.id,
+            newConnection: created.id,
+            from: userId,
+            to: targetAccountId,
+          },
+          "[composio-migration] moved",
+        );
+      } catch (error) {
+        counts.needsReauth += 1;
+        if (
+          error instanceof ComposioLegacyConnectedAccountsEndpointRetiredError
+        ) {
+          log.warn(
+            { connection: label },
+            "[composio-migration] needs-reauth: legacy create endpoint retired for this auth config",
+          );
+        } else {
+          log.error(
+            { connection: label, error },
+            "[composio-migration] needs-reauth: move failed",
+          );
+        }
+      }
+    }
+
+    cursor = page.next_cursor;
+  } while (cursor);
+
+  log.info({ counts }, "[composio-migration] pass complete");
+  return counts;
+}
+
+/**
+ * Boot-time guard that runs the migration exactly once per environment, like a
+ * DB migration. Safe to call on every startup:
+ *   - short-circuits if the ledger marker is already "done";
+ *   - takes a transaction-scoped Postgres advisory lock so concurrent replicas
+ *     can't both run it (the lock auto-releases when the transaction ends);
+ *   - on a successful pass, records the marker so future boots skip it;
+ *   - never throws — a failure just leaves the marker unset so the next boot
+ *     retries.
+ */
+export async function runComposioUserIdMigrationOnce(): Promise<void> {
+  if (!COMPOSIO_API_KEY) return;
+
+  try {
+    const existing = await prisma.runtimeConfig.findUnique({
+      where: { key: COMPOSIO_USER_ID_MIGRATION_KEY },
+    });
+    if (existing?.value === "done") return;
+
+    await prisma.$transaction(
+      async (tx) => {
+        const lockRows = await tx.$queryRaw<{ locked: boolean }[]>`
+          SELECT pg_try_advisory_xact_lock(${ADVISORY_LOCK_KEY}) AS locked
+        `;
+        if (!lockRows[0]?.locked) {
+          logger.info(
+            "[composio-migration] advisory lock held by another instance; skipping",
+          );
+          return;
+        }
+
+        // Re-check inside the lock in case a peer finished while we waited.
+        const inside = await tx.runtimeConfig.findUnique({
+          where: { key: COMPOSIO_USER_ID_MIGRATION_KEY },
+        });
+        if (inside?.value === "done") return;
+
+        const counts = await migrateComposioConnectionsToAccountId({
+          apply: true,
+          log: logger,
+          db: tx,
+        });
+        await tx.runtimeConfig.upsert({
+          where: { key: COMPOSIO_USER_ID_MIGRATION_KEY },
+          create: { key: COMPOSIO_USER_ID_MIGRATION_KEY, value: "done" },
+          update: { value: "done" },
+        });
+        logger.info(
+          { counts },
+          "[composio-migration] completed and marked done",
+        );
+      },
+      // External Composio HTTP calls run inside the lock; give the one-time pass
+      // plenty of headroom rather than the 5s interactive-tx default.
+      { timeout: 10 * 60 * 1000, maxWait: 15_000 },
+    );
+  } catch (error) {
+    logger.error(
+      { error },
+      "[composio-migration] run failed; will retry on next boot",
+    );
+  }
+}

--- a/src/api/v2/connections/types.ts
+++ b/src/api/v2/connections/types.ts
@@ -21,14 +21,14 @@ function normalizeStatus(status: string): string {
 
 export function mapComposioToResponse(
   conn: ConnectedAccountRetrieveResponse | ConnectedAccountListResponseItem,
-  deviceId: string,
+  accountId: string,
 ): ConnectionResponse {
   const slug = conn.toolkit.slug;
   return {
     connectionId: conn.id,
     serviceId: slug,
     serviceName: slug,
-    composioEntityId: deviceId,
+    composioEntityId: accountId,
     composioConnectionId: conn.id,
     status: normalizeStatus(conn.status),
   };

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -117,7 +117,7 @@ v2Router.use(
 // limits. authMiddleware applies to the whole subtree.
 v2Router.use("/agents", authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
-v2Router.use("/connections", authMiddleware, connectionsRouter);
+v2Router.use("/connections", authMiddleware, requireAccount, connectionsRouter);
 v2Router.use("/notifications/xmtp", webhookRouter);
 v2Router.use("/notifications", authMiddleware, notificationsRouter);
 // No auth: Apple authenticates via JWS signature, verified inside the handler.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   startTtlSweep as startGenerationTtlSweep,
   stopTtlSweep as stopGenerationTtlSweep,
 } from "@/api/v2/agent-templates/services/ttl-sweep";
+import { runComposioUserIdMigrationOnce } from "@/api/v2/connections/migrate-user-ids";
 import apiRouter from "./api";
 import { IS_DEVELOPMENT } from "./config";
 import { errorHandlerMiddleware } from "./middleware/errorHandler";
@@ -103,6 +104,13 @@ validateJWTKeys()
       // Generation pipeline sweep — expires stale generation rows. Runs in
       // every env now that the agent-templates router is mounted everywhere.
       startGenerationTtlSweep();
+
+      // One-time data migration: move Composio connections from deviceId to the
+      // stable accountId. Self-guards via a RuntimeConfig ledger marker so it
+      // runs exactly once per environment (like a DB migration) and is a no-op
+      // on every subsequent boot. Fired after listen so a slow/failing external
+      // call never blocks startup or health checks.
+      void runComposioUserIdMigrationOnce();
     });
 
     // Wrap the async drain steps in a void-IIFE so the SIGTERM listener

--- a/tests/connections.test.ts
+++ b/tests/connections.test.ts
@@ -56,6 +56,16 @@ const AUTH_CONFIG_ID = "ac_test_google_calendar";
 // Connections are scoped to the stable accountId; the JWT carries it and
 // requireAccount enforces its presence.
 const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+const DEVICE_ID = "device-abc";
+
+// Mint an auth token for the standard test device. Omit accountId to exercise
+// the requireAccount gate (device authenticated but not bound to an account).
+function makeToken(opts: { accountId?: string } = {}) {
+  return createJwtToken({
+    deviceId: DEVICE_ID,
+    ...(opts.accountId ? { accountId: opts.accountId } : {}),
+  });
+}
 
 const app = express();
 app.use(pinoMiddleware);
@@ -265,7 +275,7 @@ describe("Connections API", () => {
       const { stub, calls } = makeStub();
       installStub(stub);
       // Authenticated device but not bound to an account → requireAccount blocks.
-      const token = await createJwtToken({ deviceId: "device-abc" });
+      const token = await makeToken();
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
         headers: {
@@ -283,10 +293,7 @@ describe("Connections API", () => {
     test("initiate forwards accountId as userId and maps serviceId to authConfigId", async () => {
       const { stub, calls } = makeStub();
       installStub(stub);
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
@@ -315,10 +322,7 @@ describe("Connections API", () => {
     test("initiate forwards per-request redirectUri to Composio", async () => {
       const { stub, calls } = makeStub();
       installStub(stub);
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
@@ -341,10 +345,7 @@ describe("Connections API", () => {
     test("initiate rejects malformed redirectUri", async () => {
       const { stub } = makeStub();
       installStub(stub);
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
@@ -379,10 +380,7 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections/complete`, {
         method: "POST",
@@ -439,10 +437,7 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections`, {
         method: "GET",
@@ -474,10 +469,7 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections/conn_owned`, {
         method: "DELETE",
@@ -508,10 +500,7 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections/complete`, {
         method: "POST",
@@ -543,10 +532,7 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
 
       const res = await fetch(`${baseURL}/api/v2/connections/conn_other`, {
         method: "DELETE",
@@ -567,10 +553,7 @@ describe("Connections API", () => {
         },
       });
       installStub(stub);
-      const token = await createJwtToken({
-        deviceId: "device-abc",
-        accountId: ACCOUNT_ID,
-      });
+      const token = await makeToken({ accountId: ACCOUNT_ID });
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
         headers: {

--- a/tests/connections.test.ts
+++ b/tests/connections.test.ts
@@ -21,7 +21,7 @@ import {
   ComposioService,
 } from "@/api/v2/connections/composio.service";
 import { connectionsRouter } from "@/api/v2/connections/connections.router";
-import { authMiddleware } from "@/middleware/auth";
+import { authMiddleware, requireAccount } from "@/middleware/auth";
 import { jsonMiddleware } from "@/middleware/json";
 import { pinoMiddleware } from "@/middleware/pino";
 import { createJwtToken } from "@/utils/jwt";
@@ -53,11 +53,19 @@ type ComposioStub = {
 };
 
 const AUTH_CONFIG_ID = "ac_test_google_calendar";
+// Connections are scoped to the stable accountId; the JWT carries it and
+// requireAccount enforces its presence.
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 
 const app = express();
 app.use(pinoMiddleware);
 app.use(jsonMiddleware);
-app.use("/api/v2/connections", authMiddleware, connectionsRouter);
+app.use(
+  "/api/v2/connections",
+  authMiddleware,
+  requireAccount,
+  connectionsRouter,
+);
 
 let server: Server;
 const baseURL = "http://localhost:4012";
@@ -252,14 +260,33 @@ describe("Connections API", () => {
       });
       expect(res.status).toBe(401);
     });
+
+    test("initiate returns 403 when token has no accountId", async () => {
+      const { stub, calls } = makeStub();
+      installStub(stub);
+      // Authenticated device but not bound to an account → requireAccount blocks.
+      const token = await createJwtToken({ deviceId: "device-abc" });
+      const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({ serviceId: "google_calendar" }),
+      });
+      expect(res.status).toBe(403);
+      expect(calls.initiate).toEqual([]);
+    });
   });
 
   describe("happy path", () => {
-    test("initiate forwards deviceId as userId and maps serviceId to authConfigId", async () => {
+    test("initiate forwards accountId as userId and maps serviceId to authConfigId", async () => {
       const { stub, calls } = makeStub();
       installStub(stub);
-      const deviceId = "device-abc";
-      const token = await createJwtToken({ deviceId });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
@@ -277,7 +304,7 @@ describe("Connections API", () => {
       };
       expect(body.connectionRequestId).toBe("conn_1");
       expect(body.redirectUrl).toBe("https://composio.example/auth");
-      expect(calls.initiate[0]?.userId).toBe(deviceId);
+      expect(calls.initiate[0]?.userId).toBe(ACCOUNT_ID);
       expect(calls.initiate[0]?.authConfigId).toBe(AUTH_CONFIG_ID);
       // No redirectUri in body → service falls back to the env default.
       expect(calls.initiate[0]?.callbackUrl).toBe(
@@ -288,8 +315,10 @@ describe("Connections API", () => {
     test("initiate forwards per-request redirectUri to Composio", async () => {
       const { stub, calls } = makeStub();
       installStub(stub);
-      const deviceId = "device-abc";
-      const token = await createJwtToken({ deviceId });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
@@ -312,7 +341,10 @@ describe("Connections API", () => {
     test("initiate rejects malformed redirectUri", async () => {
       const { stub } = makeStub();
       installStub(stub);
-      const token = await createJwtToken({ deviceId: "device-abc" });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
@@ -332,10 +364,9 @@ describe("Connections API", () => {
     test("complete returns mapped response for owned connection", async () => {
       const { stub, accounts } = makeStub();
       installStub(stub);
-      const deviceId = "device-abc";
       accounts.set("conn_owned", {
         id: "conn_owned",
-        userId: deviceId,
+        userId: ACCOUNT_ID,
         authConfig: {
           id: AUTH_CONFIG_ID,
           isComposioManaged: true,
@@ -348,7 +379,10 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({ deviceId });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections/complete`, {
         method: "POST",
@@ -367,18 +401,17 @@ describe("Connections API", () => {
         serviceId: string;
       };
       expect(body.connectionId).toBe("conn_owned");
-      expect(body.composioEntityId).toBe(deviceId);
+      expect(body.composioEntityId).toBe(ACCOUNT_ID);
       expect(body.serviceId).toBe("google_calendar");
       expect(body.status).toBe("ACTIVE");
     });
 
-    test("list returns only this device's connections", async () => {
+    test("list returns only this account's connections", async () => {
       const { stub, accounts } = makeStub();
       installStub(stub);
-      const deviceId = "device-abc";
       accounts.set("conn_1", {
         id: "conn_1",
-        userId: deviceId,
+        userId: ACCOUNT_ID,
         authConfig: {
           id: AUTH_CONFIG_ID,
           isComposioManaged: true,
@@ -406,7 +439,10 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({ deviceId });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections`, {
         method: "GET",
@@ -423,10 +459,9 @@ describe("Connections API", () => {
     test("delete removes owned connection and returns 204", async () => {
       const { stub, accounts, calls } = makeStub();
       installStub(stub);
-      const deviceId = "device-abc";
       accounts.set("conn_owned", {
         id: "conn_owned",
-        userId: deviceId,
+        userId: ACCOUNT_ID,
         authConfig: {
           id: AUTH_CONFIG_ID,
           isComposioManaged: true,
@@ -439,7 +474,10 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({ deviceId });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections/conn_owned`, {
         method: "DELETE",
@@ -452,7 +490,7 @@ describe("Connections API", () => {
   });
 
   describe("entity mismatch", () => {
-    test("complete returns 403 when connection belongs to another device", async () => {
+    test("complete returns 403 when connection belongs to another account", async () => {
       const { stub, accounts } = makeStub();
       installStub(stub);
       accounts.set("conn_other", {
@@ -470,7 +508,10 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({ deviceId: "device-abc" });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections/complete`, {
         method: "POST",
@@ -484,7 +525,7 @@ describe("Connections API", () => {
       expect(res.status).toBe(403);
     });
 
-    test("delete returns 403 when connection belongs to another device", async () => {
+    test("delete returns 403 when connection belongs to another account", async () => {
       const { stub, accounts, calls } = makeStub();
       installStub(stub);
       accounts.set("conn_other", {
@@ -502,7 +543,10 @@ describe("Connections API", () => {
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       });
-      const token = await createJwtToken({ deviceId: "device-abc" });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
 
       const res = await fetch(`${baseURL}/api/v2/connections/conn_other`, {
         method: "DELETE",
@@ -523,7 +567,10 @@ describe("Connections API", () => {
         },
       });
       installStub(stub);
-      const token = await createJwtToken({ deviceId: "device-abc" });
+      const token = await createJwtToken({
+        deviceId: "device-abc",
+        accountId: ACCOUNT_ID,
+      });
       const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Why

Connections were registered with Composio using the per-device **`deviceId`** as Composio's `user_id`. `deviceId` changes per device / reinstall, so a user's connections fragment across devices and vanish on reinstall. This moves connections to the stable **`accountId`**, which survives device changes and gives a clean basis for per-account security/scoping.

## What changed

**Runtime (going forward)**
- All connection handlers (`initiate`/`complete`/`list`/`delete`) and the response mapper now key on `res.locals.accountId` instead of `deviceId`; `composioEntityId` is the accountId.
- `requireAccount` added to the `/connections` mount → 403 if the JWT has no account (no `deviceId` fallback).

**One-time data migration (existing connections)**
- Composio's `user_id` is immutable, but a connection can be **moved** by re-creating it from its existing credentials under a new `user_id`, then deleting the original — this carries OAuth tokens over, so **users do not re-authenticate**. The move is `retrieve → create(under accountId) → delete`.
- Classification is by **DB membership** (account vs known device), not UUID shape — so it's idempotent/convergent.
- Runs **automatically once per environment on boot** (`runComposioUserIdMigrationOnce()` in `src/index.ts`), guarded by a `RuntimeConfig` ledger marker (`composio_user_id_migration_v1`) plus a transaction-scoped Postgres advisory lock so concurrent replicas can't double-apply. Fired after `listen` so a slow/failing Composio call never blocks startup; on failure the marker stays unset and the next deploy retries.
- `dev/scripts/migrateComposioUserIds.ts` is a thin CLI over the same module for local **dry-runs** (`--apply` to perform).

## ⚠️ Validate before trusting prod auto-apply
Two risks can't be verified without a live Composio project — do the staging **dry-run** first and check the logged credential-presence:
1. **Token redaction** — if `retrieve` redacts secrets, the move can't carry credentials (→ those connections fall back to "needs re-auth").
2. **Legacy `create` retirement** — Composio is retiring the legacy create endpoint for Composio-managed OAuth (cutover 2026-05-08 new orgs / 2026-07-03 all). If retired for this org, affected connections fall back to "needs re-auth".

Both are handled gracefully (logged, left intact for the user to reconnect).

**Escape hatch:** delete the `composio_user_id_migration_v1` row in `RuntimeConfig` and redeploy to re-run.

## Verification
- ✅ `tsc --noEmit` clean (pre-existing `@/gen` protobuf errors unrelated)
- ✅ eslint clean
- ✅ 14/14 `tests/connections.test.ts` pass (incl. new no-account → 403 case)

> Base is `otr-dev` (where the connections feature lives — it isn't on `dev` yet).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783519722&installation_id=128169237&pr_number=294&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F294&signature=1fc9357fab4aaea97b845597fe2a9f79a8c3f44484c8940e7b9c736b527b68ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope Composio connections to accountId and migrate existing device-keyed connections
> - All `/api/v2/connections` endpoints now use `accountId` instead of `deviceId` for ownership, creation, and listing of Composio connections; requests without an `accountId` are rejected by a new `requireAccount` middleware added to the route.
> - A migration pass in [`migrate-user-ids.ts`](https://github.com/ephemeraHQ/convos-backend/pull/294/files#diff-cdd4ec471cc00b3d8a6c9b9fcccce39a8e8f7421527a703449493e4209d9f410) re-keys existing Composio connections from `deviceId` to `accountId`, carrying credentials when readable and rolling back if deletion of the original fails.
> - A boot-time guard (`runComposioUserIdMigrationOnce`) runs the migration once per environment at startup using a Postgres advisory lock, then marks it complete in `runtimeConfig`; a companion CLI script in [`dev/scripts/migrateComposioUserIds.ts`](https://github.com/ephemeraHQ/convos-backend/pull/294/files#diff-70437d720e989a22a5e2b297327dcdb62df81daad853f4fbd662cac0442c7238) supports dry-run/apply/force modes for local execution.
> - `mapComposioToResponse` now maps `composioEntityId` to `accountId` in responses instead of `deviceId`.
> - Risk: existing clients using tokens without an `accountId` will be rejected at the `/connections` endpoints after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f8882c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connections API now scoped to user accounts for improved data isolation and security.
  * Account binding required for all connection operations.

* **Bug Fixes**
  * Fixed connection authorization to properly verify ownership using account identifiers.

* **Chores**
  * Automatic one-time migration moved existing connections to account-based management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->