### PR TITLE
feat(agent-templates): switch builder model to opus 4.8 fast

### DIFF
--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -22,7 +22,7 @@
  *
  * Model attribution note: the wrapper records the *requested* model as
  * `$ai_model` (`openAIParams.model ?? result.model`). The default model is a
- * concrete OpenRouter id (`anthropic/claude-opus-4.7`, see `DEFAULT_MODEL` in
+ * concrete OpenRouter id (`anthropic/claude-opus-4.8-fast`, see `DEFAULT_MODEL` in
  * templateGen.ts), so PostHog prices `$ai_total_cost_usd` automatically. A
  * `BUILDER_MODEL` override should also be a concrete id (not an OpenRouter
  * `@preset/...` alias, which PostHog can't price) to keep cost resolving.

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -82,7 +82,7 @@ export const TEMPLATE_CATEGORIES = [
 // Concrete OpenRouter model id (not an OpenRouter `@preset/...` alias) so
 // PostHog LLM Analytics can price `$ai_generation` events — `$ai_total_cost_usd`
 // resolves automatically. Override per-environment with `BUILDER_MODEL`.
-const DEFAULT_MODEL = "anthropic/claude-opus-4.7";
+const DEFAULT_MODEL = "anthropic/claude-opus-4.8-fast";
 
 // Wallclock cap for every OpenRouter call (selector, classifier, main).
 // Today both JSON and SSE handler modes share a single buffered completion,
@@ -285,7 +285,7 @@ type GithubPrefetch =
 
 /** Convenience constant for test mocks — realistic placeholder metrics. */
 export const DEFAULT_TEST_METRICS: GenerationMetrics = {
-  model: "anthropic/claude-opus-4.7",
+  model: "anthropic/claude-opus-4.8-fast",
   promptTokens: 100,
   completionTokens: 200,
   latencyMs: 1500,

--- a/tests/template-gen.posthog-trace.test.ts
+++ b/tests/template-gen.posthog-trace.test.ts
@@ -82,7 +82,7 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
       apiKey: "test-or-key",
       stage: "generate",
       body: {
-        model: "anthropic/claude-opus-4.7",
+        model: "anthropic/claude-opus-4.8-fast",
         messages: [{ role: "user", content: "make me an agent" }],
         temperature: 0.7,
       },
@@ -118,7 +118,7 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
       k.startsWith("posthog"),
     );
     expect(leaked).toEqual([]);
-    expect(lastSentBody.model).toBe("anthropic/claude-opus-4.7");
+    expect(lastSentBody.model).toBe("anthropic/claude-opus-4.8-fast");
     // Provider routing prefers Bedrock (fallbacks left on by default).
     expect(lastSentBody.provider).toEqual({ order: ["amazon-bedrock"] });
   });
@@ -135,7 +135,7 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
       apiKey: "test-or-key",
       stage: "generate",
       body: {
-        model: "anthropic/claude-opus-4.7",
+        model: "anthropic/claude-opus-4.8-fast",
         messages: [{ role: "user", content: "go" }],
       },
       trace: {
@@ -151,7 +151,7 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
     expect(calls[0].distinctId).toBe("acct-1");
     expect(p.upstream_provider).toBe("Amazon Bedrock"); // from OpenRouter response
     expect(p.ai_stage).toBe("generate");
-    expect(p.requested_model).toBe("anthropic/claude-opus-4.7");
+    expect(p.requested_model).toBe("anthropic/claude-opus-4.8-fast");
     expect(p.served_model).toBe("anthropic/claude-sonnet-4.5"); // mock response.model
     expect(p.$ai_trace_id).toBe("gen-bedrock");
     expect(typeof p.latency_ms).toBe("number");
@@ -165,7 +165,7 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
       apiKey: "test-or-key",
       stage: "classifier",
       body: {
-        model: "anthropic/claude-opus-4.7",
+        model: "anthropic/claude-opus-4.8-fast",
         messages: [{ role: "user", content: "classify" }],
       },
       trace: {
@@ -198,7 +198,7 @@ describe("openRouterChatCompletion + PostHog tracing", () => {
         apiKey: "test-or-key",
         stage,
         body: {
-          model: "anthropic/claude-opus-4.7",
+          model: "anthropic/claude-opus-4.8-fast",
           messages: [{ role: "user", content: stage }],
         },
         trace: { traceId: "gen-shared", distinctId: "acct-1" },

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -250,9 +250,9 @@ describe("templateGen service — OpenRouter integration", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Model defaults to anthropic/claude-opus-4.7
+  // Model defaults to anthropic/claude-opus-4.8-fast
   // -----------------------------------------------------------------------
-  test("model defaults to anthropic/claude-opus-4.7", async () => {
+  test("model defaults to anthropic/claude-opus-4.8-fast", async () => {
     const mod = await import("@/api/v2/agent-templates/services/templateGen");
     generateTemplate = mod.generateTemplate;
 
@@ -278,7 +278,7 @@ describe("templateGen service — OpenRouter integration", () => {
     await generateTemplate({ text: "Build me a helper" });
 
     const req = getLastOpenRouterRequest();
-    expect(req.body.model).toBe("anthropic/claude-opus-4.7");
+    expect(req.body.model).toBe("anthropic/claude-opus-4.8-fast");
   });
 
   test("BUILDER_MODEL env override works", async () => {
@@ -591,7 +591,7 @@ describe("templateGen service — OpenRouter integration", () => {
     expect(selectorReq).toBeDefined();
     expect(selectorReq.body.temperature).toBe(0.2);
     expect(selectorReq.body.response_format).toBeUndefined();
-    expect(selectorReq.body.model).toBe("anthropic/claude-opus-4.7");
+    expect(selectorReq.body.model).toBe("anthropic/claude-opus-4.8-fast");
     expect(selectorReq.headers["authorization"]).toBe(`Bearer ${TEST_API_KEY}`);
 
     globalThis.fetch = originalMockFetch;


### PR DESCRIPTION
## What

Bumps the agent-template generator's default model from `anthropic/claude-opus-4.7` to `anthropic/claude-opus-4.8-fast`.

- `templateGen.ts` — `DEFAULT_MODEL` (the live generator model) and the `DEFAULT_TEST_METRICS` fixture
- `openrouter-client.ts` — doc comment referencing `DEFAULT_MODEL`
- `tests/template-gen.service.test.ts` + `tests/template-gen.posthog-trace.test.ts` — default-model assertions

`BUILDER_MODEL` env override behavior is unchanged.

## Note

The comment above `DEFAULT_MODEL` requires a **concrete OpenRouter id** (not a `@preset/...` alias) so PostHog can auto-price `$ai_total_cost_usd` on `$ai_generation` events. Worth confirming `anthropic/claude-opus-4.8-fast` is the exact OpenRouter slug and that PostHog has pricing for it, or cost attribution will fall through.

## Test

`vitest run` on both affected files: 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783562465&installation_id=128169237&pr_number=296&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F296&signature=e4b25d001023e9d09ec6bf0b44a7ee66ab8ba976112ce1aff48e7befde35b882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch agent template builder default model to `anthropic/claude-opus-4.8-fast`
> Updates `DEFAULT_MODEL` and `DEFAULT_TEST_METRICS.model` in [templateGen.ts](https://github.com/ephemeraHQ/convos-backend/pull/296/files#diff-d151881c4ab5cd2005df4016ac6a564fb6094e4ce06b69fbf9529fb70e59148a) from `anthropic/claude-opus-4.7` to `anthropic/claude-opus-4.8-fast`. Test fixtures and a comment in [openrouter-client.ts](https://github.com/ephemeraHQ/convos-backend/pull/296/files#diff-6350fa102ccf82d602fd5ecd832731a3c9feb5914c17a24758537d6e4e634626) are updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3f9e5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model version used for template generation to improve performance and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->