### PR TITLE
feat(agent-templates): allow a privileged custom model on the generation endpoint

### DIFF
--- a/prisma/migrations/20260608120000_add_generation_builder_model/migration.sql
+++ b/prisma/migrations/20260608120000_add_generation_builder_model/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+-- Optional caller-supplied model override (admin dashboard). Privileged
+-- (agent-API-key only) and used by the executor for the main generation call;
+-- null for ordinary generations, where the default builder model is used.
+ALTER TABLE "AgentTemplateGeneration"
+  ADD COLUMN "builderModel" VARCHAR(256);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -181,6 +181,10 @@ model AgentTemplateGeneration {
   // Optional caller-supplied builder/system prompt override (admin dashboard);
   // privileged (agent-API-key only) and fed to the generator by the executor.
   builderPrompt   String?          @db.Text
+  // Optional caller-supplied model override (admin dashboard); privileged
+  // (agent-API-key only) and used by the executor for the main generation call
+  // instead of the default builder model.
+  builderModel    String?          @db.VarChar(256)
   templateId      String?          @db.Uuid
   publishStatus   PublishStatus    @default(draft)
   reply           String?          @db.Text

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -20,7 +20,7 @@
  *   3. Coalesced inputs present                                 → 400
  *   4. Input length limits (text ≤ 50k, base64 ≤ 35M)           → 400
  *   5. Owner resolution (auth account or admin fallback)
- *   5b. twitterContext / builderPrompt / builderModel — agent-key only → 403
+ *   5b-5d. twitterContext / builderPrompt / builderModel — agent-key only → 403
  *   5e. builderModel unknown to OpenRouter's catalog             → 400
  *   6. Idempotency-Key header present                           → 400
  *   7. Idempotency lookup → existing { source, inputs } match   → respondPerMode

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -15,19 +15,21 @@
  *     `event: error` (failed). HTTP status is always 200 in SSE mode.
  *
  * Submit-time validation order (each check returns and short-circuits):
- *   1. Body shape (zod)                                         → 400
- *   2. Content-Length > 40 MB                                   → 413
+ *   1. Content-Length > 40 MB                                   → 413
+ *   2. Body shape (zod)                                         → 400
  *   3. Coalesced inputs present                                 → 400
  *   4. Input length limits (text ≤ 50k, base64 ≤ 35M)           → 400
  *   5. Owner resolution (auth account or admin fallback)
- *   5b-5d. twitterContext / builderPrompt / builderModel — agent-key only → 403
- *   5e. builderModel unknown to OpenRouter's catalog             → 400
- *   6. Idempotency-Key header present                           → 400
- *   7. Idempotency lookup → existing { source, inputs } match   → respondPerMode
- *   8.                  → existing different body              → 409
- *   9. Content moderation (universal)                           → 422 (content)
- *   9b. Twitter intent moderation (when twitterContext present)  → 422 (intent)
- *  10. Persist row + fire executor + respondPerMode
+ *   6. twitterContext — agent-key only                          → 403
+ *   7. builderPrompt — agent-key only                           → 403
+ *   8. builderModel — agent-key only                            → 403
+ *   9. builderModel unknown to OpenRouter's catalog             → 400
+ *  10. Idempotency-Key header present                           → 400
+ *  11. Idempotency lookup → existing { source, inputs } match   → respondPerMode
+ *  12.                  → existing different body               → 409
+ *  13. Content moderation (universal)                           → 422 (content)
+ *  14. Twitter intent moderation (when twitterContext present)  → 422 (intent)
+ *  15. Persist row + fire executor + respondPerMode
  *
  * Idempotent replays go through the SAME respondPerMode path as the original
  * submit, so a retry with `Accept: text/event-stream` or `?wait_ms=` honours
@@ -743,7 +745,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     ownerAccountId = getEffectiveOwnerId(res) ?? ADMIN_ACCOUNT_ID;
   }
 
-  // 5b. twitterContext is privileged — it ends up attributed to a real
+  // 6. twitterContext is privileged — it ends up attributed to a real
   //     twitter handle. Only the bot (agent API key) is in a position to
   //     verify handle ownership against the tweet author, so reject the
   //     field for anonymous and JWT-only callers.
@@ -754,7 +756,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 5c. builderPrompt overrides the canonical generator system prompt — an
+  // 7. builderPrompt overrides the canonical generator system prompt — an
   //     abuse-prone surface (a free general-purpose LLM, or a way to strip the
   //     design/moderation guardrails baked into the canonical prompt), so it's
   //     restricted to agent-API-key callers (the admin dashboard).
@@ -765,7 +767,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 5d. builderModel swaps the default builder model — same abuse surface
+  // 8. builderModel swaps the default builder model — same abuse surface
   //     (an arbitrary, potentially unguardrailed model), so it's restricted
   //     to agent-API-key callers like builderPrompt.
   if (body.builderModel && !isApiKeyListener) {
@@ -775,7 +777,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 5e. Validate builderModel against OpenRouter's catalog so an unknown id
+  // 9. Validate builderModel against OpenRouter's catalog so an unknown id
   //     fails fast here instead of surfacing as a terminal `failed` generation
   //     (which only reports a generic upstream error). Best-effort: the lookup
   //     fails open if the catalog is unreachable.
@@ -786,7 +788,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 6. Idempotency-Key required and MUST be a UUID (any RFC 4122 version).
+  // 10. Idempotency-Key required and MUST be a UUID (any RFC 4122 version).
   //    Both the agent API key path and anonymous submissions are owned by
   //    `ADMIN_ACCOUNT_ID`, so they share an idempotency namespace; using
   //    UUIDs (122 bits of entropy) keeps that shared namespace safe from
@@ -808,7 +810,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 7+8. Idempotency dedupe lookup. Compare the FULL body (source + inputs);
+  // 11+12. Idempotency dedupe lookup. Compare the FULL body (source + inputs);
   // same key with a different source is a 409, matching the docstring contract.
   const existing = await prisma.agentTemplateGeneration.findUnique({
     where: {
@@ -856,7 +858,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     },
   };
 
-  // 9. Content moderation gate (universal)
+  // 13. Content moderation gate (universal)
   const moderationInput =
     coalesced.kind === "text"
       ? coalesced.text
@@ -870,7 +872,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
-  // 9b. Twitter intent gate — only when twitterContext is present
+  // 14. Twitter intent gate — only when twitterContext is present
   if (body.twitterContext) {
     const intentInput =
       body.twitterContext.idea ??
@@ -892,7 +894,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     }
   }
 
-  // 10. Persist + fire executor
+  // 15. Persist + fire executor
   let created: GenerationRow;
   try {
     created = await prisma.agentTemplateGeneration.create({
@@ -977,6 +979,6 @@ export async function generationsPostHandler(req: Request, res: Response) {
     );
   });
 
-  // 11. Response mode (fresh submit, status=pending)
+  // 16. Response mode (fresh submit, status=pending)
   await respondPerMode({ req, res, ownerAccountId, row: created, isClosed });
 }

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -20,6 +20,8 @@
  *   3. Coalesced inputs present                                 → 400
  *   4. Input length limits (text ≤ 50k, base64 ≤ 35M)           → 400
  *   5. Owner resolution (auth account or admin fallback)
+ *   5b. twitterContext / builderPrompt / builderModel — agent-key only → 403
+ *   5e. builderModel unknown to OpenRouter's catalog             → 400
  *   6. Idempotency-Key header present                           → 400
  *   7. Idempotency lookup → existing { source, inputs } match   → respondPerMode
  *   8.                  → existing different body              → 409
@@ -48,6 +50,7 @@ import {
   checkTwitterIntent,
 } from "@/api/v2/agent-templates/services/moderation";
 import { type TraceContext } from "@/api/v2/agent-templates/services/openrouter-client";
+import { isKnownOpenRouterModel } from "@/api/v2/agent-templates/services/openrouter-models";
 import { resolveActor } from "@/api/v2/agent-templates/services/posthog";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
@@ -768,6 +771,17 @@ export async function generationsPostHandler(req: Request, res: Response) {
   if (body.builderModel && !isApiKeyListener) {
     res.status(403).json({
       error: "builderModel requires agent API key authentication",
+    });
+    return;
+  }
+
+  // 5e. Validate builderModel against OpenRouter's catalog so an unknown id
+  //     fails fast here instead of surfacing as a terminal `failed` generation
+  //     (which only reports a generic upstream error). Best-effort: the lookup
+  //     fails open if the catalog is unreachable.
+  if (body.builderModel && !(await isKnownOpenRouterModel(body.builderModel))) {
+    res.status(400).json({
+      error: `builderModel '${body.builderModel}' is not a valid OpenRouter model`,
     });
     return;
   }

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -62,6 +62,9 @@ const MAX_BASE64_LEN = 35_000_000;
 // Builder/system prompt override cap — generous (the canonical file prompt is
 // ~12k tokens) but bounds an obviously-abusive body.
 const MAX_BUILDER_PROMPT_LEN = 100_000;
+// Model-override cap — OpenRouter model ids are short slugs; this just bounds
+// an obviously-abusive value (matches the column's VARCHAR(256)).
+const MAX_BUILDER_MODEL_LEN = 256;
 const MAX_BODY_BYTES = 40 * 1024 * 1024;
 const MAX_WAIT_MS = 45_000;
 const DEFAULT_SSE_KEEPALIVE_MS = 15_000;
@@ -218,6 +221,11 @@ const bodySchema = z
     // fire-and-forget executor can feed it to the generator. The produced
     // template still lands as a draft via the normal pipeline.
     builderPrompt: z.string().min(1).max(MAX_BUILDER_PROMPT_LEN).optional(),
+    // Custom model that overrides the default builder model for this
+    // generation's main call. Privileged — gated to agent-API-key callers
+    // below (like builderPrompt) — and persisted on the row so the
+    // fire-and-forget executor can hand it to the generator.
+    builderModel: z.string().min(1).max(MAX_BUILDER_MODEL_LEN).optional(),
     // Asserted owner — honoured only when the caller is agent-key-auth'd;
     // ignored for JWT (JWT account always wins) and anonymous (falls
     // back to ADMIN). See the owner-resolution block below.
@@ -498,6 +506,7 @@ interface DedupeRow extends GenerationRow {
   twitterContext: unknown;
   prefill: unknown;
   builderPrompt: string | null;
+  builderModel: string | null;
 }
 
 const dedupeSelect = {
@@ -507,6 +516,7 @@ const dedupeSelect = {
   twitterContext: true,
   prefill: true,
   builderPrompt: true,
+  builderModel: true,
   status: true,
   templateId: true,
   reply: true,
@@ -528,6 +538,7 @@ function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
       twitterContext: existing.twitterContext,
       prefill: existing.prefill,
       builderPrompt: existing.builderPrompt,
+      builderModel: existing.builderModel,
     },
     {
       source: body.source,
@@ -535,6 +546,7 @@ function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
       twitterContext: body.twitterContext ?? null,
       prefill: body.prefill ?? null,
       builderPrompt: body.builderPrompt ?? null,
+      builderModel: body.builderModel ?? null,
     },
   );
 }
@@ -750,6 +762,16 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
+  // 5d. builderModel swaps the default builder model — same abuse surface
+  //     (an arbitrary, potentially unguardrailed model), so it's restricted
+  //     to agent-API-key callers like builderPrompt.
+  if (body.builderModel && !isApiKeyListener) {
+    res.status(403).json({
+      error: "builderModel requires agent API key authentication",
+    });
+    return;
+  }
+
   // 6. Idempotency-Key required and MUST be a UUID (any RFC 4122 version).
   //    Both the agent API key path and anonymous submissions are owned by
   //    `ADMIN_ACCOUNT_ID`, so they share an idempotency namespace; using
@@ -874,6 +896,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
           ? (body.prefill as Prisma.InputJsonValue)
           : Prisma.JsonNull,
         builderPrompt: body.builderPrompt ?? null,
+        builderModel: body.builderModel ?? null,
         publishStatus: body.publishStatus,
         status: "pending",
       },

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -498,6 +498,10 @@ async function _runPipeline(
   // null for ordinary generations, where the canonical prompt is used.
   const builderPrompt = generation.builderPrompt;
 
+  // Optional caller-supplied model override (admin dashboard). null for
+  // ordinary generations, where the default builder model is used.
+  const builderModel = generation.builderModel;
+
   // Actor-attribution fields shared by every capture site below, plus the
   // PostHog LLM Analytics trace id so the product event joins to the
   // `$ai_generation` spans the OpenRouter calls emit. Built once: the trace's
@@ -528,6 +532,7 @@ async function _runPipeline(
       prefill,
       trace,
       builderPrompt,
+      builderModel,
     );
   } catch (err) {
     // Meter error path

--- a/src/api/v2/agent-templates/services/openrouter-models.ts
+++ b/src/api/v2/agent-templates/services/openrouter-models.ts
@@ -1,0 +1,73 @@
+/**
+ * OpenRouter model-catalog lookup — used to validate a caller-supplied
+ * `builderModel` at submit time so an unknown model id fails fast with a 400
+ * instead of surfacing later as a terminal `failed` generation.
+ *
+ * The catalog (`GET /models`) is public and changes infrequently, so the id
+ * set is cached in-process with a TTL. Validation is best-effort: if the
+ * catalog can't be fetched and nothing is cached yet, `isKnownOpenRouterModel`
+ * fails open (returns true) so a transient OpenRouter outage doesn't block
+ * custom-model submissions — the async generation path remains the backstop.
+ */
+
+import { OPENROUTER_BASE_URL } from "@/api/v2/agent-templates/services/openrouter-client";
+import logger from "@/utils/logger";
+
+const MODELS_URL = `${OPENROUTER_BASE_URL}/models`;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const FETCH_TIMEOUT_MS = 5_000;
+
+interface ModelCache {
+  ids: Set<string>;
+  fetchedAt: number;
+}
+
+let _cache: ModelCache | null = null;
+let _testOverride: Set<string> | null = null;
+
+/** Inject a fixed model-id set for tests, bypassing the network fetch. Pass
+ *  `null` to clear the override (and the cache). */
+export function __setOpenRouterModelsForTests(ids: string[] | null): void {
+  _testOverride = ids ? new Set(ids) : null;
+  _cache = null;
+}
+
+async function fetchModelIds(): Promise<Set<string>> {
+  const res = await fetch(MODELS_URL, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenRouter /models returned HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
+  const ids = new Set<string>();
+  for (const model of json.data ?? []) {
+    if (typeof model.id === "string") ids.add(model.id);
+  }
+  if (ids.size === 0) {
+    throw new Error("OpenRouter /models returned no model ids");
+  }
+  return ids;
+}
+
+/**
+ * True when `model` is a known OpenRouter model id. Best-effort: returns true
+ * when the catalog can't be fetched and no cached set exists yet (fail-open);
+ * a stale cache is preferred over failing open when a refresh fails.
+ */
+export async function isKnownOpenRouterModel(model: string): Promise<boolean> {
+  if (_testOverride) return _testOverride.has(model);
+
+  const now = Date.now();
+  if (!_cache || now - _cache.fetchedAt > CACHE_TTL_MS) {
+    try {
+      _cache = { ids: await fetchModelIds(), fetchedAt: now };
+    } catch (err) {
+      logger.warn({ err }, "[openrouter-models] catalog fetch failed");
+      // No catalog at all → can't validate, so don't block the submission.
+      if (!_cache) return true;
+      // Otherwise fall through and validate against the stale cache.
+    }
+  }
+  return _cache.ids.has(model);
+}

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -1293,6 +1293,7 @@ export async function generateTemplate(
   prefill?: GenerationPrefill | null,
   trace?: TraceContext,
   systemPromptOverride?: string | null,
+  modelOverride?: string | null,
 ): Promise<GenerationResult> {
   // Backward compat: string input = text
   const opts: GenerateTemplateInput =
@@ -1324,7 +1325,11 @@ export async function generateTemplate(
   const intentNote = intentText ? `\n\nUser's intent: ${intentText}` : "";
 
   let userContent: any;
-  const model = getModel();
+  // A per-request override (the admin tool's custom model) wins over the
+  // config/test-seam model; an empty/whitespace value falls through to the
+  // default. Applies to this main generation call only — the GitHub selector
+  // and content classifier keep their configured models.
+  const model = modelOverride?.trim() || getModel();
 
   if (opts.imageBase64) {
     // Image path: send as image_url for vision models
@@ -1652,6 +1657,7 @@ let _generateTemplateOverride:
       prefill?: GenerationPrefill | null,
       trace?: TraceContext,
       systemPromptOverride?: string | null,
+      modelOverride?: string | null,
     ) => Promise<GenerationResult>)
   | null = null;
 
@@ -1664,6 +1670,7 @@ export function __resetGenerateTemplateForTests(
         prefill?: GenerationPrefill | null,
         trace?: TraceContext,
         systemPromptOverride?: string | null,
+        modelOverride?: string | null,
       ) => Promise<GenerationResult>)
     | null,
 ) {
@@ -1681,6 +1688,9 @@ export function __resetGenerateTemplateForTests(
  * Optional `systemPromptOverride` lets a trusted caller (the admin preview
  * tool) swap the builder system prompt for a single request without
  * persisting anything; omitted on the production generation path.
+ *
+ * Optional `modelOverride` similarly swaps the builder model for the main
+ * generation call; omitted on the production generation path.
  */
 export async function callGenerateTemplate(
   input: GenerateTemplateInput | string,
@@ -1688,6 +1698,7 @@ export async function callGenerateTemplate(
   prefill?: GenerationPrefill | null,
   trace?: TraceContext,
   systemPromptOverride?: string | null,
+  modelOverride?: string | null,
 ): Promise<GenerationResult> {
   if (_generateTemplateOverride) {
     return _generateTemplateOverride(
@@ -1696,9 +1707,17 @@ export async function callGenerateTemplate(
       prefill,
       trace,
       systemPromptOverride,
+      modelOverride,
     );
   }
-  return generateTemplate(input, signal, prefill, trace, systemPromptOverride);
+  return generateTemplate(
+    input,
+    signal,
+    prefill,
+    trace,
+    systemPromptOverride,
+    modelOverride,
+  );
 }
 
 export { BREVITY_RAIL, BUILDER_CONTRACT_RAIL };

--- a/tests/agent-templates.executor.test.ts
+++ b/tests/agent-templates.executor.test.ts
@@ -197,6 +197,70 @@ describe("generation-executor", () => {
     expect(capturedOverride).toBeNull();
   });
 
+  test("threads the row's builderModel to the generator as the model override", async () => {
+    let capturedModel: string | null | undefined;
+    __resetGenerateTemplateForTests(
+      (
+        _input,
+        _signal,
+        _prefill,
+        _trace,
+        _systemPromptOverride,
+        modelOverride,
+      ) => {
+        capturedModel = modelOverride;
+        return Promise.resolve({
+          template: fakeTemplate,
+          metrics: DEFAULT_TEST_METRICS,
+        });
+      },
+    );
+    const builderModel = "anthropic/claude-opus-4.8";
+    const gen = await prisma.agentTemplateGeneration.create({
+      data: {
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+        source: TEST_SOURCE,
+        idempotencyKey: "builder-model-threading",
+        inputs: { text: "a trivia agent" },
+        builderModel,
+        status: "pending",
+      },
+    });
+
+    await executeGeneration(gen.id);
+
+    const final = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: gen.id },
+    });
+    expect(final?.status).toBe("done");
+    expect(capturedModel).toBe(builderModel);
+  });
+
+  test("ordinary generation (no builderModel) passes no model override", async () => {
+    let capturedModel: string | null | undefined = "SENTINEL";
+    __resetGenerateTemplateForTests(
+      (
+        _input,
+        _signal,
+        _prefill,
+        _trace,
+        _systemPromptOverride,
+        modelOverride,
+      ) => {
+        capturedModel = modelOverride ?? null;
+        return Promise.resolve({
+          template: fakeTemplate,
+          metrics: DEFAULT_TEST_METRICS,
+        });
+      },
+    );
+    const gen = await createPendingGeneration("no-builder-model");
+
+    await executeGeneration(gen.id);
+
+    expect(capturedModel).toBeNull();
+  });
+
   test("preserves the user's text intent alongside an attached file", async () => {
     let capturedInput: unknown;
     let capturedProps: PostHogCaptureProperties | undefined;

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -450,6 +450,54 @@ describe("POST /generations — builderPrompt (privileged override)", () => {
   });
 });
 
+describe("POST /generations — builderModel (privileged override)", () => {
+  test("anonymous caller + builderModel → 403", async () => {
+    // builderModel swaps the default builder model, so like builderPrompt
+    // it's restricted to agent-API-key callers.
+    const res = await post(
+      { ...sampleBody, builderModel: "anthropic/claude-opus-4.8" },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": stableUuid("builder-model-anon"),
+        },
+      },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("agent-key + builderModel → 202 and persists on the row", async () => {
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const res = await post(
+      { ...sampleBody, builderModel: "anthropic/claude-opus-4.8" },
+      { headers: withKey("builder-model-ok") },
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { generationId: string };
+    const row = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: body.generationId },
+    });
+    expect(row?.builderModel).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("same key + different builderModel → 409", async () => {
+    // builderModel influences the generator's output, so it's part of the
+    // idempotent contract — a reused key with a different model must 409.
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const first = await post(
+      { ...sampleBody, builderModel: "anthropic/claude-opus-4.8" },
+      { headers: withKey("idem-builder-model-diff") },
+    );
+    expect(first.status).toBe(202);
+
+    const second = await post(
+      { ...sampleBody, builderModel: "anthropic/claude-opus-4.7" },
+      { headers: withKey("idem-builder-model-diff") },
+    );
+    expect(second.status).toBe(409);
+  });
+});
+
 describe("POST /generations — SSE mode", () => {
   test("Accept: text/event-stream emits terminal result frame", async () => {
     const res = await fetch(`${baseURL}/api/v2/agent-templates/generations`, {

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -20,6 +20,7 @@ import {
   __setExecutorTimeoutMsForTests,
 } from "@/api/v2/agent-templates/services/generation-executor";
 import { __resetModerationForTests } from "@/api/v2/agent-templates/services/moderation";
+import { __setOpenRouterModelsForTests } from "@/api/v2/agent-templates/services/openrouter-models";
 import { __resetPostHogForTests } from "@/api/v2/agent-templates/services/posthog";
 import {
   __resetGenerateTemplateForTests,
@@ -92,6 +93,11 @@ beforeAll(async () => {
   __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
   __resetPostHogForTests(() => {});
   __resetModerationForTests(() => Promise.resolve({ allowed: true }));
+  // Fixed model catalog so builderModel validation is hermetic (no network).
+  __setOpenRouterModelsForTests([
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-opus-4.7",
+  ]);
   __resetGenerateTemplateForTests(() =>
     Promise.resolve({
       template: fakeTemplate,
@@ -122,6 +128,7 @@ afterAll(async () => {
   __resetGenerateTemplateForTests(null);
   __resetPostHogForTests(null);
   __resetModerationForTests(null);
+  __setOpenRouterModelsForTests(null);
   // Restore the singleton agent-key override so it can't leak into other suites.
   __setAgentAssetsApiKeyOverrideForTests(undefined);
   await prisma.account
@@ -478,6 +485,19 @@ describe("POST /generations — builderModel (privileged override)", () => {
       where: { id: body.generationId },
     });
     expect(row?.builderModel).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("agent-key + builderModel unknown to OpenRouter → 400", async () => {
+    // Submit-time catalog validation fails fast rather than letting the bad
+    // model surface later as a terminal `failed` generation.
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const res = await post(
+      { ...sampleBody, builderModel: "anthropic/claude-opus-9.9-imaginary" },
+      { headers: withKey("builder-model-unknown") },
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("is not a valid OpenRouter model");
   });
 
   test("same key + different builderModel → 409", async () => {

--- a/tests/openrouter-models.test.ts
+++ b/tests/openrouter-models.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the OpenRouter model-catalog lookup used to validate a
+ * caller-supplied `builderModel` at submit time. Intercepts global fetch to
+ * exercise catalog matching and the fail-open path; no DB or network.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  __setOpenRouterModelsForTests,
+  isKnownOpenRouterModel,
+} from "@/api/v2/agent-templates/services/openrouter-models";
+
+const originalFetch = globalThis.fetch;
+
+function mockModelsResponse(ids: string[]) {
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: ids.map((id) => ({ id })) }),
+    })) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  // Clear the in-process cache so each test starts cold.
+  __setOpenRouterModelsForTests(null);
+});
+
+describe("isKnownOpenRouterModel", () => {
+  test("returns true for an id in the fetched catalog, false otherwise", async () => {
+    mockModelsResponse([
+      "anthropic/claude-opus-4.8",
+      "anthropic/claude-opus-4.8-fast",
+    ]);
+
+    expect(await isKnownOpenRouterModel("anthropic/claude-opus-4.8")).toBe(
+      true,
+    );
+    // Second call is served from cache (no second fetch needed).
+    expect(await isKnownOpenRouterModel("anthropic/claude-opus-4.8-fast")).toBe(
+      true,
+    );
+    expect(await isKnownOpenRouterModel("anthropic/made-up-model")).toBe(false);
+  });
+
+  test("fails open when the catalog can't be fetched and nothing is cached", async () => {
+    globalThis.fetch = () => Promise.reject(new Error("network down"));
+
+    expect(await isKnownOpenRouterModel("anything/at-all")).toBe(true);
+  });
+
+  test("test override bypasses the network entirely", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = () => {
+      fetchCalled = true;
+      return Promise.reject(new Error("should not be called"));
+    };
+    __setOpenRouterModelsForTests(["anthropic/claude-opus-4.8"]);
+
+    expect(await isKnownOpenRouterModel("anthropic/claude-opus-4.8")).toBe(
+      true,
+    );
+    expect(await isKnownOpenRouterModel("anthropic/claude-opus-4.7")).toBe(
+      false,
+    );
+    expect(fetchCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a privileged `builderModel` field to `POST /api/v2/agent-templates/generations`, mirroring the existing `builderPrompt` override pattern. It lets a trusted caller (the admin dashboard) pick the model used for a single generation instead of the default builder model.

## Behavior (mirrors `builderPrompt`)

- **Auth-gated**: returns `403 { error: "builderModel requires agent API key authentication" }` unless the caller is agent-API-key authed. Anonymous/JWT callers can't set it.
- **Submit-time validation**: an id not in OpenRouter's catalog is rejected with `400 { error: "builderModel '<x>' is not a valid OpenRouter model" }` before any row is created — so a typo'd model fails fast instead of surfacing later as a terminal `failed` generation (whose error is only a generic upstream `OpenRouter API error 400`).
- **Idempotency contract**: part of the dedupe body — reusing an `Idempotency-Key` with a different `builderModel` returns `409`.
- **Persisted** on the `AgentTemplateGeneration` row so the fire-and-forget executor can read it.
- **Threaded** into the generator as a `modelOverride`, replacing the default model for the **main generation call only** — the GitHub repo selector and content classifier keep their configured models (same scope as `builderPrompt`). Returned metrics already report the served/override model.

## Catalog validation details

- New `services/openrouter-models.ts`: looks up OpenRouter's public `GET /models`, caches the id set in-process with a 1h TTL.
- **Best-effort / fail-open**: if the catalog can't be fetched and nothing is cached, validation returns true so a transient OpenRouter outage doesn't block custom-model submissions — the async generation path remains the backstop. A stale cache is preferred over failing open when a refresh fails.
- Validation is exact-match against OpenRouter `id`s (e.g. `anthropic/claude-opus-4.8`, `anthropic/claude-opus-4.8-fast`). Callers should pass a concrete id, which also keeps PostHog cost attribution resolving (per the `DEFAULT_MODEL` note in `openrouter-client.ts`).

## Changes

- `prisma/schema.prisma` + migration — new nullable `builderModel VARCHAR(256)` column (additive, safe)
- `handlers/generations-post.ts` — request schema field, auth gate, catalog validation, idempotency (`DedupeRow`/`dedupeSelect`/`dedupeBodiesMatch`), persist
- `services/openrouter-models.ts` — catalog lookup + cache + test seam (new)
- `services/generation-executor.ts` — read `generation.builderModel`, pass to `callGenerateTemplate`
- `services/templateGen.ts` — new `modelOverride?` param on `generateTemplate`/`callGenerateTemplate`
- Tests — catalog lookup unit tests (match / fail-open / override), executor threading, handler `403`/`400`(unknown)/`202`+persist/`409`

## Test

- Typecheck clean (only pre-existing unrelated `@/gen` protobuf errors).
- No-DB unit tests pass (catalog lookup + generator threading).
- DB-backed executor/handler tests run in CI (no local Postgres in the dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow a privileged `builderModel` override on the agent template generation endpoint
> - Adds an optional `builderModel` field to the `POST /v2/agent-templates/generations` request body, persisted to a new `builderModel` column in `AgentTemplateGeneration`.
> - Restricts `builderModel` to requests authenticated with an agent API key, returning 403 otherwise.
> - Validates the provided model ID against a cached OpenRouter catalog (1-hour TTL) via a new `isKnownOpenRouterModel` utility; returns 400 on unknown models, but fails open if the catalog is unreachable and no cache exists.
> - Threads the stored `builderModel` through the generation executor into `callGenerateTemplate` as a model override, replacing the default `getModel()` selection.
> - Behavioral Change: idempotency comparisons now include `builderModel`, so reusing an `Idempotency-Key` with a different `builderModel` returns 409.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccaeef5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom AI model for template generation (authorized users only).
  * Added validation against a catalog of available models for generation requests.

* **Tests**
  * Added comprehensive test coverage for model selection override, validation, and idempotency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->