### PR TITLE
feat(agent-templates): allow a privileged custom model on the ephemeral endpoint

### DIFF
--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -4,18 +4,22 @@
  * Synchronous, NON-persisting generation. Runs the real generator and returns
  * the produced template inline — it never writes an AgentTemplate or an
  * AgentTemplateGeneration row. Built for the admin compare tool, which generates
- * throwaway candidates (with and without a builderPrompt override) purely to
- * judge prompt quality across one or more ideas; nothing should land in the
- * catalog until an admin explicitly keeps one (via the normal create endpoint).
+ * throwaway candidates (varying the builderPrompt and/or builderModel override)
+ * purely to judge prompt quality across one or more ideas; nothing should land
+ * in the catalog until an admin explicitly keeps one (via the normal create
+ * endpoint).
  *
  * Admin-only: gated to agent-API-key callers (isApiKeyListener), like the
- * privileged builderPrompt field on the async endpoint. Skips the async job
- * machinery (idempotency, status row, TTL) and content moderation — the caller
- * is trusted and nothing generated here is persisted or published.
+ * privileged builderPrompt/builderModel fields on the async endpoint. Because
+ * the whole endpoint already requires an agent API key, those overrides need no
+ * extra per-field auth gate here. Skips the async job machinery (idempotency,
+ * status row, TTL) and content moderation — the caller is trusted and nothing
+ * generated here is persisted or published.
  */
 
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { isKnownOpenRouterModel } from "@/api/v2/agent-templates/services/openrouter-models";
 import {
   callGenerateTemplate,
   type GenerateTemplateInput,
@@ -37,6 +41,9 @@ function getTimeoutMs(): number {
 const MAX_TEXT_LEN = 50_000;
 const MAX_BASE64_LEN = 35_000_000;
 const MAX_BUILDER_PROMPT_LEN = 100_000;
+// Model-override cap — OpenRouter model ids are short slugs; this just bounds
+// an obviously-abusive value (matches the async endpoint's builderModel cap).
+const MAX_BUILDER_MODEL_LEN = 256;
 
 const inputsSchema = z
   .object({
@@ -63,6 +70,7 @@ const bodySchema = z
   .object({
     inputs: inputsSchema,
     builderPrompt: z.string().min(1).max(MAX_BUILDER_PROMPT_LEN).optional(),
+    builderModel: z.string().min(1).max(MAX_BUILDER_MODEL_LEN).optional(),
     prefill: prefillSchema.optional(),
   })
   .strict();
@@ -136,6 +144,17 @@ export async function generationsEphemeralPostHandler(
 
   const prefill: GenerationPrefill | null = parsed.data.prefill ?? null;
   const builderPrompt = parsed.data.builderPrompt ?? null;
+  const builderModel = parsed.data.builderModel ?? null;
+
+  // Validate builderModel against OpenRouter's catalog so an unknown id fails
+  // fast here instead of surfacing as a generic upstream error mid-generation.
+  // Best-effort: the lookup fails open if the catalog is unreachable.
+  if (builderModel && !(await isKnownOpenRouterModel(builderModel))) {
+    res.status(400).json({
+      error: `builderModel '${builderModel}' is not a valid OpenRouter model`,
+    });
+    return;
+  }
 
   // Held in a variable so the catch can distinguish a timeout (signal.aborted)
   // from a generation error without parsing the wrapped error message.
@@ -147,6 +166,7 @@ export async function generationsEphemeralPostHandler(
       prefill,
       undefined,
       builderPrompt,
+      builderModel,
     );
     res.status(200).json({ template, metrics });
     return;

--- a/tests/agent-templates.generations-ephemeral.test.ts
+++ b/tests/agent-templates.generations-ephemeral.test.ts
@@ -6,6 +6,8 @@
  *   - Validation: missing/empty inputs                          → 400
  *   - Happy path: returns { template } inline, builderPrompt
  *     forwarded, and NOTHING persisted                          → 200
+ *   - builderModel: valid id forwarded as the model override     → 200
+ *   - builderModel: unknown to OpenRouter's catalog              → 400
  *   - Generator error: stable generic message (no leak)         → 500
  *   - Timeout: AbortSignal fires                                → 504
  */
@@ -20,6 +22,7 @@ import {
   test,
 } from "vitest";
 import { __setEphemeralTimeoutMsForTests } from "@/api/v2/agent-templates/handlers/generations-ephemeral-post";
+import { __setOpenRouterModelsForTests } from "@/api/v2/agent-templates/services/openrouter-models";
 import {
   __resetGenerateTemplateForTests,
   DEFAULT_TEST_METRICS,
@@ -46,8 +49,12 @@ const apiKeyHeaders = {
 const noKeyHeaders = { "Content-Type": "application/json" };
 
 // Records the args the generator was called with, so a test can assert the
-// builderPrompt override is forwarded (the 5th param, systemPromptOverride).
-let lastCall: { systemPromptOverride?: string | null } | null = null;
+// overrides are forwarded: builderPrompt as the 5th param (systemPromptOverride)
+// and builderModel as the 6th (modelOverride).
+let lastCall: {
+  systemPromptOverride?: string | null;
+  modelOverride?: string | null;
+} | null = null;
 
 let baseURL: string;
 let closeServer: () => Promise<void>;
@@ -61,6 +68,11 @@ const post = (body: unknown, headers: Record<string, string> = apiKeyHeaders) =>
 
 beforeAll(async () => {
   __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+  // Fixed model catalog so builderModel validation is hermetic (no network).
+  __setOpenRouterModelsForTests([
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-opus-4.7",
+  ]);
   const server = await startAgentTemplatesServer(TEST_PORT);
   baseURL = server.baseURL;
   closeServer = server.close;
@@ -69,10 +81,17 @@ beforeAll(async () => {
 beforeEach(() => {
   lastCall = null;
   __setEphemeralTimeoutMsForTests(null);
-  // Default: a fast, successful generation that records its override arg.
+  // Default: a fast, successful generation that records its override args.
   __resetGenerateTemplateForTests(
-    (_input, _signal, _prefill, _trace, systemPromptOverride) => {
-      lastCall = { systemPromptOverride };
+    (
+      _input,
+      _signal,
+      _prefill,
+      _trace,
+      systemPromptOverride,
+      modelOverride,
+    ) => {
+      lastCall = { systemPromptOverride, modelOverride };
       return Promise.resolve({
         template: fakeTemplate,
         metrics: DEFAULT_TEST_METRICS,
@@ -87,6 +106,7 @@ afterEach(() => {
 
 afterAll(async () => {
   __resetGenerateTemplateForTests(null);
+  __setOpenRouterModelsForTests(null);
   __setAgentAssetsApiKeyOverrideForTests(undefined);
   await closeServer();
 });
@@ -137,6 +157,28 @@ describe("POST /generations/ephemeral — happy path", () => {
       where: { agentName: fakeTemplate.agentName },
     });
     expect(after).toBe(before);
+  });
+});
+
+describe("POST /generations/ephemeral — builderModel (privileged override)", () => {
+  test("valid id is forwarded to the generator as the model override", async () => {
+    const res = await post({
+      inputs: { idea: "a wine club sommelier" },
+      builderModel: "anthropic/claude-opus-4.8",
+    });
+    expect(res.status).toBe(200);
+    // The override reaches the generator as the 6th param (modelOverride).
+    expect(lastCall?.modelOverride).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("unknown id (not in OpenRouter's catalog) → 400", async () => {
+    const res = await post({
+      inputs: { idea: "x" },
+      builderModel: "anthropic/claude-opus-9.9-imaginary",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("is not a valid OpenRouter model");
   });
 });
 


### PR DESCRIPTION
## What

Extends the privileged `builderModel` override added to the async generation endpoint in #297 to the **ephemeral** (non-persisting) endpoint, `POST /api/v2/agent-templates/generations/ephemeral`. The admin compare tool can now vary the builder model alongside `builderPrompt` on throwaway candidates.

## Behavior

- **Accepted field**: optional `builderModel` (string, ≤256 chars) in the request body, mirroring the async endpoint's cap.
- **No extra auth gate needed**: the whole ephemeral endpoint is already gated to agent-API-key callers (`isApiKeyListener` → `403` otherwise). Unlike the async endpoint — which allows anonymous/JWT callers and so needs a per-field `403` for `builderModel` — there's no anonymous path to gate here.
- **Submit-time catalog validation**: an id not in OpenRouter's catalog is rejected with `400 { error: "builderModel '<x>' is not a valid OpenRouter model" }` before generation. Best-effort / fail-open if the catalog is unreachable (reuses the existing `isKnownOpenRouterModel` helper and its 1h cache from #297).
- **Threaded** into `callGenerateTemplate` as the `modelOverride` (6th arg), replacing the default model for the **main generation call only** — same scope as `builderPrompt`.
- **No persistence, idempotency, or schema changes** — ephemeral never writes a row, so none of #297's DB/dedupe plumbing applies.

## Changes

- `handlers/generations-ephemeral-post.ts` — `builderModel` schema field, catalog validation, thread into the generator; docstring updated.
- `tests/agent-templates.generations-ephemeral.test.ts` — valid id forwarded as the model override (`200`), and unknown id (`400`); hermetic catalog via `__setOpenRouterModelsForTests`.

## Test

- Typecheck clean (only the pre-existing unrelated `@/gen` protobuf errors).
- The two new `builderModel` tests pass locally (no DB needed). The pre-existing DB-backed happy-path test runs in CI — no local Postgres in the dev worktree, same as #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783578889&installation_id=128169237&pr_number=298&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F298&signature=a59b1585e33978e7cec8dd04f140894fbca9ec902276a00ef431ff4644eb80ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow a custom builder model override on the ephemeral agent-template generation endpoint
> - Adds an optional `builderModel` field to the `POST /api/v2/agent-templates/generations/ephemeral` request body, capped at 256 characters.
> - Validates the provided model against OpenRouter's catalog via `isKnownOpenRouterModel`; returns 400 with a specific error message for unrecognized models.
> - Forwards valid `builderModel` values to `callGenerateTemplate` as a model override argument.
> - Adds hermetic tests using `__setOpenRouterModelsForTests` to cover the happy path (200, model forwarded) and the rejection path (400, unknown model).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 324f40e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for builder model override when generating agent templates
  * Implemented validation to ensure builder models are recognized; invalid selections return error responses

* **Tests**
  * Extended test coverage for builder model validation and override behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->