### PR TITLE
feat(agent-templates): SSE keepalive for the ephemeral endpoint

### DIFF
--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -125,17 +125,25 @@ function coalesce(
 // ---------------------------------------------------------------------------
 
 /** Outcome of one ephemeral generation, classified once so the JSON and SSE
- *  response paths can render it without re-inspecting the error. */
+ *  response paths can render it without re-inspecting the error.
+ *  `aborted` = the client disconnected mid-flight; there's no one to respond
+ *  to, so callers bail without writing. */
 type Outcome =
   | { kind: "ok"; result: GenerationResult }
   | { kind: "timeout" }
+  | { kind: "aborted" }
   | { kind: "error" };
 
 async function runGeneration(
   log: Request["log"],
   args: {
     input: GenerateTemplateInput;
+    /** Composed signal handed to the generator — aborts on timeout OR client
+     *  disconnect, so the upstream OpenRouter call is cancelled either way. */
     signal: AbortSignal;
+    /** The 90s ceiling alone, kept separate so a disconnect-driven abort isn't
+     *  misclassified (and logged) as a timeout. */
+    timeoutSignal: AbortSignal;
     prefill: GenerationPrefill | null;
     builderPrompt: string | null;
     builderModel: string | null;
@@ -152,11 +160,18 @@ async function runGeneration(
     );
     return { kind: "ok", result };
   } catch (err) {
-    // signal.aborted distinguishes a timeout from a generation error without
-    // parsing the wrapped error message.
-    if (args.signal.aborted) {
+    // The 90s ceiling is the only abort we surface as a timeout.
+    if (args.timeoutSignal.aborted) {
       log.warn({ err }, "[ephemeral-generation] generation timed out");
       return { kind: "timeout" };
+    }
+    // Composed signal aborted but not the timeout → the client hung up. The
+    // result is discarded anyway, so this is expected, not an error.
+    if (args.signal.aborted) {
+      log.info(
+        "[ephemeral-generation] client disconnected; generation aborted",
+      );
+      return { kind: "aborted" };
     }
     // Keep the specifics in logs; callers surface a stable, generic message
     // (matches the other agent-templates handlers).
@@ -219,10 +234,28 @@ export async function generationsEphemeralPostHandler(
     return;
   }
 
-  const signal = AbortSignal.timeout(getTimeoutMs());
+  // Abort the upstream generation on the 90s ceiling OR a client disconnect.
+  // Unlike the async endpoint (whose executor runs to completion to persist a
+  // result), an ephemeral result is discarded the moment the client hangs up,
+  // so finishing it would just burn model capacity. The timeout signal is kept
+  // separate so a disconnect isn't misclassified as a timeout.
+  const timeoutSignal = AbortSignal.timeout(getTimeoutMs());
+  const abort = new AbortController();
+  timeoutSignal.addEventListener(
+    "abort",
+    () => {
+      abort.abort();
+    },
+    { once: true },
+  );
+  res.on("close", () => {
+    abort.abort();
+  });
+
   const generationArgs = {
     input: coalesced,
-    signal,
+    signal: abort.signal,
+    timeoutSignal,
     prefill,
     builderPrompt,
     builderModel,
@@ -232,21 +265,14 @@ export async function generationsEphemeralPostHandler(
   // frame. Mirrors the async endpoint's contract so a long generation never
   // holds a silent connection.
   if ((req.headers.accept || "").includes("text/event-stream")) {
-    // Read the disconnect flag through a function so it's observed at call
-    // time (a direct boolean read would be narrowed to its initial value).
-    let closed = false;
-    res.on("close", () => {
-      closed = true;
-    });
-    const isClosed = () => closed;
-
     const keepalive = startSseStream(res);
     const outcome = await runGeneration(req.log, generationArgs);
     clearInterval(keepalive);
 
-    // Client hung up mid-generation — the keep-alive is already cleared and
-    // there's no persisted result to deliver, so just bail.
-    if (isClosed() || res.writableEnded || res.destroyed) return;
+    // Client hung up mid-generation — its result was discarded and the stream
+    // is gone, so there's nothing to write.
+    if (outcome.kind === "aborted" || res.writableEnded || res.destroyed)
+      return;
 
     // The client can still drop between the check above and the write below;
     // a write on a closed socket throws, so swallow it (nobody's listening).
@@ -269,6 +295,7 @@ export async function generationsEphemeralPostHandler(
 
   // JSON mode: hold the connection and return the template inline.
   const outcome = await runGeneration(req.log, generationArgs);
+  if (outcome.kind === "aborted" || res.writableEnded || res.destroyed) return;
   if (outcome.kind === "ok") {
     res.status(200).json({
       template: outcome.result.template,

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -186,9 +186,9 @@ export async function generationsEphemeralPostHandler(
 ) {
   const isApiKeyListener = res.locals.isApiKeyListener ?? false;
   if (!isApiKeyListener) {
-    res
-      .status(403)
-      .json({ error: "ephemeral generation requires agent API key auth" });
+    res.status(403).json({
+      error: "ephemeral generation requires agent API key authentication",
+    });
     return;
   }
 
@@ -204,19 +204,26 @@ export async function generationsEphemeralPostHandler(
   if (!coalesced) {
     res.status(400).json({
       error:
-        "No usable input — provide one of text, idea, content, url, pdfBase64, or imageBase64",
+        "inputs must include one of text, idea, content, url, pdfBase64, or imageBase64",
     });
     return;
   }
   if (coalesced.text && coalesced.text.length > MAX_TEXT_LEN) {
-    res.status(400).json({ error: `text exceeds ${MAX_TEXT_LEN} characters` });
+    res.status(400).json({
+      error: `Text exceeds maximum length of ${MAX_TEXT_LEN} characters`,
+    });
     return;
   }
-  if (
-    (coalesced.pdfBase64 && coalesced.pdfBase64.length > MAX_BASE64_LEN) ||
-    (coalesced.imageBase64 && coalesced.imageBase64.length > MAX_BASE64_LEN)
-  ) {
-    res.status(400).json({ error: "attached file exceeds the size limit" });
+  if (coalesced.pdfBase64 && coalesced.pdfBase64.length > MAX_BASE64_LEN) {
+    res.status(400).json({
+      error: `PDF base64 exceeds maximum length of ${MAX_BASE64_LEN} characters`,
+    });
+    return;
+  }
+  if (coalesced.imageBase64 && coalesced.imageBase64.length > MAX_BASE64_LEN) {
+    res.status(400).json({
+      error: `Image base64 exceeds maximum length of ${MAX_BASE64_LEN} characters`,
+    });
     return;
   }
 

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -248,15 +248,21 @@ export async function generationsEphemeralPostHandler(
     // there's no persisted result to deliver, so just bail.
     if (isClosed() || res.writableEnded || res.destroyed) return;
 
-    if (outcome.kind === "ok") {
-      writeSseEvent(res, "result", {
-        template: outcome.result.template,
-        metrics: outcome.result.metrics,
-      });
-    } else if (outcome.kind === "timeout") {
-      writeSseEvent(res, "error", { error: "Generation timed out" });
-    } else {
-      writeSseEvent(res, "error", { error: "Generation failed" });
+    // The client can still drop between the check above and the write below;
+    // a write on a closed socket throws, so swallow it (nobody's listening).
+    try {
+      if (outcome.kind === "ok") {
+        writeSseEvent(res, "result", {
+          template: outcome.result.template,
+          metrics: outcome.result.metrics,
+        });
+      } else if (outcome.kind === "timeout") {
+        writeSseEvent(res, "error", { error: "Generation timed out" });
+      } else {
+        writeSseEvent(res, "error", { error: "Generation failed" });
+      }
+    } catch {
+      // Client disconnected mid-write — swallow.
     }
     return;
   }

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -1,13 +1,26 @@
 /**
  * Handler for POST /api/v2/agent-templates/generations/ephemeral
  *
- * Synchronous, NON-persisting generation. Runs the real generator and returns
- * the produced template inline — it never writes an AgentTemplate or an
- * AgentTemplateGeneration row. Built for the admin compare tool, which generates
- * throwaway candidates (varying the builderPrompt and/or builderModel override)
- * purely to judge prompt quality across one or more ideas; nothing should land
- * in the catalog until an admin explicitly keeps one (via the normal create
- * endpoint).
+ * NON-persisting generation. Runs the real generator and hands back the
+ * produced template inline — it never writes an AgentTemplate or an
+ * AgentTemplateGeneration row. Built for the admin compare tool, which
+ * generates throwaway candidates (varying the builderPrompt and/or builderModel
+ * override) purely to judge prompt quality across one or more ideas; nothing
+ * should land in the catalog until an admin explicitly keeps one (via the
+ * normal create endpoint).
+ *
+ * Response modes (content-negotiated, mirroring the async endpoint):
+ *   - SSE (Accept: text/event-stream): emits a keep-alive every 15s while the
+ *     generation runs, then closes with `event: result` carrying
+ *     { template, metrics } or `event: error` on timeout/failure. HTTP status
+ *     is always 200 in SSE mode. This is the path that honours the
+ *     "never hold an idle connection" contract — a generation can run close to
+ *     the 90s ceiling, well past where an intermediary would drop a silent
+ *     connection.
+ *   - JSON (default): holds the connection and returns { template, metrics }
+ *     (200), 504 on timeout, or 500 on failure. Simpler, but with no heartbeat
+ *     a long generation risks an intermediary timeout, so SSE is preferred for
+ *     anything but the fastest calls.
  *
  * Admin-only: gated to agent-API-key callers (isApiKeyListener), like the
  * privileged builderPrompt/builderModel fields on the async endpoint. Because
@@ -19,11 +32,16 @@
 
 import type { Request, Response } from "express";
 import { z } from "zod";
+import {
+  startSseStream,
+  writeSseEvent,
+} from "@/api/v2/agent-templates/lib/sse";
 import { isKnownOpenRouterModel } from "@/api/v2/agent-templates/services/openrouter-models";
 import {
   callGenerateTemplate,
   type GenerateTemplateInput,
   type GenerationPrefill,
+  type GenerationResult,
 } from "@/api/v2/agent-templates/services/templateGen";
 
 // One synchronous generation, kept under typical edge/proxy request ceilings.
@@ -102,6 +120,51 @@ function coalesce(
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+/** Outcome of one ephemeral generation, classified once so the JSON and SSE
+ *  response paths can render it without re-inspecting the error. */
+type Outcome =
+  | { kind: "ok"; result: GenerationResult }
+  | { kind: "timeout" }
+  | { kind: "error" };
+
+async function runGeneration(
+  log: Request["log"],
+  args: {
+    input: GenerateTemplateInput;
+    signal: AbortSignal;
+    prefill: GenerationPrefill | null;
+    builderPrompt: string | null;
+    builderModel: string | null;
+  },
+): Promise<Outcome> {
+  try {
+    const result = await callGenerateTemplate(
+      args.input,
+      args.signal,
+      args.prefill,
+      undefined,
+      args.builderPrompt,
+      args.builderModel,
+    );
+    return { kind: "ok", result };
+  } catch (err) {
+    // signal.aborted distinguishes a timeout from a generation error without
+    // parsing the wrapped error message.
+    if (args.signal.aborted) {
+      log.warn({ err }, "[ephemeral-generation] generation timed out");
+      return { kind: "timeout" };
+    }
+    // Keep the specifics in logs; callers surface a stable, generic message
+    // (matches the other agent-templates handlers).
+    log.error({ err }, "[ephemeral-generation] generation failed");
+    return { kind: "error" };
+  }
+}
+
 export async function generationsEphemeralPostHandler(
   req: Request,
   res: Response,
@@ -156,30 +219,60 @@ export async function generationsEphemeralPostHandler(
     return;
   }
 
-  // Held in a variable so the catch can distinguish a timeout (signal.aborted)
-  // from a generation error without parsing the wrapped error message.
   const signal = AbortSignal.timeout(getTimeoutMs());
-  try {
-    const { template, metrics } = await callGenerateTemplate(
-      coalesced,
-      signal,
-      prefill,
-      undefined,
-      builderPrompt,
-      builderModel,
-    );
-    res.status(200).json({ template, metrics });
-    return;
-  } catch (err) {
-    if (signal.aborted) {
-      req.log.warn({ err }, "[ephemeral-generation] generation timed out");
-      res.status(504).json({ error: "Generation timed out" });
-      return;
+  const generationArgs = {
+    input: coalesced,
+    signal,
+    prefill,
+    builderPrompt,
+    builderModel,
+  };
+
+  // SSE mode: heartbeat while the generation runs, then a single terminal
+  // frame. Mirrors the async endpoint's contract so a long generation never
+  // holds a silent connection.
+  if ((req.headers.accept || "").includes("text/event-stream")) {
+    // Read the disconnect flag through a function so it's observed at call
+    // time (a direct boolean read would be narrowed to its initial value).
+    let closed = false;
+    res.on("close", () => {
+      closed = true;
+    });
+    const isClosed = () => closed;
+
+    const keepalive = startSseStream(res);
+    const outcome = await runGeneration(req.log, generationArgs);
+    clearInterval(keepalive);
+
+    // Client hung up mid-generation — the keep-alive is already cleared and
+    // there's no persisted result to deliver, so just bail.
+    if (isClosed() || res.writableEnded || res.destroyed) return;
+
+    if (outcome.kind === "ok") {
+      writeSseEvent(res, "result", {
+        template: outcome.result.template,
+        metrics: outcome.result.metrics,
+      });
+    } else if (outcome.kind === "timeout") {
+      writeSseEvent(res, "error", { error: "Generation timed out" });
+    } else {
+      writeSseEvent(res, "error", { error: "Generation failed" });
     }
-    // Keep the specifics in logs; return a stable, generic message to the
-    // client (matches the other agent-templates handlers).
-    req.log.error({ err }, "[ephemeral-generation] generation failed");
-    res.status(500).json({ error: "Generation failed" });
     return;
   }
+
+  // JSON mode: hold the connection and return the template inline.
+  const outcome = await runGeneration(req.log, generationArgs);
+  if (outcome.kind === "ok") {
+    res.status(200).json({
+      template: outcome.result.template,
+      metrics: outcome.result.metrics,
+    });
+    return;
+  }
+  if (outcome.kind === "timeout") {
+    res.status(504).json({ error: "Generation timed out" });
+    return;
+  }
+  res.status(500).json({ error: "Generation failed" });
 }

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -46,6 +46,11 @@ import { randomUUID } from "node:crypto";
 import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
+import {
+  startSseStream,
+  writeSseEvent,
+  writeSseHeaders,
+} from "@/api/v2/agent-templates/lib/sse";
 import { executeGeneration } from "@/api/v2/agent-templates/services/generation-executor";
 import {
   checkContent,
@@ -72,7 +77,6 @@ const MAX_BUILDER_PROMPT_LEN = 100_000;
 const MAX_BUILDER_MODEL_LEN = 256;
 const MAX_BODY_BYTES = 40 * 1024 * 1024;
 const MAX_WAIT_MS = 45_000;
-const DEFAULT_SSE_KEEPALIVE_MS = 15_000;
 
 // RFC 4122 UUID format. Version digit is any 1-5 (accepts v4 random,
 // v5 namespaced, etc.); variant nibble is 8/9/a/b.
@@ -95,24 +99,6 @@ function nextPollIntervalMs(attempt: number): number {
   if (attempt < 8) return 500;
   if (attempt < 16) return 1000;
   return 2000;
-}
-
-// ---------------------------------------------------------------------------
-// Test seams
-// ---------------------------------------------------------------------------
-
-let _sseKeepaliveMsOverride: number | null = null;
-
-/**
- * Override the SSE keep-alive interval for tests.
- * Pass `null` to restore the default 15 000 ms.
- */
-export function __setSseKeepaliveMsForTests(ms: number | null): void {
-  _sseKeepaliveMsOverride = ms;
-}
-
-function getSseKeepaliveMs(): number {
-  return _sseKeepaliveMsOverride ?? DEFAULT_SSE_KEEPALIVE_MS;
 }
 
 // ---------------------------------------------------------------------------
@@ -402,28 +388,6 @@ function parseWaitMs(raw: unknown): number {
 // SSE mode helpers
 // ---------------------------------------------------------------------------
 
-function startSseStream(res: Response): ReturnType<typeof setInterval> {
-  res.status(200);
-  res.setHeader("Content-Type", "text/event-stream");
-  res.setHeader("Cache-Control", "no-cache");
-  res.setHeader("Connection", "keep-alive");
-  res.flushHeaders();
-
-  const keepalive = setInterval(() => {
-    try {
-      res.write(":\n\n");
-    } catch {
-      // Client gone — swallow
-    }
-  }, getSseKeepaliveMs());
-
-  res.on("close", () => {
-    clearInterval(keepalive);
-  });
-
-  return keepalive;
-}
-
 async function streamUntilTerminal(args: {
   res: Response;
   keepalive: ReturnType<typeof setInterval>;
@@ -451,23 +415,18 @@ async function streamUntilTerminal(args: {
       firstIteration = false;
 
       if (!row) {
-        const data = JSON.stringify({ error: "Generation not found" });
-        res.write(`event: error\ndata: ${data}\n\n`);
-        res.end();
+        writeSseEvent(res, "error", { error: "Generation not found" });
         return;
       }
       if (isTerminal(row.status)) {
         if (row.status === "done") {
-          const data = JSON.stringify(toResponse(row));
-          res.write(`event: result\ndata: ${data}\n\n`);
+          writeSseEvent(res, "result", toResponse(row));
         } else {
-          const data = JSON.stringify({
+          writeSseEvent(res, "error", {
             error: row.error || "Generation failed",
             ...toResponse(row),
           });
-          res.write(`event: error\ndata: ${data}\n\n`);
         }
-        res.end();
         return;
       }
 
@@ -481,11 +440,9 @@ async function streamUntilTerminal(args: {
     // error frame if the stream is still live; otherwise just clean up.
     if (!res.writableEnded && !res.destroyed) {
       try {
-        const data = JSON.stringify({
+        writeSseEvent(res, "error", {
           error: err instanceof Error ? err.message : "Stream failed",
         });
-        res.write(`event: error\ndata: ${data}\n\n`);
-        res.end();
       } catch {
         // Swallow write-after-close
       }
@@ -576,22 +533,15 @@ async function respondPerMode(args: {
   if (accept.includes("text/event-stream")) {
     // Terminal already? Skip the keepalive setup and just emit the terminal frame.
     if (isTerminal(row.status)) {
-      res.status(200);
-      res.setHeader("Content-Type", "text/event-stream");
-      res.setHeader("Cache-Control", "no-cache");
-      res.setHeader("Connection", "keep-alive");
-      res.flushHeaders();
+      writeSseHeaders(res);
       if (row.status === "done") {
-        const data = JSON.stringify(toResponse(row));
-        res.write(`event: result\ndata: ${data}\n\n`);
+        writeSseEvent(res, "result", toResponse(row));
       } else {
-        const data = JSON.stringify({
+        writeSseEvent(res, "error", {
           error: row.error || "Generation failed",
           ...toResponse(row),
         });
-        res.write(`event: error\ndata: ${data}\n\n`);
       }
-      res.end();
       return;
     }
 

--- a/src/api/v2/agent-templates/lib/sse.ts
+++ b/src/api/v2/agent-templates/lib/sse.ts
@@ -67,7 +67,8 @@ export function startSseStream(res: Response): ReturnType<typeof setInterval> {
 }
 
 /** Write a terminal SSE frame (`event: <name>\ndata: <json>\n\n`) and end the
- *  stream. Caller clears any keep-alive interval. */
+ *  stream. The caller clears any keep-alive interval before calling this;
+ *  `startSseStream`'s close handler is the backstop if it doesn't. */
 export function writeSseEvent(
   res: Response,
   event: "result" | "error",

--- a/src/api/v2/agent-templates/lib/sse.ts
+++ b/src/api/v2/agent-templates/lib/sse.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared Server-Sent-Events helpers for the agent-templates generation
+ * endpoints.
+ *
+ * Both the async builder (POST /generations) and the ephemeral compare
+ * endpoint (POST /generations/ephemeral) hold a connection open while a
+ * generation runs. To keep that connection from sitting silent — which an
+ * intermediary or client would treat as dead — a held connection emits a
+ * comment keep-alive every DEFAULT_SSE_KEEPALIVE_MS and closes with a single
+ * terminal frame (`event: result` or `event: error`). HTTP status is always
+ * 200 in SSE mode; error detail rides in the terminal frame.
+ */
+
+import type { Response } from "express";
+
+/**
+ * Keep-alive heartbeat interval. Paired with the 45s long-poll ceiling, this
+ * bounds how long a held SSE connection can sit silent before an intermediary
+ * (or the client) would treat it as dead.
+ */
+const DEFAULT_SSE_KEEPALIVE_MS = 15_000;
+
+let _sseKeepaliveMsOverride: number | null = null;
+
+/**
+ * Override the SSE keep-alive interval for tests.
+ * Pass `null` to restore the default 15 000 ms.
+ */
+export function __setSseKeepaliveMsForTests(ms: number | null): void {
+  _sseKeepaliveMsOverride = ms;
+}
+
+function getSseKeepaliveMs(): number {
+  return _sseKeepaliveMsOverride ?? DEFAULT_SSE_KEEPALIVE_MS;
+}
+
+/** Flush the SSE response headers. */
+export function writeSseHeaders(res: Response): void {
+  res.status(200);
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  res.flushHeaders();
+}
+
+/**
+ * Flush SSE headers and start the keep-alive heartbeat. Returns the interval
+ * handle. The interval is cleared automatically when the connection closes;
+ * callers also clear it once they write the terminal frame.
+ */
+export function startSseStream(res: Response): ReturnType<typeof setInterval> {
+  writeSseHeaders(res);
+
+  const keepalive = setInterval(() => {
+    try {
+      res.write(":\n\n");
+    } catch {
+      // Client gone — swallow
+    }
+  }, getSseKeepaliveMs());
+
+  res.on("close", () => {
+    clearInterval(keepalive);
+  });
+
+  return keepalive;
+}
+
+/** Write a terminal SSE frame (`event: <name>\ndata: <json>\n\n`) and end the
+ *  stream. Caller clears any keep-alive interval. */
+export function writeSseEvent(
+  res: Response,
+  event: "result" | "error",
+  data: unknown,
+): void {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  res.end();
+}

--- a/tests/agent-templates.generations-ephemeral.test.ts
+++ b/tests/agent-templates.generations-ephemeral.test.ts
@@ -22,6 +22,7 @@ import {
   test,
 } from "vitest";
 import { __setEphemeralTimeoutMsForTests } from "@/api/v2/agent-templates/handlers/generations-ephemeral-post";
+import { __setSseKeepaliveMsForTests } from "@/api/v2/agent-templates/lib/sse";
 import { __setOpenRouterModelsForTests } from "@/api/v2/agent-templates/services/openrouter-models";
 import {
   __resetGenerateTemplateForTests,
@@ -45,6 +46,10 @@ const fakeTemplate = makeFakeTemplate({
 const apiKeyHeaders = {
   "Content-Type": "application/json",
   "X-Agent-API-Key": validAgentAssetsApiKey,
+};
+const sseApiKeyHeaders = {
+  ...apiKeyHeaders,
+  Accept: "text/event-stream",
 };
 const noKeyHeaders = { "Content-Type": "application/json" };
 
@@ -102,6 +107,7 @@ beforeEach(() => {
 
 afterEach(() => {
   __setEphemeralTimeoutMsForTests(null);
+  __setSseKeepaliveMsForTests(null);
 });
 
 afterAll(async () => {
@@ -209,5 +215,88 @@ describe("POST /generations/ephemeral — error mapping", () => {
     expect(res.status).toBe(504);
     const body = (await res.json()) as { error: string };
     expect(body.error.toLowerCase()).toContain("timed out");
+  });
+});
+
+describe("POST /generations/ephemeral — SSE mode", () => {
+  test("emits `event: result` carrying the template, forwards builderPrompt", async () => {
+    const res = await post(
+      {
+        inputs: { idea: "a wine club sommelier" },
+        builderPrompt: "CUSTOM BUILDER PROMPT",
+      },
+      sseApiKeyHeaders,
+    );
+
+    // HTTP status is always 200 in SSE mode; the payload rides in the frame.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    const text = await res.text();
+    expect(text).toContain("event: result");
+    expect(text).not.toContain("event: error");
+    expect(text).toContain(fakeTemplate.agentName);
+    expect(text).toContain('"metrics":');
+
+    // The override still reaches the generator on the streaming path.
+    expect(lastCall?.systemPromptOverride).toBe("CUSTOM BUILDER PROMPT");
+  });
+
+  test("emits `event: error` on generator failure (no leak)", async () => {
+    __resetGenerateTemplateForTests(() =>
+      Promise.reject(new Error("boom: internal secret detail")),
+    );
+    const res = await post({ inputs: { idea: "x" } }, sseApiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("event: error");
+    expect(text).not.toContain("event: result");
+    expect(text).toContain("Generation failed");
+    expect(text).not.toContain("secret");
+  });
+
+  test("emits `event: error` on timeout", async () => {
+    __setEphemeralTimeoutMsForTests(20);
+    __resetGenerateTemplateForTests(
+      (_input, signal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        }),
+    );
+    const res = await post({ inputs: { idea: "x" } }, sseApiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("event: error");
+    expect(text.toLowerCase()).toContain("timed out");
+  });
+
+  test("emits keep-alive frames before the terminal result", async () => {
+    // Slow the generation so the keep-alive interval fires before it resolves.
+    __resetGenerateTemplateForTests(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ template: fakeTemplate, metrics: DEFAULT_TEST_METRICS });
+          }, 300);
+        }),
+    );
+    __setSseKeepaliveMsForTests(50);
+
+    const res = await post({ inputs: { idea: "x" } }, sseApiKeyHeaders);
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    expect(text).toContain(":\n\n");
+    expect(text).toContain("event: result");
+
+    // Keep-alive comment frames must precede the terminal frame.
+    const keepaliveIdx = text.indexOf(":\n\n");
+    const resultIdx = text.indexOf("event: result");
+    expect(keepaliveIdx).toBeGreaterThanOrEqual(0);
+    expect(keepaliveIdx).toBeLessThan(resultIdx);
   });
 });

--- a/tests/agent-templates.generations-ephemeral.test.ts
+++ b/tests/agent-templates.generations-ephemeral.test.ts
@@ -299,4 +299,45 @@ describe("POST /generations/ephemeral — SSE mode", () => {
     expect(keepaliveIdx).toBeGreaterThanOrEqual(0);
     expect(keepaliveIdx).toBeLessThan(resultIdx);
   });
+
+  test("client disconnect aborts the upstream generation", async () => {
+    let sawCall = false;
+    let abortedDuringGeneration = false;
+    // Hang until the signal aborts, recording that the abort propagated to the
+    // generator (i.e. the upstream OpenRouter call would be cancelled).
+    __resetGenerateTemplateForTests(
+      (_input, signal) =>
+        new Promise((_resolve, reject) => {
+          sawCall = true;
+          signal?.addEventListener("abort", () => {
+            abortedDuringGeneration = true;
+            reject(new Error("aborted"));
+          });
+        }),
+    );
+    __setSseKeepaliveMsForTests(50);
+
+    const controller = new AbortController();
+    const pending = fetch(
+      `${baseURL}/api/v2/agent-templates/generations/ephemeral`,
+      {
+        method: "POST",
+        headers: sseApiKeyHeaders,
+        body: JSON.stringify({ inputs: { idea: "x" } }),
+        signal: controller.signal,
+      },
+    );
+
+    // Let the server start the generation, then drop the connection.
+    await new Promise((r) => setTimeout(r, 100));
+    controller.abort();
+    await pending.catch(() => {
+      /* expected — client aborted */
+    });
+
+    // Give the server a tick to observe res `close` and propagate the abort.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(sawCall).toBe(true);
+    expect(abortedDuringGeneration).toBe(true);
+  });
 });

--- a/tests/agent-templates.generations.sse.test.ts
+++ b/tests/agent-templates.generations.sse.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
-import { __setSseKeepaliveMsForTests } from "@/api/v2/agent-templates/handlers/generations-post";
+import { __setSseKeepaliveMsForTests } from "@/api/v2/agent-templates/lib/sse";
 import {
   __resetGenerationExecutorForTests,
   __setExecutorTimeoutMsForTests,

--- a/tests/agent-templates.generations.sse.test.ts
+++ b/tests/agent-templates.generations.sse.test.ts
@@ -152,6 +152,48 @@ describe("SSE mode — terminal frames", () => {
     expect(text).toContain('"status":"failed"');
     expect(text).toContain("OpenRouter request timed out");
   });
+
+  test("SSE replay of an already-terminal generation emits the frame immediately, no keep-alive", async () => {
+    __resetGenerateTemplateForTests(() =>
+      Promise.resolve({
+        template: fakeTemplate,
+        metrics: DEFAULT_TEST_METRICS,
+      }),
+    );
+    // Aggressive keep-alive: if the replay wrongly took the polling path, a
+    // `:\n\n` frame would show up well within the test window.
+    __setSseKeepaliveMsForTests(50);
+
+    const headers = sseHeaders("sse-already-terminal");
+
+    // First request drives the generation to `done`. Drain the whole stream so
+    // the row is terminal in the DB before the replay fires.
+    const first = await fetch(`${baseURL}/api/v2/agent-templates/generations`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(sampleBody),
+    });
+    expect(await first.text()).toContain("event: result");
+
+    // Replay with the same Idempotency-Key + body → dedupe path finds the
+    // already-`done` row and must emit the terminal frame immediately,
+    // skipping keep-alive setup entirely.
+    const replay = await fetch(
+      `${baseURL}/api/v2/agent-templates/generations`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(sampleBody),
+      },
+    );
+    expect(replay.status).toBe(200);
+    expect(replay.headers.get("content-type")).toContain("text/event-stream");
+
+    const text = await replay.text();
+    expect(text).toContain("event: result");
+    expect(text).toContain('"status":"done"');
+    expect(text).not.toContain(":\n\n");
+  });
 });
 
 describe("SSE mode — keep-alive", () => {


### PR DESCRIPTION
## What

The ephemeral compare endpoint (`POST /generations/ephemeral`) was the one place that violated the async path's "never hold an idle connection" contract — it held a connection open for up to ~90s with no heartbeat. It now speaks the **same SSE/chunked keepalive contract** as the async endpoint, and the SSE transport both endpoints share is extracted into one module.

## Changes

**New `src/api/v2/agent-templates/lib/sse.ts`** — single source for the SSE transport:
- `DEFAULT_SSE_KEEPALIVE_MS` (15s) + the `__setSseKeepaliveMsForTests` seam
- `startSseStream(res)` — flush headers, start the heartbeat, auto-clear on close
- `writeSseHeaders(res)` / `writeSseEvent(res, "result"|"error", data)`

**`generations-ephemeral-post.ts`** — content-negotiates exactly like the async endpoint:
- `Accept: text/event-stream` → keep-alive every 15s while the generator runs, then one terminal frame: `event: result` carrying `{ template, metrics }`, or `event: error` on timeout/failure (HTTP always 200 in SSE mode).
- Otherwise → existing synchronous JSON (200/504/500), unchanged.
- A small `runGeneration()` classifies the outcome once so both modes render it without re-inspecting the error; the privileged `builderModel` param + `isKnownOpenRouterModel` gate are preserved.

**`generations-post.ts`** — deletes its inline SSE helpers/keepalive seam and imports them from `lib/sse`; the DB-poll loop and `respondPerMode` emit through `writeSseEvent`/`writeSseHeaders`. ~74 lines lighter, behavior identical.

## Why this split

The truly shared part is the SSE *transport* (headers, heartbeat, terminal frame) — now in `lib/sse.ts`. The *drive loop* differs by nature: the async path polls a DB row to terminal; ephemeral awaits one in-memory promise. Those stay in their handlers.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check`: clean
- 75 generation tests passing: ephemeral 12 (8 existing + 4 new SSE — result/error/timeout frames and keepalive-before-terminal ordering), async SSE 4 (now importing the relocated seam), generations-post/get/twitter 59 (untouched by the refactor)

## Caller note

The heartbeat engages only when the client sends `Accept: text/event-stream` (mirroring the async endpoint). The plain-JSON path still holds the connection with no heartbeat — fine for fast calls, but the admin compare frontend should request SSE and consume `event: result` / `event: error` to get the keepalive guarantee for long generations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783608685&installation_id=128169237&pr_number=299&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F299&signature=90d58617a823b519d8cac36479cec0bf0f7736c85c36d05d2be9ee1cc7f40fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SSE keep-alive support to the ephemeral agent template generations endpoint
> - Adds SSE response mode to the ephemeral generations endpoint ([generations-ephemeral-post.ts](https://github.com/ephemeraHQ/convos-backend/pull/299/files#diff-a98bbe11ac3fc5df05a8bb4914369c8322efb51f105dfc4dbcb1642e58342874)), sending keep-alive frames during generation and a terminal event frame with the result or error.
> - Extracts shared SSE utilities (`startSseStream`, `writeSseEvent`, `writeSseHeaders`) into [lib/sse.ts](https://github.com/ephemeraHQ/convos-backend/pull/299/files#diff-a875352ad6fa8470a8e8a05560759b8a084532e82005999c953c3966cd0e3f01) and updates [generations-post.ts](https://github.com/ephemeraHQ/convos-backend/pull/299/files#diff-cfa09e429c402af1c503dbdd05b6690b9fc157c69a9c4ce543a4bc481c3f5624) to use them.
> - Introduces a `runGeneration` helper that classifies outcomes as `ok`, `timeout`, `aborted`, or `error`, treating client disconnects as non-errors and aborting upstream generation when the client disconnects.
> - Behavioral Change: In SSE mode, the HTTP status is always 200; timeout and error conditions are communicated via terminal SSE event frames instead of 504/500 status codes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 445917e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Server-Sent Events (SSE) streaming support for generation endpoints, enabling real-time progressive responses alongside JSON mode.
  * Implemented connection keep-alive heartbeats during long-running operations to maintain stability.

* **Bug Fixes**
  * Improved timeout handling with appropriate HTTP status codes for streaming responses.
  * Enhanced error handling to prevent exposing sensitive details in streaming error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->