### PR TITLE
feat(agents): direct-add agent joins — conversationId instead of slug, no confirm round-trip

### DIFF
--- a/src/api/v2/agents/handlers/assistant-config.ts
+++ b/src/api/v2/agents/handlers/assistant-config.ts
@@ -17,6 +17,11 @@ export const joinStatusEnum = z.enum([
   "starting",
   "pending_acceptance",
   "joined",
+  // The runtime marks an assistant "ready" once its container has booted —
+  // strictly after "joined". Treat it as joined wherever joins are awaited;
+  // leaving it out of the enum makes the status parse fail (502) for any
+  // assistant polled after boot completes.
+  "ready",
   "failed",
 ]);
 

--- a/src/api/v2/agents/handlers/join-status.ts
+++ b/src/api/v2/agents/handlers/join-status.ts
@@ -42,8 +42,10 @@ const ERRORS = {
  * Polls the assistant runtime service for the current join status of an
  * instance dispatched via POST /api/v2/agents/join.
  *
- * Returns `joined: true` once `joinStatus === "joined"`, mirroring the
- * boolean the legacy pool API returned synchronously from /api/pool/claim.
+ * Returns `joined: true` once `joinStatus` is `"joined"` or `"ready"` (the
+ * runtime advances joined → ready when the agent finishes booting),
+ * mirroring the boolean the legacy pool API returned synchronously from
+ * /api/pool/claim.
  */
 export async function joinStatusHandler(req: Request, res: Response) {
   const assistantApiUrl = getAssistantApiUrl();
@@ -127,7 +129,7 @@ export async function joinStatusHandler(req: Request, res: Response) {
       success: true,
       instanceId: result.data.instanceId,
       joinStatus,
-      joined: joinStatus === "joined",
+      joined: joinStatus === "joined" || joinStatus === "ready",
       inboxId,
       conversationId,
       joinFailureReason,

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -9,6 +9,7 @@ import {
   getAssistantApiUrl,
   getJoinPollIntervalMs,
   getJoinWaitBudgetMs,
+  type AssistantStatus,
 } from "./assistant-config";
 
 const AGENT_BUILDER_ONBOARDING = "agent-builder";
@@ -46,15 +47,36 @@ const optionsSchema = z
 // would be discarded. The caller-facing contract is now: send `templateId`
 // to apply a template; send neither for a bare agent. There is no escape
 // hatch for inline `instructions` — templates are the unit.
+//
+// `slug` and `conversationId` select the join mechanism (exactly one): with
+// a slug, the runtime joins via the invite's join-request DM; with a
+// conversationId, the agent is provisioned in direct-add mode — the response
+// carries the agent's `inboxId`, the caller adds it to the declared group
+// with addMembers, and the runtime attaches when it observes the resulting
+// group welcome. No confirmation call exists.
 const bodySchema = z
   .object({
-    slug: z.string().min(1, "Slug is required").max(2048),
+    slug: z.string().min(1, "slug must not be empty").max(2048).optional(),
+    // Normalized to lowercase: the runtime forwards this to Herald, whose
+    // conversation-id schema is lowercase-only hex.
+    conversationId: z
+      .string()
+      .regex(/^[0-9a-f]+$/i, "conversationId must be a hex string")
+      .min(8)
+      .max(128)
+      .transform((v) => v.toLowerCase())
+      .optional(),
     templateId: z.string().uuid().optional(),
     name: z.string().min(1).max(256).optional(),
     profileImage: z.string().min(1).max(2048).optional(),
     options: optionsSchema.optional(),
   })
-  .strict();
+  .strict()
+  .refine((b) => (b.slug === undefined) !== (b.conversationId === undefined), {
+    message:
+      "Provide exactly one of slug (invite join) or conversationId (direct-add)",
+    path: ["conversationId"],
+  });
 
 const FORCE_ERROR_DELAY_MS = 5_000;
 
@@ -95,7 +117,12 @@ type PollOutcome =
   | { kind: "failed"; reason: string | null }
   | { kind: "pending" };
 
-async function pollUntilJoined(args: {
+type RegisteredOutcome =
+  | { kind: "registered"; inboxId: string }
+  | { kind: "failed"; reason: string | null }
+  | { kind: "pending" };
+
+async function pollAssistantStatus<Outcome>(args: {
   assistantBaseUrl: string;
   instanceId: string;
   authHeader: string | undefined;
@@ -103,7 +130,9 @@ async function pollUntilJoined(args: {
   pollIntervalMs: number;
   log: Request["log"];
   abortSignal?: AbortSignal;
-}): Promise<PollOutcome> {
+  // Maps an upstream status row to a final outcome, or null to keep polling.
+  check: (status: AssistantStatus) => Outcome | null;
+}): Promise<Outcome | { kind: "pending" }> {
   const {
     assistantBaseUrl,
     instanceId,
@@ -112,6 +141,7 @@ async function pollUntilJoined(args: {
     pollIntervalMs,
     log,
     abortSignal,
+    check,
   } = args;
 
   const headers: Record<string, string> = {};
@@ -128,6 +158,11 @@ async function pollUntilJoined(args: {
       return { kind: "pending" };
     }
 
+    // Cap each status fetch by the remaining wait budget so a hung upstream
+    // GET can't hold the response open past the deadline.
+    const fetchTimeoutMs = Math.min(POLL_TIMEOUT_MS, deadlineMs - Date.now());
+    if (fetchTimeoutMs <= 0) break;
+
     try {
       const upstream = await fetch(
         `${assistantBaseUrl}/api/assistants/${encodeURIComponent(instanceId)}`,
@@ -136,10 +171,10 @@ async function pollUntilJoined(args: {
           headers,
           signal: abortSignal
             ? AbortSignal.any([
-                AbortSignal.timeout(POLL_TIMEOUT_MS),
+                AbortSignal.timeout(fetchTimeoutMs),
                 abortSignal,
               ])
-            : AbortSignal.timeout(POLL_TIMEOUT_MS),
+            : AbortSignal.timeout(fetchTimeoutMs),
         },
       );
 
@@ -156,13 +191,9 @@ async function pollUntilJoined(args: {
             { issues: parsed.error.issues, instanceId },
             "Assistant status poll returned malformed body",
           );
-        } else if (parsed.data.joinStatus === "joined") {
-          return { kind: "joined" };
-        } else if (parsed.data.joinStatus === "failed") {
-          return {
-            kind: "failed",
-            reason: parsed.data.joinFailureReason ?? null,
-          };
+        } else {
+          const outcome = check(parsed.data);
+          if (outcome !== null) return outcome;
         }
       }
     } catch (err) {
@@ -183,20 +214,68 @@ async function pollUntilJoined(args: {
   return { kind: "pending" };
 }
 
+function pollUntilJoined(
+  args: Omit<Parameters<typeof pollAssistantStatus<PollOutcome>>[0], "check">,
+): Promise<PollOutcome> {
+  return pollAssistantStatus<PollOutcome>({
+    ...args,
+    check: (status) => {
+      if (status.joinStatus === "joined" || status.joinStatus === "ready") {
+        return { kind: "joined" };
+      }
+      if (status.joinStatus === "failed") {
+        return { kind: "failed", reason: status.joinFailureReason ?? null };
+      }
+      return null;
+    },
+  });
+}
+
+// Direct-add mode waits only for Herald registration (inboxId lands in the
+// status row), not for the join itself — the join happens after the caller
+// adds the inbox to the group.
+function pollUntilRegistered(
+  args: Omit<
+    Parameters<typeof pollAssistantStatus<RegisteredOutcome>>[0],
+    "check"
+  >,
+): Promise<RegisteredOutcome> {
+  return pollAssistantStatus<RegisteredOutcome>({
+    ...args,
+    check: (status) => {
+      if (status.joinStatus === "failed") {
+        return { kind: "failed", reason: status.joinFailureReason ?? null };
+      }
+      if (status.inboxId)
+        return { kind: "registered", inboxId: status.inboxId };
+      return null;
+    },
+  });
+}
+
 /**
  * Handler for POST /api/v2/agents/join
  *
  * Requests an AI agent to join a conversation. Internally dispatches the
  * assistant runtime service (convos-assistants) `POST /api/assistants`
- * workflow with the conversation's invite URL, then server-side polls
- * the upstream status until the agent has joined, the workflow has failed,
- * or the wait budget has elapsed.
+ * workflow, then server-side polls the upstream status.
  *
- * Response shape preserves the legacy synchronous contract:
+ * With `slug`, the runtime joins via the invite's join-request DM and the
+ * poll waits until the agent has joined, the workflow has failed, or the
+ * wait budget has elapsed:
  *
  *   { success: true, joined: true  }                  — agent joined within window
  *   { success: true, joined: false, instanceId: ... } — still provisioning;
  *     caller may poll GET /api/v2/agents/join/:instanceId
+ *
+ * With `conversationId` (direct-add), the poll waits only until the agent's
+ * XMTP inbox is registered and responds with it; the caller then adds the
+ * inbox to the declared group with addMembers, and the runtime attaches once
+ * it observes the resulting group welcome — no further calls required:
+ *
+ *   { success: true, joined: false, instanceId, inboxId } — add this inbox
+ *   { success: true, joined: false, instanceId, inboxId: null } — registration
+ *     still in flight; poll GET /api/v2/agents/join/:instanceId for inboxId
  *
  * On upstream `failed`, returns 502 AGENT_PROVISION_FAILED.
  *
@@ -267,7 +346,8 @@ export async function joinHandler(req: Request, res: Response) {
     return;
   }
 
-  const { slug, templateId, name, profileImage, options } = parsed.data;
+  const { slug, conversationId, templateId, name, profileImage, options } =
+    parsed.data;
   // Avoid logging the raw slug (it's a join-token granting conversation
   // access) and the raw `options` (caller-controlled input). Log only the
   // public `templateId` reference + option keys so volumes/cardinality
@@ -409,7 +489,6 @@ export async function joinHandler(req: Request, res: Response) {
 
   let instanceId: string;
   try {
-    const joinUrl = buildInviteUrl(slug);
     const dispatchHeaders: Record<string, string> = {
       "Content-Type": "application/json",
     };
@@ -450,8 +529,13 @@ export async function joinHandler(req: Request, res: Response) {
         })
       : null;
 
+    // Direct-add sends the declared conversationId instead of a joinUrl —
+    // the runtime then skips the invite dance and watches the conversation
+    // for the group welcome the caller's addMembers produces.
     const dispatchBody: Record<string, unknown> = {
-      joinUrl,
+      ...(slug !== undefined
+        ? { joinUrl: buildInviteUrl(slug) }
+        : { conversationId }),
       template: joinPayload?.template ?? null,
       ownerAccountId: joiningUserAccountId,
     };
@@ -543,6 +627,55 @@ export async function joinHandler(req: Request, res: Response) {
     );
     const { status, ...body } = ERRORS.AGENT_PROVISION_FAILED;
     res.status(status).json({ success: false, ...body });
+    return;
+  }
+
+  // Direct-add: wait only for Herald registration so the caller gets the
+  // inboxId to add to the group; the join completes when the runtime
+  // observes the group welcome their addMembers produces.
+  if (slug === undefined) {
+    const outcome = await pollUntilRegistered({
+      assistantBaseUrl,
+      instanceId,
+      authHeader,
+      deadlineMs: Date.now() + getJoinWaitBudgetMs(),
+      pollIntervalMs: getJoinPollIntervalMs(),
+      log: req.log,
+      abortSignal: clientDisconnect.signal,
+    });
+
+    if (clientDisconnect.signal.aborted) {
+      req.log.info(
+        { instanceId },
+        "Client disconnected during poll — aborting silently",
+      );
+      return;
+    }
+
+    if (outcome.kind === "failed") {
+      req.log.error(
+        { instanceId, reason: outcome.reason },
+        "Assistant workflow reported failed before registration",
+      );
+      const { status, ...body } = ERRORS.AGENT_PROVISION_FAILED;
+      res.status(status).json({ success: false, ...body });
+      return;
+    }
+
+    // Pending: registration outlasted the wait budget; the caller polls
+    // GET /api/v2/agents/join/:instanceId, which carries inboxId.
+    if (outcome.kind === "pending") {
+      req.log.info(
+        { instanceId },
+        "Agent registration still pending after server-side wait budget",
+      );
+    }
+    res.status(200).json({
+      success: true,
+      joined: false,
+      instanceId,
+      inboxId: outcome.kind === "registered" ? outcome.inboxId : null,
+    });
     return;
   }
 

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -88,11 +88,18 @@ function jsonResponse(status: number, body: unknown): Response {
 
 describe("agents join (assistant API)", () => {
   let server: Server;
-  const baseURL = "http://localhost:4015";
+  // Assigned from the OS-picked port in beforeAll — a fixed port flakes with
+  // EADDRINUSE under parallel test runs.
+  let baseURL: string;
 
   beforeAll(async () => {
     await new Promise<void>((resolve) => {
-      server = app.listen(4015, () => {
+      server = app.listen(0, () => {
+        const addr = server.address();
+        if (!addr || typeof addr === "string") {
+          throw new Error("Failed to resolve test server address");
+        }
+        baseURL = `http://127.0.0.1:${addr.port}`;
         resolve();
       });
     });
@@ -167,12 +174,182 @@ describe("agents join (assistant API)", () => {
       expect(data.error).toBe("AGENT_POOL_UNAVAILABLE");
     });
 
-    test("returns 400 when slug is missing", async () => {
-      const res = await post({});
+    const DIRECT_ADD_CONVERSATION_ID = "abc123def4567890";
+
+    test("conversationId → direct-add: dispatches it instead of joinUrl, returns inboxId once registered", async () => {
+      mockFetchImpl = (url, init) => {
+        if (init?.method === "POST") {
+          expect(url).toBe(`${ASSISTANT_URL}/api/assistants`);
+          const body = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          expect(body).not.toHaveProperty("joinUrl");
+          // Uppercase in the request — normalized to lowercase for the
+          // runtime (Herald's conversation-id schema is lowercase-only).
+          expect(body.conversationId).toBe(DIRECT_ADD_CONVERSATION_ID);
+          expect(body.template).toBeNull();
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-direct" }),
+          );
+        }
+        expect(url).toBe(`${ASSISTANT_URL}/api/assistants/inst-direct`);
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-direct",
+            joinStatus: "starting",
+            inboxId: "inbox-direct-1",
+          }),
+        );
+      };
+
+      const res = await post({
+        conversationId: DIRECT_ADD_CONVERSATION_ID.toUpperCase(),
+      });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        success: boolean;
+        joined: boolean;
+        instanceId: string;
+        inboxId: string | null;
+      };
+      expect(data.success).toBe(true);
+      expect(data.joined).toBe(false);
+      expect(data.instanceId).toBe("inst-direct");
+      expect(data.inboxId).toBe("inbox-direct-1");
+    });
+
+    test("direct-add → polls past a null inboxId until registration lands", async () => {
+      let pollCount = 0;
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-direct-2" }),
+          );
+        }
+        pollCount += 1;
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-direct-2",
+            joinStatus: "starting",
+            inboxId: pollCount < 3 ? null : "inbox-direct-2",
+          }),
+        );
+      };
+
+      const res = await post({ conversationId: DIRECT_ADD_CONVERSATION_ID });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { inboxId: string | null };
+      expect(data.inboxId).toBe("inbox-direct-2");
+      expect(pollCount).toBeGreaterThanOrEqual(3);
+    });
+
+    test("direct-add → inboxId:null when registration outlasts the wait budget", async () => {
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-direct-slow" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-direct-slow",
+            joinStatus: "starting",
+            inboxId: null,
+          }),
+        );
+      };
+
+      const res = await post({ conversationId: DIRECT_ADD_CONVERSATION_ID });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        success: boolean;
+        joined: boolean;
+        instanceId: string;
+        inboxId: string | null;
+      };
+      expect(data.success).toBe(true);
+      expect(data.joined).toBe(false);
+      expect(data.instanceId).toBe("inst-direct-slow");
+      expect(data.inboxId).toBeNull();
+    });
+
+    test("no slug → 502 when the workflow fails before registration", async () => {
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-direct-bad" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-direct-bad",
+            joinStatus: "failed",
+            joinFailureReason: "attestation not configured",
+          }),
+        );
+      };
+
+      const res = await post({ conversationId: DIRECT_ADD_CONVERSATION_ID });
+      expect(res.status).toBe(502);
+      const data = (await res.json()) as { success: boolean; error: string };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("AGENT_PROVISION_FAILED");
+    });
+
+    test.each([
+      ["neither slug nor conversationId", {}],
+      [
+        "both slug and conversationId",
+        { slug: "abc", conversationId: DIRECT_ADD_CONVERSATION_ID },
+      ],
+      ["non-hex conversationId", { conversationId: "not hex!" }],
+    ])("%s → 400 INVALID_REQUEST, nothing dispatched", async (_label, body) => {
+      let dispatched = false;
+      mockFetchImpl = () => {
+        dispatched = true;
+        return Promise.reject(new Error("should not dispatch"));
+      };
+
+      const res = await post(body);
       expect(res.status).toBe(400);
       const data = (await res.json()) as { success: boolean; error: string };
       expect(data.success).toBe(false);
       expect(data.error).toBe("INVALID_REQUEST");
+      expect(dispatched).toBe(false);
+    });
+
+    test("slug join: a poll that lands on 'ready' counts as joined", async () => {
+      // The runtime advances joined → ready when boot completes; a poll can
+      // observe only the latter. Treating it as not-joined burned the whole
+      // wait budget (and the enum once 502'd on it) — pin the mapping.
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(jsonResponse(200, { instanceId: "inst-rdy" }));
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-rdy",
+            joinStatus: "ready",
+            inboxId: "inbox-rdy",
+            conversationId: "conv-rdy",
+            joinFailureReason: null,
+            createdAt: 1715000000000,
+            destroyedAt: null,
+          }),
+        );
+      };
+
+      const res = await post({ slug: "ready-slug" });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        success: boolean;
+        joined: boolean;
+        instanceId: string;
+      };
+      expect(data.success).toBe(true);
+      expect(data.joined).toBe(true);
+      expect(data.instanceId).toBe("inst-rdy");
     });
 
     test("returns joined:true once upstream reports joined", async () => {
@@ -807,6 +984,29 @@ describe("agents join (assistant API)", () => {
       expect(data.joinStatus).toBe("joined");
       expect(data.inboxId).toBe("inbox-1");
       expect(data.conversationId).toBe("conv-1");
+    });
+
+    test("returns joined=true when upstream reports ready (post-boot)", async () => {
+      // "ready" lands after the runtime finishes booting; treating it as
+      // not-joined (or failing the enum parse) was a real 502 bug — pin it.
+      mockFetchImpl = () =>
+        Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-99",
+            joinStatus: "ready",
+            inboxId: "inbox-1",
+            conversationId: "conv-1",
+          }),
+        );
+
+      const res = await getStatus("inst-99");
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        joined: boolean;
+        joinStatus: string;
+      };
+      expect(data.joined).toBe(true);
+      expect(data.joinStatus).toBe("ready");
     });
 
     test("returns joined=false when status is starting", async () => {


### PR DESCRIPTION
## Summary

Direct-add agent joins: `POST /v2/agents/join` now accepts **exactly one** of `slug` (invite flow, unchanged) or `conversationId` (direct-add, lowercase-hex-normalized). With a `conversationId` the handler dispatches the assistant runtime without a `joinUrl`, waits only for Herald registration, and responds with the agent's `inboxId`. The caller adds that inbox to the declared group with `addMembers` and is done — the runtime observes the resulting XMTP group welcome and attaches, so **no confirmation endpoint exists**.

Also in this PR:
- `pollAssistantStatus` caps each upstream status fetch by the remaining wait budget (a hung GET could previously hold the response ~5s past the deadline).
- Join tests bind to an OS-assigned port instead of a fixed one (parallel-run EADDRINUSE flake).
- `joinStatusEnum` gains the missing `"ready"` value (pre-existing bug: any status poll after an assistant finished booting returned 502).

## Cross-repo set (deploy order: herald → assistants → backend → apps)

herald-lite#109 · convos-assistants#2074 · **this PR** · convos-ios#1033 · convos-client#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add direct-add agent join flow using `conversationId` instead of slug
> - `POST /api/v2/agents/join` now accepts either a `slug` or a `conversationId` (hex-encoded, lowercase-normalized); exactly one must be provided.
> - Direct-add joins poll only until registration (`inboxId` is available) and return `{ joined: false, instanceId, inboxId }` immediately, skipping the full join confirmation round-trip.
> - Both `"joined"` and `"ready"` upstream statuses are now treated as joined in the slug-based flow and in `GET /api/v2/agents/join/:instanceId`.
> - Per-poll fetch timeouts are now capped to the remaining wait budget to avoid exceeding the overall deadline.
> - Behavioral Change: slug-based joins now return `joined: true` when upstream status is `"ready"`, which was previously not accepted by the schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 972ded5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added alternative agent joining method using conversationId, complementing invite-based joins.

* **Bug Fixes**
  * Agents in "ready" status now correctly report as joined.

* **Tests**
  * Expanded test coverage for agent joining modes; fixed port-binding flakiness in test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->