### PR TITLE
feat(connections): backend-mediated Composio exec + permission bundles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,12 @@ AGENT_ASSETS_API_KEY=
 # Auth configs are looked up dynamically from Composio by toolkit slug.
 COMPOSIO_API_KEY=
 COMPOSIO_CONNECTION_CALLBACK_URL=convos://connections/callback
+# Dedicated credential for POST /v2/composio/exec (the agent tool-execution
+# proxy). Held only by the trusted assistants worker (sent as X-Composio-Exec-Key)
+# and MUST match the worker's COMPOSIO_EXEC_API_KEY. Deliberately DISTINCT from
+# AGENT_ASSETS_API_KEY so the worker's generic backend proxy can't authenticate
+# an exec call. /v2/composio/exec returns 503 if unset.
+COMPOSIO_EXEC_API_KEY=
 
 # REQUIRED — Public Playroom origin for agent template URLs.
 # Backend refuses to start without it. Env-specific: https://dev.convos.org / https://convos.org.

--- a/docs/plans/connections-bundles-backend.md
+++ b/docs/plans/connections-bundles-backend.md
@@ -1,0 +1,175 @@
+# Connections Permission Bundles — Backend + Cross-Platform Contract
+
+> **Status**: Plan (not yet implemented)
+> **Created**: 2026-06-11 · **Owner**: Louis
+> **Approved iOS plan this builds on**: convos-ios `docs/plans/connections-picker-bundles-draft.md` (PR #869, marked **approved**)
+> **Builds on**: the exec/grant mediation work — convos-backend `louis/composio-exec` (`docs/plans/composio-exec-grant-mediation.md`)
+
+## Why this exists
+
+Review finding #3 (read-grant-can-write) can't be closed the obvious way: iOS/Android
+have no Composio **action slugs** to send — they only know a toolkit and coarse verbs,
+and two of the three grant entry points have no verb at all. The approved bundles plan
+solves this properly: the user grants human-named **bundles** ("Events"), the device
+persists only **bundle ids**, and the **backend** resolves a bundle → Composio actions at
+exec time. This doc is the backend + cross-platform contract for that model. It supersedes
+the interim `actions: []` plumbing and the verb-classification idea.
+
+## Determination: one backend source, served to clients (not embedded per platform)
+
+Decisions taken 2026-06-11:
+
+- **Catalog storage = code config** in convos-backend (a versioned TS module). Changing
+  copy/actions is a PR + redeploy; the served JSON + grant contract are identical
+  regardless of storage, so a later move to DB-backed is non-breaking.
+- **Contract = OpenAPI / JSON Schema in convos-backend.** Note: convos-backend has **no
+  OpenAPI/schema convention today** — this establishes one (see Open Questions).
+
+Where each piece lives:
+
+| Piece                                                              | Lives in                                        | Shared with iOS/Android how                               | Why                                                           |
+| ------------------------------------------------------------------ | ----------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------- |
+| Catalog data (services → bundles → actions, copy, icons, versions) | **convos-backend** (single source, code config) | Served via `GET /v2/connections/services`                 | One source; re-map actions without an app release             |
+| `bundle_id → action` resolution                                    | **convos-backend only** (exec)                  | Not shared — clients never resolve                        | Clients stay slug-free; resolution is the security boundary   |
+| Config JSON shape (the contract)                                   | Backend-defined; published as a **schema**      | iOS `Codable` + Android `data class` decode the same JSON | Language-agnostic JSON + one schema = no per-platform catalog |
+| Grant wire shape `{service_id, service_version, bundle_ids}`       | Backend contract                                | Both clients send on grant; backend enforces              | Specified in the approved iOS plan                            |
+| Picker UI (render cards, cache, toggles)                           | **iOS** and **Android** each                    | —                                                         | Pure presentation over the fetched JSON                       |
+| Staleness (`stale_resource`)                                       | Backend signals; clients refetch                | Existing CapabilityResult codec                           | iOS plan §Versioning                                          |
+
+**Net:** nothing about the catalog is platform-specific; the only per-platform work is the
+picker rendering the same JSON. No slug ever reaches a client.
+
+## The contract (to publish as JSON Schema / OpenAPI)
+
+**`GET /v2/connections/services`** — the picker config. Per the iOS plan:
+
+```jsonc
+{
+  "services": [
+    {
+      "id": "googlecalendar", // == Composio toolkit slug
+      "composio_slug": "googlecalendar",
+      "version": 1, // bump on ANY change to this service
+      "display_name": { "en": "Google Calendar" },
+      "icon": { "format": "png", "base64": "..." },
+      "bundles": [
+        {
+          "id": "calendar.events", // persisted on the grant
+          "title": { "en": "Events" },
+          "description": { "en": "View and edit events on all calendars" },
+          "default_enabled": false,
+          "composio_actions": ["GOOGLECALENDAR_LIST_EVENTS", "..."], // backend-only; see note
+        },
+      ],
+    },
+  ],
+}
+```
+
+- Localized strings always carry `en` (guaranteed fallback).
+- **Open:** does the served payload include `composio_actions`? The plan says the device
+  "never has to know exactly which actions a bundle holds." Recommend the public config
+  **omits `composio_actions`** (slugs stay backend-only); they live in the code config but
+  are stripped from the GET response. Decide before publishing the schema.
+
+**`POST /v2/connections/grants`** — grant body gains bundle fields:
+
+```jsonc
+{
+  "ownerInboxId": "...",
+  "granteeInboxId": "...",
+  "conversationId": "...",
+  "toolkit": "googlecalendar", // == service_id
+  "serviceVersion": 1, // for stale detection
+  "bundleIds": ["calendar.events"],
+} // replaces the interim `actions`
+```
+
+## How exec authorization changes
+
+Today (`exec.ts`): a grant carries `actions[]`; empty ⇒ whole toolkit. New model:
+
+1. Grant stores `bundleIds[]` (and keeps `actions[]` as a legacy/fallback).
+2. At exec, allowed actions = `grant.actions ∪ resolveBundleActions(toolkit, grant.bundleIds)`
+   using the **current** catalog (so re-mapping needs no client update — the point of bundles).
+3. If the allowed set is non-empty, the requested action must be in it (else `no_grant`).
+4. **Transition default:** a grant with neither actions nor bundleIds ⇒ whole toolkit, with
+   a warning log. Once clients always send bundleIds, tighten to fail-closed.
+
+`resolveBundleActions` and the catalog are drafted in `src/api/v2/connections/bundles.config.ts`
+(scaffold only — created while exploring; not wired up).
+
+## Implementation breakdown
+
+### Phase A — backend foundation (convos-backend, `louis/composio-exec` or a stacked branch)
+
+1. `bundles.config.ts` — catalog + `getServiceConfig` + `resolveBundleActions` (scaffolded).
+2. `GET /v2/connections/services` — serve the catalog (strip `composio_actions` if we decide
+   slugs stay backend-only); versioned; cacheable (respect cache headers).
+3. Schema: `ConnectionGrant.bundleIds String[] @default([])` (+ optional `serviceVersion Int?`) + migration.
+4. `grants-post`: accept `bundleIds` (+ `serviceVersion`); store. Keep `actions` for transition.
+5. `exec`: resolve bundle → actions and enforce (above).
+6. **Contract schema**: publish the GET response + grant body as JSON Schema/OpenAPI
+   (establish the convention — see Open Questions).
+7. Tests: catalog resolution; exec enforces bundle scope (read bundle can't write); GET shape.
+
+Phase A is **backward-compatible and inert** until clients send `bundleIds` (legacy grants →
+whole toolkit), so it can land before the picker exists.
+
+### Phase B — iOS picker (convos-ios, PR #869)
+
+- Fetch + cache `GET /v2/connections/services`; render one card per bundle (title, description,
+  toggle); on Done send `{toolkit, serviceVersion, bundleIds}`; handle `stale_resource` by
+  refetching and retrying. Replace the interim `actions: []` push (from
+  `louis/connection-grants-backend-push`) with `bundleIds`.
+
+### Phase C — Android picker
+
+- Same flow from the same served JSON + schema. No catalog duplication.
+
+## Relationship to work already landed
+
+- exec/grant backbone, the #1 (dedicated exec key + proxyConvos lockdown) and #2 (drop client
+  connectionId) security fixes, and #4 (natural-key revocation) are **done**.
+- The iOS `actions: []` plumbing (interim #3) is **superseded** by `bundleIds`; the backend
+  `actions` column stays as a transition/legacy fallback and can be dropped once bundles ship.
+
+## Contract schemas (the convention)
+
+Hand-authored JSON Schema (Draft 2020-12), no new npm dependency — this is the
+convos-backend contract convention going forward. Add a schema under `docs/schemas/`
+for any client-facing wire shape and keep the handler zod schema as the runtime
+source of truth (the JSON Schema mirrors it):
+
+- `docs/schemas/connections-services.schema.json` — `GET /v2/connections/services`
+  response (mirrors `toPublicServiceConfig`; **omits** `composio_actions`).
+- `docs/schemas/connection-grant.schema.json` — `POST /v2/connections/grants` body
+  (mirrors `grants-post.ts` `bodySchema`).
+
+## Resolved decisions (2026-06-11, Phase A)
+
+1. **Served config omits `composio_actions`.** Slugs stay backend-only; the public
+   bundle carries `{id, title, description, defaultEnabled}` and the service carries
+   `{id, composioSlug, version, displayName}` (icon optional, omitted in v1). Implemented
+   as `toPublicServiceConfig` in `bundles.config.ts`.
+2. **Contract = hand-authored JSON Schema** under `docs/schemas/` (above). No generator,
+   no new dependency.
+3. **Auth on `GET /v2/connections/services` = `authMiddleware` (JWT) only**, NOT
+   `requireAccount` (the catalog isn't account-scoped). Mounted in `src/api/v2/index.ts`
+   as a dedicated route declared before the requireAccount-gated `/connections` mount.
+   Short private cache (`max-age=300`).
+4. **`serviceVersion Int?` stored for audit/telemetry only.** exec always resolves bundles
+   against the current catalog, never this value.
+5. **Transition default kept (not fail-closed yet).** A grant with neither `actions` nor
+   `bundleIds` ⇒ whole toolkit, with `req.log.warn`. Tighten once iOS+Android both send
+   `bundleIds`.
+6. **Seeded `googlecalendar` only.** Catalog is structured so more services are trivial to add.
+
+## Open questions (remaining)
+
+1. **Transition tightening**: when do we flip the empty-scope default from whole-toolkit to
+   fail-closed (after iOS+Android both send bundleIds)?
+2. **Catalog seeding**: which services/bundles for v1 beyond googlecalendar, and who owns the
+   action lists (pulled from Composio's toolkit metadata?).
+3. **Icons**: format/transport (base64 inline vs URL) once the picker needs them — the
+   payload size/caching tradeoff is deferred.

--- a/docs/schemas/connection-grant.schema.json
+++ b/docs/schemas/connection-grant.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://convos.org/schemas/connection-grant.schema.json",
+  "title": "POST /v2/connections/grants request body",
+  "description": "Body iOS/Android send to issue a connection grant. ownerAccountId is taken from the authenticated JWT, never the body, so a caller can only grant access to their own connections. Source of truth: src/api/v2/connections/handlers/grants-post.ts (bodySchema).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["ownerInboxId", "granteeInboxId", "conversationId", "toolkit"],
+  "properties": {
+    "ownerInboxId": {
+      "description": "The owner's own XMTP inbox id.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "granteeInboxId": {
+      "description": "The agent allowed to act.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "conversationId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "toolkit": {
+      "description": "Composio toolkit slug; equals a service `id` from GET /v2/connections/services.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "actions": {
+      "description": "Legacy/transition: explicit Composio action slugs. Empty/omitted ⇒ whole toolkit. Superseded by bundleIds.",
+      "type": "array",
+      "maxItems": 128,
+      "items": { "type": "string", "minLength": 1, "maxLength": 128 }
+    },
+    "bundleIds": {
+      "description": "Granted permission-bundle ids (e.g. \"calendar.events\"). The backend resolves these to actions at exec; clients never send slugs.",
+      "type": "array",
+      "maxItems": 128,
+      "items": { "type": "string", "minLength": 1, "maxLength": 128 }
+    },
+    "serviceVersion": {
+      "description": "Catalog service version the client granted against. Stored for audit/telemetry only — exec resolves against the current catalog.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "expiresAt": {
+      "description": "RFC 3339 / ISO 8601 datetime. Omitted ⇒ no expiry.",
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/docs/schemas/connection-grant.schema.json
+++ b/docs/schemas/connection-grant.schema.json
@@ -2,9 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://convos.org/schemas/connection-grant.schema.json",
   "title": "POST /v2/connections/grants request body",
-  "description": "Body iOS/Android send to issue a connection grant. ownerAccountId is taken from the authenticated JWT, never the body, so a caller can only grant access to their own connections. Source of truth: src/api/v2/connections/handlers/grants-post.ts (bodySchema).",
+  "description": "Body iOS/Android send to issue a connection grant. ownerAccountId is taken from the authenticated JWT, never the body, so a caller can only grant access to their own connections. Unknown fields are silently ignored (stripped) by the server — `connectionId` deliberately so (a bearer capability the client must not pin). Source of truth: src/api/v2/connections/handlers/grants-post.ts (bodySchema).",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["ownerInboxId", "granteeInboxId", "conversationId", "toolkit"],
   "properties": {
     "ownerInboxId": {
@@ -37,7 +37,7 @@
       "items": { "type": "string", "minLength": 1, "maxLength": 128 }
     },
     "bundleIds": {
-      "description": "Granted permission-bundle ids (e.g. \"calendar.events\"). The backend resolves these to actions at exec; clients never send slugs.",
+      "description": "Granted permission-bundle ids (e.g. \"calendar.events\"). The backend resolves these to actions at exec; clients never send slugs. Each id must exist in the catalog for `toolkit` (GET /v2/connections/services); an unknown id is rejected with 400 {code: \"unknown_bundle\", bundleId}.",
       "type": "array",
       "maxItems": 128,
       "items": { "type": "string", "minLength": 1, "maxLength": 128 }

--- a/docs/schemas/connections-services.schema.json
+++ b/docs/schemas/connections-services.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://convos.org/schemas/connections-services.schema.json",
+  "title": "GET /v2/connections/services response",
+  "description": "The connections-picker catalog. Backend-owned services and permission bundles, with Composio action slugs stripped (slugs stay backend-only; clients persist only bundle ids). Source of truth: src/api/v2/connections/bundles.config.ts (toPublicServiceConfig).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["services"],
+  "properties": {
+    "services": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/PublicServiceConfig" }
+    }
+  },
+  "$defs": {
+    "LocalizedString": {
+      "description": "A localized string map. MUST always carry an \"en\" key (the guaranteed fallback).",
+      "type": "object",
+      "required": ["en"],
+      "properties": {
+        "en": { "type": "string" }
+      },
+      "additionalProperties": { "type": "string" }
+    },
+    "PublicBundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "description", "defaultEnabled"],
+      "properties": {
+        "id": {
+          "description": "Stable id persisted on the grant, e.g. \"calendar.events\".",
+          "type": "string"
+        },
+        "title": { "$ref": "#/$defs/LocalizedString" },
+        "description": { "$ref": "#/$defs/LocalizedString" },
+        "defaultEnabled": { "type": "boolean" }
+      }
+    },
+    "PublicServiceConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "composioSlug", "version", "displayName", "bundles"],
+      "properties": {
+        "id": {
+          "description": "Equals the Composio toolkit slug; sent back as `toolkit` on a grant.",
+          "type": "string"
+        },
+        "composioSlug": { "type": "string" },
+        "version": {
+          "description": "Bumped whenever anything about this service changes; clients refetch on a mismatch (stale detection).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "displayName": { "$ref": "#/$defs/LocalizedString" },
+        "icon": {
+          "description": "Optional service icon. Omitted in v1.",
+          "type": "object",
+          "required": ["format", "base64"],
+          "properties": {
+            "format": { "type": "string" },
+            "base64": { "type": "string" }
+          }
+        },
+        "bundles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PublicBundle" }
+        }
+      }
+    }
+  }
+}

--- a/prisma/migrations/20260609120000_add_connection_grant/migration.sql
+++ b/prisma/migrations/20260609120000_add_connection_grant/migration.sql
@@ -1,0 +1,37 @@
+-- Consent records for backend-mediated Composio tool execution (fork Y).
+--
+-- iOS issues one row per approved capability request; POST /v2/composio/exec
+-- reads them to authorize an agent call, then resolves the connection and calls
+-- Composio server-side. ownerAccountId is stamped from the issuer's JWT, so an
+-- owner can only grant access to their own connections. connectionId is the
+-- Composio bearer capability — stored backend-side, never returned to an agent.
+
+-- CreateTable
+CREATE TABLE "ConnectionGrant" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "ownerAccountId" UUID NOT NULL,
+    "ownerInboxId" TEXT NOT NULL,
+    "granteeInboxId" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "toolkit" TEXT NOT NULL,
+    "actions" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "connectionId" TEXT,
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ConnectionGrant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: one grant per (owner, grantee, conversation, toolkit) — re-issue upserts
+CREATE UNIQUE INDEX "ConnectionGrant_ownerAccountId_granteeInboxId_conversationI_key" ON "ConnectionGrant"("ownerAccountId", "granteeInboxId", "conversationId", "toolkit");
+
+-- CreateIndex: exec lookup by (grantee, conversation)
+CREATE INDEX "ConnectionGrant_granteeInboxId_conversationId_idx" ON "ConnectionGrant"("granteeInboxId", "conversationId");
+
+-- CreateIndex: owner list/revoke
+CREATE INDEX "ConnectionGrant_ownerAccountId_idx" ON "ConnectionGrant"("ownerAccountId");
+
+-- AddForeignKey
+ALTER TABLE "ConnectionGrant" ADD CONSTRAINT "ConnectionGrant_ownerAccountId_fkey" FOREIGN KEY ("ownerAccountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260611150000_add_grant_bundle_ids/migration.sql
+++ b/prisma/migrations/20260611150000_add_grant_bundle_ids/migration.sql
@@ -1,0 +1,16 @@
+-- Permission bundles for connection grants.
+--
+-- iOS/Android persist human-named *bundle ids* (e.g. "calendar.events") instead
+-- of Composio action slugs; POST /v2/composio/exec resolves a bundle to its
+-- actions against the backend catalog (src/api/v2/connections/bundles.config.ts).
+-- serviceVersion is the catalog version the client granted against, stored for
+-- audit/telemetry only — exec always resolves against the CURRENT catalog.
+--
+-- NOTE: bundleIds is NOT NULL with an array default to match Prisma's
+-- `String[] @default([])` exactly (the earlier `actions` column shipped as a
+-- nullable TEXT[] by mistake — not repeated here).
+
+-- AlterTable
+ALTER TABLE "ConnectionGrant"
+    ADD COLUMN "bundleIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    ADD COLUMN "serviceVersion" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,6 +114,45 @@ model Account {
   credits                  UserCredits?
   creditLedger             CreditLedger[]
   subscriptions            Subscription[]
+  connectionGrants         ConnectionGrant[]
+}
+
+/// Consent record for backend-mediated Composio tool execution (fork Y).
+///
+/// iOS issues one row when the owner approves a capability request: "owner
+/// (ownerAccountId) lets agent (granteeInboxId) use `toolkit` in this
+/// conversation." The backend's POST /v2/composio/exec reads these to decide
+/// whether an agent call is authorized, then resolves the connection and calls
+/// Composio itself — the agent never holds or names a connection id.
+///
+/// ownerAccountId is set from the issuer's authenticated JWT (never a body
+/// field), so an owner can only grant access to their own connections.
+/// connectionId is the Composio connected-account id (a bearer capability); it
+/// is stored backend-side and never returned to an agent. See
+/// docs/plans/composio-exec-grant-mediation.md.
+model ConnectionGrant {
+  id             String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  ownerAccountId String    @db.Uuid
+  ownerInboxId   String
+  granteeInboxId String
+  conversationId String
+  toolkit        String
+  /// Allowed Composio action slugs (e.g. GOOGLECALENDAR_EVENTS_LIST). Empty
+  /// means the whole toolkit; tighten to per-action as scoped sessions prove out.
+  actions        String[]  @default([])
+  /// Composio connected-account id, when iOS pins it. Bearer capability —
+  /// backend-only, never sent to an agent. Null ⇒ resolve from (owner, toolkit).
+  connectionId   String?
+  expiresAt      DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  owner Account @relation(fields: [ownerAccountId], references: [id], onDelete: Cascade)
+
+  @@unique([ownerAccountId, granteeInboxId, conversationId, toolkit])
+  @@index([granteeInboxId, conversationId])
+  @@index([ownerAccountId])
 }
 
 enum PublishStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,7 +139,16 @@ model ConnectionGrant {
   toolkit        String
   /// Allowed Composio action slugs (e.g. GOOGLECALENDAR_EVENTS_LIST). Empty
   /// means the whole toolkit; tighten to per-action as scoped sessions prove out.
+  /// Legacy/transition: superseded by bundleIds, kept as a fallback.
   actions        String[]  @default([])
+  /// Granted permission-bundle ids (e.g. "calendar.events"). The backend
+  /// resolves these to Composio actions at exec via bundles.config.ts — clients
+  /// never see slugs. Empty + empty actions ⇒ whole toolkit (transition default).
+  bundleIds      String[]  @default([])
+  /// Catalog service version the client granted against. Stored for
+  /// audit/telemetry only — exec always resolves bundles against the CURRENT
+  /// catalog, never this value.
+  serviceVersion Int?
   /// Composio connected-account id, when iOS pins it. Bearer capability —
   /// backend-only, never sent to an agent. Null ⇒ resolve from (owner, toolkit).
   connectionId   String?

--- a/src/api/v2/composio/composio.router.ts
+++ b/src/api/v2/composio/composio.router.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { execHandler } from "./handlers/exec";
+
+// Agent-facing Composio surface. Mounted under agentApiKeyAuth (see v2/index).
+// The shared agent key only authenticates the caller; per-account authorization
+// happens in the handler against the trusted identity + grant store.
+export const composioRouter = Router();
+
+composioRouter.post("/exec", execHandler);

--- a/src/api/v2/composio/handlers/exec.ts
+++ b/src/api/v2/composio/handlers/exec.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { resolveBundleActions } from "@/api/v2/connections/bundles.config";
 import { createComposioService } from "@/api/v2/connections/composio.service";
 import { prisma } from "@/utils/prisma";
 import { resolveTrustedCaller } from "../trusted-identity";
@@ -56,15 +57,30 @@ export async function execHandler(req: Request, res: Response) {
     },
   });
 
-  // Action scope: empty actions ⇒ whole toolkit; otherwise the action must be
-  // listed (no verb escalation). Owner scope: if the agent named a member
-  // (onBehalfOf), keep only that owner's grant — this is how a group query
-  // targets one person ("Alice's calendar") without touching anyone else's.
-  const applicable = grants.filter(
-    (g) =>
-      (g.actions.length === 0 || g.actions.includes(action)) &&
-      (onBehalfOf === undefined || g.ownerInboxId === onBehalfOf),
-  );
+  // Action scope: the allowed set is the UNION of the grant's legacy `actions`
+  // and the actions its `bundleIds` resolve to against the CURRENT catalog (so
+  // re-mapping a bundle needs no client update — the point of bundles). If that
+  // union is empty (neither actions nor bundleIds — a legacy/transition grant)
+  // the grant authorizes the whole toolkit, logged as a warning; once clients
+  // always send bundleIds this default tightens to fail-closed. Owner scope: if
+  // the agent named a member (onBehalfOf), keep only that owner's grant — this
+  // is how a group query targets one person ("Alice's calendar") without
+  // touching anyone else's.
+  const applicable = grants.filter((g) => {
+    if (onBehalfOf !== undefined && g.ownerInboxId !== onBehalfOf) return false;
+    const allowed = new Set<string>(g.actions);
+    for (const a of resolveBundleActions(g.toolkit, g.bundleIds)) {
+      allowed.add(a);
+    }
+    if (allowed.size === 0) {
+      req.log.warn(
+        { grantId: g.id, toolkit, action },
+        "[Composio] exec: grant has no actions/bundleIds — whole-toolkit (transition default)",
+      );
+      return true;
+    }
+    return allowed.has(action);
+  });
   if (applicable.length === 0) {
     req.log.warn(
       { agentInboxId: caller.agentInboxId, toolkit, action, onBehalfOf },

--- a/src/api/v2/composio/handlers/exec.ts
+++ b/src/api/v2/composio/handlers/exec.ts
@@ -4,13 +4,17 @@ import { createComposioService } from "@/api/v2/connections/composio.service";
 import { prisma } from "@/utils/prisma";
 import { resolveTrustedCaller } from "../trusted-identity";
 
-// The agent contract: only what the toolkit needs. No connection id, no account
-// id — the backend resolves those from the trusted caller + the grant store, so
-// a compromised agent has no field with which to name another account.
+// The agent contract: only what the toolkit needs, plus an optional owner
+// selector. No connection id, no account id — the backend resolves those from
+// the trusted caller + the grant store. `onBehalfOf` is the inbox id of the
+// member whose connection to act on (e.g. "query Alice's calendar" in a group);
+// it is only a SELECTOR among the agent's authorized grants — naming a member
+// who never granted this agent simply yields no_grant, so it cannot widen access.
 const bodySchema = z.object({
   toolkit: z.string().min(1).max(128),
   action: z.string().min(1).max(128),
   args: z.record(z.unknown()).default({}),
+  onBehalfOf: z.string().min(1).max(256).optional(),
 });
 
 export async function execHandler(req: Request, res: Response) {
@@ -21,7 +25,7 @@ export async function execHandler(req: Request, res: Response) {
       .json({ code: "invalid_request", issues: parsed.error.issues });
     return;
   }
-  const { toolkit, action, args } = parsed.data;
+  const { toolkit, action, args, onBehalfOf } = parsed.data;
 
   // Fail closed: without a forgery-proof (conversationId, agentInboxId), exec
   // cannot safely decide whose connection to use. See trusted-identity.ts.
@@ -53,27 +57,31 @@ export async function execHandler(req: Request, res: Response) {
   });
 
   // Action scope: empty actions ⇒ whole toolkit; otherwise the action must be
-  // listed (no verb escalation).
+  // listed (no verb escalation). Owner scope: if the agent named a member
+  // (onBehalfOf), keep only that owner's grant — this is how a group query
+  // targets one person ("Alice's calendar") without touching anyone else's.
   const applicable = grants.filter(
-    (g) => g.actions.length === 0 || g.actions.includes(action),
+    (g) =>
+      (g.actions.length === 0 || g.actions.includes(action)) &&
+      (onBehalfOf === undefined || g.ownerInboxId === onBehalfOf),
   );
   if (applicable.length === 0) {
     req.log.warn(
-      { agentInboxId: caller.agentInboxId, toolkit, action },
+      { agentInboxId: caller.agentInboxId, toolkit, action, onBehalfOf },
       "[Composio] exec: no matching grant",
     );
     res.status(403).json({ code: "no_grant" });
     return;
   }
 
-  // Tier 1 bounds resolution to grants in this conversation. If several owners
-  // shared the same toolkit here, we can't disambiguate without the verified
-  // sender (Tier 2) — fail closed rather than guess whose data to touch.
+  // Multiple owners shared the same toolkit in this conversation and the agent
+  // didn't say whose to use. Fail closed and tell it to pass `onBehalfOf` rather
+  // than guess whose data to touch.
   const owners = new Set(applicable.map((g) => g.ownerAccountId));
   if (owners.size > 1) {
     req.log.warn(
       { conversationId: caller.conversationId, toolkit, owners: owners.size },
-      "[Composio] exec: ambiguous grant (Tier 2 needed)",
+      "[Composio] exec: ambiguous grant — onBehalfOf required",
     );
     res.status(409).json({ code: "ambiguous_grant" });
     return;
@@ -82,14 +90,14 @@ export async function execHandler(req: Request, res: Response) {
   const grant = applicable[0];
 
   try {
-    // connectionId (bearer capability) is resolved server-side and never
-    // returned to the agent.
-    const connectedAccountId =
-      grant.connectionId ??
-      (await service.resolveConnectionId({
-        userId: grant.ownerAccountId,
-        toolkit,
-      }));
+    // The connection (bearer capability) is resolved SERVER-SIDE from the
+    // owner's own account — never from a client-supplied id — and never returned
+    // to the agent. This is what makes a stolen connection id unusable: there is
+    // no path that acts on a caller-named connection.
+    const connectedAccountId = await service.resolveConnectionId({
+      userId: grant.ownerAccountId,
+      toolkit,
+    });
     if (!connectedAccountId) {
       req.log.warn(
         { ownerAccountId: grant.ownerAccountId, toolkit },

--- a/src/api/v2/composio/handlers/exec.ts
+++ b/src/api/v2/composio/handlers/exec.ts
@@ -1,0 +1,116 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { createComposioService } from "@/api/v2/connections/composio.service";
+import { prisma } from "@/utils/prisma";
+import { resolveTrustedCaller } from "../trusted-identity";
+
+// The agent contract: only what the toolkit needs. No connection id, no account
+// id — the backend resolves those from the trusted caller + the grant store, so
+// a compromised agent has no field with which to name another account.
+const bodySchema = z.object({
+  toolkit: z.string().min(1).max(128),
+  action: z.string().min(1).max(128),
+  args: z.record(z.unknown()).default({}),
+});
+
+export async function execHandler(req: Request, res: Response) {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", issues: parsed.error.issues });
+    return;
+  }
+  const { toolkit, action, args } = parsed.data;
+
+  // Fail closed: without a forgery-proof (conversationId, agentInboxId), exec
+  // cannot safely decide whose connection to use. See trusted-identity.ts.
+  const caller = await resolveTrustedCaller(req);
+  if (!caller) {
+    req.log.warn({ toolkit, action }, "[Composio] exec: no trusted identity");
+    res.status(403).json({ code: "trusted_identity_unavailable" });
+    return;
+  }
+
+  const service = createComposioService();
+  if (!service) {
+    res.status(503).json({ error: "Connections not configured" });
+    return;
+  }
+
+  // Authorize on the grant, keyed by the TRUSTED identity (never body fields):
+  // the agent (granteeInboxId) must hold a live grant for this conversation,
+  // toolkit, and action.
+  const now = new Date();
+  const grants = await prisma.connectionGrant.findMany({
+    where: {
+      granteeInboxId: caller.agentInboxId,
+      conversationId: caller.conversationId,
+      toolkit,
+      revokedAt: null,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+    },
+  });
+
+  // Action scope: empty actions ⇒ whole toolkit; otherwise the action must be
+  // listed (no verb escalation).
+  const applicable = grants.filter(
+    (g) => g.actions.length === 0 || g.actions.includes(action),
+  );
+  if (applicable.length === 0) {
+    req.log.warn(
+      { agentInboxId: caller.agentInboxId, toolkit, action },
+      "[Composio] exec: no matching grant",
+    );
+    res.status(403).json({ code: "no_grant" });
+    return;
+  }
+
+  // Tier 1 bounds resolution to grants in this conversation. If several owners
+  // shared the same toolkit here, we can't disambiguate without the verified
+  // sender (Tier 2) — fail closed rather than guess whose data to touch.
+  const owners = new Set(applicable.map((g) => g.ownerAccountId));
+  if (owners.size > 1) {
+    req.log.warn(
+      { conversationId: caller.conversationId, toolkit, owners: owners.size },
+      "[Composio] exec: ambiguous grant (Tier 2 needed)",
+    );
+    res.status(409).json({ code: "ambiguous_grant" });
+    return;
+  }
+
+  const grant = applicable[0];
+
+  try {
+    // connectionId (bearer capability) is resolved server-side and never
+    // returned to the agent.
+    const connectedAccountId =
+      grant.connectionId ??
+      (await service.resolveConnectionId({
+        userId: grant.ownerAccountId,
+        toolkit,
+      }));
+    if (!connectedAccountId) {
+      req.log.warn(
+        { ownerAccountId: grant.ownerAccountId, toolkit },
+        "[Composio] exec: no connection for owner+toolkit",
+      );
+      res.status(409).json({ code: "connection_not_found" });
+      return;
+    }
+
+    const result = await service.execute({
+      action,
+      userId: grant.ownerAccountId,
+      arguments: args,
+      connectedAccountId,
+    });
+
+    res.status(200).json({ data: result.data });
+    return;
+  } catch (error) {
+    req.log.error({ error, toolkit, action }, "[Composio] exec failed");
+    res.status(502).json({ error: "Tool execution failed" });
+    return;
+  }
+}

--- a/src/api/v2/composio/handlers/exec.ts
+++ b/src/api/v2/composio/handlers/exec.ts
@@ -25,7 +25,7 @@ export async function execHandler(req: Request, res: Response) {
 
   // Fail closed: without a forgery-proof (conversationId, agentInboxId), exec
   // cannot safely decide whose connection to use. See trusted-identity.ts.
-  const caller = await resolveTrustedCaller(req);
+  const caller = resolveTrustedCaller(req);
   if (!caller) {
     req.log.warn({ toolkit, action }, "[Composio] exec: no trusted identity");
     res.status(403).json({ code: "trusted_identity_unavailable" });

--- a/src/api/v2/composio/handlers/exec.ts
+++ b/src/api/v2/composio/handlers/exec.ts
@@ -59,26 +59,34 @@ export async function execHandler(req: Request, res: Response) {
 
   // Action scope: the allowed set is the UNION of the grant's legacy `actions`
   // and the actions its `bundleIds` resolve to against the CURRENT catalog (so
-  // re-mapping a bundle needs no client update — the point of bundles). If that
-  // union is empty (neither actions nor bundleIds — a legacy/transition grant)
-  // the grant authorizes the whole toolkit, logged as a warning; once clients
-  // always send bundleIds this default tightens to fail-closed. Owner scope: if
-  // the agent named a member (onBehalfOf), keep only that owner's grant — this
-  // is how a group query targets one person ("Alice's calendar") without
-  // touching anyone else's.
+  // re-mapping a bundle needs no client update — the point of bundles). The
+  // whole-toolkit transition default applies ONLY to true legacy grants that
+  // carry NEITHER actions NOR bundleIds; once clients always send bundleIds it
+  // tightens to fail-closed. A grant that DOES carry actions or bundleIds is
+  // scoped to exactly what they resolve to — if the union does not contain the
+  // requested action (including a union left EMPTY because the bundle ids are
+  // unknown/stale to the catalog), the grant is not applicable: fail closed
+  // (no_grant), never fall back to whole-toolkit. Owner scope: if the agent
+  // named a member (onBehalfOf), keep only that owner's grant — this is how a
+  // group query targets one person ("Alice's calendar") without touching
+  // anyone else's.
   const applicable = grants.filter((g) => {
     if (onBehalfOf !== undefined && g.ownerInboxId !== onBehalfOf) return false;
-    const allowed = new Set<string>(g.actions);
-    for (const a of resolveBundleActions(g.toolkit, g.bundleIds)) {
-      allowed.add(a);
-    }
-    if (allowed.size === 0) {
+    if (g.actions.length === 0 && g.bundleIds.length === 0) {
       req.log.warn(
         { grantId: g.id, toolkit, action },
         "[Composio] exec: grant has no actions/bundleIds — whole-toolkit (transition default)",
       );
       return true;
     }
+    const resolved = resolveBundleActions(g.toolkit, g.bundleIds);
+    if (g.bundleIds.length > 0 && resolved.length === 0) {
+      req.log.warn(
+        { grantId: g.id, toolkit, bundleIds: g.bundleIds },
+        "[Composio] exec: grant bundleIds resolve to no actions (unknown/stale) — fail closed",
+      );
+    }
+    const allowed = new Set<string>([...g.actions, ...resolved]);
     return allowed.has(action);
   });
   if (applicable.length === 0) {

--- a/src/api/v2/composio/handlers/exec.ts
+++ b/src/api/v2/composio/handlers/exec.ts
@@ -131,11 +131,26 @@ export async function execHandler(req: Request, res: Response) {
       return;
     }
 
+    // Composio refuses manual execution against the implicit "latest" toolkit
+    // version (TOOL_VERSION_REQUIRED). Pin the toolkit's current published
+    // version, resolved from Composio and cached in-process; if it cannot be
+    // determined, fail closed rather than skip the version check.
+    const version = await service.resolveToolkitVersion(toolkit);
+    if (!version) {
+      req.log.error(
+        { toolkit, action },
+        "[Composio] exec: toolkit version unresolved",
+      );
+      res.status(502).json({ code: "toolkit_version_unresolved" });
+      return;
+    }
+
     const result = await service.execute({
       action,
       userId: grant.ownerAccountId,
       arguments: args,
       connectedAccountId,
+      version,
     });
 
     res.status(200).json({ data: result.data });

--- a/src/api/v2/composio/trusted-identity.ts
+++ b/src/api/v2/composio/trusted-identity.ts
@@ -1,0 +1,51 @@
+import type { Request } from "express";
+
+/**
+ * The cryptographically-trusted caller of a POST /v2/composio/exec request.
+ *
+ * `agentInboxId` and `conversationId` MUST come from a signal the agent cannot
+ * forge — not from the request body. The agent authenticates with the shared
+ * agent API key, which proves "an agent is calling," not "for whom"; so the
+ * exec authorization (grant lookup) must key off this trusted identity, never
+ * off agent-supplied fields.
+ */
+export type TrustedCaller = {
+  conversationId: string;
+  /** The agent acting — matched against ConnectionGrant.granteeInboxId. */
+  agentInboxId: string;
+};
+
+/**
+ * Resolves the trusted caller for an exec request, or null when no trusted
+ * signal is available (fail-closed → exec returns 403).
+ *
+ * Production has NO resolver wired yet: this backend cannot see Herald's
+ * HMAC-signed sender or the conversation membership (no Herald client, no
+ * membership table). Until that lands — the worker forwards Herald's signed
+ * envelope and the backend re-verifies the HMAC — exec must fail closed rather
+ * than trust an agent-named conversation/inbox. See
+ * docs/plans/composio-exec-grant-mediation.md (Tier 2 sub-question).
+ */
+export type TrustedCallerResolver = (
+  req: Request,
+) => Promise<TrustedCaller | null>;
+
+const FAIL_CLOSED: TrustedCallerResolver = () => Promise.resolve(null);
+
+let resolver: TrustedCallerResolver = FAIL_CLOSED;
+
+export function resolveTrustedCaller(
+  req: Request,
+): Promise<TrustedCaller | null> {
+  return resolver(req);
+}
+
+/**
+ * Override the resolver — used by tests to exercise the grant→Composio path
+ * with a known trusted caller. Pass null to restore the fail-closed default.
+ */
+export function __setTrustedCallerResolverForTests(
+  override: TrustedCallerResolver | null,
+): void {
+  resolver = override ?? FAIL_CLOSED;
+}

--- a/src/api/v2/composio/trusted-identity.ts
+++ b/src/api/v2/composio/trusted-identity.ts
@@ -1,13 +1,31 @@
 import type { Request } from "express";
 
 /**
- * The cryptographically-trusted caller of a POST /v2/composio/exec request.
+ * Identity headers stamped by the TRUSTED assistants worker.
  *
- * `agentInboxId` and `conversationId` MUST come from a signal the agent cannot
- * forge — not from the request body. The agent authenticates with the shared
- * agent API key, which proves "an agent is calling," not "for whom"; so the
- * exec authorization (grant lookup) must key off this trusted identity, never
- * off agent-supplied fields.
+ * Trust model: /v2/composio is mounted behind agentApiKeyAuth, and the agent
+ * API key lives exclusively in the assistants worker (Cloudflare DO) — the
+ * agent container gets no key and cannot reach this surface. The worker's
+ * composio.internal outbound handler builds a FRESH request to exec: it copies
+ * only {toolkit, action, args} from the container and sets these headers from
+ * its own state (the conversationId pinned at instance creation and the
+ * instance's own inboxId), never from container input. The same key+worker
+ * trust already gates the credits surface in production.
+ *
+ * A request bearing the key but missing these headers is fail-closed by
+ * resolveTrustedCaller returning null (exec → 403): body fields or
+ * container-supplied headers can never substitute, because the worker
+ * overwrites them.
+ */
+export const CONVERSATION_ID_HEADER = "x-convos-conversation-id";
+export const AGENT_INBOX_ID_HEADER = "x-convos-agent-inbox-id";
+
+const MAX_HEADER_LENGTH = 256;
+
+/**
+ * The trusted caller of a POST /v2/composio/exec request: which agent, acting
+ * in which conversation. Matched against ConnectionGrant rows — never derived
+ * from the request body.
  */
 export type TrustedCaller = {
   conversationId: string;
@@ -15,37 +33,16 @@ export type TrustedCaller = {
   agentInboxId: string;
 };
 
-/**
- * Resolves the trusted caller for an exec request, or null when no trusted
- * signal is available (fail-closed → exec returns 403).
- *
- * Production has NO resolver wired yet: this backend cannot see Herald's
- * HMAC-signed sender or the conversation membership (no Herald client, no
- * membership table). Until that lands — the worker forwards Herald's signed
- * envelope and the backend re-verifies the HMAC — exec must fail closed rather
- * than trust an agent-named conversation/inbox. See
- * docs/plans/composio-exec-grant-mediation.md (Tier 2 sub-question).
- */
-export type TrustedCallerResolver = (
-  req: Request,
-) => Promise<TrustedCaller | null>;
-
-const FAIL_CLOSED: TrustedCallerResolver = () => Promise.resolve(null);
-
-let resolver: TrustedCallerResolver = FAIL_CLOSED;
-
-export function resolveTrustedCaller(
-  req: Request,
-): Promise<TrustedCaller | null> {
-  return resolver(req);
-}
-
-/**
- * Override the resolver — used by tests to exercise the grant→Composio path
- * with a known trusted caller. Pass null to restore the fail-closed default.
- */
-export function __setTrustedCallerResolverForTests(
-  override: TrustedCallerResolver | null,
-): void {
-  resolver = override ?? FAIL_CLOSED;
+export function resolveTrustedCaller(req: Request): TrustedCaller | null {
+  const conversationId = req.header(CONVERSATION_ID_HEADER)?.trim() ?? "";
+  const agentInboxId = req.header(AGENT_INBOX_ID_HEADER)?.trim() ?? "";
+  if (
+    !conversationId ||
+    !agentInboxId ||
+    conversationId.length > MAX_HEADER_LENGTH ||
+    agentInboxId.length > MAX_HEADER_LENGTH
+  ) {
+    return null;
+  }
+  return { conversationId, agentInboxId };
 }

--- a/src/api/v2/connections/bundles.config.ts
+++ b/src/api/v2/connections/bundles.config.ts
@@ -44,7 +44,12 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
     composioSlug: "googlecalendar",
     // v2: added the read-only calendar.events.read bundle (contract: bump on
     // ANY change to the service).
-    version: 2,
+    // v3: corrected the list slug GOOGLECALENDAR_LIST_EVENTS →
+    // GOOGLECALENDAR_EVENTS_LIST. Verified against the live Composio v3 tool
+    // catalog (2026-06-11): GOOGLECALENDAR_LIST_EVENTS does not exist (404);
+    // GOOGLECALENDAR_EVENTS_LIST / _CREATE_EVENT / _UPDATE_EVENT /
+    // _DELETE_EVENT are all served.
+    version: 3,
     displayName: { en: "Google Calendar" },
     bundles: [
       {
@@ -53,7 +58,7 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
         description: { en: "View and edit events on all calendars" },
         defaultEnabled: false,
         composioActions: [
-          "GOOGLECALENDAR_LIST_EVENTS",
+          "GOOGLECALENDAR_EVENTS_LIST",
           "GOOGLECALENDAR_CREATE_EVENT",
           "GOOGLECALENDAR_UPDATE_EVENT",
           "GOOGLECALENDAR_DELETE_EVENT",
@@ -67,7 +72,7 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
         title: { en: "View events" },
         description: { en: "View events on all calendars" },
         defaultEnabled: false,
-        composioActions: ["GOOGLECALENDAR_LIST_EVENTS"],
+        composioActions: ["GOOGLECALENDAR_EVENTS_LIST"],
       },
     ],
   },

--- a/src/api/v2/connections/bundles.config.ts
+++ b/src/api/v2/connections/bundles.config.ts
@@ -42,7 +42,9 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
   {
     id: "googlecalendar",
     composioSlug: "googlecalendar",
-    version: 1,
+    // v2: added the read-only calendar.events.read bundle (contract: bump on
+    // ANY change to the service).
+    version: 2,
     displayName: { en: "Google Calendar" },
     bundles: [
       {
@@ -56,6 +58,16 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
           "GOOGLECALENDAR_UPDATE_EVENT",
           "GOOGLECALENDAR_DELETE_EVENT",
         ],
+      },
+      {
+        // Read-only sibling of calendar.events: proves the scoping invariant
+        // (a read-scoped grant must never authorize a write). MUST NOT contain
+        // any CREATE/UPDATE/DELETE/PATCH slug.
+        id: "calendar.events.read",
+        title: { en: "View events" },
+        description: { en: "View events on all calendars" },
+        defaultEnabled: false,
+        composioActions: ["GOOGLECALENDAR_LIST_EVENTS"],
       },
     ],
   },

--- a/src/api/v2/connections/bundles.config.ts
+++ b/src/api/v2/connections/bundles.config.ts
@@ -61,14 +61,17 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
     // catalog now offers only calendar.events (retitled "View and edit
     // events"); calendar.events.read is deprecated (hidden, still resolvable
     // and grantable — grants in the wild carry it).
-    version: 4,
+    // v5: copy aligned with the Figma design — row title "Events", subtitle
+    // "View and edit events on all calendars". Copy-only, but the contract is
+    // bump on ANY change (copy included).
+    version: 5,
     displayName: { en: "Google Calendar" },
     bundles: [
       {
         id: "calendar.events",
-        title: { en: "View and edit events" },
+        title: { en: "Events" },
         description: {
-          en: "View, create, update, and delete events on all calendars",
+          en: "View and edit events on all calendars",
         },
         defaultEnabled: false,
         composioActions: [

--- a/src/api/v2/connections/bundles.config.ts
+++ b/src/api/v2/connections/bundles.config.ts
@@ -25,6 +25,14 @@ export type Bundle = {
   defaultEnabled: boolean;
   /** Composio action slugs this bundle grants. The only slug list in the system. */
   composioActions: string[];
+  /**
+   * A retired bundle: hidden from the public catalog (clients can no longer
+   * discover it) but still resolvable at exec time AND still grantable, so
+   * (a) existing grants persisting this id keep working and (b) old clients
+   * holding a cached catalog (up to its TTL) can still round-trip a grant.
+   * Never delete a bundle id that may exist on a grant — deprecate it instead.
+   */
+  deprecated?: boolean;
 };
 
 export type ServiceConfig = {
@@ -49,13 +57,19 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
     // catalog (2026-06-11): GOOGLECALENDAR_LIST_EVENTS does not exist (404);
     // GOOGLECALENDAR_EVENTS_LIST / _CREATE_EVENT / _UPDATE_EVENT /
     // _DELETE_EVENT are all served.
-    version: 3,
+    // v4: product decision — the picker shows ONE calendar toggle. The public
+    // catalog now offers only calendar.events (retitled "View and edit
+    // events"); calendar.events.read is deprecated (hidden, still resolvable
+    // and grantable — grants in the wild carry it).
+    version: 4,
     displayName: { en: "Google Calendar" },
     bundles: [
       {
         id: "calendar.events",
-        title: { en: "Events" },
-        description: { en: "View and edit events on all calendars" },
+        title: { en: "View and edit events" },
+        description: {
+          en: "View, create, update, and delete events on all calendars",
+        },
         defaultEnabled: false,
         composioActions: [
           "GOOGLECALENDAR_EVENTS_LIST",
@@ -65,14 +79,17 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
         ],
       },
       {
-        // Read-only sibling of calendar.events: proves the scoping invariant
-        // (a read-scoped grant must never authorize a write). MUST NOT contain
-        // any CREATE/UPDATE/DELETE/PATCH slug.
+        // DEPRECATED (v4): folded into the single calendar.events toggle.
+        // Kept so existing grants persisting this id still resolve to LIST at
+        // exec, and so old clients on a cached v2/v3 catalog can still grant
+        // it. Read-only invariant still holds: MUST NOT contain any
+        // CREATE/UPDATE/DELETE/PATCH slug.
         id: "calendar.events.read",
         title: { en: "View events" },
         description: { en: "View events on all calendars" },
         defaultEnabled: false,
         composioActions: ["GOOGLECALENDAR_EVENTS_LIST"],
+        deprecated: true,
       },
     ],
   },
@@ -111,19 +128,25 @@ export type PublicServiceConfig = {
   bundles: PublicBundle[];
 };
 
-/** Strip `composioActions` so no slug ever reaches a client. */
+/**
+ * Strip `composioActions` so no slug ever reaches a client, and drop
+ * deprecated bundles: clients only ever see (and offer) the live catalog,
+ * while the internal one keeps resolving ids that grants already persist.
+ */
 export function toPublicServiceConfig(svc: ServiceConfig): PublicServiceConfig {
   return {
     id: svc.id,
     composioSlug: svc.composioSlug,
     version: svc.version,
     displayName: svc.displayName,
-    bundles: svc.bundles.map((b) => ({
-      id: b.id,
-      title: b.title,
-      description: b.description,
-      defaultEnabled: b.defaultEnabled,
-    })),
+    bundles: svc.bundles
+      .filter((b) => !b.deprecated)
+      .map((b) => ({
+        id: b.id,
+        title: b.title,
+        description: b.description,
+        defaultEnabled: b.defaultEnabled,
+      })),
   };
 }
 
@@ -136,6 +159,8 @@ export function getPublicServiceConfigs(): PublicServiceConfig[] {
  * The union of Composio action slugs granted by `bundleIds` on a service.
  * Unknown service or unknown bundle ids contribute nothing (fail-closed): a
  * grant that references only stale/unknown bundles authorizes no actions.
+ * Deprecated bundles DO resolve — that is the whole point of deprecating
+ * (instead of deleting) a bundle id that grants in the wild still carry.
  */
 export function resolveBundleActions(
   serviceId: string,

--- a/src/api/v2/connections/bundles.config.ts
+++ b/src/api/v2/connections/bundles.config.ts
@@ -1,0 +1,137 @@
+// Backend-owned service / permission-bundle catalog.
+//
+// Per the approved iOS plan (convos-ios docs/plans/connections-picker-bundles-draft.md):
+// the connections picker shows one card per *bundle* (a human intent like
+// "Events"), the device persists only the granted `bundle_id`s, and the backend
+// resolves a bundle to its Composio action slugs at execution time. This keeps
+// the app free of Composio slugs and lets us re-map actions without an app
+// release — bump a service's `version` whenever anything about it changes.
+//
+// This catalog is the source of truth for two things:
+//   1. GET /v2/connections/services — the config the picker fetches.
+//   2. exec authorization — granted bundle ids → the set of allowed actions.
+//
+// Extending it is data work (add services/bundles below + bump `version`); the
+// action slugs come from Composio's toolkit action list.
+
+/** A localized string map. MUST always carry an "en" key (the guaranteed fallback). */
+export type LocalizedString = { en: string } & Record<string, string>;
+
+export type Bundle = {
+  /** Stable id persisted on the grant, e.g. "calendar.events". */
+  id: string;
+  title: LocalizedString;
+  description: LocalizedString;
+  defaultEnabled: boolean;
+  /** Composio action slugs this bundle grants. The only slug list in the system. */
+  composioActions: string[];
+};
+
+export type ServiceConfig = {
+  /** Equals the Composio toolkit slug. */
+  id: string;
+  composioSlug: string;
+  /** Bumped whenever anything about this service changes (copy, icon, any bundle). */
+  version: number;
+  displayName: LocalizedString;
+  bundles: Bundle[];
+};
+
+// Seeded with the plan's reference service. Add more services/bundles here.
+export const SERVICE_CONFIGS: ServiceConfig[] = [
+  {
+    id: "googlecalendar",
+    composioSlug: "googlecalendar",
+    version: 1,
+    displayName: { en: "Google Calendar" },
+    bundles: [
+      {
+        id: "calendar.events",
+        title: { en: "Events" },
+        description: { en: "View and edit events on all calendars" },
+        defaultEnabled: false,
+        composioActions: [
+          "GOOGLECALENDAR_LIST_EVENTS",
+          "GOOGLECALENDAR_CREATE_EVENT",
+          "GOOGLECALENDAR_UPDATE_EVENT",
+          "GOOGLECALENDAR_DELETE_EVENT",
+        ],
+      },
+    ],
+  },
+];
+
+const BY_SERVICE = new Map<string, ServiceConfig>(
+  SERVICE_CONFIGS.map((s) => [s.id.toLowerCase(), s]),
+);
+
+export function getServiceConfig(serviceId: string): ServiceConfig | undefined {
+  return BY_SERVICE.get(serviceId.toLowerCase());
+}
+
+// --- Public (client-facing) view of the catalog ------------------------------
+//
+// The Composio action slugs are the security boundary and stay backend-only:
+// clients persist only bundle ids and never resolve actions. The public bundle
+// therefore exposes only what the picker needs to render and to round-trip on a
+// grant: id (persisted), copy, and the default toggle. Icons are omitted for now
+// (kept optional in the contract).
+
+/** A bundle as served to clients — no `composioActions`. */
+export type PublicBundle = {
+  id: string;
+  title: LocalizedString;
+  description: LocalizedString;
+  defaultEnabled: boolean;
+};
+
+/** A service as served to clients — bundles carry no slugs. */
+export type PublicServiceConfig = {
+  id: string;
+  composioSlug: string;
+  version: number;
+  displayName: LocalizedString;
+  bundles: PublicBundle[];
+};
+
+/** Strip `composioActions` so no slug ever reaches a client. */
+export function toPublicServiceConfig(svc: ServiceConfig): PublicServiceConfig {
+  return {
+    id: svc.id,
+    composioSlug: svc.composioSlug,
+    version: svc.version,
+    displayName: svc.displayName,
+    bundles: svc.bundles.map((b) => ({
+      id: b.id,
+      title: b.title,
+      description: b.description,
+      defaultEnabled: b.defaultEnabled,
+    })),
+  };
+}
+
+/** The full public catalog the picker fetches via GET /v2/connections/services. */
+export function getPublicServiceConfigs(): PublicServiceConfig[] {
+  return SERVICE_CONFIGS.map(toPublicServiceConfig);
+}
+
+/**
+ * The union of Composio action slugs granted by `bundleIds` on a service.
+ * Unknown service or unknown bundle ids contribute nothing (fail-closed): a
+ * grant that references only stale/unknown bundles authorizes no actions.
+ */
+export function resolveBundleActions(
+  serviceId: string,
+  bundleIds: string[],
+): string[] {
+  const svc = getServiceConfig(serviceId);
+  if (!svc || bundleIds.length === 0) return [];
+  const granted = new Set(bundleIds);
+  const actions = new Set<string>();
+  for (const bundle of svc.bundles) {
+    if (granted.has(bundle.id)) {
+      for (const action of bundle.composioActions) actions.add(action);
+    }
+  }
+  return [...actions];
+}

--- a/src/api/v2/connections/composio.service.ts
+++ b/src/api/v2/connections/composio.service.ts
@@ -107,6 +107,49 @@ export class ComposioService {
   async delete(connectionId: string) {
     return this.composio.connectedAccounts.delete(connectionId);
   }
+
+  /**
+   * Resolve the connectedAccountId for (userId, toolkit) when a grant did not
+   * pin one. Picks the first connection matching the toolkit; returns null if
+   * the account has no connection for it.
+   *
+   * The connectedAccountId is a bearer capability — callers keep it server-side
+   * and never return it to an agent.
+   */
+  async resolveConnectionId(args: {
+    userId: string;
+    toolkit: string;
+  }): Promise<string | null> {
+    const list = await this.composio.connectedAccounts.list({
+      userIds: [args.userId],
+    });
+    const normalized = args.toolkit.toLowerCase();
+    const items: ConnectedAccountListResponseItem[] = list.items;
+    const match = items.find(
+      (item) => item.toolkit.slug.toLowerCase() === normalized,
+    );
+    return match?.id ?? null;
+  }
+
+  /**
+   * Execute a Composio tool action on behalf of an account. The connection is
+   * resolved and injected server-side; the agent never holds or names a
+   * connectedAccountId. `userId` is the data owner (stable accountId).
+   */
+  async execute(args: {
+    action: string;
+    userId: string;
+    arguments: Record<string, unknown>;
+    connectedAccountId?: string;
+  }) {
+    return this.composio.tools.execute(args.action, {
+      userId: args.userId,
+      arguments: args.arguments,
+      ...(args.connectedAccountId
+        ? { connectedAccountId: args.connectedAccountId }
+        : {}),
+    });
+  }
 }
 
 let cached: ComposioService | null = null;

--- a/src/api/v2/connections/composio.service.ts
+++ b/src/api/v2/connections/composio.service.ts
@@ -11,9 +11,17 @@ const AUTH_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000;
 
 type AuthConfigCacheEntry = { authConfigId: string | null; expiresAt: number };
 
+// Toolkit versions are date-stamped releases (e.g. "20260429_00") published a
+// few times a month; an hour of staleness only delays picking up a NEW release,
+// it never serves an invalid version.
+const TOOLKIT_VERSION_CACHE_TTL_MS = 60 * 60 * 1000;
+
+type ToolkitVersionCacheEntry = { version: string; expiresAt: number };
+
 export class ComposioService {
   private composio: Composio;
   private authConfigCache = new Map<string, AuthConfigCacheEntry>();
+  private toolkitVersionCache = new Map<string, ToolkitVersionCacheEntry>();
 
   constructor(args: { composio: Composio }) {
     this.composio = args.composio;
@@ -68,6 +76,49 @@ export class ComposioService {
       expiresAt: now + AUTH_CONFIG_CACHE_TTL_MS,
     });
     return authConfigId;
+  }
+
+  /**
+   * Resolve the CURRENT published version of a toolkit (e.g. "20260429_00").
+   * Composio refuses manual `tools.execute` against the implicit "latest"
+   * version (TOOL_VERSION_REQUIRED), so exec pins the newest version at call
+   * time instead of hardcoding one that silently ages. Versions are
+   * date-stamped (YYYYMMDD_NN), so the lexicographic max is the newest.
+   * Returns null when Composio reports no versions — callers fail closed.
+   * Misses are NOT cached: a transient gap must not stick for an hour.
+   */
+  async resolveToolkitVersion(toolkit: string): Promise<string | null> {
+    const now = Date.now();
+    const normalized = toolkit.toLowerCase();
+    const hit = this.toolkitVersionCache.get(normalized);
+    if (hit && hit.expiresAt > now) {
+      return hit.version;
+    }
+
+    const info = await this.composio.toolkits.get(normalized);
+    const versions = info.meta.availableVersions ?? [];
+    const version = versions.reduce<string | null>(
+      (max, candidate) => (max === null || candidate > max ? candidate : max),
+      null,
+    );
+
+    if (!version) {
+      logger.warn(
+        { toolkit: normalized },
+        "[Composio] resolveToolkitVersion: no available versions",
+      );
+      return null;
+    }
+
+    logger.info(
+      { toolkit: normalized, version },
+      "[Composio] resolveToolkitVersion: resolved",
+    );
+    this.toolkitVersionCache.set(normalized, {
+      version,
+      expiresAt: now + TOOLKIT_VERSION_CACHE_TTL_MS,
+    });
+    return version;
   }
 
   async initiate(args: {
@@ -135,12 +186,15 @@ export class ComposioService {
    * Execute a Composio tool action on behalf of an account. The connection is
    * resolved and injected server-side; the agent never holds or names a
    * connectedAccountId. `userId` is the data owner (stable accountId).
+   * `version` is the pinned toolkit version (see resolveToolkitVersion) —
+   * without it the SDK rejects manual execution (TOOL_VERSION_REQUIRED).
    */
   async execute(args: {
     action: string;
     userId: string;
     arguments: Record<string, unknown>;
     connectedAccountId?: string;
+    version?: string;
   }) {
     return this.composio.tools.execute(args.action, {
       userId: args.userId,
@@ -148,6 +202,7 @@ export class ComposioService {
       ...(args.connectedAccountId
         ? { connectedAccountId: args.connectedAccountId }
         : {}),
+      ...(args.version ? { version: args.version } : {}),
     });
   }
 }

--- a/src/api/v2/connections/connections.router.ts
+++ b/src/api/v2/connections/connections.router.ts
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { completeHandler } from "./handlers/complete";
 import { deleteHandler } from "./handlers/delete";
+import { grantsDeleteHandler } from "./handlers/grants-delete";
+import { grantsListHandler } from "./handlers/grants-list";
+import { grantsPostHandler } from "./handlers/grants-post";
 import { initiateHandler } from "./handlers/initiate";
 import { listHandler } from "./handlers/list";
 
@@ -8,5 +11,13 @@ export const connectionsRouter = Router();
 
 connectionsRouter.post("/initiate", initiateHandler);
 connectionsRouter.post("/complete", completeHandler);
+
+// Capability grants: iOS issues/lists/revokes consent records that the
+// backend's POST /v2/composio/exec reads to authorize agent tool calls.
+// Declared before "/:id" so "/grants" is never swallowed by the param route.
+connectionsRouter.post("/grants", grantsPostHandler);
+connectionsRouter.get("/grants", grantsListHandler);
+connectionsRouter.delete("/grants/:id", grantsDeleteHandler);
+
 connectionsRouter.get("/", listHandler);
 connectionsRouter.delete("/:id", deleteHandler);

--- a/src/api/v2/connections/connections.router.ts
+++ b/src/api/v2/connections/connections.router.ts
@@ -4,6 +4,7 @@ import { deleteHandler } from "./handlers/delete";
 import { grantsDeleteHandler } from "./handlers/grants-delete";
 import { grantsListHandler } from "./handlers/grants-list";
 import { grantsPostHandler } from "./handlers/grants-post";
+import { grantsRevokeHandler } from "./handlers/grants-revoke";
 import { initiateHandler } from "./handlers/initiate";
 import { listHandler } from "./handlers/list";
 
@@ -17,6 +18,10 @@ connectionsRouter.post("/complete", completeHandler);
 // Declared before "/:id" so "/grants" is never swallowed by the param route.
 connectionsRouter.post("/grants", grantsPostHandler);
 connectionsRouter.get("/grants", grantsListHandler);
+// Revoke by natural key (toolkit [+ conversation] [+ grantee]) — reliable even
+// when the client lost the grant id. Declared before "/grants/:id" so "revoke"
+// isn't captured as an :id.
+connectionsRouter.post("/grants/revoke", grantsRevokeHandler);
 connectionsRouter.delete("/grants/:id", grantsDeleteHandler);
 
 connectionsRouter.get("/", listHandler);

--- a/src/api/v2/connections/handlers/grants-delete.ts
+++ b/src/api/v2/connections/handlers/grants-delete.ts
@@ -1,0 +1,45 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const paramsSchema = z.object({ id: z.string().uuid() });
+
+// Revoke a grant. Soft-delete (revokedAt) to keep an audit trail and to match
+// the iOS connection_event.revoked signal. Scoped to the caller's own grants —
+// the WHERE includes ownerAccountId, so a caller can never revoke another
+// account's grant.
+export async function grantsDeleteHandler(req: Request, res: Response) {
+  const accountId = res.locals.accountId;
+  if (!accountId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = paramsSchema.safeParse(req.params);
+  if (!parsed.success) {
+    res.status(400).json({ code: "invalid_request" });
+    return;
+  }
+
+  const result = await prisma.connectionGrant.updateMany({
+    where: {
+      id: parsed.data.id,
+      ownerAccountId: accountId,
+      revokedAt: null,
+    },
+    data: { revokedAt: new Date() },
+  });
+
+  if (result.count === 0) {
+    // Not found, not owned, or already revoked — all indistinguishable to the
+    // caller on purpose (don't leak existence of another account's grant).
+    res.status(404).json({ code: "not_found" });
+    return;
+  }
+
+  req.log.info(
+    { accountId, grantId: parsed.data.id },
+    "[Composio] grant revoked",
+  );
+  res.status(204).end();
+}

--- a/src/api/v2/connections/handlers/grants-list.ts
+++ b/src/api/v2/connections/handlers/grants-list.ts
@@ -1,0 +1,29 @@
+import type { Request, Response } from "express";
+import { prisma } from "@/utils/prisma";
+
+// Lists the caller's own (non-revoked) grants. connectionId is deliberately
+// omitted from the wire — it is a bearer capability that stays backend-side.
+export async function grantsListHandler(req: Request, res: Response) {
+  const accountId = res.locals.accountId;
+  if (!accountId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const grants = await prisma.connectionGrant.findMany({
+    where: { ownerAccountId: accountId, revokedAt: null },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      ownerInboxId: true,
+      granteeInboxId: true,
+      conversationId: true,
+      toolkit: true,
+      actions: true,
+      expiresAt: true,
+      createdAt: true,
+    },
+  });
+
+  res.status(200).json({ grants });
+}

--- a/src/api/v2/connections/handlers/grants-list.ts
+++ b/src/api/v2/connections/handlers/grants-list.ts
@@ -3,6 +3,8 @@ import { prisma } from "@/utils/prisma";
 
 // Lists the caller's own (non-revoked) grants. connectionId is deliberately
 // omitted from the wire — it is a bearer capability that stays backend-side.
+// `actions` (raw Composio slugs) is omitted too: slugs are the backend-only
+// security boundary, clients only ever reason in bundle ids.
 export async function grantsListHandler(req: Request, res: Response) {
   const accountId = res.locals.accountId;
   if (!accountId) {
@@ -19,7 +21,7 @@ export async function grantsListHandler(req: Request, res: Response) {
       granteeInboxId: true,
       conversationId: true,
       toolkit: true,
-      actions: true,
+      bundleIds: true,
       expiresAt: true,
       createdAt: true,
     },

--- a/src/api/v2/connections/handlers/grants-post.ts
+++ b/src/api/v2/connections/handlers/grants-post.ts
@@ -1,0 +1,89 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+// iOS issues a grant when the owner approves a capability request. The owner is
+// taken from the authenticated JWT (res.locals.accountId), never the body, so a
+// caller can only grant access to their own connections.
+const bodySchema = z.object({
+  // The owner's own XMTP inbox. A pointer the agent resolves against; it is
+  // bound to ownerAccountId, so a wrong value only breaks the owner's own
+  // resolution — it cannot reach another account's data.
+  ownerInboxId: z.string().min(1).max(256),
+  // The agent allowed to act (iOS #812 grantedToInboxId).
+  granteeInboxId: z.string().min(1).max(256),
+  conversationId: z.string().min(1).max(256),
+  toolkit: z.string().min(1).max(128),
+  // Allowed action slugs; empty ⇒ whole toolkit.
+  actions: z.array(z.string().min(1).max(128)).max(128).optional(),
+  // Composio connected-account id, when iOS pins it. Bearer capability —
+  // stored backend-side, never returned to an agent.
+  connectionId: z.string().min(1).max(256).optional(),
+  expiresAt: z.string().datetime().optional(),
+});
+
+export async function grantsPostHandler(req: Request, res: Response) {
+  const accountId = res.locals.accountId;
+  if (!accountId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    req.log.warn(
+      { accountId, issues: parsed.error.issues },
+      "[Composio] grant body validation failed",
+    );
+    res
+      .status(400)
+      .json({ code: "invalid_request", issues: parsed.error.issues });
+    return;
+  }
+
+  const {
+    ownerInboxId,
+    granteeInboxId,
+    conversationId,
+    toolkit,
+    actions,
+    connectionId,
+    expiresAt,
+  } = parsed.data;
+
+  // One grant per (owner, grantee, conversation, toolkit): re-approval updates
+  // the same row (refreshes scope/expiry, clears a prior revocation).
+  const grant = await prisma.connectionGrant.upsert({
+    where: {
+      ownerAccountId_granteeInboxId_conversationId_toolkit: {
+        ownerAccountId: accountId,
+        granteeInboxId,
+        conversationId,
+        toolkit,
+      },
+    },
+    create: {
+      ownerAccountId: accountId,
+      ownerInboxId,
+      granteeInboxId,
+      conversationId,
+      toolkit,
+      actions: actions ?? [],
+      connectionId: connectionId ?? null,
+      expiresAt: expiresAt ? new Date(expiresAt) : null,
+    },
+    update: {
+      ownerInboxId,
+      actions: actions ?? [],
+      connectionId: connectionId ?? null,
+      expiresAt: expiresAt ? new Date(expiresAt) : null,
+      revokedAt: null,
+    },
+  });
+
+  req.log.info(
+    { accountId, grantId: grant.id, granteeInboxId, conversationId, toolkit },
+    "[Composio] grant issued",
+  );
+  res.status(200).json({ id: grant.id });
+}

--- a/src/api/v2/connections/handlers/grants-post.ts
+++ b/src/api/v2/connections/handlers/grants-post.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { getServiceConfig } from "@/api/v2/connections/bundles.config";
 import { prisma } from "@/utils/prisma";
 
 // iOS issues a grant when the owner approves a capability request. The owner is
@@ -62,6 +63,26 @@ export async function grantsPostHandler(req: Request, res: Response) {
     serviceVersion,
     expiresAt,
   } = parsed.data;
+
+  // Defense in depth (on top of exec failing closed on unresolvable bundles):
+  // reject unknown bundle ids at write time so a stale/typo'd client gets an
+  // actionable 400 instead of a grant that silently authorizes nothing. Every
+  // bundle id must exist in the catalog for this toolkit; bundleIds against a
+  // toolkit absent from the catalog are equally unknown. Toolkits outside the
+  // catalog stay grantable with empty/absent bundleIds (legacy path).
+  if (bundleIds && bundleIds.length > 0) {
+    const svc = getServiceConfig(toolkit);
+    const known = new Set(svc?.bundles.map((b) => b.id) ?? []);
+    const unknown = bundleIds.find((id) => !known.has(id));
+    if (unknown !== undefined) {
+      req.log.warn(
+        { accountId, toolkit, bundleId: unknown },
+        "[Composio] grant rejected: unknown bundle id",
+      );
+      res.status(400).json({ code: "unknown_bundle", bundleId: unknown });
+      return;
+    }
+  }
 
   // One grant per (owner, grantee, conversation, toolkit): re-approval updates
   // the same row (refreshes scope/expiry, clears a prior revocation).

--- a/src/api/v2/connections/handlers/grants-post.ts
+++ b/src/api/v2/connections/handlers/grants-post.ts
@@ -70,6 +70,10 @@ export async function grantsPostHandler(req: Request, res: Response) {
   // bundle id must exist in the catalog for this toolkit; bundleIds against a
   // toolkit absent from the catalog are equally unknown. Toolkits outside the
   // catalog stay grantable with empty/absent bundleIds (legacy path).
+  // Deprecated bundles are deliberately still grantable: an old app holding a
+  // cached catalog (up to its TTL) may legitimately round-trip one, and the
+  // grant still resolves at exec — so rejecting it would only break old
+  // clients without protecting anything.
   if (bundleIds && bundleIds.length > 0) {
     const svc = getServiceConfig(toolkit);
     const known = new Set(svc?.bundles.map((b) => b.id) ?? []);

--- a/src/api/v2/connections/handlers/grants-post.ts
+++ b/src/api/v2/connections/handlers/grants-post.ts
@@ -16,11 +16,15 @@ const bodySchema = z.object({
   toolkit: z.string().min(1).max(128),
   // Allowed action slugs; empty ⇒ whole toolkit.
   actions: z.array(z.string().min(1).max(128)).max(128).optional(),
-  // Composio connected-account id, when iOS pins it. Bearer capability —
-  // stored backend-side, never returned to an agent.
-  connectionId: z.string().min(1).max(256).optional(),
   expiresAt: z.string().datetime().optional(),
 });
+
+// NOTE: we deliberately do NOT accept a `connectionId` from the client. A
+// connected-account id is a Composio bearer capability and is NOT cross-checked
+// against the owner — accepting one would let a caller pin a *victim's*
+// connection to their own grant. exec resolves the connection server-side from
+// (ownerAccountId, toolkit), which can only ever return the owner's own
+// connections. Any `connectionId` field in the body is silently ignored.
 
 export async function grantsPostHandler(req: Request, res: Response) {
   const accountId = res.locals.accountId;
@@ -47,7 +51,6 @@ export async function grantsPostHandler(req: Request, res: Response) {
     conversationId,
     toolkit,
     actions,
-    connectionId,
     expiresAt,
   } = parsed.data;
 
@@ -69,13 +72,11 @@ export async function grantsPostHandler(req: Request, res: Response) {
       conversationId,
       toolkit,
       actions: actions ?? [],
-      connectionId: connectionId ?? null,
       expiresAt: expiresAt ? new Date(expiresAt) : null,
     },
     update: {
       ownerInboxId,
       actions: actions ?? [],
-      connectionId: connectionId ?? null,
       expiresAt: expiresAt ? new Date(expiresAt) : null,
       revokedAt: null,
     },

--- a/src/api/v2/connections/handlers/grants-post.ts
+++ b/src/api/v2/connections/handlers/grants-post.ts
@@ -14,8 +14,15 @@ const bodySchema = z.object({
   granteeInboxId: z.string().min(1).max(256),
   conversationId: z.string().min(1).max(256),
   toolkit: z.string().min(1).max(128),
-  // Allowed action slugs; empty ⇒ whole toolkit.
+  // Allowed action slugs; empty ⇒ whole toolkit. Legacy/transition — superseded
+  // by bundleIds, kept as a fallback so older clients keep working.
   actions: z.array(z.string().min(1).max(128)).max(128).optional(),
+  // Granted permission-bundle ids (e.g. "calendar.events"). The backend resolves
+  // these to Composio actions at exec; clients never send slugs.
+  bundleIds: z.array(z.string().min(1).max(128)).max(128).optional(),
+  // Catalog service version the client granted against. Stored for
+  // audit/telemetry only — exec resolves bundles against the current catalog.
+  serviceVersion: z.number().int().nonnegative().optional(),
   expiresAt: z.string().datetime().optional(),
 });
 
@@ -51,6 +58,8 @@ export async function grantsPostHandler(req: Request, res: Response) {
     conversationId,
     toolkit,
     actions,
+    bundleIds,
+    serviceVersion,
     expiresAt,
   } = parsed.data;
 
@@ -72,11 +81,15 @@ export async function grantsPostHandler(req: Request, res: Response) {
       conversationId,
       toolkit,
       actions: actions ?? [],
+      bundleIds: bundleIds ?? [],
+      serviceVersion: serviceVersion ?? null,
       expiresAt: expiresAt ? new Date(expiresAt) : null,
     },
     update: {
       ownerInboxId,
       actions: actions ?? [],
+      bundleIds: bundleIds ?? [],
+      serviceVersion: serviceVersion ?? null,
       expiresAt: expiresAt ? new Date(expiresAt) : null,
       revokedAt: null,
     },

--- a/src/api/v2/connections/handlers/grants-revoke.ts
+++ b/src/api/v2/connections/handlers/grants-revoke.ts
@@ -1,0 +1,59 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+// Revoke by NATURAL KEY rather than by grant id. iOS may not hold the backend
+// grant id (the create succeeded but the id-save failed, or the grant predates
+// this flow), which would otherwise strand a live grant the user thinks they
+// revoked. The owner is taken from the JWT, so a caller can only ever revoke
+// their own grants. Filters narrow the scope:
+//   { toolkit }                                   → disconnect: every grant for it
+//   { toolkit, conversationId }                   → un-share in one conversation
+//   { toolkit, conversationId, granteeInboxId }   → one agent
+const bodySchema = z.object({
+  toolkit: z.string().min(1).max(128),
+  conversationId: z.string().min(1).max(256).optional(),
+  granteeInboxId: z.string().min(1).max(256).optional(),
+});
+
+export async function grantsRevokeHandler(req: Request, res: Response) {
+  const accountId = res.locals.accountId;
+  if (!accountId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", issues: parsed.error.issues });
+    return;
+  }
+  const { toolkit, conversationId, granteeInboxId } = parsed.data;
+
+  // Soft-delete (revokedAt), scoped to the caller's own account. Already-revoked
+  // rows are excluded so the count reflects what this call actually changed.
+  const result = await prisma.connectionGrant.updateMany({
+    where: {
+      ownerAccountId: accountId,
+      toolkit,
+      ...(conversationId ? { conversationId } : {}),
+      ...(granteeInboxId ? { granteeInboxId } : {}),
+      revokedAt: null,
+    },
+    data: { revokedAt: new Date() },
+  });
+
+  req.log.info(
+    {
+      accountId,
+      toolkit,
+      conversationId,
+      granteeInboxId,
+      revoked: result.count,
+    },
+    "[Composio] grants revoked by natural key",
+  );
+  res.status(200).json({ revoked: result.count });
+}

--- a/src/api/v2/connections/handlers/services-get.ts
+++ b/src/api/v2/connections/handlers/services-get.ts
@@ -1,0 +1,17 @@
+import type { Request, Response } from "express";
+import { getPublicServiceConfigs } from "@/api/v2/connections/bundles.config";
+
+// GET /v2/connections/services — the connections-picker catalog.
+//
+// Serves the backend-owned service/bundle catalog with Composio action slugs
+// stripped (see toPublicServiceConfig): clients render one card per bundle and
+// persist only bundle ids; the backend alone resolves bundle → actions at exec.
+//
+// JWT-only (authMiddleware), NOT account-scoped: the catalog is the same for
+// everyone, so requireAccount is intentionally not applied (see the mount in
+// src/api/v2/index.ts). The payload is small and stable per deploy; clients
+// refetch on a `version` bump (stale detection), so we set a short cache TTL.
+export function servicesGetHandler(_req: Request, res: Response) {
+  res.setHeader("Cache-Control", "private, max-age=300");
+  res.status(200).json({ services: getPublicServiceConfigs() });
+}

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -1,5 +1,9 @@
 import { Router } from "express";
-import { agentApiKeyAuth, authOrAgentApiKeyAuth } from "@/middleware/agentAuth";
+import {
+  agentApiKeyAuth,
+  authOrAgentApiKeyAuth,
+  composioExecAuth,
+} from "@/middleware/agentAuth";
 import {
   appCheckOnlyMiddleware,
   authMiddleware,
@@ -119,9 +123,11 @@ v2Router.use(
 v2Router.use("/agents", authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
 v2Router.use("/connections", authMiddleware, requireAccount, connectionsRouter);
-// Agent-facing tool execution. Agent API key authenticates the caller; the
-// exec handler authorizes per-account against the trusted identity + grants.
-v2Router.use("/composio", agentApiKeyAuth, composioRouter);
+// Agent-facing tool execution. A DEDICATED exec key (held only by the trusted
+// worker, never in the container, and not injected by the generic convos.internal
+// proxy) authenticates the caller; the exec handler then authorizes per-account
+// against the worker-stamped identity headers + the grant store.
+v2Router.use("/composio", composioExecAuth, composioRouter);
 v2Router.use("/notifications/xmtp", webhookRouter);
 v2Router.use("/notifications", authMiddleware, notificationsRouter);
 // No auth: Apple authenticates via JWS signature, verified inside the handler.

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -33,6 +33,7 @@ import { attachmentsRouter } from "./attachments/attachments.router";
 import { authRouter } from "./auth/auth.router";
 import { composioRouter } from "./composio/composio.router";
 import { connectionsRouter } from "./connections/connections.router";
+import { servicesGetHandler } from "./connections/handlers/services-get";
 import { dailyRefillRouter } from "./credits/daily.router";
 import { devRouter } from "./dev/dev.router";
 import { deviceRouter } from "./device/device.router";
@@ -122,6 +123,11 @@ v2Router.use(
 // limits. authMiddleware applies to the whole subtree.
 v2Router.use("/agents", authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
+// The connections-picker catalog is JWT-only (NOT account-scoped): the catalog
+// is identical for every user, so requireAccount is deliberately not applied.
+// Declared BEFORE the requireAccount-gated /connections mount so this more
+// specific path is matched first and never forced through requireAccount.
+v2Router.get("/connections/services", authMiddleware, servicesGetHandler);
 v2Router.use("/connections", authMiddleware, requireAccount, connectionsRouter);
 // Agent-facing tool execution. A DEDICATED exec key (held only by the trusted
 // worker, never in the container, and not injected by the generic convos.internal

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -27,6 +27,7 @@ import { renewBatchHandler } from "./assets/handlers/renew-batch";
 import { testLifecycleHandler } from "./assets/handlers/test-lifecycle";
 import { attachmentsRouter } from "./attachments/attachments.router";
 import { authRouter } from "./auth/auth.router";
+import { composioRouter } from "./composio/composio.router";
 import { connectionsRouter } from "./connections/connections.router";
 import { dailyRefillRouter } from "./credits/daily.router";
 import { devRouter } from "./dev/dev.router";
@@ -118,6 +119,9 @@ v2Router.use(
 v2Router.use("/agents", authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
 v2Router.use("/connections", authMiddleware, requireAccount, connectionsRouter);
+// Agent-facing tool execution. Agent API key authenticates the caller; the
+// exec handler authorizes per-account against the trusted identity + grants.
+v2Router.use("/composio", agentApiKeyAuth, composioRouter);
 v2Router.use("/notifications/xmtp", webhookRouter);
 v2Router.use("/notifications", authMiddleware, notificationsRouter);
 // No auth: Apple authenticates via JWS signature, verified inside the handler.

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,12 @@ export const AGENT_ASSETS_API_KEY = process.env.AGENT_ASSETS_API_KEY || "";
 // Composio (optional — /v2/connections/* endpoints return 503 if not configured).
 // Auth configs are resolved dynamically from Composio by toolkit slug; no local mapping.
 export const COMPOSIO_API_KEY = process.env.COMPOSIO_API_KEY || "";
+// Dedicated credential for POST /v2/composio/exec — held ONLY by the trusted
+// assistants worker, never forwarded into the agent container. Distinct from
+// AGENT_ASSETS_API_KEY so the worker's generic convos.internal proxy (which
+// injects the agent key for any backend path) cannot satisfy the exec auth.
+// Endpoint returns 503 if unset.
+export const COMPOSIO_EXEC_API_KEY = process.env.COMPOSIO_EXEC_API_KEY || "";
 export const COMPOSIO_CONNECTION_CALLBACK_URL =
   process.env.COMPOSIO_CONNECTION_CALLBACK_URL ||
   "convos://connections/callback";

--- a/src/middleware/agentAuth.ts
+++ b/src/middleware/agentAuth.ts
@@ -1,11 +1,16 @@
 import { createHash, timingSafeEqual } from "crypto";
 import type { NextFunction, Request, Response } from "express";
-import { AGENT_ASSETS_API_KEY } from "@/config";
+import { AGENT_ASSETS_API_KEY, COMPOSIO_EXEC_API_KEY } from "@/config";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { maskKeyPrefix } from "@/utils/mask";
 import { authMiddleware } from "./auth";
 
 export const AGENT_API_KEY_HEADER = "X-Agent-API-Key";
+// Dedicated header for the Composio exec endpoint. The trusted worker's
+// proxyComposioExec sets it; the generic convos.internal proxy never does, so a
+// container that smuggles a request to /api/v2/composio/exec through the generic
+// proxy cannot authenticate (it has no way to produce this secret).
+export const COMPOSIO_EXEC_API_KEY_HEADER = "X-Composio-Exec-Key";
 const MIN_AGENT_API_KEY_LENGTH = 32;
 
 // ---------------------------------------------------------------------------
@@ -83,6 +88,68 @@ export const agentApiKeyAuth = (
       "agent_api_key.unauthorized",
     );
     res.status(401).json({ error: "Invalid or missing agent API key" });
+    return;
+  }
+
+  next();
+};
+
+// ---------------------------------------------------------------------------
+// Composio exec auth — separate secret, separate header (see header doc above)
+// ---------------------------------------------------------------------------
+
+let _composioExecApiKeyOverride: string | null | undefined = undefined;
+
+function getComposioExecApiKey(): string {
+  if (_composioExecApiKeyOverride !== undefined) {
+    return (_composioExecApiKeyOverride ?? "").trim();
+  }
+  return COMPOSIO_EXEC_API_KEY.trim();
+}
+
+/** Override `COMPOSIO_EXEC_API_KEY` for tests (same contract as the agent-key
+ *  override: string overrides, `null` simulates unset → 503, `undefined`
+ *  clears). */
+export function __setComposioExecApiKeyOverrideForTests(
+  key: string | null | undefined,
+): void {
+  _composioExecApiKeyOverride = key;
+}
+
+/**
+ * Authenticates POST /v2/composio/exec against COMPOSIO_EXEC_API_KEY via the
+ * X-Composio-Exec-Key header. Deliberately distinct from agentApiKeyAuth: the
+ * worker's generic convos.internal proxy injects the *agent* key for arbitrary
+ * backend paths, so reusing it here would let a container smuggle an exec call
+ * (with forged identity headers) through that proxy. This secret lives only in
+ * the worker and is set only by proxyComposioExec.
+ */
+export const composioExecAuth = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const expectedKey = getComposioExecApiKey();
+
+  if (!expectedKey || expectedKey.length < MIN_AGENT_API_KEY_LENGTH) {
+    req.log.error("composio_exec_api_key.not_configured");
+    res.status(503).json({ error: "Composio exec API key not configured" });
+    return;
+  }
+
+  const providedKey = req.header(COMPOSIO_EXEC_API_KEY_HEADER)?.trim() ?? "";
+  if (!providedKey) {
+    req.log.warn({ reason: "missing" }, "composio_exec_api_key.unauthorized");
+    res.status(401).json({ error: "Invalid or missing Composio exec key" });
+    return;
+  }
+
+  if (!constantTimeSecretCompare(providedKey, expectedKey)) {
+    req.log.warn(
+      { reason: "mismatch", providedPrefix: maskKeyPrefix(providedKey) },
+      "composio_exec_api_key.unauthorized",
+    );
+    res.status(401).json({ error: "Invalid or missing Composio exec key" });
     return;
   }
 

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -11,8 +11,8 @@ import {
 } from "vitest";
 import { composioRouter } from "@/api/v2/composio/composio.router";
 import {
-  __setTrustedCallerResolverForTests,
-  type TrustedCaller,
+  AGENT_INBOX_ID_HEADER,
+  CONVERSATION_ID_HEADER,
 } from "@/api/v2/composio/trusted-identity";
 import {
   __resetComposioServiceForTests,
@@ -82,18 +82,35 @@ function installComposioStub(
   );
 }
 
-function trust(caller: TrustedCaller | null) {
-  __setTrustedCallerResolverForTests(
-    caller ? () => Promise.resolve(caller) : null,
-  );
+// In production these headers are stamped by the trusted assistants worker
+// (which alone holds the agent API key); the container never sets them.
+function workerHeaders(
+  caller: { conversationId?: string; agentInboxId?: string } = {
+    conversationId: CONVERSATION,
+    agentInboxId: AGENT_INBOX,
+  },
+): Record<string, string> {
+  return {
+    ...(caller.conversationId
+      ? { [CONVERSATION_ID_HEADER]: caller.conversationId }
+      : {}),
+    ...(caller.agentInboxId
+      ? { [AGENT_INBOX_ID_HEADER]: caller.agentInboxId }
+      : {}),
+  };
 }
 
-function exec(body: unknown, key: string | null = AGENT_KEY) {
+function exec(
+  body: unknown,
+  opts: { key?: string | null; headers?: Record<string, string> } = {},
+) {
+  const key = opts.key === undefined ? AGENT_KEY : opts.key;
   return fetch(`${baseURL}/api/v2/composio/exec`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...(key ? { [AGENT_API_KEY_HEADER]: key } : {}),
+      ...(opts.headers ?? {}),
     },
     body: JSON.stringify(body),
   });
@@ -126,11 +143,9 @@ afterAll(async () => {
   });
   __setAgentAssetsApiKeyOverrideForTests(undefined);
   __resetComposioServiceForTests(null);
-  __setTrustedCallerResolverForTests(null);
 });
 
 afterEach(() => {
-  __setTrustedCallerResolverForTests(null);
   __resetComposioServiceForTests(null);
 });
 
@@ -138,23 +153,25 @@ afterEach(() => {
 
 describe("POST /v2/composio/exec — auth + fail-closed (no DB)", () => {
   test("401 without an agent API key", async () => {
-    const res = await exec(VALID_BODY, null);
+    const res = await exec(VALID_BODY, { key: null });
     expect(res.status).toBe(401);
   });
 
   test("401 with a wrong agent API key", async () => {
-    const res = await exec(VALID_BODY, "wrong".repeat(10));
+    const res = await exec(VALID_BODY, { key: "wrong".repeat(10) });
     expect(res.status).toBe(401);
   });
 
   test("400 on an invalid body (missing action)", async () => {
-    const res = await exec({ toolkit: "googlecalendar" });
+    const res = await exec(
+      { toolkit: "googlecalendar" },
+      { headers: workerHeaders() },
+    );
     expect(res.status).toBe(400);
     expect((await asJson<{ code: string }>(res)).code).toBe("invalid_request");
   });
 
-  test("403 fail-closed when no trusted identity is available", async () => {
-    // Default resolver returns null — the agent cannot be authorized.
+  test("403 fail-closed when the worker identity headers are absent", async () => {
     const res = await exec(VALID_BODY);
     expect(res.status).toBe(403);
     expect((await asJson<{ code: string }>(res)).code).toBe(
@@ -162,9 +179,32 @@ describe("POST /v2/composio/exec — auth + fail-closed (no DB)", () => {
     );
   });
 
-  test("agent-named fields cannot substitute for a trusted identity", async () => {
+  test("403 fail-closed when only one identity header is present", async () => {
+    const res = await exec(VALID_BODY, {
+      headers: workerHeaders({ conversationId: CONVERSATION }),
+    });
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe(
+      "trusted_identity_unavailable",
+    );
+  });
+
+  test("403 fail-closed on an oversized identity header", async () => {
+    const res = await exec(VALID_BODY, {
+      headers: workerHeaders({
+        conversationId: "c".repeat(300),
+        agentInboxId: AGENT_INBOX,
+      }),
+    });
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe(
+      "trusted_identity_unavailable",
+    );
+  });
+
+  test("agent-named body fields cannot substitute for the identity headers", async () => {
     // Even if the agent stuffs identity-looking fields into the body, exec
-    // still fail-closes: resolution ignores the body entirely.
+    // still fail-closes: resolution reads only the worker-stamped headers.
     const res = await exec({
       ...VALID_BODY,
       conversationId: CONVERSATION,
@@ -197,7 +237,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     accountIds.length = 0;
   });
 
-  test("executes when a live grant matches the trusted caller", async () => {
+  test("executes when a live grant matches the worker-stamped caller", async () => {
     const ownerAccountId = await makeAccount();
     await prisma.connectionGrant.create({
       data: {
@@ -217,9 +257,8 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         return Promise.resolve({ data: { events: [] } });
       },
     });
-    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
 
-    const res = await exec(VALID_BODY);
+    const res = await exec(VALID_BODY, { headers: workerHeaders() });
     expect(res.status).toBe(200);
     expect((await asJson<{ data: unknown }>(res)).data).toEqual({ events: [] });
     // Composio is called with the OWNER's accountId, resolved server-side.
@@ -231,8 +270,31 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
 
   test("403 no_grant when the agent holds no grant here", async () => {
     installComposioStub();
-    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
-    const res = await exec(VALID_BODY);
+    const res = await exec(VALID_BODY, { headers: workerHeaders() });
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+  });
+
+  test("403 no_grant for the same agent in a DIFFERENT conversation", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        connectionId: "conn_pinned",
+      },
+    });
+    installComposioStub();
+    const res = await exec(VALID_BODY, {
+      headers: workerHeaders({
+        conversationId: "conv-other",
+        agentInboxId: AGENT_INBOX,
+      }),
+    });
     expect(res.status).toBe(403);
     expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
   });
@@ -251,11 +313,10 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
       },
     });
     installComposioStub();
-    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
-    const res = await exec({
-      ...VALID_BODY,
-      action: "GOOGLECALENDAR_EVENTS_DELETE",
-    });
+    const res = await exec(
+      { ...VALID_BODY, action: "GOOGLECALENDAR_EVENTS_DELETE" },
+      { headers: workerHeaders() },
+    );
     expect(res.status).toBe(403);
     expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
   });
@@ -275,8 +336,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
       },
     });
     installComposioStub();
-    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
-    const res = await exec(VALID_BODY);
+    const res = await exec(VALID_BODY, { headers: workerHeaders() });
     expect(res.status).toBe(403);
     expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
   });
@@ -298,8 +358,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
       });
     }
     installComposioStub();
-    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
-    const res = await exec(VALID_BODY);
+    const res = await exec(VALID_BODY, { headers: workerHeaders() });
     expect(res.status).toBe(409);
     expect((await asJson<{ code: string }>(res)).code).toBe("ambiguous_grant");
   });
@@ -327,8 +386,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         { id: "conn_resolved", userId: ownerAccountId, slug: "googlecalendar" },
       ],
     });
-    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
-    const res = await exec(VALID_BODY);
+    const res = await exec(VALID_BODY, { headers: workerHeaders() });
     expect(res.status).toBe(200);
     expect(seen).toMatchObject({ connectedAccountId: "conn_resolved" });
   });

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -19,9 +19,9 @@ import {
   ComposioService,
 } from "@/api/v2/connections/composio.service";
 import {
-  __setAgentAssetsApiKeyOverrideForTests,
-  AGENT_API_KEY_HEADER,
-  agentApiKeyAuth,
+  __setComposioExecApiKeyOverrideForTests,
+  COMPOSIO_EXEC_API_KEY_HEADER,
+  composioExecAuth,
 } from "@/middleware/agentAuth";
 import { jsonMiddleware } from "@/middleware/json";
 import { pinoMiddleware } from "@/middleware/pino";
@@ -31,14 +31,14 @@ vi.mock("firebase-admin/app");
 vi.mock("firebase-admin/app-check");
 vi.mock("firebase-admin/messaging");
 
-const AGENT_KEY = "x".repeat(40);
+const EXEC_KEY = "x".repeat(40);
 const AGENT_INBOX = "agent-inbox-1";
 const CONVERSATION = "conv-1";
 
 const app = express();
 app.use(pinoMiddleware);
 app.use(jsonMiddleware);
-app.use("/api/v2/composio", agentApiKeyAuth, composioRouter);
+app.use("/api/v2/composio", composioExecAuth, composioRouter);
 
 let server: Server;
 const baseURL = "http://localhost:4014";
@@ -104,12 +104,12 @@ function exec(
   body: unknown,
   opts: { key?: string | null; headers?: Record<string, string> } = {},
 ) {
-  const key = opts.key === undefined ? AGENT_KEY : opts.key;
+  const key = opts.key === undefined ? EXEC_KEY : opts.key;
   return fetch(`${baseURL}/api/v2/composio/exec`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...(key ? { [AGENT_API_KEY_HEADER]: key } : {}),
+      ...(key ? { [COMPOSIO_EXEC_API_KEY_HEADER]: key } : {}),
       ...(opts.headers ?? {}),
     },
     body: JSON.stringify(body),
@@ -127,7 +127,7 @@ const VALID_BODY = {
 };
 
 beforeAll(async () => {
-  __setAgentAssetsApiKeyOverrideForTests(AGENT_KEY);
+  __setComposioExecApiKeyOverrideForTests(EXEC_KEY);
   await new Promise<void>((resolve) => {
     server = app.listen(4014, () => {
       resolve();
@@ -141,7 +141,7 @@ afterAll(async () => {
       resolve();
     });
   });
-  __setAgentAssetsApiKeyOverrideForTests(undefined);
+  __setComposioExecApiKeyOverrideForTests(undefined);
   __resetComposioServiceForTests(null);
 });
 
@@ -237,7 +237,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     accountIds.length = 0;
   });
 
-  test("executes when a live grant matches the worker-stamped caller", async () => {
+  test("executes when a live grant matches — connection resolved server-side", async () => {
     const ownerAccountId = await makeAccount();
     await prisma.connectionGrant.create({
       data: {
@@ -247,7 +247,6 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         conversationId: CONVERSATION,
         toolkit: "googlecalendar",
         actions: [],
-        connectionId: "conn_pinned",
       },
     });
     let seen: { userId: string; connectedAccountId?: string } | null = null;
@@ -256,16 +255,56 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         seen = body;
         return Promise.resolve({ data: { events: [] } });
       },
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
     });
 
     const res = await exec(VALID_BODY, { headers: workerHeaders() });
     expect(res.status).toBe(200);
     expect((await asJson<{ data: unknown }>(res)).data).toEqual({ events: [] });
-    // Composio is called with the OWNER's accountId, resolved server-side.
+    // Composio is called with the OWNER's accountId and a connection resolved
+    // from that account — never a client-supplied id.
     expect(seen).toMatchObject({
       userId: ownerAccountId,
-      connectedAccountId: "conn_pinned",
+      connectedAccountId: "conn_owned",
     });
+  });
+
+  test("a client-supplied connection id in the body is ignored (#2)", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+      },
+    });
+    let seen: { connectedAccountId?: string } | null = null;
+    installComposioStub({
+      execute: (_slug, body) => {
+        seen = body;
+        return Promise.resolve({ data: {} });
+      },
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+    });
+    // The agent tries to smuggle a foreign connection id; exec must ignore it
+    // and use the owner's own resolved connection.
+    const res = await exec(
+      {
+        ...VALID_BODY,
+        connectionId: "ca_victim",
+        connectedAccountId: "ca_victim",
+      },
+      { headers: workerHeaders() },
+    );
+    expect(res.status).toBe(200);
+    expect(seen).toMatchObject({ connectedAccountId: "conn_owned" });
   });
 
   test("403 no_grant when the agent holds no grant here", async () => {
@@ -285,7 +324,6 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         conversationId: CONVERSATION,
         toolkit: "googlecalendar",
         actions: [],
-        connectionId: "conn_pinned",
       },
     });
     installComposioStub();
@@ -309,7 +347,6 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         conversationId: CONVERSATION,
         toolkit: "googlecalendar",
         actions: ["GOOGLECALENDAR_EVENTS_LIST"],
-        connectionId: "conn_pinned",
       },
     });
     installComposioStub();
@@ -331,7 +368,6 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         conversationId: CONVERSATION,
         toolkit: "googlecalendar",
         actions: [],
-        connectionId: "conn_pinned",
         revokedAt: new Date(),
       },
     });
@@ -341,53 +377,68 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
   });
 
-  test("409 ambiguous_grant when two owners shared the toolkit in one conversation", async () => {
-    const ownerA = await makeAccount();
-    const ownerB = await makeAccount();
-    for (const ownerAccountId of [ownerA, ownerB]) {
-      await prisma.connectionGrant.create({
-        data: {
-          ownerAccountId,
-          ownerInboxId: `inbox-${ownerAccountId}`,
-          granteeInboxId: AGENT_INBOX,
-          conversationId: CONVERSATION,
-          toolkit: "googlecalendar",
-          actions: [],
-          connectionId: `conn_${ownerAccountId}`,
-        },
-      });
+  describe("onBehalfOf owner selector (group queries)", () => {
+    async function seedTwoOwners() {
+      const alice = await makeAccount();
+      const bob = await makeAccount();
+      for (const [accountId, inbox] of [
+        [alice, "alice-inbox"],
+        [bob, "bob-inbox"],
+      ] as const) {
+        await prisma.connectionGrant.create({
+          data: {
+            ownerAccountId: accountId,
+            ownerInboxId: inbox,
+            granteeInboxId: AGENT_INBOX,
+            conversationId: CONVERSATION,
+            toolkit: "googlecalendar",
+            actions: [],
+          },
+        });
+      }
+      return { alice, bob };
     }
-    installComposioStub();
-    const res = await exec(VALID_BODY, { headers: workerHeaders() });
-    expect(res.status).toBe(409);
-    expect((await asJson<{ code: string }>(res)).code).toBe("ambiguous_grant");
-  });
 
-  test("resolves the connection from (owner, toolkit) when the grant pins none", async () => {
-    const ownerAccountId = await makeAccount();
-    await prisma.connectionGrant.create({
-      data: {
-        ownerAccountId,
-        ownerInboxId: "owner-inbox",
-        granteeInboxId: AGENT_INBOX,
-        conversationId: CONVERSATION,
-        toolkit: "googlecalendar",
-        actions: [],
-        connectionId: null,
-      },
+    test("409 ambiguous_grant when two owners shared and onBehalfOf is omitted", async () => {
+      await seedTwoOwners();
+      installComposioStub();
+      const res = await exec(VALID_BODY, { headers: workerHeaders() });
+      expect(res.status).toBe(409);
+      expect((await asJson<{ code: string }>(res)).code).toBe(
+        "ambiguous_grant",
+      );
     });
-    let seen: { connectedAccountId?: string } | null = null;
-    installComposioStub({
-      execute: (_slug, body) => {
-        seen = body;
-        return Promise.resolve({ data: {} });
-      },
-      connections: [
-        { id: "conn_resolved", userId: ownerAccountId, slug: "googlecalendar" },
-      ],
+
+    test("onBehalfOf selects that member's own connection", async () => {
+      const { bob } = await seedTwoOwners();
+      let seen: { userId: string; connectedAccountId?: string } | null = null;
+      installComposioStub({
+        execute: (_slug, body) => {
+          seen = body;
+          return Promise.resolve({ data: { ok: true } });
+        },
+        connections: [{ id: "conn_bob", userId: bob, slug: "googlecalendar" }],
+      });
+      const res = await exec(
+        { ...VALID_BODY, onBehalfOf: "bob-inbox" },
+        { headers: workerHeaders() },
+      );
+      expect(res.status).toBe(200);
+      expect(seen).toMatchObject({
+        userId: bob,
+        connectedAccountId: "conn_bob",
+      });
     });
-    const res = await exec(VALID_BODY, { headers: workerHeaders() });
-    expect(res.status).toBe(200);
-    expect(seen).toMatchObject({ connectedAccountId: "conn_resolved" });
+
+    test("403 no_grant when onBehalfOf names a member who never granted", async () => {
+      await seedTwoOwners();
+      installComposioStub();
+      const res = await exec(
+        { ...VALID_BODY, onBehalfOf: "carol-inbox" },
+        { headers: workerHeaders() },
+      );
+      expect(res.status).toBe(403);
+      expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+    });
   });
 });

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -601,6 +601,10 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
   });
 
   test("read-only bundle: read is allowed, writes are no_grant", async () => {
+    // calendar.events.read is DEPRECATED since googlecalendar v4 (hidden from
+    // the public catalog) but real grants persist it — this test is the
+    // backward-compat guarantee that those grants keep resolving to LIST,
+    // and ONLY to LIST, at exec time.
     const ownerAccountId = await makeAccount();
     await prisma.connectionGrant.create({
       data: {

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -359,11 +359,10 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
   });
 
   // Bundle scope: a grant carrying bundleIds authorizes exactly the actions the
-  // bundle resolves to (resolveBundleActions against the current catalog). The
-  // "calendar.events" bundle includes LIST/CREATE/UPDATE/DELETE but a different
-  // bundle limited to reads must NOT authorize a write. We exercise the boundary
-  // by granting only "calendar.events" and asserting an action OUTSIDE it (a
-  // settings action) is rejected, while an in-bundle action is allowed.
+  // bundle resolves to (resolveBundleActions against the current catalog) — no
+  // more. In-bundle actions are allowed, out-of-bundle actions are no_grant,
+  // a read-only bundle never authorizes a write, and unresolvable bundle ids
+  // fail CLOSED (never the whole-toolkit transition default).
   test("bundle scope: an action inside the granted bundle is allowed", async () => {
     const ownerAccountId = await makeAccount();
     await prisma.connectionGrant.create({
@@ -416,6 +415,107 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     );
     expect(res.status).toBe(403);
     expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+  });
+
+  test("fail-closed: unresolvable bundleIds authorize NOTHING (codex exploit)", async () => {
+    // The exploit: a grant whose bundleIds don't resolve against the catalog
+    // used to fall through to the whole-toolkit transition default (fail-open).
+    // It must now be inapplicable for EVERY action — read or write.
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        bundleIds: ["calendar.bogus"],
+        serviceVersion: 2,
+      },
+    });
+    installComposioStub({
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+    });
+    for (const action of [
+      "GOOGLECALENDAR_LIST_EVENTS",
+      "GOOGLECALENDAR_DELETE_EVENT",
+    ]) {
+      const res = await exec(
+        { ...VALID_BODY, action },
+        { headers: workerHeaders() },
+      );
+      expect(res.status).toBe(403);
+      expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+    }
+  });
+
+  test("read-only bundle: read is allowed, writes are no_grant", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        bundleIds: ["calendar.events.read"],
+        serviceVersion: 2,
+      },
+    });
+    installComposioStub({
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+    });
+
+    const read = await exec(
+      { ...VALID_BODY, action: "GOOGLECALENDAR_LIST_EVENTS" },
+      { headers: workerHeaders() },
+    );
+    expect(read.status).toBe(200);
+
+    for (const action of [
+      "GOOGLECALENDAR_CREATE_EVENT",
+      "GOOGLECALENDAR_DELETE_EVENT",
+    ]) {
+      const res = await exec(
+        { ...VALID_BODY, action },
+        { headers: workerHeaders() },
+      );
+      expect(res.status).toBe(403);
+      expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+    }
+  });
+
+  test("legacy transition: no actions AND no bundleIds still means whole-toolkit", async () => {
+    // The transition default survives ONLY for true legacy grants (both scope
+    // fields empty) — even a write action passes. Tightens once clients always
+    // send bundleIds.
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+      },
+    });
+    installComposioStub({
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+    });
+    const res = await exec(
+      { ...VALID_BODY, action: "GOOGLECALENDAR_DELETE_EVENT" },
+      { headers: workerHeaders() },
+    );
+    expect(res.status).toBe(200);
   });
 
   test("403 no_grant once the grant is revoked", async () => {

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -358,6 +358,66 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
   });
 
+  // Bundle scope: a grant carrying bundleIds authorizes exactly the actions the
+  // bundle resolves to (resolveBundleActions against the current catalog). The
+  // "calendar.events" bundle includes LIST/CREATE/UPDATE/DELETE but a different
+  // bundle limited to reads must NOT authorize a write. We exercise the boundary
+  // by granting only "calendar.events" and asserting an action OUTSIDE it (a
+  // settings action) is rejected, while an in-bundle action is allowed.
+  test("bundle scope: an action inside the granted bundle is allowed", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        bundleIds: ["calendar.events"],
+        serviceVersion: 1,
+      },
+    });
+    installComposioStub({
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+    });
+    const res = await exec(
+      { ...VALID_BODY, action: "GOOGLECALENDAR_CREATE_EVENT" },
+      { headers: workerHeaders() },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("bundle scope: an action outside the granted bundle is no_grant", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        bundleIds: ["calendar.events"],
+        serviceVersion: 1,
+      },
+    });
+    installComposioStub({
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+    });
+    // Not in the calendar.events bundle's action list.
+    const res = await exec(
+      { ...VALID_BODY, action: "GOOGLECALENDAR_DELETE_CALENDAR" },
+      { headers: workerHeaders() },
+    );
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+  });
+
   test("403 no_grant once the grant is revoked", async () => {
     const ownerAccountId = await makeAccount();
     await prisma.connectionGrant.create({

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -43,15 +43,23 @@ app.use("/api/v2/composio", composioExecAuth, composioRouter);
 let server: Server;
 const baseURL = "http://localhost:4014";
 
-// Minimal Composio stub: exec touches tools.execute and (when a grant pins no
-// connection) connectedAccounts.list.
+// The toolkit version the stub publishes; exec must pin it on every execute.
+const STUB_TOOLKIT_VERSION = "20260429_00";
+
+// Minimal Composio stub: exec touches tools.execute, toolkits.get (version
+// pinning) and (when a grant pins no connection) connectedAccounts.list.
 function installComposioStub(
   opts: {
     execute?: (
       slug: string,
-      body: { userId: string; connectedAccountId?: string },
+      body: {
+        userId: string;
+        connectedAccountId?: string;
+        version?: string;
+      },
     ) => Promise<unknown>;
     connections?: Array<{ id: string; userId: string; slug: string }>;
+    toolkitVersions?: string[];
   } = {},
 ) {
   const stub = {
@@ -62,6 +70,14 @@ function installComposioStub(
           _slug: string,
           _body: { userId: string; connectedAccountId?: string },
         ) => Promise.resolve({ data: { ok: true } })),
+    },
+    toolkits: {
+      get: (_slug: string) =>
+        Promise.resolve({
+          meta: {
+            availableVersions: opts.toolkitVersions ?? [STUB_TOOLKIT_VERSION],
+          },
+        }),
     },
     connectedAccounts: {
       list: (query: { userIds?: string[] }) => {
@@ -218,6 +234,99 @@ describe("POST /v2/composio/exec — auth + fail-closed (no DB)", () => {
   });
 });
 
+// --- No DB required: toolkit version resolution (unit) ---
+
+describe("ComposioService.resolveToolkitVersion (no DB)", () => {
+  function makeService(
+    get: (slug: string) => Promise<unknown>,
+  ): ComposioService {
+    const stub = { toolkits: { get } };
+    return new ComposioService({
+      composio: stub as unknown as ConstructorParameters<
+        typeof ComposioService
+      >[0]["composio"],
+    });
+  }
+
+  test("resolves the NEWEST version (lexicographic max), not list order", async () => {
+    const service = makeService(() =>
+      Promise.resolve({
+        meta: {
+          availableVersions: ["20260427_00", "20260429_00", "20260422_01"],
+        },
+      }),
+    );
+    expect(await service.resolveToolkitVersion("googlecalendar")).toBe(
+      "20260429_00",
+    );
+  });
+
+  test("caches per toolkit and normalizes the slug case", async () => {
+    let calls = 0;
+    const service = makeService((slug) => {
+      calls += 1;
+      expect(slug).toBe("googlecalendar");
+      return Promise.resolve({ meta: { availableVersions: ["20260429_00"] } });
+    });
+    expect(await service.resolveToolkitVersion("googlecalendar")).toBe(
+      "20260429_00",
+    );
+    expect(await service.resolveToolkitVersion("GoogleCalendar")).toBe(
+      "20260429_00",
+    );
+    expect(calls).toBe(1);
+  });
+
+  test("returns null when no versions are published — and does NOT cache the miss", async () => {
+    let calls = 0;
+    const service = makeService(() => {
+      calls += 1;
+      return Promise.resolve({
+        meta:
+          calls === 1
+            ? { availableVersions: [] }
+            : { availableVersions: ["20260429_00"] },
+      });
+    });
+    expect(await service.resolveToolkitVersion("googlecalendar")).toBeNull();
+    // A transient gap must not stick: the next call retries and succeeds.
+    expect(await service.resolveToolkitVersion("googlecalendar")).toBe(
+      "20260429_00",
+    );
+    expect(calls).toBe(2);
+  });
+
+  test("returns null when availableVersions is absent from the response", async () => {
+    const service = makeService(() => Promise.resolve({ meta: {} }));
+    expect(await service.resolveToolkitVersion("googlecalendar")).toBeNull();
+  });
+
+  test("execute forwards the pinned version to the SDK", async () => {
+    let seen: { version?: string } | null = null;
+    const stub = {
+      tools: {
+        execute: (_slug: string, body: { version?: string }) => {
+          seen = body;
+          return Promise.resolve({ data: {} });
+        },
+      },
+    };
+    const service = new ComposioService({
+      composio: stub as unknown as ConstructorParameters<
+        typeof ComposioService
+      >[0]["composio"],
+    });
+    await service.execute({
+      action: "GOOGLECALENDAR_EVENTS_LIST",
+      userId: "acct-1",
+      arguments: {},
+      connectedAccountId: "conn-1",
+      version: "20260429_00",
+    });
+    expect(seen).toMatchObject({ version: "20260429_00" });
+  });
+});
+
 // --- DB-backed: requires the test Postgres (pnpm test:local) ---
 
 describe("POST /v2/composio/exec — grant authorization (DB)", () => {
@@ -249,7 +358,11 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
         actions: [],
       },
     });
-    let seen: { userId: string; connectedAccountId?: string } | null = null;
+    let seen: {
+      userId: string;
+      connectedAccountId?: string;
+      version?: string;
+    } | null = null;
     installComposioStub({
       execute: (_slug, body) => {
         seen = body;
@@ -263,12 +376,47 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     const res = await exec(VALID_BODY, { headers: workerHeaders() });
     expect(res.status).toBe(200);
     expect((await asJson<{ data: unknown }>(res)).data).toEqual({ events: [] });
-    // Composio is called with the OWNER's accountId and a connection resolved
-    // from that account — never a client-supplied id.
+    // Composio is called with the OWNER's accountId, a connection resolved
+    // from that account — never a client-supplied id — and the toolkit's
+    // current version pinned (manual exec rejects implicit "latest").
     expect(seen).toMatchObject({
       userId: ownerAccountId,
       connectedAccountId: "conn_owned",
+      version: STUB_TOOLKIT_VERSION,
     });
+  });
+
+  test("502 toolkit_version_unresolved when Composio reports no versions — fail closed", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+      },
+    });
+    let executed = false;
+    installComposioStub({
+      execute: () => {
+        executed = true;
+        return Promise.resolve({ data: {} });
+      },
+      connections: [
+        { id: "conn_owned", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+      toolkitVersions: [],
+    });
+
+    const res = await exec(VALID_BODY, { headers: workerHeaders() });
+    expect(res.status).toBe(502);
+    expect((await asJson<{ code: string }>(res)).code).toBe(
+      "toolkit_version_unresolved",
+    );
+    // Fail closed means the tool is never executed unversioned.
+    expect(executed).toBe(false);
   });
 
   test("a client-supplied connection id in the body is ignored (#2)", async () => {

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -351,7 +351,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     });
     installComposioStub();
     const res = await exec(
-      { ...VALID_BODY, action: "GOOGLECALENDAR_EVENTS_DELETE" },
+      { ...VALID_BODY, action: "GOOGLECALENDAR_DELETE_EVENT" },
       { headers: workerHeaders() },
     );
     expect(res.status).toBe(403);
@@ -410,7 +410,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     });
     // Not in the calendar.events bundle's action list.
     const res = await exec(
-      { ...VALID_BODY, action: "GOOGLECALENDAR_DELETE_CALENDAR" },
+      { ...VALID_BODY, action: "GOOGLECALENDAR_CALENDARS_DELETE" },
       { headers: workerHeaders() },
     );
     expect(res.status).toBe(403);
@@ -440,7 +440,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
       ],
     });
     for (const action of [
-      "GOOGLECALENDAR_LIST_EVENTS",
+      "GOOGLECALENDAR_EVENTS_LIST",
       "GOOGLECALENDAR_DELETE_EVENT",
     ]) {
       const res = await exec(
@@ -473,7 +473,7 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
     });
 
     const read = await exec(
-      { ...VALID_BODY, action: "GOOGLECALENDAR_LIST_EVENTS" },
+      { ...VALID_BODY, action: "GOOGLECALENDAR_EVENTS_LIST" },
       { headers: workerHeaders() },
     );
     expect(read.status).toBe(200);

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -1,0 +1,335 @@
+import type { Server } from "node:http";
+import express from "express";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { composioRouter } from "@/api/v2/composio/composio.router";
+import {
+  __setTrustedCallerResolverForTests,
+  type TrustedCaller,
+} from "@/api/v2/composio/trusted-identity";
+import {
+  __resetComposioServiceForTests,
+  ComposioService,
+} from "@/api/v2/connections/composio.service";
+import {
+  __setAgentAssetsApiKeyOverrideForTests,
+  AGENT_API_KEY_HEADER,
+  agentApiKeyAuth,
+} from "@/middleware/agentAuth";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+const AGENT_KEY = "x".repeat(40);
+const AGENT_INBOX = "agent-inbox-1";
+const CONVERSATION = "conv-1";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/composio", agentApiKeyAuth, composioRouter);
+
+let server: Server;
+const baseURL = "http://localhost:4014";
+
+// Minimal Composio stub: exec touches tools.execute and (when a grant pins no
+// connection) connectedAccounts.list.
+function installComposioStub(
+  opts: {
+    execute?: (
+      slug: string,
+      body: { userId: string; connectedAccountId?: string },
+    ) => Promise<unknown>;
+    connections?: Array<{ id: string; userId: string; slug: string }>;
+  } = {},
+) {
+  const stub = {
+    tools: {
+      execute:
+        opts.execute ??
+        ((
+          _slug: string,
+          _body: { userId: string; connectedAccountId?: string },
+        ) => Promise.resolve({ data: { ok: true } })),
+    },
+    connectedAccounts: {
+      list: (query: { userIds?: string[] }) => {
+        const wanted = query.userIds ?? [];
+        const items = (opts.connections ?? [])
+          .filter((c) => wanted.includes(c.userId))
+          .map((c) => ({ id: c.id, toolkit: { slug: c.slug } }));
+        return Promise.resolve({ items, totalPages: 1, nextCursor: null });
+      },
+    },
+  };
+  __resetComposioServiceForTests(
+    new ComposioService({
+      composio: stub as unknown as ConstructorParameters<
+        typeof ComposioService
+      >[0]["composio"],
+    }),
+  );
+}
+
+function trust(caller: TrustedCaller | null) {
+  __setTrustedCallerResolverForTests(
+    caller ? () => Promise.resolve(caller) : null,
+  );
+}
+
+function exec(body: unknown, key: string | null = AGENT_KEY) {
+  return fetch(`${baseURL}/api/v2/composio/exec`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(key ? { [AGENT_API_KEY_HEADER]: key } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function asJson<T>(res: Response): Promise<T> {
+  return (await res.json()) as T;
+}
+
+const VALID_BODY = {
+  toolkit: "googlecalendar",
+  action: "GOOGLECALENDAR_EVENTS_LIST",
+  args: {},
+};
+
+beforeAll(async () => {
+  __setAgentAssetsApiKeyOverrideForTests(AGENT_KEY);
+  await new Promise<void>((resolve) => {
+    server = app.listen(4014, () => {
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+  __setAgentAssetsApiKeyOverrideForTests(undefined);
+  __resetComposioServiceForTests(null);
+  __setTrustedCallerResolverForTests(null);
+});
+
+afterEach(() => {
+  __setTrustedCallerResolverForTests(null);
+  __resetComposioServiceForTests(null);
+});
+
+// --- No DB required: auth, validation, and the fail-closed security boundary ---
+
+describe("POST /v2/composio/exec — auth + fail-closed (no DB)", () => {
+  test("401 without an agent API key", async () => {
+    const res = await exec(VALID_BODY, null);
+    expect(res.status).toBe(401);
+  });
+
+  test("401 with a wrong agent API key", async () => {
+    const res = await exec(VALID_BODY, "wrong".repeat(10));
+    expect(res.status).toBe(401);
+  });
+
+  test("400 on an invalid body (missing action)", async () => {
+    const res = await exec({ toolkit: "googlecalendar" });
+    expect(res.status).toBe(400);
+    expect((await asJson<{ code: string }>(res)).code).toBe("invalid_request");
+  });
+
+  test("403 fail-closed when no trusted identity is available", async () => {
+    // Default resolver returns null — the agent cannot be authorized.
+    const res = await exec(VALID_BODY);
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe(
+      "trusted_identity_unavailable",
+    );
+  });
+
+  test("agent-named fields cannot substitute for a trusted identity", async () => {
+    // Even if the agent stuffs identity-looking fields into the body, exec
+    // still fail-closes: resolution ignores the body entirely.
+    const res = await exec({
+      ...VALID_BODY,
+      conversationId: CONVERSATION,
+      granteeInboxId: AGENT_INBOX,
+      accountId: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe(
+      "trusted_identity_unavailable",
+    );
+  });
+});
+
+// --- DB-backed: requires the test Postgres (pnpm test:local) ---
+
+describe("POST /v2/composio/exec — grant authorization (DB)", () => {
+  const accountIds: string[] = [];
+
+  async function makeAccount(): Promise<string> {
+    const account = await prisma.account.create({ data: {} });
+    accountIds.push(account.id);
+    return account.id;
+  }
+
+  afterEach(async () => {
+    await prisma.connectionGrant.deleteMany({
+      where: { ownerAccountId: { in: accountIds } },
+    });
+    await prisma.account.deleteMany({ where: { id: { in: accountIds } } });
+    accountIds.length = 0;
+  });
+
+  test("executes when a live grant matches the trusted caller", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        connectionId: "conn_pinned",
+      },
+    });
+    let seen: { userId: string; connectedAccountId?: string } | null = null;
+    installComposioStub({
+      execute: (_slug, body) => {
+        seen = body;
+        return Promise.resolve({ data: { events: [] } });
+      },
+    });
+    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
+
+    const res = await exec(VALID_BODY);
+    expect(res.status).toBe(200);
+    expect((await asJson<{ data: unknown }>(res)).data).toEqual({ events: [] });
+    // Composio is called with the OWNER's accountId, resolved server-side.
+    expect(seen).toMatchObject({
+      userId: ownerAccountId,
+      connectedAccountId: "conn_pinned",
+    });
+  });
+
+  test("403 no_grant when the agent holds no grant here", async () => {
+    installComposioStub();
+    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
+    const res = await exec(VALID_BODY);
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+  });
+
+  test("403 no_grant when the action is outside the granted scope", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: ["GOOGLECALENDAR_EVENTS_LIST"],
+        connectionId: "conn_pinned",
+      },
+    });
+    installComposioStub();
+    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
+    const res = await exec({
+      ...VALID_BODY,
+      action: "GOOGLECALENDAR_EVENTS_DELETE",
+    });
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+  });
+
+  test("403 no_grant once the grant is revoked", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        connectionId: "conn_pinned",
+        revokedAt: new Date(),
+      },
+    });
+    installComposioStub();
+    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
+    const res = await exec(VALID_BODY);
+    expect(res.status).toBe(403);
+    expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
+  });
+
+  test("409 ambiguous_grant when two owners shared the toolkit in one conversation", async () => {
+    const ownerA = await makeAccount();
+    const ownerB = await makeAccount();
+    for (const ownerAccountId of [ownerA, ownerB]) {
+      await prisma.connectionGrant.create({
+        data: {
+          ownerAccountId,
+          ownerInboxId: `inbox-${ownerAccountId}`,
+          granteeInboxId: AGENT_INBOX,
+          conversationId: CONVERSATION,
+          toolkit: "googlecalendar",
+          actions: [],
+          connectionId: `conn_${ownerAccountId}`,
+        },
+      });
+    }
+    installComposioStub();
+    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
+    const res = await exec(VALID_BODY);
+    expect(res.status).toBe(409);
+    expect((await asJson<{ code: string }>(res)).code).toBe("ambiguous_grant");
+  });
+
+  test("resolves the connection from (owner, toolkit) when the grant pins none", async () => {
+    const ownerAccountId = await makeAccount();
+    await prisma.connectionGrant.create({
+      data: {
+        ownerAccountId,
+        ownerInboxId: "owner-inbox",
+        granteeInboxId: AGENT_INBOX,
+        conversationId: CONVERSATION,
+        toolkit: "googlecalendar",
+        actions: [],
+        connectionId: null,
+      },
+    });
+    let seen: { connectedAccountId?: string } | null = null;
+    installComposioStub({
+      execute: (_slug, body) => {
+        seen = body;
+        return Promise.resolve({ data: {} });
+      },
+      connections: [
+        { id: "conn_resolved", userId: ownerAccountId, slug: "googlecalendar" },
+      ],
+    });
+    trust({ conversationId: CONVERSATION, agentInboxId: AGENT_INBOX });
+    const res = await exec(VALID_BODY);
+    expect(res.status).toBe(200);
+    expect(seen).toMatchObject({ connectedAccountId: "conn_resolved" });
+  });
+});

--- a/tests/connection-grants-validation.test.ts
+++ b/tests/connection-grants-validation.test.ts
@@ -44,6 +44,8 @@ describe("POST /v2/connections/grants — bundleIds validation (no DB)", () => {
   });
 
   test("400 unknown_bundle when one id of several is unknown — names the bad one", async () => {
+    // calendar.events.read is deprecated (hidden from the public catalog) yet
+    // deliberately still KNOWN to validation — only calendar.nope is rejected.
     const res = await request(makeApp())
       .post("/grants")
       .send({

--- a/tests/connection-grants-validation.test.ts
+++ b/tests/connection-grants-validation.test.ts
@@ -1,0 +1,74 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, test, vi } from "vitest";
+import { grantsPostHandler } from "@/api/v2/connections/handlers/grants-post";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+// Handler-level validation tests — no DB. Bundle-id validation fires BEFORE any
+// prisma call, so a stub auth shim is enough; the happy path (which persists)
+// lives in tests/connection-grants.test.ts (DB-backed, pnpm test:local).
+function makeApp() {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use(jsonMiddleware);
+  app.use((_req, res, next) => {
+    res.locals.accountId = "acct-validation-test";
+    next();
+  });
+  app.post("/grants", grantsPostHandler);
+  return app;
+}
+
+const BASE_BODY = {
+  ownerInboxId: "owner-inbox",
+  granteeInboxId: "agent-inbox",
+  conversationId: "conv-1",
+  toolkit: "googlecalendar",
+};
+
+describe("POST /v2/connections/grants — bundleIds validation (no DB)", () => {
+  test("400 unknown_bundle for a bundle id missing from the toolkit's catalog", async () => {
+    const res = await request(makeApp())
+      .post("/grants")
+      .send({ ...BASE_BODY, bundleIds: ["calendar.bogus"] });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      code: "unknown_bundle",
+      bundleId: "calendar.bogus",
+    });
+  });
+
+  test("400 unknown_bundle when one id of several is unknown — names the bad one", async () => {
+    const res = await request(makeApp())
+      .post("/grants")
+      .send({
+        ...BASE_BODY,
+        bundleIds: ["calendar.events.read", "calendar.nope"],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      code: "unknown_bundle",
+      bundleId: "calendar.nope",
+    });
+  });
+
+  test("400 unknown_bundle for bundleIds on a toolkit absent from the catalog", async () => {
+    const res = await request(makeApp())
+      .post("/grants")
+      .send({
+        ...BASE_BODY,
+        toolkit: "notion",
+        bundleIds: ["calendar.events"],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      code: "unknown_bundle",
+      bundleId: "calendar.events",
+    });
+  });
+});

--- a/tests/connection-grants.test.ts
+++ b/tests/connection-grants.test.ts
@@ -107,8 +107,10 @@ describe("Connection grants API", () => {
     expect(res.status).toBe(403);
   });
 
-  test("issues a grant stamped with the JWT's accountId (not a body field)", async () => {
+  test("issues a grant stamped with the JWT's accountId, and ignores a body connectionId (#2)", async () => {
     const accountId = await makeAccount();
+    // GRANT_BODY carries a connectionId; the API must NOT persist it (a bearer
+    // capability the client cannot be trusted to pin). Resolution is server-side.
     const res = await postGrant(accountId, GRANT_BODY);
     expect(res.status).toBe(200);
     const { id } = await asJson<{ id: string }>(res);
@@ -116,7 +118,7 @@ describe("Connection grants API", () => {
     const row = await prisma.connectionGrant.findUnique({ where: { id } });
     expect(row?.ownerAccountId).toBe(accountId);
     expect(row?.granteeInboxId).toBe("agent-inbox");
-    expect(row?.connectionId).toBe("conn_1");
+    expect(row?.connectionId).toBeNull();
   });
 
   test("re-issuing the same (owner, grantee, conversation, toolkit) upserts and un-revokes", async () => {

--- a/tests/connection-grants.test.ts
+++ b/tests/connection-grants.test.ts
@@ -160,6 +160,54 @@ describe("Connection grants API", () => {
     expect(grants[0]).not.toHaveProperty("connectionId");
   });
 
+  test("GET returns bundleIds and never raw Composio action slugs", async () => {
+    const mine = await makeAccount();
+    // GRANT_BODY carries a raw slug in `actions`; the stored row has it, but
+    // the wire must not — clients only ever reason in bundle ids.
+    await postGrant(mine, { ...GRANT_BODY, bundleIds: ["calendar.events"] });
+
+    const res = await fetch(`${baseURL}/api/v2/connections/grants`, {
+      headers: { "X-Convos-AuthToken": await token(mine) },
+    });
+    expect(res.status).toBe(200);
+    const raw = await res.text();
+    expect(raw).not.toMatch(/GOOGLECALENDAR_/);
+    const { grants } = JSON.parse(raw) as {
+      grants: Array<{ bundleIds?: string[] }>;
+    };
+    expect(grants).toHaveLength(1);
+    expect(grants[0]).not.toHaveProperty("actions");
+    expect(grants[0].bundleIds).toEqual(["calendar.events"]);
+  });
+
+  test("POST persists catalog-known bundleIds; unknown ones are 400 unknown_bundle", async () => {
+    const accountId = await makeAccount();
+    const ok = await postGrant(accountId, {
+      ...GRANT_BODY,
+      actions: [],
+      bundleIds: ["calendar.events.read"],
+      serviceVersion: 2,
+    });
+    expect(ok.status).toBe(200);
+    const { id } = await asJson<{ id: string }>(ok);
+    const row = await prisma.connectionGrant.findUnique({ where: { id } });
+    expect(row?.bundleIds).toEqual(["calendar.events.read"]);
+    expect(row?.serviceVersion).toBe(2);
+
+    // Validation is also covered no-DB in connection-grants-validation.test.ts;
+    // this asserts the full HTTP wiring rejects before any write.
+    const bad = await postGrant(accountId, {
+      ...GRANT_BODY,
+      conversationId: "conv-bad",
+      bundleIds: ["calendar.bogus"],
+    });
+    expect(bad.status).toBe(400);
+    expect(await asJson<{ code: string; bundleId: string }>(bad)).toEqual({
+      code: "unknown_bundle",
+      bundleId: "calendar.bogus",
+    });
+  });
+
   test("DELETE revokes the caller's own grant (soft-delete)", async () => {
     const accountId = await makeAccount();
     const { id } = await asJson<{ id: string }>(

--- a/tests/connection-grants.test.ts
+++ b/tests/connection-grants.test.ts
@@ -180,8 +180,11 @@ describe("Connection grants API", () => {
     expect(grants[0].bundleIds).toEqual(["calendar.events"]);
   });
 
-  test("POST persists catalog-known bundleIds; unknown ones are 400 unknown_bundle", async () => {
+  test("POST persists catalog-known bundleIds (incl. DEPRECATED ones); unknown ones are 400 unknown_bundle", async () => {
     const accountId = await makeAccount();
+    // calendar.events.read is deprecated (hidden from the public catalog since
+    // googlecalendar v4) but MUST stay grantable: old clients may round-trip
+    // it from a cached catalog until their TTL expires.
     const ok = await postGrant(accountId, {
       ...GRANT_BODY,
       actions: [],

--- a/tests/connection-grants.test.ts
+++ b/tests/connection-grants.test.ts
@@ -1,0 +1,190 @@
+import type { Server } from "node:http";
+import express from "express";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { connectionsRouter } from "@/api/v2/connections/connections.router";
+import { authMiddleware, requireAccount } from "@/middleware/auth";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use(
+  "/api/v2/connections",
+  authMiddleware,
+  requireAccount,
+  connectionsRouter,
+);
+
+let server: Server;
+const baseURL = "http://localhost:4015";
+
+const accountIds: string[] = [];
+
+async function makeAccount(): Promise<string> {
+  const account = await prisma.account.create({ data: {} });
+  accountIds.push(account.id);
+  return account.id;
+}
+
+function token(accountId: string): Promise<string> {
+  return createJwtToken({ deviceId: "device-grants", accountId });
+}
+
+async function asJson<T>(res: Response): Promise<T> {
+  return (await res.json()) as T;
+}
+
+async function postGrant(accountId: string, body: unknown) {
+  return fetch(`${baseURL}/api/v2/connections/grants`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Convos-AuthToken": await token(accountId),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const GRANT_BODY = {
+  ownerInboxId: "owner-inbox",
+  granteeInboxId: "agent-inbox",
+  conversationId: "conv-1",
+  toolkit: "googlecalendar",
+  actions: ["GOOGLECALENDAR_EVENTS_LIST"],
+  connectionId: "conn_1",
+};
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = app.listen(4015, () => {
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  await prisma.connectionGrant.deleteMany({
+    where: { ownerAccountId: { in: accountIds } },
+  });
+  await prisma.account.deleteMany({ where: { id: { in: accountIds } } });
+  accountIds.length = 0;
+});
+
+describe("Connection grants API", () => {
+  test("403 when the device is not bound to an account", async () => {
+    const tok = await createJwtToken({ deviceId: "device-grants" });
+    const res = await fetch(`${baseURL}/api/v2/connections/grants`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Convos-AuthToken": tok,
+      },
+      body: JSON.stringify(GRANT_BODY),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("issues a grant stamped with the JWT's accountId (not a body field)", async () => {
+    const accountId = await makeAccount();
+    const res = await postGrant(accountId, GRANT_BODY);
+    expect(res.status).toBe(200);
+    const { id } = await asJson<{ id: string }>(res);
+
+    const row = await prisma.connectionGrant.findUnique({ where: { id } });
+    expect(row?.ownerAccountId).toBe(accountId);
+    expect(row?.granteeInboxId).toBe("agent-inbox");
+    expect(row?.connectionId).toBe("conn_1");
+  });
+
+  test("re-issuing the same (owner, grantee, conversation, toolkit) upserts and un-revokes", async () => {
+    const accountId = await makeAccount();
+    const first = await asJson<{ id: string }>(
+      await postGrant(accountId, GRANT_BODY),
+    );
+    // Revoke it, then re-issue — the row should come back live with new scope.
+    await prisma.connectionGrant.update({
+      where: { id: first.id },
+      data: { revokedAt: new Date() },
+    });
+    const second = await asJson<{ id: string }>(
+      await postGrant(accountId, { ...GRANT_BODY, actions: [] }),
+    );
+    expect(second.id).toBe(first.id);
+    const row = await prisma.connectionGrant.findUnique({
+      where: { id: first.id },
+    });
+    expect(row?.revokedAt).toBeNull();
+    expect(row?.actions).toEqual([]);
+  });
+
+  test("GET lists only the caller's own grants and omits connectionId", async () => {
+    const mine = await makeAccount();
+    const other = await makeAccount();
+    await postGrant(mine, GRANT_BODY);
+    await postGrant(other, { ...GRANT_BODY, conversationId: "conv-other" });
+
+    const res = await fetch(`${baseURL}/api/v2/connections/grants`, {
+      headers: { "X-Convos-AuthToken": await token(mine) },
+    });
+    expect(res.status).toBe(200);
+    const { grants } = await asJson<{
+      grants: Array<{ conversationId: string }>;
+    }>(res);
+    expect(grants).toHaveLength(1);
+    expect(grants[0].conversationId).toBe("conv-1");
+    expect(grants[0]).not.toHaveProperty("connectionId");
+  });
+
+  test("DELETE revokes the caller's own grant (soft-delete)", async () => {
+    const accountId = await makeAccount();
+    const { id } = await asJson<{ id: string }>(
+      await postGrant(accountId, GRANT_BODY),
+    );
+    const res = await fetch(`${baseURL}/api/v2/connections/grants/${id}`, {
+      method: "DELETE",
+      headers: { "X-Convos-AuthToken": await token(accountId) },
+    });
+    expect(res.status).toBe(204);
+    const row = await prisma.connectionGrant.findUnique({ where: { id } });
+    expect(row?.revokedAt).not.toBeNull();
+  });
+
+  test("DELETE cannot revoke another account's grant (404, not touched)", async () => {
+    const owner = await makeAccount();
+    const attacker = await makeAccount();
+    const { id } = await asJson<{ id: string }>(
+      await postGrant(owner, GRANT_BODY),
+    );
+
+    const res = await fetch(`${baseURL}/api/v2/connections/grants/${id}`, {
+      method: "DELETE",
+      headers: { "X-Convos-AuthToken": await token(attacker) },
+    });
+    expect(res.status).toBe(404);
+    const row = await prisma.connectionGrant.findUnique({ where: { id } });
+    expect(row?.revokedAt).toBeNull();
+  });
+});

--- a/tests/connection-grants.test.ts
+++ b/tests/connection-grants.test.ts
@@ -189,4 +189,64 @@ describe("Connection grants API", () => {
     const row = await prisma.connectionGrant.findUnique({ where: { id } });
     expect(row?.revokedAt).toBeNull();
   });
+
+  async function postRevoke(
+    accountId: string,
+    body: { toolkit: string; conversationId?: string; granteeInboxId?: string },
+  ) {
+    return fetch(`${baseURL}/api/v2/connections/grants/revoke`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Convos-AuthToken": await token(accountId),
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test("revoke-by-natural-key revokes a stranded grant without its id (#4)", async () => {
+    const accountId = await makeAccount();
+    // Simulate the strand: backend grant is live, the client lost its id.
+    await postGrant(accountId, GRANT_BODY);
+    const res = await postRevoke(accountId, {
+      toolkit: GRANT_BODY.toolkit,
+      conversationId: GRANT_BODY.conversationId,
+      granteeInboxId: GRANT_BODY.granteeInboxId,
+    });
+    expect(res.status).toBe(200);
+    expect((await asJson<{ revoked: number }>(res)).revoked).toBe(1);
+    const rows = await prisma.connectionGrant.findMany({
+      where: { ownerAccountId: accountId },
+    });
+    expect(rows.every((r) => r.revokedAt !== null)).toBe(true);
+  });
+
+  test("revoke by toolkit alone clears every grant for that connection", async () => {
+    const accountId = await makeAccount();
+    await postGrant(accountId, GRANT_BODY);
+    await postGrant(accountId, {
+      ...GRANT_BODY,
+      conversationId: "conv-2",
+      granteeInboxId: "agent-2",
+    });
+    const res = await postRevoke(accountId, { toolkit: GRANT_BODY.toolkit });
+    expect((await asJson<{ revoked: number }>(res)).revoked).toBe(2);
+  });
+
+  test("revoke-by-natural-key cannot touch another account's grants", async () => {
+    const owner = await makeAccount();
+    const attacker = await makeAccount();
+    await postGrant(owner, GRANT_BODY);
+
+    const res = await postRevoke(attacker, {
+      toolkit: GRANT_BODY.toolkit,
+      conversationId: GRANT_BODY.conversationId,
+    });
+    expect(res.status).toBe(200);
+    expect((await asJson<{ revoked: number }>(res)).revoked).toBe(0);
+    const rows = await prisma.connectionGrant.findMany({
+      where: { ownerAccountId: owner },
+    });
+    expect(rows.every((r) => r.revokedAt === null)).toBe(true);
+  });
 });

--- a/tests/connections-bundles.test.ts
+++ b/tests/connections-bundles.test.ts
@@ -66,6 +66,18 @@ describe("bundles catalog — resolveBundleActions (no DB)", () => {
       expect(a).not.toMatch(/CREATE|UPDATE|DELETE|PATCH/);
     }
   });
+
+  test("DEPRECATED bundles still resolve — legacy grants must keep working", () => {
+    // calendar.events.read was retired from the public catalog in v4 but
+    // real grants persist it; deprecation must never break exec resolution.
+    const readBundle = getServiceConfig("googlecalendar")?.bundles.find(
+      (b) => b.id === "calendar.events.read",
+    );
+    expect(readBundle?.deprecated).toBe(true);
+    expect(
+      resolveBundleActions("googlecalendar", ["calendar.events.read"]),
+    ).toEqual(["GOOGLECALENDAR_EVENTS_LIST"]);
+  });
 });
 
 describe("bundles catalog — getServiceConfig (no DB)", () => {
@@ -76,9 +88,9 @@ describe("bundles catalog — getServiceConfig (no DB)", () => {
     expect(svc?.bundles.map((b) => b.id)).toContain("calendar.events.read");
   });
 
-  test("googlecalendar version was bumped for the read bundle (contract: bump on ANY change)", () => {
+  test("googlecalendar version was bumped for the single-bundle merge (contract: bump on ANY change)", () => {
     expect(getServiceConfig("googlecalendar")?.version).toBeGreaterThanOrEqual(
-      2,
+      4,
     );
   });
 
@@ -124,5 +136,23 @@ describe("bundles catalog — public view strips slugs (no DB)", () => {
 
   test("public catalog covers every seeded service", () => {
     expect(getPublicServiceConfigs()).toHaveLength(SERVICE_CONFIGS.length);
+  });
+
+  test("googlecalendar serves exactly ONE bundle: 'View and edit events'", () => {
+    // Product decision (2026-06-12): a single user-facing toggle covering
+    // read+write. The read-only sibling is deprecated and must not be offered.
+    const gcal = getPublicServiceConfigs().find(
+      (s) => s.id === "googlecalendar",
+    );
+    expect(gcal).toBeDefined();
+    expect(gcal!.bundles).toHaveLength(1);
+    expect(gcal!.bundles[0].id).toBe("calendar.events");
+    expect(gcal!.bundles[0].title.en).toBe("View and edit events");
+  });
+
+  test("deprecated bundles are excluded from the public view, and the flag never leaks", () => {
+    const json = JSON.stringify(getPublicServiceConfigs());
+    expect(json).not.toContain("calendar.events.read");
+    expect(json).not.toContain("deprecated");
   });
 });

--- a/tests/connections-bundles.test.ts
+++ b/tests/connections-bundles.test.ts
@@ -15,7 +15,7 @@ describe("bundles catalog — resolveBundleActions (no DB)", () => {
     const actions = resolveBundleActions("googlecalendar", ["calendar.events"]);
     expect(actions).toEqual(
       expect.arrayContaining([
-        "GOOGLECALENDAR_LIST_EVENTS",
+        "GOOGLECALENDAR_EVENTS_LIST",
         "GOOGLECALENDAR_CREATE_EVENT",
         "GOOGLECALENDAR_UPDATE_EVENT",
         "GOOGLECALENDAR_DELETE_EVENT",
@@ -60,7 +60,7 @@ describe("bundles catalog — resolveBundleActions (no DB)", () => {
       "calendar.events.read",
     ]);
     expect(actions.length).toBeGreaterThan(0);
-    expect(actions).toContain("GOOGLECALENDAR_LIST_EVENTS");
+    expect(actions).toContain("GOOGLECALENDAR_EVENTS_LIST");
     // The scoping invariant: a read bundle must never carry a mutating slug.
     for (const a of actions) {
       expect(a).not.toMatch(/CREATE|UPDATE|DELETE|PATCH/);

--- a/tests/connections-bundles.test.ts
+++ b/tests/connections-bundles.test.ts
@@ -138,16 +138,21 @@ describe("bundles catalog — public view strips slugs (no DB)", () => {
     expect(getPublicServiceConfigs()).toHaveLength(SERVICE_CONFIGS.length);
   });
 
-  test("googlecalendar serves exactly ONE bundle: 'View and edit events'", () => {
+  test("googlecalendar serves exactly ONE bundle: 'Events'", () => {
     // Product decision (2026-06-12): a single user-facing toggle covering
     // read+write. The read-only sibling is deprecated and must not be offered.
+    // Copy per the Figma design: row title "Events", subtitle (description)
+    // "View and edit events on all calendars".
     const gcal = getPublicServiceConfigs().find(
       (s) => s.id === "googlecalendar",
     );
     expect(gcal).toBeDefined();
     expect(gcal!.bundles).toHaveLength(1);
     expect(gcal!.bundles[0].id).toBe("calendar.events");
-    expect(gcal!.bundles[0].title.en).toBe("View and edit events");
+    expect(gcal!.bundles[0].title.en).toBe("Events");
+    expect(gcal!.bundles[0].description.en).toBe(
+      "View and edit events on all calendars",
+    );
   });
 
   test("deprecated bundles are excluded from the public view, and the flag never leaks", () => {

--- a/tests/connections-bundles.test.ts
+++ b/tests/connections-bundles.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "vitest";
+import {
+  getPublicServiceConfigs,
+  getServiceConfig,
+  resolveBundleActions,
+  SERVICE_CONFIGS,
+  toPublicServiceConfig,
+} from "@/api/v2/connections/bundles.config";
+
+// Pure catalog logic — no DB, no HTTP. Covers bundle → action resolution and
+// the public (slug-stripped) view served by GET /v2/connections/services.
+
+describe("bundles catalog — resolveBundleActions (no DB)", () => {
+  test("resolves a known bundle to its action slugs", () => {
+    const actions = resolveBundleActions("googlecalendar", ["calendar.events"]);
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        "GOOGLECALENDAR_LIST_EVENTS",
+        "GOOGLECALENDAR_CREATE_EVENT",
+        "GOOGLECALENDAR_UPDATE_EVENT",
+        "GOOGLECALENDAR_DELETE_EVENT",
+      ]),
+    );
+  });
+
+  test("service id match is case-insensitive", () => {
+    expect(resolveBundleActions("GoogleCalendar", ["calendar.events"])).toEqual(
+      resolveBundleActions("googlecalendar", ["calendar.events"]),
+    );
+  });
+
+  test("unknown service contributes nothing", () => {
+    expect(resolveBundleActions("notaservice", ["calendar.events"])).toEqual(
+      [],
+    );
+  });
+
+  test("unknown bundle id contributes nothing (stale grant ⇒ no actions)", () => {
+    expect(resolveBundleActions("googlecalendar", ["calendar.bogus"])).toEqual(
+      [],
+    );
+  });
+
+  test("empty bundleIds resolves to no actions", () => {
+    expect(resolveBundleActions("googlecalendar", [])).toEqual([]);
+  });
+
+  test("union dedupes across overlapping bundles", () => {
+    // Passing the same bundle twice must not duplicate actions.
+    const once = resolveBundleActions("googlecalendar", ["calendar.events"]);
+    const twice = resolveBundleActions("googlecalendar", [
+      "calendar.events",
+      "calendar.events",
+    ]);
+    expect(new Set(twice)).toEqual(new Set(once));
+  });
+});
+
+describe("bundles catalog — getServiceConfig (no DB)", () => {
+  test("returns the seeded googlecalendar service", () => {
+    const svc = getServiceConfig("googlecalendar");
+    expect(svc?.id).toBe("googlecalendar");
+    expect(svc?.bundles.map((b) => b.id)).toContain("calendar.events");
+  });
+
+  test("returns undefined for an unknown service", () => {
+    expect(getServiceConfig("notaservice")).toBeUndefined();
+  });
+});
+
+describe("bundles catalog — public view strips slugs (no DB)", () => {
+  test("toPublicServiceConfig drops composioActions from every bundle", () => {
+    const svc = getServiceConfig("googlecalendar");
+    expect(svc).toBeDefined();
+    const pub = toPublicServiceConfig(svc!);
+    for (const b of pub.bundles) {
+      expect(b).not.toHaveProperty("composioActions");
+      expect(Object.keys(b).sort()).toEqual([
+        "defaultEnabled",
+        "description",
+        "id",
+        "title",
+      ]);
+      expect(typeof b.id).toBe("string");
+      expect(typeof b.title.en).toBe("string");
+      expect(typeof b.description.en).toBe("string");
+      expect(typeof b.defaultEnabled).toBe("boolean");
+    }
+  });
+
+  test("getPublicServiceConfigs serializes with no slug anywhere", () => {
+    const json = JSON.stringify(getPublicServiceConfigs());
+    // No Composio action slug should survive into the public payload.
+    expect(json).not.toMatch(/GOOGLECALENDAR_/);
+    expect(json).not.toMatch(/composioActions/);
+  });
+
+  test("public service keeps id/composioSlug/version/displayName", () => {
+    const [svc] = getPublicServiceConfigs();
+    expect(svc.id).toBe("googlecalendar");
+    expect(svc.composioSlug).toBe("googlecalendar");
+    expect(typeof svc.version).toBe("number");
+    expect(svc.displayName.en).toBe("Google Calendar");
+  });
+
+  test("public catalog covers every seeded service", () => {
+    expect(getPublicServiceConfigs()).toHaveLength(SERVICE_CONFIGS.length);
+  });
+});

--- a/tests/connections-bundles.test.ts
+++ b/tests/connections-bundles.test.ts
@@ -54,6 +54,18 @@ describe("bundles catalog — resolveBundleActions (no DB)", () => {
     ]);
     expect(new Set(twice)).toEqual(new Set(once));
   });
+
+  test("calendar.events.read resolves to read-only slugs — no write verbs", () => {
+    const actions = resolveBundleActions("googlecalendar", [
+      "calendar.events.read",
+    ]);
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions).toContain("GOOGLECALENDAR_LIST_EVENTS");
+    // The scoping invariant: a read bundle must never carry a mutating slug.
+    for (const a of actions) {
+      expect(a).not.toMatch(/CREATE|UPDATE|DELETE|PATCH/);
+    }
+  });
 });
 
 describe("bundles catalog — getServiceConfig (no DB)", () => {
@@ -61,6 +73,13 @@ describe("bundles catalog — getServiceConfig (no DB)", () => {
     const svc = getServiceConfig("googlecalendar");
     expect(svc?.id).toBe("googlecalendar");
     expect(svc?.bundles.map((b) => b.id)).toContain("calendar.events");
+    expect(svc?.bundles.map((b) => b.id)).toContain("calendar.events.read");
+  });
+
+  test("googlecalendar version was bumped for the read bundle (contract: bump on ANY change)", () => {
+    expect(getServiceConfig("googlecalendar")?.version).toBeGreaterThanOrEqual(
+      2,
+    );
   });
 
   test("returns undefined for an unknown service", () => {

--- a/tests/connections-services.test.ts
+++ b/tests/connections-services.test.ts
@@ -89,7 +89,7 @@ describe("GET /v2/connections/services (no DB)", () => {
     expect(JSON.stringify(body)).not.toMatch(/composioActions/);
   });
 
-  test("googlecalendar offers a single 'View and edit events' bundle — deprecated read bundle hidden", async () => {
+  test("googlecalendar offers a single 'Events' bundle — deprecated read bundle hidden", async () => {
     // Product decision: ONE picker toggle for calendar (read+write). The
     // retired calendar.events.read id stays exec-resolvable internally but
     // must never be offered to clients again.
@@ -105,7 +105,10 @@ describe("GET /v2/connections/services (no DB)", () => {
     expect(gcal!.version).toBeGreaterThanOrEqual(4);
     expect(gcal!.bundles).toHaveLength(1);
     expect(gcal!.bundles[0].id).toBe("calendar.events");
-    expect(gcal!.bundles[0].title.en).toBe("View and edit events");
+    expect(gcal!.bundles[0].title.en).toBe("Events");
+    expect(gcal!.bundles[0].description.en).toBe(
+      "View and edit events on all calendars",
+    );
     expect(JSON.stringify(body)).not.toContain("calendar.events.read");
     expect(JSON.stringify(body)).not.toContain("deprecated");
   });

--- a/tests/connections-services.test.ts
+++ b/tests/connections-services.test.ts
@@ -1,0 +1,99 @@
+import express from "express";
+import request from "supertest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { servicesGetHandler } from "@/api/v2/connections/handlers/services-get";
+import { authMiddleware } from "@/middleware/auth";
+import { pinoMiddleware } from "@/middleware/pino";
+import { createJwtToken, validateJWTKeys } from "@/utils/jwt";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+// Mirrors the production wiring: JWT-only (authMiddleware), NOT requireAccount.
+function makeApp() {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.get("/connections/services", authMiddleware, servicesGetHandler);
+  return app;
+}
+
+type ServicesResponse = {
+  services: Array<{
+    id: string;
+    composioSlug: string;
+    version: number;
+    displayName: { en: string };
+    bundles: Array<{
+      id: string;
+      title: { en: string };
+      description: { en: string };
+      defaultEnabled: boolean;
+    }>;
+  }>;
+};
+
+beforeAll(async () => {
+  await validateJWTKeys();
+});
+
+describe("GET /v2/connections/services (no DB)", () => {
+  test("401 without a JWT", async () => {
+    const res = await request(makeApp()).get("/connections/services");
+    expect(res.status).toBe(401);
+  });
+
+  test("200 with a device-only JWT (no requireAccount)", async () => {
+    // A device-only token carries no accountId; the catalog is not account
+    // scoped, so it must still succeed — this guards the wiring decision.
+    const token = await createJwtToken({ deviceId: "dev-catalog" });
+    const res = await request(makeApp())
+      .get("/connections/services")
+      .set("X-Convos-AuthToken", token);
+    expect(res.status).toBe(200);
+  });
+
+  test("response shape matches the contract and strips slugs", async () => {
+    const token = await createJwtToken({ deviceId: "dev-catalog" });
+    const res = await request(makeApp())
+      .get("/connections/services")
+      .set("X-Convos-AuthToken", token);
+    expect(res.status).toBe(200);
+
+    const body = res.body as ServicesResponse;
+    expect(Array.isArray(body.services)).toBe(true);
+    expect(body.services.length).toBeGreaterThan(0);
+
+    const gcal = body.services.find((s) => s.id === "googlecalendar");
+    expect(gcal).toBeDefined();
+    expect(gcal!.id).toBe("googlecalendar");
+    expect(gcal!.composioSlug).toBe("googlecalendar");
+    expect(typeof gcal!.version).toBe("number");
+    expect(gcal!.displayName.en).toBe("Google Calendar");
+    expect(gcal!.bundles.length).toBeGreaterThan(0);
+    for (const b of gcal!.bundles) {
+      expect(Object.keys(b).sort()).toEqual([
+        "defaultEnabled",
+        "description",
+        "id",
+        "title",
+      ]);
+      expect(typeof b.id).toBe("string");
+      expect(typeof b.title.en).toBe("string");
+      expect(typeof b.description.en).toBe("string");
+      expect(typeof b.defaultEnabled).toBe("boolean");
+    }
+
+    // No Composio action slug may leak into the served payload.
+    expect(JSON.stringify(body)).not.toMatch(/GOOGLECALENDAR_/);
+    expect(JSON.stringify(body)).not.toMatch(/composioActions/);
+  });
+
+  test("sets a private cache header", async () => {
+    const token = await createJwtToken({ deviceId: "dev-catalog" });
+    const res = await request(makeApp())
+      .get("/connections/services")
+      .set("X-Convos-AuthToken", token);
+    expect(res.headers["cache-control"]).toContain("private");
+  });
+});

--- a/tests/connections-services.test.ts
+++ b/tests/connections-services.test.ts
@@ -89,6 +89,27 @@ describe("GET /v2/connections/services (no DB)", () => {
     expect(JSON.stringify(body)).not.toMatch(/composioActions/);
   });
 
+  test("googlecalendar offers a single 'View and edit events' bundle — deprecated read bundle hidden", async () => {
+    // Product decision: ONE picker toggle for calendar (read+write). The
+    // retired calendar.events.read id stays exec-resolvable internally but
+    // must never be offered to clients again.
+    const token = await createJwtToken({ deviceId: "dev-catalog" });
+    const res = await request(makeApp())
+      .get("/connections/services")
+      .set("X-Convos-AuthToken", token);
+    expect(res.status).toBe(200);
+
+    const body = res.body as ServicesResponse;
+    const gcal = body.services.find((s) => s.id === "googlecalendar");
+    expect(gcal).toBeDefined();
+    expect(gcal!.version).toBeGreaterThanOrEqual(4);
+    expect(gcal!.bundles).toHaveLength(1);
+    expect(gcal!.bundles[0].id).toBe("calendar.events");
+    expect(gcal!.bundles[0].title.en).toBe("View and edit events");
+    expect(JSON.stringify(body)).not.toContain("calendar.events.read");
+    expect(JSON.stringify(body)).not.toContain("deprecated");
+  });
+
   test("sets a private cache header", async () => {
     const token = await createJwtToken({ deviceId: "dev-catalog" });
     const res = await request(makeApp())


### PR DESCRIPTION
## Summary
- Backend-mediated Composio execution: agents no longer hold any Composio credential. The assistants worker proxies tool calls to `POST /api/v2/composio/exec` with a dedicated `X-Composio-Exec-Key` and worker-stamped trusted identity headers; connection resolution is server-side (client-supplied `connectionId` is never accepted), with `onBehalfOf` stamping.
- Permission bundles: backend-owned catalog, `GET /v2/connections/services` (JWT-only, Composio slugs stripped). Grants carry `{toolkit, serviceVersion, bundleIds}`; exec authorizes union(grant.actions, resolved bundle actions) and fails closed (`unknown_bundle` 400 at grant creation, `no_grant` 403 on unresolvable unions).
- Google Calendar ships a single "View and edit events" bundle (service v4); the interim read-only bundle is deprecated — hidden from the public catalog but still resolvable so existing grants keep working.
- Grant revocation by natural key (reliable revocation) and toolkit-version pinning for manual exec (runtime resolution with 1h cache, fail-closed `toolkit_version_unresolved`).

Stacked on #294 (accountId scoping) — merge that first. Security model: #286 (updated 1-pager).
iOS counterpart: xmtplabs/convos-ios#1047 + #1048. Assistants counterpart: `louis/composio-backend-exec`.

## Test plan
- Unit + DB-backed suites green locally (exec grant chain 27/27, connections 43/43, single-bundle 25 no-DB + 38 DB-backed); typecheck/lint/prettier clean.
- E2E verified: agent → worker proxy → exec → Composio round-trip returns real calendar events; fail-closed paths covered by regression tests from two adversarial reviews.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783808051&installation_id=128169237&pr_number=303&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F303&signature=a340eff9bf840e69b7a01ddf2060de79929f4f069d0598d89b27e00e87c6373e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add backend-mediated Composio exec endpoint with connection grants and permission bundles
> - Adds a `POST /v2/composio/exec` route protected by a dedicated `COMPOSIO_EXEC_API_KEY` (`composioExecAuth` middleware) that authorizes tool execution using DB-stored `ConnectionGrant` rows, resolves connected accounts server-side, and pins toolkit versions via a 1-hour cache in `ComposioService`.
> - Introduces a `ConnectionGrant` Prisma model (with migrations) scoped by owner account, grantee inbox, conversation, and toolkit, supporting both raw action slugs and named permission bundle ids.
> - Adds a backend-owned permission bundle catalog in [`bundles.config.ts`](https://github.com/ephemeraHQ/convos-backend/pull/303/files#diff-220b04f44b8e0c1006d679a16bb8c8a6b17e2f628cf10fdb42661f9a5b08495f) seeded with a `googlecalendar` service and two bundles; the catalog resolves action slugs at exec time and exposes a public (slug-free) view.
> - Exposes CRUD grant management endpoints at `POST/GET /v2/connections/grants`, `DELETE /v2/connections/grants/:id`, and `POST /v2/connections/grants/revoke` with upsert and bulk-revoke semantics.
> - Adds `GET /v2/connections/services` (JWT-only, no account required) to serve the public bundle catalog with a 5-minute private cache header.
> - Risk: exec is fail-closed — grants with `bundleIds` that resolve to zero actions, unresolved toolkit versions, or ambiguous multi-owner situations all return 4xx rather than falling back.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a98c4cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->