### PR TITLE
fix(connections): migrate Composio initiate() to link() before 2026-07-03 sunset

### DIFF
--- a/src/api/v2/connections/composio.service.ts
+++ b/src/api/v2/connections/composio.service.ts
@@ -121,12 +121,20 @@ export class ComposioService {
     return version;
   }
 
+  /**
+   * Start an OAuth connection flow for a user. Named after our endpoint
+   * (POST /connections/initiate); internally this uses the SDK's `link()` —
+   * Composio retires `connectedAccounts.initiate()` for Composio-managed
+   * OAuth on 2026-07-03 (see https://docs.composio.dev/docs/changelog/2026/04/24).
+   * `link()` returns the same ConnectionRequest shape ({ id, status,
+   * redirectUrl }), so the endpoint response is unchanged.
+   */
   async initiate(args: {
     userId: string;
     authConfigId: string;
     callbackUrl?: string;
   }) {
-    return this.composio.connectedAccounts.initiate(
+    return this.composio.connectedAccounts.link(
       args.userId,
       args.authConfigId,
       {

--- a/tests/connections.test.ts
+++ b/tests/connections.test.ts
@@ -31,8 +31,11 @@ vi.mock("firebase-admin/app-check");
 vi.mock("firebase-admin/messaging");
 
 // Stub shapes — match just what the service touches on the Composio client.
+// `initiate()` is deliberately absent: the SDK retires it for Composio-managed
+// OAuth on 2026-07-03, so the service must only call `link()`. A regression
+// back to `initiate()` would throw here and fail the happy-path tests.
 type ConnectedAccountsStub = {
-  initiate: (
+  link: (
     userId: string,
     authConfigId: string,
     options?: { callbackUrl?: string },
@@ -88,7 +91,7 @@ function makeStub(
 ): {
   stub: ComposioStub;
   calls: {
-    initiate: Array<{
+    link: Array<{
       userId: string;
       authConfigId: string;
       callbackUrl?: string;
@@ -104,7 +107,7 @@ function makeStub(
     ConnectedAccountListResponseItem & { userId: string }
   >();
   const calls = {
-    initiate: [] as Array<{
+    link: [] as Array<{
       userId: string;
       authConfigId: string;
       callbackUrl?: string;
@@ -114,8 +117,8 @@ function makeStub(
     authConfigsList: [] as AuthConfigListParams[],
   };
   const defaults: ConnectedAccountsStub = {
-    initiate: (userId, authConfigId, options) => {
-      calls.initiate.push({
+    link: (userId, authConfigId, options) => {
+      calls.link.push({
         userId,
         authConfigId,
         callbackUrl: options?.callbackUrl,
@@ -285,7 +288,7 @@ describe("Connections API", () => {
         body: JSON.stringify({ serviceId: "google_calendar" }),
       });
       expect(res.status).toBe(403);
-      expect(calls.initiate).toEqual([]);
+      expect(calls.link).toEqual([]);
     });
   });
 
@@ -311,12 +314,50 @@ describe("Connections API", () => {
       };
       expect(body.connectionRequestId).toBe("conn_1");
       expect(body.redirectUrl).toBe("https://composio.example/auth");
-      expect(calls.initiate[0]?.userId).toBe(ACCOUNT_ID);
-      expect(calls.initiate[0]?.authConfigId).toBe(AUTH_CONFIG_ID);
+      expect(calls.link[0]?.userId).toBe(ACCOUNT_ID);
+      expect(calls.link[0]?.authConfigId).toBe(AUTH_CONFIG_ID);
       // No redirectUri in body → service falls back to the env default.
-      expect(calls.initiate[0]?.callbackUrl).toBe(
-        "convos://connections/callback",
-      );
+      expect(calls.link[0]?.callbackUrl).toBe("convos://connections/callback");
+    });
+
+    test("initiate returns null redirectUrl when Composio omits one", async () => {
+      const { stub } = makeStub({
+        overrides: {
+          link: (_userId, _authConfigId, _options) =>
+            Promise.resolve({
+              id: "conn_no_redirect",
+              status: "INITIATED",
+              redirectUrl: null,
+              waitForConnection: () =>
+                Promise.reject(new Error("not used in tests")),
+              toJSON: () => ({
+                id: "conn_no_redirect",
+                status: "INITIATED",
+                redirectUrl: null,
+              }),
+              toString: () => "conn_no_redirect",
+            }),
+        },
+      });
+      installStub(stub);
+      const token = await makeToken({ accountId: ACCOUNT_ID });
+
+      const res = await fetch(`${baseURL}/api/v2/connections/initiate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Convos-AuthToken": token,
+        },
+        body: JSON.stringify({ serviceId: "google_calendar" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        connectionRequestId: string;
+        redirectUrl: string | null;
+      };
+      expect(body.connectionRequestId).toBe("conn_no_redirect");
+      expect(body.redirectUrl).toBeNull();
     });
 
     test("initiate forwards per-request redirectUri to Composio", async () => {
@@ -337,7 +378,7 @@ describe("Connections API", () => {
       });
 
       expect(res.status).toBe(200);
-      expect(calls.initiate[0]?.callbackUrl).toBe(
+      expect(calls.link[0]?.callbackUrl).toBe(
         "convos-dev://connections/callback",
       );
     });


### PR DESCRIPTION
## Why

The Composio SDK logs a deprecation on every connection initiation: `connectedAccounts.initiate()` stops working for Composio-managed OAuth on **2026-07-03** (legacy `POST /api/v3/connected_accounts` retirement — see https://docs.composio.dev/docs/changelog/2026/04/24). `connectedAccounts.link()` is the replacement.

## Drop-in claim verified

Checked `@composio/core` 0.10.0 typings (no SDK bump needed — `link()` exists in the installed version):

- Both return `Promise<ConnectionRequest>` (`{ id, status, redirectUrl }`) — identical.
- Options delta: `link()` takes `{ callbackUrl?, alias?, allowMultiple?, experimental? }` vs `initiate()`'s `{ callbackUrl?, alias?, allowMultiple?, config? }`. It drops `config` (custom-auth state we never pass) and adds `experimental`. We only pass `callbackUrl`, so it is a drop-in swap for our usage.

## What changed

- `ComposioService.initiate()` (single SDK call site in the repo) now calls `connectedAccounts.link()`; wrapper name kept to match `POST /api/v2/connections/initiate`.
- HTTP response unchanged: `{ connectionRequestId, redirectUrl }`.
- Tests: SDK stub now exposes `link()` only (a regression back to `initiate()` would throw and fail the happy path); added a null-`redirectUrl` passthrough test.

## Test evidence

- `vitest run` on connections.test.ts, connections-bundles, connections-services, connection-grants, connection-grants-validation, composio-exec: **78/78 passed**.
- `pnpm check` (typecheck + prettier + eslint): exit 0 (3 pre-existing warnings in unrelated `openrouter-client.ts`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783869781&installation_id=128169237&pr_number=304&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F304&signature=be350669ba290db8a204a2366f2f6801e70bf1d3e61a983fc585c3f9092c33e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `ComposioService` from deprecated `connectedAccounts.initiate()` to `connectedAccounts.link()`
> Replaces the internal SDK call in [composio.service.ts](https://github.com/ephemeraHQ/convos-backend/pull/304/files#diff-6593711c01a3896e6d2a47dc67231944a6a4dca809085915d42f0dc5c0c0a148) ahead of the 2026-07-03 sunset of `connectedAccounts.initiate`. The returned `ConnectionRequest` shape is identical, so external behavior is unchanged. Tests in [connections.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/304/files#diff-a945eff059c8826c6c6ad4902b3132bef942e78130f62ff45ed1bdd45e1f3a4f) are updated to stub and assert against `link` instead of `initiate`, and a new test covers the `redirectUrl: null` case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0bf047.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Composio SDK integration for the OAuth connection flow implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->