### PR TITLE
feat(agents): harden agent-create paths — canonical accountIdSchema, requireAccount shape gate, zod-validated assistant dispatch

### DIFF
--- a/src/api/v2/accounts/middleware/meGuard.ts
+++ b/src/api/v2/accounts/middleware/meGuard.ts
@@ -1,7 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
-import { z } from "zod";
-
-const accountIdSchema = z.string().uuid();
+import { accountIdSchema } from "@/utils/account-id";
 
 /**
  * Reject any :accountId path param that is not a valid UUID. UUID parsing IS

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { pickCollisionFreeId } from "@/api/v2/agent-templates/lib/pick-collision-free-id";
 import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
 import { revalidateTemplate } from "@/api/v2/agent-templates/services/revalidate-dashboard";
+import { accountIdSchema } from "@/utils/account-id";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
@@ -32,7 +33,7 @@ const bodySchema = z
     // the generations POST endpoint's owner-assertion contract so a trusted
     // agent runtime can attribute a created template to the user it's acting
     // on behalf of rather than the ADMIN seed account.
-    ownerAccountId: z.string().uuid().optional(),
+    ownerAccountId: accountIdSchema.optional(),
     // Provenance for forks. When a row is created as a copy of an existing
     // template (e.g. the runtime forking a catalog template a group adopted),
     // this records the source id. The FK (`forkedFromId → AgentTemplate.id`,

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -59,6 +59,7 @@ import {
 import { type TraceContext } from "@/api/v2/agent-templates/services/openrouter-client";
 import { isKnownOpenRouterModel } from "@/api/v2/agent-templates/services/openrouter-models";
 import { resolveActor } from "@/api/v2/agent-templates/services/posthog";
+import { accountIdSchema } from "@/utils/account-id";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { prisma } from "@/utils/prisma";
@@ -220,7 +221,7 @@ const bodySchema = z
     // Asserted owner — honoured only when the caller is agent-key-auth'd;
     // ignored for JWT (JWT account always wins) and anonymous (falls
     // back to ADMIN). See the owner-resolution block below.
-    ownerAccountId: z.string().uuid().optional(),
+    ownerAccountId: accountIdSchema.optional(),
   })
   .strict();
 

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import { z } from "zod";
 import { buildJoinPayload } from "@/api/v2/agents/lib/build-join-payload";
 import { XMTP_ENV } from "@/config";
+import { accountIdSchema } from "@/utils/account-id";
 import { prisma } from "@/utils/prisma";
 import {
   assistantStatusSchema,
@@ -100,6 +101,11 @@ const ERRORS = {
     error: "AGENT_POOL_TIMEOUT",
     message: "Agent provisioning request timed out",
   },
+  JOIN_DISPATCH_INVALID: {
+    status: 500,
+    error: "JOIN_DISPATCH_INVALID",
+    message: "Internal error building agent dispatch",
+  },
 } as const;
 
 function buildInviteUrl(slug: string): string {
@@ -111,6 +117,34 @@ function buildInviteUrl(slug: string): string {
 const assistantDispatchSchema = z.object({
   instanceId: z.string().min(1),
 });
+
+// Egress contract for POST {assistant}/api/assistants. The envelope is
+// strict and `ownerAccountId` is required — an agent must never be
+// provisioned without an owner (the pre-#231 ownerless-agent bug class).
+// `template` interior stays loose: it is built from an already-validated
+// DB row; this schema guards the envelope, not template evolution.
+// Adding a wire field requires updating this schema (.strict() turns a missed
+// field into a 500 on every join — deliberately loud), and conversationId here
+// is lowercase-only by design: the inbound schema's .transform has already
+// canonicalized it.
+const dispatchBodySchema = z
+  .object({
+    joinUrl: z.string().url().optional(),
+    conversationId: z
+      .string()
+      .regex(/^[0-9a-f]+$/)
+      .min(8)
+      .max(128)
+      .optional(),
+    template: z.record(z.string(), z.unknown()).nullable(),
+    ownerAccountId: accountIdSchema,
+    options: optionsSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (b) => (b.joinUrl === undefined) !== (b.conversationId === undefined),
+    { message: "Exactly one of joinUrl or conversationId" },
+  );
 
 type PollOutcome =
   | { kind: "joined" }
@@ -543,6 +577,17 @@ export async function joinHandler(req: Request, res: Response) {
       dispatchBody.options = upstreamOptions;
     }
 
+    const dispatchParse = dispatchBodySchema.safeParse(dispatchBody);
+    if (!dispatchParse.success) {
+      req.log.error(
+        { issues: dispatchParse.error.issues },
+        "Dispatch body failed validation - refusing to dispatch",
+      );
+      const { status, ...body } = ERRORS.JOIN_DISPATCH_INVALID;
+      res.status(status).json({ success: false, ...body });
+      return;
+    }
+
     const dispatchRes = await fetch(`${assistantBaseUrl}/api/assistants`, {
       method: "POST",
       headers: dispatchHeaders,
@@ -550,7 +595,7 @@ export async function joinHandler(req: Request, res: Response) {
         AbortSignal.timeout(DISPATCH_TIMEOUT_MS),
         clientDisconnect.signal,
       ]),
-      body: JSON.stringify(dispatchBody),
+      body: JSON.stringify(dispatchParse.data),
     });
 
     if (!dispatchRes.ok) {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,7 +1,9 @@
 import type { NextFunction, Request, Response } from "express";
+import { accountIdSchema } from "@/utils/account-id";
 import { AppError } from "@/utils/errors";
 import { verifyAppCheckToken } from "@/utils/firebase";
 import { isNotificationExtensionOnlyToken, verifyJwtToken } from "@/utils/jwt";
+import logger from "@/utils/logger";
 import { getRuntimeConfig } from "@/utils/runtimeConfig";
 
 export const AUTH_HEADER = "X-Convos-AuthToken";
@@ -175,11 +177,15 @@ export const authMiddlewareAllowNSE = async (
 };
 
 export const requireAccount = (
-  _req: Request,
+  req: Request,
   res: Response,
   next: NextFunction,
 ) => {
-  if (!res.locals.accountId) {
+  if (!accountIdSchema.safeParse(res.locals.accountId).success) {
+    ((req as { log?: Request["log"] }).log ?? logger).warn(
+      { accountIdPresent: res.locals.accountId !== undefined },
+      "requireAccount rejected request",
+    );
     res.status(403).json({ error: "Account required" });
     return;
   }

--- a/src/utils/account-id.ts
+++ b/src/utils/account-id.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+/**
+ * Canonical account-id shape. Account ids are UUIDs (`Account.id` is
+ * `@db.Uuid`; JWTs carry the same value). All account-id validation must
+ * import this schema — hand-rolled `z.string().uuid()` copies drift.
+ */
+export const accountIdSchema = z.string().uuid();

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,6 +1,7 @@
 import * as jose from "jose";
 import { z } from "zod";
 import { JWT_ISSUER, JWT_PRIVATE_KEY, JWT_PUBLIC_KEY } from "@/config";
+import { accountIdSchema } from "@/utils/account-id";
 import { deviceIdSchema } from "@/utils/device-id";
 import { AppError } from "@/utils/errors";
 import logger from "@/utils/logger";
@@ -23,7 +24,7 @@ export type V2JWTPayload = {
 
 const v2JWTPayloadSchema = z.object({
   deviceId: deviceIdSchema,
-  accountId: z.string().uuid().optional(),
+  accountId: accountIdSchema.optional(),
   metadata: z
     .object({
       notificationExtensionOnly: z.boolean().optional(),

--- a/tests/account-id.test.ts
+++ b/tests/account-id.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { accountIdSchema } from "@/utils/account-id";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 
 describe("accountIdSchema", () => {
   test("accepts a v4 uuid", () => {
@@ -10,9 +11,7 @@ describe("accountIdSchema", () => {
   });
 
   test("accepts the ADMIN seed uuid", () => {
-    const result = accountIdSchema.safeParse(
-      "48a05ef4-4a71-57a0-957f-a3d410992b31",
-    );
+    const result = accountIdSchema.safeParse(ADMIN_ACCOUNT_ID);
     expect(result.success).toBe(true);
   });
 

--- a/tests/account-id.test.ts
+++ b/tests/account-id.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { accountIdSchema } from "@/utils/account-id";
+
+describe("accountIdSchema", () => {
+  test("accepts a v4 uuid", () => {
+    const result = accountIdSchema.safeParse(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts the ADMIN seed uuid", () => {
+    const result = accountIdSchema.safeParse(
+      "48a05ef4-4a71-57a0-957f-a3d410992b31",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test.each([
+    ["garbage string", "not-a-uuid"],
+    ["uppercase garbage", "NOT-A-UUID-AT-ALL-NOPE"],
+    ["empty string", ""],
+    ["uuid with trailing junk", "11111111-1111-4111-8111-111111111111x"],
+    ["null", null],
+    ["number", 42],
+    ["undefined", undefined],
+  ])("rejects %s", (_label, value) => {
+    const result = accountIdSchema.safeParse(value);
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -37,7 +37,7 @@ const TEST_ACCOUNT_HEADER = "x-test-account-id";
 // noise; instead default a placeholder accountId so every test mirrors
 // production's authenticated-only contract, and let individual tests
 // override identity via a header.
-const DEFAULT_TEST_ACCOUNT_ID = "default-test-account";
+const DEFAULT_TEST_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 function testAccountMiddleware(
   req: Request,
   res: ExpressResponse,
@@ -721,7 +721,9 @@ describe("agents join (assistant API)", () => {
           const body = JSON.parse(init.body as string) as {
             ownerAccountId?: string;
           };
-          expect(body.ownerAccountId).toBe("user-bare");
+          expect(body.ownerAccountId).toBe(
+            "44444444-4444-4444-8444-444444444444",
+          );
           return Promise.resolve(
             jsonResponse(200, { instanceId: "inst-bare" }),
           );
@@ -731,7 +733,10 @@ describe("agents join (assistant API)", () => {
         );
       };
 
-      const res = await post({ slug: "x" }, { accountId: "user-bare" });
+      const res = await post(
+        { slug: "x" },
+        { accountId: "44444444-4444-4444-8444-444444444444" },
+      );
       expect(res.status).toBe(200);
     });
 
@@ -746,7 +751,9 @@ describe("agents join (assistant API)", () => {
             template: Record<string, unknown>;
             ownerAccountId?: string;
           };
-          expect(body.ownerAccountId).toBe("user-1");
+          expect(body.ownerAccountId).toBe(
+            "55555555-5555-4555-8555-555555555555",
+          );
           // Full AgentTemplate JSON (including prompt) rides as a single
           // top-level field. No `name`/`instructions`/`metadata` split.
           expect(body.template).toBeDefined();
@@ -765,7 +772,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post(
         { slug: "x", templateId: template.id },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(200);
     });
@@ -800,7 +807,7 @@ describe("agents join (assistant API)", () => {
           name: "Custom Name",
           profileImage: "https://cdn.example.com/custom.png",
         },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(200);
     });
@@ -810,7 +817,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post(
         { slug: "x", templateId: "33333333-3333-4333-8333-333333333333" },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(404);
       const data = (await res.json()) as { error: string };
@@ -824,7 +831,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post(
         { slug: "x", templateId: "33333333-3333-4333-8333-333333333333" },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(410);
       const data = (await res.json()) as { error: string };
@@ -842,7 +849,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post(
         { slug: "x", templateId: "33333333-3333-4333-8333-333333333333" },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(500);
       const data = (await res.json()) as { error: string };
@@ -852,7 +859,10 @@ describe("agents join (assistant API)", () => {
     test("draft template: owner can use it", async () => {
       __setTemplateFinderForTests(() =>
         Promise.resolve(
-          baseTemplate({ status: "draft", ownerAccountId: "user-1" }),
+          baseTemplate({
+            status: "draft",
+            ownerAccountId: "55555555-5555-4555-8555-555555555555",
+          }),
         ),
       );
 
@@ -867,7 +877,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post(
         { slug: "x", templateId: "33333333-3333-4333-8333-333333333333" },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(200);
     });
@@ -881,7 +891,7 @@ describe("agents join (assistant API)", () => {
 
       const res = await post(
         { slug: "x", templateId: "33333333-3333-4333-8333-333333333333" },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(403);
       const data = (await res.json()) as { error: string };
@@ -896,7 +906,7 @@ describe("agents join (assistant API)", () => {
           templateId: "33333333-3333-4333-8333-333333333333",
           options: { onboarding: "agent-builder" },
         },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(400);
       const data = (await res.json()) as { error: string };
@@ -927,9 +937,54 @@ describe("agents join (assistant API)", () => {
           templateId: "33333333-3333-4333-8333-333333333333",
           options: { onboarding: "first-impression" },
         },
-        { accountId: "user-1" },
+        { accountId: "55555555-5555-4555-8555-555555555555" },
       );
       expect(res.status).toBe(200);
+    });
+
+    test("dispatch body carries the joining user's uuid ownerAccountId", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+      mockFetchImpl = (url, init) => {
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-uuid-owner" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-uuid-owner",
+            joinStatus: "starting",
+            inboxId: "inbox-uuid-owner",
+          }),
+        );
+      };
+
+      const res = await post({ conversationId: "abcdef1234567890" });
+      expect(res.status).toBe(200);
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody!.ownerAccountId).toBe(DEFAULT_TEST_ACCOUNT_ID);
+    });
+
+    test("refuses to dispatch when accountId is not a uuid", async () => {
+      let fetchCalled = false;
+      mockFetchImpl = () => {
+        fetchCalled = true;
+        return Promise.reject(new Error("should not dispatch"));
+      };
+
+      const res = await post(
+        { conversationId: "abcdef1234567890" },
+        { accountId: "not-a-uuid" },
+      );
+      expect(res.status).toBe(500);
+      const data = (await res.json()) as { success: boolean; error: string };
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("JOIN_DISPATCH_INVALID");
+      expect(fetchCalled).toBe(false);
     });
   });
 

--- a/tests/auth-require-account.test.ts
+++ b/tests/auth-require-account.test.ts
@@ -8,10 +8,10 @@ vi.mock("firebase-admin/app-check");
 vi.mock("firebase-admin/messaging");
 
 describe("requireAccount middleware", () => {
-  function makeApp(accountId?: string) {
+  function makeApp(accountId?: unknown) {
     const app = express();
     app.use((_req, res, next) => {
-      res.locals.accountId = accountId;
+      res.locals.accountId = accountId as never;
       next();
     });
     app.get("/gated", requireAccount, (_req, res) => {
@@ -32,9 +32,46 @@ describe("requireAccount middleware", () => {
     expect(res.body).toEqual({ error: "Account required" });
   });
 
-  test("200 when accountId present", async () => {
+  test("403 when accountId is truthy but not a uuid", async () => {
     const res = await request(makeApp("acct-1")).get("/gated");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Account required" });
+  });
+
+  test("200 when accountId is a uuid", async () => {
+    const res = await request(
+      makeApp("11111111-1111-4111-8111-111111111111"),
+    ).get("/gated");
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
+  });
+
+  test("warn log carries presence flag only, never the value", async () => {
+    const warn = vi.fn();
+    const app = express();
+    app.use((req, res, next) => {
+      (req as unknown as { log: { warn: typeof warn } }).log = { warn };
+      res.locals.accountId = "super-secret-not-uuid";
+      next();
+    });
+    app.get("/gated", requireAccount, (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get("/gated");
+    expect(res.status).toBe(403);
+    expect(warn).toHaveBeenCalledWith(
+      { accountIdPresent: true },
+      "requireAccount rejected request",
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(
+      "super-secret-not-uuid",
+    );
+  });
+
+  test("403 when accountId is not a string", async () => {
+    const res = await request(makeApp(123)).get("/gated");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Account required" });
   });
 });


### PR DESCRIPTION
## Why

A production agent was once created upstream without `ownerAccountId`, breaking later account checks. Root cause traced to the pre-#231 window where `/agents/join` lacked `requireAccount` and dispatched `ownerAccountId: undefined` to convos-assistants. That door is closed, but nothing structurally prevented regression: the dispatch body was hand-built and unvalidated, the account-id shape was hand-rolled at four sites, and `requireAccount` only truthy-checked.

## What

- **`src/utils/account-id.ts`** — canonical `accountIdSchema = z.string().uuid()`, mirroring the `idempotency-key.ts` chokepoint pattern.
- **Reuse at all hand-rolled sites** — jwt payload, template create, generations create, meGuard. Behavior-neutral (identical semantics, removes drift-prone copies).
- **`requireAccount` shape gate** — `safeParse` instead of truthy check; absent OR malformed locals now 403 centrally. Same 403 status + body byte-for-byte. Warn log carries a presence flag only — the value is never logged (test-pinned). JWT verify already enforces uuid shape, so the only reachable new rejections are backend bugs.
- **Egress contract on the assistant dispatch** (the core guard) — strict `dispatchBodySchema` parsed before every upstream fetch: `ownerAccountId` required uuid, `joinUrl` XOR `conversationId`, template interior deliberately loose. Parse failure = backend invariant violation: 500 `JOIN_DISPATCH_INVALID` + error log, fetch never called. Even if route middleware regresses or a new dispatch path appears, nothing reaches upstream without a valid owner. The fetch sends `dispatchParse.data`, so what's validated is exactly what hits the wire.

Test fixtures migrated to uuid account ids (the new gates reject the old placeholder strings — correctly).

## Behavior change for valid callers

None. Every change is invisible to requests that were valid before: same status codes, same bodies, same accepted inputs.

## Testing

- 976 passed / 0 failed / 1 known skip across 112 files; `pnpm check` clean.
- New coverage: account-id schema unit tests; requireAccount non-uuid + non-string rejection + no-value-leak log assertion; dispatch body carries uuid ownerAccountId (slug and direct-add modes); non-uuid accountId → 500 + upstream fetch never called.

## Note for merging

`fbac/agent-templates-strip-passthrough` (sibling PR) touches the same `create.ts` schema block — merge this PR first, then rebase that one (trivial conflict: re-indent engulfs the `ownerAccountId` line).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783872555&installation_id=128169237&pr_number=305&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F305&signature=ee9fa5b5be2c013ced9d5f9c13980588fada89c922db7803eba78ca298d7c3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden agent-create paths with canonical `accountIdSchema` and validated assistant dispatch
> - Adds a shared `accountIdSchema` (`z.string().uuid()`) in [`utils/account-id.ts`](https://github.com/ephemeraHQ/convos-backend/pull/305/files#diff-37161ef6b7cb3f9d6e4f5c5eb12e576a8e1e2b20e38e91e8126a98c874965639) and replaces all inline UUID validators across middleware, handlers, and JWT utils with this canonical schema.
> - Strengthens `requireAccount` middleware to reject non-UUID `accountId` values with 403 (previously only checked truthiness); logs a warning with an `accountIdPresent` flag on rejection.
> - Adds a strict Zod `dispatchBodySchema` in [`agents/handlers/join.ts`](https://github.com/ephemeraHQ/convos-backend/pull/305/files#diff-56b3806a78b9509421cf23cd82891715d11c219bad27f45a5a9ff9665a18cd7c) that validates the dispatch envelope before sending to the assistant runtime; returns 500 `JOIN_DISPATCH_INVALID` on failure.
> - Risk: non-UUID `accountId` values that previously passed `requireAccount` now receive 403, which is a breaking behavioral change for any callers using non-UUID account IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d4c550.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Account ID validation is now consistently enforced across the application with improved error handling.
  * Enhanced error responses for invalid account identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->