### PR TITLE
fix(agent-templates): strip unknown keys on create instead of passthrough

### DIFF
--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -9,45 +9,37 @@ import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { prisma } from "@/utils/prisma";
 import { validateSlug } from "@/utils/reserved-slugs";
 
-const bodySchema = z
-  .object({
-    agentName: z.string().trim().min(1),
-    avatarUrl: z.string().nullable().optional(),
-    category: z.string().nullable().optional(),
-    connections: z.array(z.string()).optional(),
-    description: z.string().nullable().optional(),
-    emoji: z.string().nullable().optional(),
-    featured: z.boolean().optional(),
-    prompt: z
-      .string()
-      .max(50_000, {
-        message: "prompt exceeds maximum length of 50_000 characters",
-      })
-      .refine((value) => value.trim().length > 0, {
-        message: "prompt is required",
-      }),
-    slug: z.string().optional(),
-    tools: z.array(z.string()).optional(),
-    // Asserted owner — honoured only when the caller is agent-key-auth'd;
-    // ignored for JWT (the JWT account always wins) and anonymous. Mirrors
-    // the generations POST endpoint's owner-assertion contract so a trusted
-    // agent runtime can attribute a created template to the user it's acting
-    // on behalf of rather than the ADMIN seed account.
-    ownerAccountId: accountIdSchema.optional(),
-    // Provenance for forks. When a row is created as a copy of an existing
-    // template (e.g. the runtime forking a catalog template a group adopted),
-    // this records the source id. The FK (`forkedFromId → AgentTemplate.id`,
-    // ON DELETE SET NULL) is the canonical check — a dangling reference fails
-    // the insert and maps to the same 400 as a bad ownerAccountId below.
-    forkedFromId: z.string().uuid().optional(),
-  })
-  // .passthrough() (not .strict()) is intentional: create accepts a full
-  // AgentTemplate-shaped body and silently IGNORES the fields it derives
-  // server-side (status, version, firstPublishedAt, …) instead of 400ing, so a
-  // caller can POST a serialized template verbatim. The "ignores server-pinned
-  // fields" test pins this. (generations-post.ts uses .strict() because its
-  // body is a bespoke request envelope, not a template — different by design.)
-  .passthrough();
+const bodySchema = z.object({
+  agentName: z.string().trim().min(1),
+  avatarUrl: z.string().nullable().optional(),
+  category: z.string().nullable().optional(),
+  connections: z.array(z.string()).optional(),
+  description: z.string().nullable().optional(),
+  emoji: z.string().nullable().optional(),
+  featured: z.boolean().optional(),
+  prompt: z
+    .string()
+    .max(50_000, {
+      message: "prompt exceeds maximum length of 50_000 characters",
+    })
+    .refine((value) => value.trim().length > 0, {
+      message: "prompt is required",
+    }),
+  slug: z.string().optional(),
+  tools: z.array(z.string()).optional(),
+  // Asserted owner — honoured only when the caller is agent-key-auth'd;
+  // ignored for JWT (the JWT account always wins) and anonymous. Mirrors
+  // the generations POST endpoint's owner-assertion contract so a trusted
+  // agent runtime can attribute a created template to the user it's acting
+  // on behalf of rather than the ADMIN seed account.
+  ownerAccountId: accountIdSchema.optional(),
+  // Provenance for forks. When a row is created as a copy of an existing
+  // template (e.g. the runtime forking a catalog template a group adopted),
+  // this records the source id. The FK (`forkedFromId → AgentTemplate.id`,
+  // ON DELETE SET NULL) is the canonical check — a dangling reference fails
+  // the insert and maps to the same 400 as a bad ownerAccountId below.
+  forkedFromId: z.string().uuid().optional(),
+});
 
 type CreateBody = z.infer<typeof bodySchema>;
 

--- a/tests/agent-templates.create.test.ts
+++ b/tests/agent-templates.create.test.ts
@@ -172,6 +172,22 @@ describe("Agent template create endpoint", () => {
     expect(row.forkedFromId).toBeNull();
   });
 
+  test("strips unknown body keys - accepted, never stored, never echoed", async () => {
+    const { body, response } = await createTemplate({
+      agentName: "Create Test Strip Probe",
+      prompt: "You are helpful",
+      totallyUnknownKey: "should vanish",
+    });
+
+    expect(response.status).toBe(201);
+    expect(body).not.toHaveProperty("totallyUnknownKey");
+
+    const row = await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id: body.id as string },
+    });
+    expect(JSON.stringify(row)).not.toContain("should vanish");
+  });
+
   test("auto-derives slugs and allows duplicates (disambiguated by hashed-slug URL)", async () => {
     const ids: string[] = [];
 


### PR DESCRIPTION
## Why

The create body schema used `.passthrough()`, letting unknown body keys flow into `parsed.data`. Nothing reads them today (`createTemplateRow` enumerates fields explicitly), but any future code consuming `parsed.data` would see unvalidated client input — a latent mass-assignment surface.

## What

Remove `.passthrough()` → zod default strip. Caller-facing contract is identical: a serialized template POSTed verbatim is still accepted, server-derived fields are still silently ignored, no new 400s — the existing "ignores server-pinned fields" test still pins this. The change only guarantees `parsed.data` contains nothing but declared fields.

New pinning test asserts the full contract: unknown key → 201, never echoed in the response, never stored in the row.

## Testing

963 passed / 0 failed / 1 known skip across 111 files; `pnpm check` clean.

## Note for merging

Conflicts with #305 on the same schema block (re-indent). Merge #305 first; this branch then needs a trivial rebase (keep the strip-form schema, swap `ownerAccountId` to `accountIdSchema.optional()`, keep the import).

Follow-up candidates (backlogged, out of scope): `patch.ts`, `publish.ts`, `detail.ts`, `list.ts`, `apple-ssn.ts` still use `.passthrough()` — `patch.ts` is the priority since it mutates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783872569&installation_id=128169237&pr_number=306&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F306&signature=f54178e33e69108f4e5730a3492129e0a45e46a966ba2e27cc9cfdb60e6d3be1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip unknown keys on agent template create instead of passing them through
> Removes `.passthrough()` from the `bodySchema` Zod schema in [create.ts](https://github.com/ephemeraHQ/convos-backend/pull/306/files#diff-714fff4a3ad1a492d81a2b2d8d50c7f554618c6ecb35734dab8f9256eced205b), reverting to Zod's default strip behavior. Unknown keys in the request body are now silently dropped rather than preserved in the parsed result and stored. A new test in [agent-templates.create.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/306/files#diff-a72e946e9c120297cb3f3af6e8d8346c76eb3f65a2decc05dc8fd48fff24511b) asserts that unknown keys are accepted but not echoed in the response or persisted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70391cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored validation logic for agent template creation for improved code clarity while maintaining all existing behavior and validation rules.

* **Tests**
  * Enhanced test coverage to verify the agent template creation API properly rejects unknown request fields and prevents them from being stored, strengthening API robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->