### PR TITLE
Extend telemetry allowlists for client metric inventory

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -244,6 +244,9 @@ export const TELEMETRY_METRIC_PREFIXES = [
   "message.",
   "push.",
   "worker.",
+  "session.",
+  "storage.",
+  "stream.",
 ] as const;
 
 // Resource attributes allowed through (cardinality policy: nothing
@@ -261,9 +264,13 @@ export const TELEMETRY_ALLOWED_RESOURCE_ATTRS = new Set([
 ]);
 
 // Data point attributes allowed through (same cardinality/PII policy as
-// resource attrs — they become Datadog metric tags). Deny-all until a client
-// has a concrete need for a point-level dimension; add keys here then.
-export const TELEMETRY_ALLOWED_POINT_ATTRS = new Set<string>([]);
+// resource attrs — they become Datadog metric tags). "key" is the client
+// meter sub-dimension (e.g. stream.content_type key=text/plain); values are
+// app-enumerated, never user data.
+// Note: only attribute KEYS are enforced here — value-level cardinality/PII
+// discipline is the client's responsibility; review any new `key` call site
+// against the cardinality policy before shipping.
+export const TELEMETRY_ALLOWED_POINT_ATTRS = new Set<string>(["key"]);
 
 // How long dedup rows are kept (covers client retry horizon).
 export const TELEMETRY_BATCH_TTL_MS = 48 * 60 * 60 * 1000;

--- a/tests/telemetry-otlp.test.ts
+++ b/tests/telemetry-otlp.test.ts
@@ -284,4 +284,62 @@ describe("prepareBatch", () => {
       "https://example.com/schema",
     );
   });
+
+  test("allows session/storage/stream metric prefixes", () => {
+    for (const name of [
+      "session.delete_account",
+      "storage.conversations.fetch",
+      "stream.process_message",
+    ]) {
+      const out = prepareBatch(makeBody({ metricName: name }), baseOpts);
+      expect(out.isEmpty).toBe(false);
+    }
+  });
+
+  test("keeps the 'key' data point attribute", () => {
+    const body = makeBody();
+    body.resourceMetrics[0].scopeMetrics[0].metrics[0].sum.dataPoints[0].attributes =
+      [{ key: "key", value: { stringValue: "text/plain" } }] as never;
+    const out = prepareBatch(body, baseOpts);
+    const fwd = out.body as unknown as TestBody;
+    const dp = fwd.resourceMetrics[0].scopeMetrics[0].metrics[0].sum
+      ?.dataPoints[0] as { attributes?: { key: string }[] };
+    expect(dp.attributes?.map((a) => a.key)).toEqual(["key"]);
+    // only "key" present, nothing to strip
+    expect(out.strippedPointAttrKeys).toEqual([]);
+  });
+
+  test("keeps the 'key' attribute on histogram data points too", () => {
+    const body = makeBody();
+    body.resourceMetrics[0].scopeMetrics[0].metrics = [
+      {
+        name: "api.authenticate",
+        unit: "ms",
+        histogram: {
+          aggregationTemporality: 1,
+          dataPoints: [
+            {
+              startTimeUnixNano: ms(NOW_MS - 61_000).toString(),
+              timeUnixNano: ms(NOW_MS - 60_000).toString(),
+              count: "5",
+              sum: 1234.5,
+              bucketCounts: ["1", "4"],
+              explicitBounds: [100],
+              attributes: [
+                { key: "key", value: { stringValue: "wifi" } },
+                { key: "user.id", value: { stringValue: "u-123" } },
+              ],
+            },
+          ],
+        },
+      } as never,
+    ];
+    const out = prepareBatch(body, baseOpts);
+    const dp = (out.body as unknown as TestBody).resourceMetrics[0]
+      .scopeMetrics[0].metrics[0].histogram!.dataPoints[0] as {
+      attributes?: { key: string }[];
+    };
+    expect(dp.attributes?.map((a) => a.key)).toEqual(["key"]);
+    expect(out.strippedPointAttrKeys).toEqual(["user.id"]);
+  });
 });


### PR DESCRIPTION
## Summary

The Android client's full metric inventory (75 meters) uses three prefixes missing from `TELEMETRY_METRIC_PREFIXES` — `session.`, `storage.`, `stream.` — and a batch containing any disallowed name is rejected 400 in its entirety. It also emits a `key` data-point attribute (the meter sub-dimension, e.g. `stream.content_type` key=`text/plain`; bounded, app-enumerated values), which the deny-all point-attr allowlist would strip.

- Add the three prefixes
- Allow the single point attribute `key`; comment documents that only attribute keys are enforced server-side — value cardinality stays the client's responsibility
- Tests: prefix acceptance (asserting non-empty prepared batch), `key` survival on sum and histogram data points (with a disallowed attr stripped alongside)

Follow-up to #301; unblocks the convos-client exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783875650&installation_id=128169237&pr_number=307&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F307&signature=0094ad880f93bc51e130e147b75a65ac55ac3950f0546957b880d55c8228a3cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend telemetry allowlists to accept `session.`, `storage.`, and `stream.` metric prefixes and `key` data point attribute
> - Adds `session.`, `storage.`, and `stream.` to `TELEMETRY_METRIC_PREFIXES` in [config.ts](https://github.com/ephemeraHQ/convos-backend/pull/307/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012) so metrics with these prefixes pass the allowlist validator.
> - Changes `TELEMETRY_ALLOWED_POINT_ATTRS` from an empty set to `{'key'}`, preserving the `key` attribute on sum and histogram data points while stripping all others.
> - Adds tests covering all three new prefixes and the `key` attribute retention on both sum and histogram metrics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4042cb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated telemetry metric collection configuration to enable tracking of session, storage, and streaming metrics with refined attribute filtering and validation.

* **Tests**
  * Added comprehensive test coverage for telemetry metric name validation, attribute filtering, and data point attribute preservation in both standard and histogram metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->