### PR TITLE
fix(agent-templates): repair escaped-emoji text from builder generations

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -928,7 +928,7 @@ async function tryGithubPassthrough(
         repoDescription ||
         `Assistant based on ${owner}/${repo}.`,
       category: selection.category || "Work",
-      emoji: selection.emoji || "📦",
+      emoji: sanitizeEmojiField(selection.emoji ?? "") || "📦",
     },
     type,
   );
@@ -1250,7 +1250,7 @@ async function tryContentPassthrough(
       agentName: classification.agentName || "Agent",
       description: classification.description || "A Convos agent.",
       category: classification.category || "Work",
-      emoji: classification.emoji || "🤖",
+      emoji: sanitizeEmojiField(classification.emoji ?? "") || "🤖",
     },
     classification.passthroughType,
   );
@@ -1587,6 +1587,42 @@ export async function generateTemplate(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Escaped-emoji repair — exported for testing
+// ---------------------------------------------------------------------------
+
+// Completions occasionally arrive with emoji written as literal `\uXXXX`
+// escape TEXT instead of glyphs — constrained json_schema decoding biases the
+// model toward ASCII escape tokens, and it can even split a surrogate pair.
+// On the wire the backslash itself is then JSON-escaped, so JSON.parse hands
+// back literal `\ud83c…` characters that render verbatim in clients.
+
+/** Decode literal surrogate-pair escape text (`\ud83c\udf24` → 🌤) plus the
+ *  emoji-sequence escapes VS15/VS16, ZWJ, and keycap, then drop any leftover
+ *  lone-surrogate escape — a broken half of a pair with nothing to recover. */
+export function decodeEmojiEscapes(text: string): string {
+  return text
+    .replace(/\\u(d[89ab][0-9a-f]{2})\\u(d[c-f][0-9a-f]{2})/gi, (_, hi, lo) =>
+      String.fromCharCode(parseInt(hi, 16), parseInt(lo, 16)),
+    )
+    .replace(/\\u(fe0e|fe0f|200d|20e3)/gi, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16)),
+    )
+    .replace(/\\ud[89a-f][0-9a-f]{2}/gi, "");
+}
+
+/** Repair + gate the `emoji` field: decode escape text, then require at least
+ *  one emoji-class character. Anything else (prose, escape debris) becomes ""
+ *  so a non-emoji string can never ship in the field. */
+export function sanitizeEmojiField(emoji: string): string {
+  const decoded = decodeEmojiEscapes(emoji).trim();
+  return /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20e3/u.test(
+    decoded,
+  )
+    ? decoded
+    : "";
+}
+
 /** Parse and validate LLM response into a GeneratedTemplate. Exported for testing. */
 export function parseTemplateResponse(
   content: string,
@@ -1636,11 +1672,16 @@ export function parseTemplateResponse(
   }
 
   return {
-    agentName: parsed.agentName,
-    description: parsed.description || "",
-    prompt: parsed.prompt,
+    agentName: decodeEmojiEscapes(parsed.agentName).trim(),
+    description:
+      typeof parsed.description === "string"
+        ? decodeEmojiEscapes(parsed.description)
+        : "",
+    prompt: decodeEmojiEscapes(parsed.prompt),
     category: parsed.category || "",
-    emoji: parsed.emoji || "",
+    emoji: sanitizeEmojiField(
+      typeof parsed.emoji === "string" ? parsed.emoji : "",
+    ),
     tools: Array.isArray(parsed.tools) ? parsed.tools : [],
   };
 }

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -1597,9 +1597,21 @@ export async function generateTemplate(
 // On the wire the backslash itself is then JSON-escaped, so JSON.parse hands
 // back literal `\ud83c…` characters that render verbatim in clients.
 
-/** Decode literal surrogate-pair escape text (`\ud83c\udf24` → 🌤) plus the
- *  emoji-sequence escapes VS15/VS16, ZWJ, and keycap, then drop any leftover
- *  lone-surrogate escape — a broken half of a pair with nothing to recover. */
+/** Matches any emoji-class character — pictographs, regional indicators
+ *  (flags), or the keycap combining mark: the classes a valid `emoji` field
+ *  value must contain at least one of. */
+const EMOJI_CLASS_REGEX =
+  /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20e3/u;
+
+/**
+ * Decode literal `\uXXXX` escape text into the characters it names.
+ *
+ * Handles surrogate pairs (`\ud83c\udf24` → 🌤) and the emoji-sequence
+ * escapes — variation selectors VS15/VS16, zero-width joiner, and the keycap
+ * combining mark — then drops any leftover lone-surrogate escape: a broken
+ * half of a pair with nothing to recover. Text without escape sequences
+ * passes through unchanged.
+ */
 export function decodeEmojiEscapes(text: string): string {
   return text
     .replace(/\\u(d[89ab][0-9a-f]{2})\\u(d[c-f][0-9a-f]{2})/gi, (_, hi, lo) =>
@@ -1611,16 +1623,17 @@ export function decodeEmojiEscapes(text: string): string {
     .replace(/\\ud[89a-f][0-9a-f]{2}/gi, "");
 }
 
-/** Repair + gate the `emoji` field: decode escape text, then require at least
- *  one emoji-class character. Anything else (prose, escape debris) becomes ""
- *  so a non-emoji string can never ship in the field. */
+/**
+ * Repair and gate an `emoji` field value.
+ *
+ * Decodes escape text via `decodeEmojiEscapes`, trims, and returns the
+ * result only when it contains at least one emoji-class character (per
+ * `EMOJI_CLASS_REGEX`). Anything else — prose, escape debris, blanks —
+ * becomes "" so a non-emoji string can never ship in the field.
+ */
 export function sanitizeEmojiField(emoji: string): string {
   const decoded = decodeEmojiEscapes(emoji).trim();
-  return /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20e3/u.test(
-    decoded,
-  )
-    ? decoded
-    : "";
+  return EMOJI_CLASS_REGEX.test(decoded) ? decoded : "";
 }
 
 /** Parse and validate LLM response into a GeneratedTemplate. Exported for testing. */

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -1772,6 +1772,77 @@ describe("templateGen service — OpenRouter integration", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Escaped-emoji repair — decodeEmojiEscapes / sanitizeEmojiField
+  // -----------------------------------------------------------------------
+  test("decodeEmojiEscapes decodes surrogate-pair escape text into glyphs", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    const { decodeEmojiEscapes } = mod;
+
+    expect(decodeEmojiEscapes("Weather \\ud83c\\udf24\\ufe0f report")).toBe(
+      "Weather 🌤️ report",
+    );
+    // Uppercase hex decodes too
+    expect(decodeEmojiEscapes("\\uD83E\\uDD16")).toBe("🤖");
+    // Text without escape sequences passes through untouched
+    expect(decodeEmojiEscapes("plain text")).toBe("plain text");
+  });
+
+  test("decodeEmojiEscapes drops lone-surrogate escape debris", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    const { decodeEmojiEscapes } = mod;
+
+    expect(decodeEmojiEscapes("Skyler \\ud83c")).toBe("Skyler ");
+    expect(decodeEmojiEscapes("x \\udf24 y")).toBe("x  y");
+  });
+
+  test("sanitizeEmojiField repairs escape text and rejects non-emoji", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    const { sanitizeEmojiField } = mod;
+
+    expect(sanitizeEmojiField("\\ud83c\\udf24\\ufe0f")).toBe("🌤️");
+    expect(sanitizeEmojiField("🤖")).toBe("🤖");
+    expect(sanitizeEmojiField("🇺🇸")).toBe("🇺🇸");
+    expect(sanitizeEmojiField("#️⃣")).toBe("#️⃣");
+    // Prose, lone-surrogate debris, and blanks all empty out
+    expect(sanitizeEmojiField("robot")).toBe("");
+    expect(sanitizeEmojiField("\\ud83c")).toBe("");
+    expect(sanitizeEmojiField("  ")).toBe("");
+  });
+
+  test("parseTemplateResponse repairs double-escaped emoji from the wire", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    const { parseTemplateResponse } = mod;
+
+    // Simulates a completion whose strings carry emoji as literal escape
+    // text: JSON.stringify re-escapes the backslashes exactly as the wire
+    // JSON does, so JSON.parse yields literal `\ud83c…` text pre-repair.
+    const content = JSON.stringify({
+      agentName: "Skyler \\ud83c",
+      prompt: "Give forecasts. Sign off with \\ud83c\\udf24\\ufe0f.",
+      emoji: "\\ud83c\\udf24\\ufe0f",
+      description: "Weather \\ud83c\\udf24\\ufe0f friend",
+      category: "Local",
+      tools: [],
+    });
+
+    const result = parseTemplateResponse(content);
+    expect(result.agentName).toBe("Skyler");
+    expect(result.prompt).toBe("Give forecasts. Sign off with 🌤️.");
+    expect(result.description).toBe("Weather 🌤️ friend");
+    expect(result.emoji).toBe("🌤️");
+  });
+
+  test("parseTemplateResponse blanks a non-emoji emoji field", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    const { parseTemplateResponse } = mod;
+
+    const result = parseTemplateResponse(
+      JSON.stringify({ agentName: "Bot", prompt: "x", emoji: "weather" }),
+    );
+    expect(result.emoji).toBe("");
+  });
+
+  // -----------------------------------------------------------------------
   // appendBrevityRail exported and works correctly
   // -----------------------------------------------------------------------
   test("appendBrevityRail appends rail with separator", async () => {


### PR DESCRIPTION
## Summary

A builder generation shipped an agent (dev template `3f6023de-e986-472b-a54a-23a02563f99a`, "Skyler") whose `emoji` field holds the literal 18-character text `\ud83c\udf24\ufe0f` instead of 🌤️ — rendered verbatim in the app. The prompt body of the same row carries matching debris, including broken lone surrogates (`Skyler \ud83c`), so the model wrote emoji as `\uXXXX` escape *text*; on the wire the backslashes were JSON-escaped, `JSON.parse` faithfully returned literal backslash text, and nothing downstream validates the field (`json_schema` only enforces `type: "string"`).

## Fix

- `decodeEmojiEscapes`: decodes literal surrogate-pair escape text and emoji-sequence escapes (VS15/VS16, ZWJ, keycap), and drops lone-surrogate halves. Applied to `agentName`, `description`, and `prompt` in `parseTemplateResponse`.
- `sanitizeEmojiField`: decode + require at least one emoji-class character (`Extended_Pictographic`, regional indicator, or keycap), else `""`. Applied to the emoji field on all three producer paths: main generation, GitHub passthrough (`📦` fallback), and pasted-content classifier (`🤖` fallback).
- Passthrough prompt content is intentionally not decoded — it's user/repo-authored, where literal `\uXXXX` text can be legitimate.

Existing rows written before this fix (e.g. Skyler) keep the corrupt value; that one is broken beyond the emoji ("Let me restart this properly" mid-prompt) and is worth regenerating rather than patching.

## Testing

- `pnpm vitest run tests/template-gen.service.test.ts` — 51/51 pass (5 new tests cover decode, lone-surrogate debris, field gating, and an end-to-end double-escaped wire payload).
- `pnpm typecheck`, `pnpm format:check`, `pnpm eslint` on touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882994&installation_id=128169237&pr_number=308&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F308&signature=6aec8dc9e16a6a427b050a3447538c4acc8ae74ff2d20fc3a052aa9614b307f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix escaped-emoji text in agent template builder generations
> - Adds `decodeEmojiEscapes` to convert literal Unicode escape sequences (e.g. `\uD83C\uDF24`) from model outputs into real glyphs, handling surrogate pairs, ZWJ sequences, and keycap combiners.
> - Adds `sanitizeEmojiField` to validate that an emoji field contains at least one actual emoji character, returning an empty string otherwise.
> - Applies these helpers in `parseTemplateResponse` so `agentName`, `description`, and `prompt` no longer contain raw escape text, and `emoji` is either a valid emoji or blank.
> - Applies `sanitizeEmojiField` in `tryGithubPassthrough` and `tryContentPassthrough` so malformed emoji values fall back to their defaults (`📦` and `🤖`).
> - Behavioral Change: agent templates that previously surfaced literal escape debris (e.g. `\uD83C\uDF24`) in text fields will now show decoded glyphs or empty strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75dea4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed emoji field handling in agent template generation to properly decode escaped emoji sequences and validate characters. Invalid or malformed emoji data is now sanitized for consistency.

* **Tests**
  * Added comprehensive unit tests for emoji decoding and sanitization behavior, including edge cases and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->