### PR TITLE
feat(agent-templates): builder awareness of connection grants

### DIFF
--- a/prisma/migrations/20260616120000_add_generation_connections/migration.sql
+++ b/prisma/migrations/20260616120000_add_generation_connections/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+-- Neutral service ids (e.g. "googlecalendar") the caller flagged the agent as
+-- using. Validated against the supported-services catalog
+-- (src/api/v2/connections/bundles.config.ts) at submit; the executor appends a
+-- capabilities directive to the generator and overlays these onto the produced
+-- template's `connections`. Open input (no privileged gate): stamping a
+-- connection grants nothing — the grant is issued later, at provisioning.
+--
+-- NOT NULL with an array default to match Prisma's `String[] @default([])`
+-- exactly; backfills existing rows to the empty array.
+ALTER TABLE "AgentTemplateGeneration"
+  ADD COLUMN "connections" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -233,6 +233,14 @@ model AgentTemplateGeneration {
   // (agent-API-key only) and used by the executor for the main generation call
   // instead of the default builder model.
   builderModel    String?          @db.VarChar(256)
+  // Neutral service ids (e.g. "googlecalendar") the caller flagged the agent as
+  // using — validated against the supported-services catalog at submit, read by
+  // the executor (which appends a capabilities directive to the generator and
+  // overlays these onto the produced template's `connections`). Open: stamping a
+  // connection grants nothing, it only records the template uses the service;
+  // the grant itself is issued later, at provisioning. Stored raw like
+  // `inputs`/`prefill` (the executor normalizes against the catalog).
+  connections     String[]         @default([])
   // The draft agent shown while the build runs — { agentName, emoji,
   // description } — written by the distill stage and surfaced as `preview` on
   // in-progress (202) poll responses. The full agent arrives via `templateId`
@@ -316,7 +324,7 @@ model CreditLedger {
   delta            BigInt
   reason           LedgerReason
   idempotencyKey   String
-  scope            String       @db.VarChar(32) @default("transaction")
+  scope            String       @default("transaction") @db.VarChar(32)
   balanceAfter     BigInt?
   usdCostMicros    BigInt?
   markupRate       Decimal?     @db.Decimal(8, 4)

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -37,6 +37,10 @@ import {
   writeSseEvent,
 } from "@/api/v2/agent-templates/lib/sse";
 import {
+  applyConnections,
+  resolveConnectionIds,
+} from "@/api/v2/agent-templates/lib/template-connections";
+import {
   attachmentsArraySchema,
   resolveAttachments,
   type AttachmentRef,
@@ -49,6 +53,7 @@ import {
   type GenerationPrefill,
   type GenerationResult,
 } from "@/api/v2/agent-templates/services/templateGen";
+import { getServiceConfig } from "@/api/v2/connections/bundles.config";
 import { AppError } from "@/utils/errors";
 
 // One synchronous generation, kept under typical edge/proxy request ceilings.
@@ -68,6 +73,10 @@ const MAX_BUILDER_PROMPT_LEN = 100_000;
 // Model-override cap — OpenRouter model ids are short slugs; this just bounds
 // an obviously-abusive value (matches the async endpoint's builderModel cap).
 const MAX_BUILDER_MODEL_LEN = 256;
+// Connection-slug caps — short service slugs; the real gate is the catalog
+// lookup below (matches the async endpoint's connection caps).
+const MAX_CONNECTION_SLUG_LEN = 64;
+const MAX_CONNECTIONS = 16;
 
 const inputsSchema = z
   .object({
@@ -93,6 +102,14 @@ const bodySchema = z
     builderPrompt: z.string().min(1).max(MAX_BUILDER_PROMPT_LEN).optional(),
     builderModel: z.string().min(1).max(MAX_BUILDER_MODEL_LEN).optional(),
     prefill: prefillSchema.optional(),
+    // Neutral service ids the throwaway agent should use — same shape + catalog
+    // validation as the async endpoint. Drives the generator's capabilities
+    // directive and is overlaid onto the returned (non-persisted) template's
+    // `connections`. Bare slugs on the wire, no `composio:` prefix.
+    connections: z
+      .array(z.string().trim().min(1).max(MAX_CONNECTION_SLUG_LEN))
+      .max(MAX_CONNECTIONS)
+      .optional(),
   })
   .strict();
 
@@ -123,6 +140,9 @@ async function runGeneration(
     prefill: GenerationPrefill | null;
     builderPrompt: string | null;
     builderModel: string | null;
+    /** Canonical catalog service ids. Fed to the generator (capabilities
+     *  directive) and overlaid onto the returned template's `connections`. */
+    connectionIds: string[];
   },
 ): Promise<Outcome> {
   try {
@@ -133,8 +153,18 @@ async function runGeneration(
       undefined,
       args.builderPrompt,
       args.builderModel,
+      args.connectionIds,
     );
-    return { kind: "ok", result };
+    // Overlay the connections onto the returned template (replacing the
+    // generator's hardcoded []), so the throwaway candidate the admin tool shows
+    // records the same services its prompt was written to use.
+    return {
+      kind: "ok",
+      result: {
+        ...result,
+        template: applyConnections(result.template, args.connectionIds),
+      },
+    };
   } catch (err) {
     // The 90s ceiling is the only abort we surface as a timeout.
     if (args.timeoutSignal.aborted) {
@@ -218,6 +248,20 @@ export async function generationsEphemeralPostHandler(
     return;
   }
 
+  // Validate connections against the supported-services catalog — unknown → 400,
+  // same as the async endpoint. Then normalize to canonical ids for the
+  // generator directive + the template overlay.
+  const requestedConnections = parsed.data.connections;
+  if (requestedConnections) {
+    for (const serviceId of requestedConnections) {
+      if (!getServiceConfig(serviceId)) {
+        res.status(400).json({ error: `Unknown connection '${serviceId}'` });
+        return;
+      }
+    }
+  }
+  const connectionIds = resolveConnectionIds(requestedConnections);
+
   // Abort the upstream generation on the 90s ceiling OR a client disconnect.
   // Unlike the async endpoint (whose executor runs to completion to persist a
   // result), an ephemeral result is discarded the moment the client hangs up,
@@ -290,6 +334,7 @@ export async function generationsEphemeralPostHandler(
     prefill,
     builderPrompt,
     builderModel,
+    connectionIds,
   };
 
   // SSE mode: heartbeat while the generation runs, then a single terminal

--- a/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-ephemeral-post.ts
@@ -162,7 +162,10 @@ async function runGeneration(
       kind: "ok",
       result: {
         ...result,
-        template: applyConnections(result.template, args.connectionIds),
+        template: applyConnections({
+          template: result.template,
+          connectionIds: args.connectionIds,
+        }),
       },
     };
   } catch (err) {
@@ -260,7 +263,7 @@ export async function generationsEphemeralPostHandler(
       }
     }
   }
-  const connectionIds = resolveConnectionIds(requestedConnections);
+  const connectionIds = resolveConnectionIds({ raw: requestedConnections });
 
   // Abort the upstream generation on the 90s ceiling OR a client disconnect.
   // Unlike the async endpoint (whose executor runs to completion to persist a

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -66,6 +66,7 @@ import {
   writeSseEvent,
   writeSseHeaders,
 } from "@/api/v2/agent-templates/lib/sse";
+import { resolveConnectionIds } from "@/api/v2/agent-templates/lib/template-connections";
 import {
   attachmentsArraySchema,
   type AttachmentRef,
@@ -536,6 +537,16 @@ const dedupeSelect = {
   updatedAt: true,
 } as const;
 
+/** Reduce a raw connections list to the comparable set used for idempotency
+ *  dedupe: canonical catalog ids, deduped (via `resolveConnectionIds`) and
+ *  sorted so the comparison is order-insensitive. The row persists the raw list;
+ *  only this comparison is normalized. */
+function normalizeConnectionsForDedupe(
+  raw: string[] | null | undefined,
+): string[] {
+  return resolveConnectionIds({ raw }).sort();
+}
+
 /** Compare the full idempotent contract — every field that influences
  *  the generator's output or the persisted template's identity. A
  *  mismatch on any of them means the second caller wants a different
@@ -550,11 +561,14 @@ function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
       prefill: existing.prefill,
       builderPrompt: existing.builderPrompt,
       builderModel: existing.builderModel,
-      // Non-nullable array column (defaults to []), so compare against the
-      // body's `?? []` — an omitted `connections` matches a stored []. Rows that
-      // predate this column also read back [], so old idempotency keys replayed
-      // without connections still dedupe instead of 409ing.
-      connections: existing.connections,
+      // Connections are a set: normalize both sides to canonical, deduped,
+      // sorted catalog ids before comparing so semantically equivalent replays
+      // dedupe instead of 409ing — different casing (`GoogleCalendar` vs
+      // `googlecalendar`), duplicates, and ordering all collapse to the same
+      // value the executor would resolve. An omitted list and a stored [] also
+      // match (resolveConnectionIds maps null/undefined → []), so old keys
+      // replayed without connections still dedupe.
+      connections: normalizeConnectionsForDedupe(existing.connections),
     },
     {
       source: body.source,
@@ -563,7 +577,7 @@ function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
       prefill: body.prefill ?? null,
       builderPrompt: body.builderPrompt ?? null,
       builderModel: body.builderModel ?? null,
-      connections: body.connections ?? [],
+      connections: normalizeConnectionsForDedupe(body.connections),
     },
   );
 }

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -32,6 +32,7 @@
  *   7. builderPrompt — agent-key only                           → 403
  *   8. builderModel — agent-key only                            → 403
  *   9. builderModel unknown to OpenRouter's catalog             → 400
+ *  9b. connections unknown to the services catalog (open)       → 400
  *  10. Idempotency-Key header present                           → 400
  *  11. Idempotency lookup → existing { source, inputs } match   → respondPerMode
  *  12.                  → existing different body               → 409
@@ -82,6 +83,7 @@ import {
 import { type TraceContext } from "@/api/v2/agent-templates/services/openrouter-client";
 import { isKnownOpenRouterModel } from "@/api/v2/agent-templates/services/openrouter-models";
 import { resolveActor } from "@/api/v2/agent-templates/services/posthog";
+import { getServiceConfig } from "@/api/v2/connections/bundles.config";
 import { BUILD_ATTACHMENTS_MAX_TOTAL_BYTES } from "@/config";
 import { accountIdSchema } from "@/utils/account-id";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
@@ -102,6 +104,10 @@ const MAX_BUILDER_PROMPT_LEN = 100_000;
 const MAX_BUILDER_MODEL_LEN = 256;
 const MAX_BODY_BYTES = 40 * 1024 * 1024;
 const MAX_WAIT_MS = 45_000;
+// Connection-slug caps — service ids are short slugs; these just bound an
+// obviously-abusive body. The real gate is the catalog lookup below.
+const MAX_CONNECTION_SLUG_LEN = 64;
+const MAX_CONNECTIONS = 16;
 
 // RFC 4122 UUID format. Version digit is any 1-5 (accepts v4 random,
 // v5 namespaced, etc.); variant nibble is 8/9/a/b.
@@ -240,6 +246,19 @@ const bodySchema = z
     // below (like builderPrompt) — and persisted on the row so the
     // fire-and-forget executor can hand it to the generator.
     builderModel: z.string().min(1).max(MAX_BUILDER_MODEL_LEN).optional(),
+    // Neutral service ids (e.g. ["googlecalendar"]) flagging which external
+    // services the generated agent should use. Caller-pinned and persisted on
+    // the row like `prefill`; the executor appends a capabilities directive to
+    // the generator and overlays these onto the produced template's
+    // `connections`. Open (no privileged gate) — stamping a connection grants
+    // nothing; the grant is issued later, at provisioning. Each id is validated
+    // against the supported-services catalog below (unknown → 400); zod here
+    // only bounds shape/size. Bare slugs on the wire — no `composio:` prefix —
+    // so templates stay agnostic to the connection provider.
+    connections: z
+      .array(z.string().trim().min(1).max(MAX_CONNECTION_SLUG_LEN))
+      .max(MAX_CONNECTIONS)
+      .optional(),
     // Asserted owner — honoured only when the caller is agent-key-auth'd;
     // ignored for JWT (JWT account always wins) and anonymous (falls
     // back to ADMIN). See the owner-resolution block below.
@@ -495,6 +514,7 @@ interface DedupeRow extends GenerationRow {
   prefill: unknown;
   builderPrompt: string | null;
   builderModel: string | null;
+  connections: string[];
 }
 
 const dedupeSelect = {
@@ -505,6 +525,7 @@ const dedupeSelect = {
   prefill: true,
   builderPrompt: true,
   builderModel: true,
+  connections: true,
   status: true,
   templateId: true,
   reply: true,
@@ -529,6 +550,11 @@ function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
       prefill: existing.prefill,
       builderPrompt: existing.builderPrompt,
       builderModel: existing.builderModel,
+      // Non-nullable array column (defaults to []), so compare against the
+      // body's `?? []` — an omitted `connections` matches a stored []. Rows that
+      // predate this column also read back [], so old idempotency keys replayed
+      // without connections still dedupe instead of 409ing.
+      connections: existing.connections,
     },
     {
       source: body.source,
@@ -537,6 +563,7 @@ function dedupeBodiesMatch(existing: DedupeRow, body: Body): boolean {
       prefill: body.prefill ?? null,
       builderPrompt: body.builderPrompt ?? null,
       builderModel: body.builderModel ?? null,
+      connections: body.connections ?? [],
     },
   );
 }
@@ -779,6 +806,23 @@ export async function generationsPostHandler(req: Request, res: Response) {
     return;
   }
 
+  // 9b. Validate connections against the supported-services catalog — fail-fast
+  //     400 on an unknown service, same shape as the builderModel check. Open
+  //     (no agent-API-key gate): unlike builderPrompt/builderModel, stamping a
+  //     connection grants nothing — it only produces a template that records it
+  //     uses the service. The real authz boundary is grant issuance + exec, both
+  //     downstream.
+  if (body.connections) {
+    for (const serviceId of body.connections) {
+      if (!getServiceConfig(serviceId)) {
+        res.status(400).json({
+          error: `Unknown connection '${serviceId}'`,
+        });
+        return;
+      }
+    }
+  }
+
   // 10. Idempotency-Key required and MUST be a UUID (any RFC 4122 version).
   //    Both the agent API key path and anonymous submissions are owned by
   //    `ADMIN_ACCOUNT_ID`, so they share an idempotency namespace; using
@@ -956,6 +1000,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
           : Prisma.JsonNull,
         builderPrompt: body.builderPrompt ?? null,
         builderModel: body.builderModel ?? null,
+        connections: body.connections ?? [],
         publishStatus: body.publishStatus,
         status: "pending",
       },

--- a/src/api/v2/agent-templates/lib/template-connections.ts
+++ b/src/api/v2/agent-templates/lib/template-connections.ts
@@ -12,9 +12,11 @@ import { getServiceConfig } from "@/api/v2/connections/bundles.config";
  *  carried onto the template. Storing the catalog's neutral `id` keeps the
  *  template agnostic to the connection provider — the vendor binding lives only
  *  in the catalog + exec layers. */
-export function resolveConnectionIds(
-  raw: string[] | null | undefined,
-): string[] {
+export function resolveConnectionIds({
+  raw,
+}: {
+  raw: string[] | null | undefined;
+}): string[] {
   if (!raw || raw.length === 0) return [];
   const ids: string[] = [];
   const seen = new Set<string>();
@@ -28,14 +30,17 @@ export function resolveConnectionIds(
   return ids;
 }
 
-/** Overlay the resolved connection ids onto a generated template, replacing the
- *  generator's hardcoded `connections: []`. The bridge that lets downstream
- *  provisioning issue a grant per connection once the agent has an inbox in a
- *  conversation. No-op when nothing connected (keeps the existing []). */
-export function applyConnections<T extends { connections: string[] }>(
-  template: T,
-  connectionIds: string[],
-): T {
-  if (connectionIds.length === 0) return template;
+/** Overlay the resolved connection ids onto a generated template, replacing
+ *  whatever `connections` the generator produced. The bridge that lets
+ *  downstream provisioning issue a grant per connection once the agent has an
+ *  inbox in a conversation. Always stamps `connectionIds` (including `[]`) so a
+ *  model-produced value can't leak onto the template when nothing connected. */
+export function applyConnections<T extends { connections: string[] }>({
+  template,
+  connectionIds,
+}: {
+  template: T;
+  connectionIds: string[];
+}): T {
   return { ...template, connections: connectionIds };
 }

--- a/src/api/v2/agent-templates/lib/template-connections.ts
+++ b/src/api/v2/agent-templates/lib/template-connections.ts
@@ -1,0 +1,41 @@
+// Shared helpers that turn the caller-supplied connection slugs into the
+// `connections` array on a generated template. Used by both generation paths:
+// the async executor (persists the template) and the ephemeral handler (returns
+// it inline). Kept here so the normalize + overlay logic lives in one place.
+
+import { getServiceConfig } from "@/api/v2/connections/bundles.config";
+
+/** Normalize raw connection slugs to canonical, deduplicated catalog service
+ *  ids. The caller (each generation handler) validated every slug against the
+ *  same catalog before this point, so entries resolve; an unknown id (e.g. a
+ *  service retired between submit and run) is dropped fail-closed rather than
+ *  carried onto the template. Storing the catalog's neutral `id` keeps the
+ *  template agnostic to the connection provider — the vendor binding lives only
+ *  in the catalog + exec layers. */
+export function resolveConnectionIds(
+  raw: string[] | null | undefined,
+): string[] {
+  if (!raw || raw.length === 0) return [];
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const slug of raw) {
+    const svc = getServiceConfig(slug);
+    if (svc && !seen.has(svc.id)) {
+      seen.add(svc.id);
+      ids.push(svc.id);
+    }
+  }
+  return ids;
+}
+
+/** Overlay the resolved connection ids onto a generated template, replacing the
+ *  generator's hardcoded `connections: []`. The bridge that lets downstream
+ *  provisioning issue a grant per connection once the agent has an inbox in a
+ *  conversation. No-op when nothing connected (keeps the existing []). */
+export function applyConnections<T extends { connections: string[] }>(
+  template: T,
+  connectionIds: string[],
+): T {
+  if (connectionIds.length === 0) return template;
+  return { ...template, connections: connectionIds };
+}

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -27,6 +27,10 @@ import type { Prisma } from "@prisma/client";
 import type { AgentPreview } from "@/api/v2/agent-templates/lib/generation-preview";
 import { pickCollisionFreeId } from "@/api/v2/agent-templates/lib/pick-collision-free-id";
 import {
+  applyConnections,
+  resolveConnectionIds,
+} from "@/api/v2/agent-templates/lib/template-connections";
+import {
   AttachmentModerationError,
   resolveAttachments,
   type AttachmentRef,
@@ -537,6 +541,11 @@ async function _runPipeline(
   // ordinary generations, where the default builder model is used.
   const builderModel = generation.builderModel;
 
+  // Connections the caller flagged at submit, normalized to canonical catalog
+  // ids. Fed to the generator (drives the capabilities directive so the prompt +
+  // welcome lean on the service) and overlaid onto the persisted template below.
+  const connectionIds = resolveConnectionIds(generation.connections);
+
   // Actor-attribution fields shared by every capture site below, plus the
   // PostHog LLM Analytics trace id so the product event joins to the
   // `$ai_generation` spans the OpenRouter calls emit. Built once: the trace's
@@ -655,6 +664,7 @@ async function _runPipeline(
       trace,
       builderPrompt,
       builderModel,
+      connectionIds,
     );
   } catch (err) {
     // Meter error path
@@ -686,8 +696,13 @@ async function _runPipeline(
   // Overlay the allowlisted identity fields onto the LLM output so the persisted
   // metadata matches the card shown on the early polls verbatim. `identity`
   // is the distilled identity (or the caller's pins where supplied) — the same
-  // value fed into the generator above, so the prompt body agrees with the metadata.
-  const templateToPersist = applyPrefill(templateResult.template, identity);
+  // value fed into the generator above, so the prompt body agrees with the
+  // metadata. Then overlay the resolved connections, replacing the generator's
+  // hardcoded `connections: []` so the template records the services it uses.
+  const templateToPersist = applyConnections(
+    applyPrefill(templateResult.template, identity),
+    connectionIds,
+  );
   let persisted: { id: string; slug: string };
   try {
     persisted = await persistTemplate(

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -544,7 +544,7 @@ async function _runPipeline(
   // Connections the caller flagged at submit, normalized to canonical catalog
   // ids. Fed to the generator (drives the capabilities directive so the prompt +
   // welcome lean on the service) and overlaid onto the persisted template below.
-  const connectionIds = resolveConnectionIds(generation.connections);
+  const connectionIds = resolveConnectionIds({ raw: generation.connections });
 
   // Actor-attribution fields shared by every capture site below, plus the
   // PostHog LLM Analytics trace id so the product event joins to the
@@ -699,10 +699,10 @@ async function _runPipeline(
   // value fed into the generator above, so the prompt body agrees with the
   // metadata. Then overlay the resolved connections, replacing the generator's
   // hardcoded `connections: []` so the template records the services it uses.
-  const templateToPersist = applyConnections(
-    applyPrefill(templateResult.template, identity),
+  const templateToPersist = applyConnections({
+    template: applyPrefill(templateResult.template, identity),
     connectionIds,
-  );
+  });
   let persisted: { id: string; slug: string };
   try {
     persisted = await persistTemplate(

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -27,6 +27,7 @@
 
 import { APIConnectionTimeoutError, APIError, APIUserAbortError } from "openai";
 import { z } from "zod";
+import { getServiceConfig } from "@/api/v2/connections/bundles.config";
 import {
   BUILDER_CLASSIFIER_MODEL,
   BUILDER_EXA_SERVICE_KEY,
@@ -348,6 +349,38 @@ function buildIdentityDirective(prefill?: GenerationPrefill | null): string {
     `\n\nREQUIRED IDENTITY — the user has already pinned part of this assistant's identity. ` +
     `Use these exact values; do NOT substitute different ones: ${parts.join(", ")}. ` +
     closing
+  );
+}
+
+/** Build the user-message addendum that tells the generator which external
+ *  services the agent is connected to, so the prompt, instructions, and WELCOME
+ *  MESSAGE lean on those capabilities (e.g. "you can view and edit the group's
+ *  calendar events"). Copy is sourced from the catalog — `displayName` plus each
+ *  live bundle's `title`/`description` — so it tracks the same blessed services
+ *  the grant + exec layers use. Returns "" when nothing resolves (the handler
+ *  validates against the same catalog, so unknown ids never reach here; the
+ *  guard is defensive). */
+function buildCapabilitiesDirective(connections?: string[] | null): string {
+  if (!connections || connections.length === 0) return "";
+  const lines: string[] = [];
+  for (const serviceId of connections) {
+    const svc = getServiceConfig(serviceId);
+    if (!svc) continue;
+    const caps = svc.bundles
+      .filter((b) => !b.deprecated)
+      .map((b) => `${b.title.en} (${b.description.en})`)
+      .join(", ");
+    lines.push(caps ? `${svc.displayName.en} — ${caps}` : svc.displayName.en);
+  }
+  if (lines.length === 0) return "";
+  const many = lines.length > 1;
+  return (
+    `\n\nCONNECTED CAPABILITIES — the user has connected this assistant to the ` +
+    `following external service${many ? "s" : ""}, and it can use ${many ? "them" : "it"} ` +
+    `live in the group chat. Write the prompt, the instructions, and the WELCOME ` +
+    `MESSAGE so the assistant actively leans on ${many ? "these capabilities" : "this capability"} ` +
+    `(don't just mention ${many ? "them" : "it"} — make ${many ? "them" : "it"} central to what it does):\n` +
+    lines.map((l) => `- ${l}`).join("\n")
   );
 }
 
@@ -1312,6 +1345,7 @@ export async function generateTemplate(
   trace?: TraceContext,
   systemPromptOverride?: string | null,
   modelOverride?: string | null,
+  connections?: string[] | null,
 ): Promise<GenerationResult> {
   // Backward compat: string input = text
   const opts: GenerateTemplateInput =
@@ -1457,21 +1491,26 @@ export async function generateTemplate(
     userContent = `Create an assistant based on the following content:\n\n---\n${extracted}\n---`;
   }
 
-  // Caller-pinned identity: fold the already-chosen name/emoji into the user
-  // message so the model writes agentName, the prompt body, all self-references,
-  // and the WELCOME MESSAGE as this named assistant. Without this the model
-  // invents its own identity and the persist-stage applyPrefill overlay leaves
-  // the card's name at odds with the prompt the assistant actually runs on.
-  const identityDirective = buildIdentityDirective(prefill);
-  if (identityDirective) {
+  // Fold two user-message addenda into the directive text:
+  //   - Caller-pinned identity (name/emoji), so the model writes agentName, the
+  //     prompt body, every self-reference, and the WELCOME MESSAGE as this named
+  //     assistant. Without it the model invents its own identity and the
+  //     persist-stage applyPrefill overlay leaves the card's name at odds with
+  //     the prompt the assistant actually runs on.
+  //   - Connected capabilities, so the prompt + welcome lean on the external
+  //     services the agent has access to (the grant itself is issued later).
+  // Both ride the same trailing-edge slot; each already opens with `\n\n`.
+  const userDirective =
+    buildIdentityDirective(prefill) + buildCapabilitiesDirective(connections);
+  if (userDirective) {
     if (typeof userContent === "string") {
-      userContent = `${userContent}${identityDirective}`;
+      userContent = `${userContent}${userDirective}`;
     } else if (
       Array.isArray(userContent) &&
       userContent[0]?.type === "text" &&
       typeof userContent[0].text === "string"
     ) {
-      userContent[0].text = `${userContent[0].text}${identityDirective}`;
+      userContent[0].text = `${userContent[0].text}${userDirective}`;
     }
   }
 
@@ -1739,6 +1778,7 @@ let _generateTemplateOverride:
       trace?: TraceContext,
       systemPromptOverride?: string | null,
       modelOverride?: string | null,
+      connections?: string[] | null,
     ) => Promise<GenerationResult>)
   | null = null;
 
@@ -1752,6 +1792,7 @@ export function __resetGenerateTemplateForTests(
         trace?: TraceContext,
         systemPromptOverride?: string | null,
         modelOverride?: string | null,
+        connections?: string[] | null,
       ) => Promise<GenerationResult>)
     | null,
 ) {
@@ -1772,6 +1813,10 @@ export function __resetGenerateTemplateForTests(
  *
  * Optional `modelOverride` similarly swaps the builder model for the main
  * generation call; omitted on the production generation path.
+ *
+ * Optional `connections` are the neutral service ids the agent is connected to;
+ * they drive the capabilities directive appended to the user message so the
+ * generated prompt/welcome lean on those services.
  */
 export async function callGenerateTemplate(
   input: GenerateTemplateInput | string,
@@ -1780,6 +1825,7 @@ export async function callGenerateTemplate(
   trace?: TraceContext,
   systemPromptOverride?: string | null,
   modelOverride?: string | null,
+  connections?: string[] | null,
 ): Promise<GenerationResult> {
   if (_generateTemplateOverride) {
     return _generateTemplateOverride(
@@ -1789,6 +1835,7 @@ export async function callGenerateTemplate(
       trace,
       systemPromptOverride,
       modelOverride,
+      connections,
     );
   }
   return generateTemplate(
@@ -1798,6 +1845,7 @@ export async function callGenerateTemplate(
     trace,
     systemPromptOverride,
     modelOverride,
+    connections,
   );
 }
 

--- a/tests/agent-templates.executor.test.ts
+++ b/tests/agent-templates.executor.test.ts
@@ -395,6 +395,86 @@ describe("generation-executor", () => {
     expect(capturedModel).toBeNull();
   });
 
+  test("threads the row's connections to the generator and overlays canonical ids onto the template", async () => {
+    let capturedConnections: string[] | null | undefined;
+    __resetGenerateTemplateForTests(
+      (
+        _input,
+        _signal,
+        _prefill,
+        _trace,
+        _systemPromptOverride,
+        _modelOverride,
+        connections,
+      ) => {
+        capturedConnections = connections;
+        return Promise.resolve({
+          template: fakeTemplate,
+          metrics: DEFAULT_TEST_METRICS,
+        });
+      },
+    );
+    const gen = await prisma.agentTemplateGeneration.create({
+      data: {
+        ownerAccountId: ADMIN_ACCOUNT_ID,
+        source: TEST_SOURCE,
+        idempotencyKey: "connections-threading",
+        inputs: { text: "a calendar agent" },
+        // Mixed case + a duplicate to exercise catalog normalization + dedupe.
+        connections: ["GoogleCalendar", "googlecalendar"],
+        status: "pending",
+      },
+    });
+
+    await executeGeneration(gen.id);
+
+    const final = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: gen.id },
+    });
+    expect(final?.status).toBe("done");
+    // Normalized to the catalog's canonical neutral id, deduped — both fed to the
+    // generator and overlaid onto the persisted template.
+    expect(capturedConnections).toEqual(["googlecalendar"]);
+
+    const template = await prisma.agentTemplate.findUnique({
+      where: { id: final?.templateId as string },
+    });
+    expect(template?.connections).toEqual(["googlecalendar"]);
+  });
+
+  test("ordinary generation (no connections) leaves template.connections empty", async () => {
+    let capturedConnections: string[] | null | undefined = ["SENTINEL"];
+    __resetGenerateTemplateForTests(
+      (
+        _input,
+        _signal,
+        _prefill,
+        _trace,
+        _systemPromptOverride,
+        _modelOverride,
+        connections,
+      ) => {
+        capturedConnections = connections;
+        return Promise.resolve({
+          template: fakeTemplate,
+          metrics: DEFAULT_TEST_METRICS,
+        });
+      },
+    );
+    const gen = await createPendingGeneration("no-connections");
+
+    await executeGeneration(gen.id);
+
+    const final = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: gen.id },
+    });
+    expect(capturedConnections).toEqual([]);
+    const template = await prisma.agentTemplate.findUnique({
+      where: { id: final?.templateId as string },
+    });
+    expect(template?.connections).toEqual([]);
+  });
+
   test("preserves the user's text intent alongside an attached file", async () => {
     let capturedInput: unknown;
     let capturedProps: PostHogCaptureProperties | undefined;

--- a/tests/agent-templates.executor.test.ts
+++ b/tests/agent-templates.executor.test.ts
@@ -455,8 +455,10 @@ describe("generation-executor", () => {
         connections,
       ) => {
         capturedConnections = connections;
+        // Model emits a non-empty `connections` — the overlay must replace it
+        // with [] (always-stamp), not let the model-produced value leak through.
         return Promise.resolve({
-          template: fakeTemplate,
+          template: { ...fakeTemplate, connections: ["model-produced-leak"] },
           metrics: DEFAULT_TEST_METRICS,
         });
       },
@@ -472,6 +474,8 @@ describe("generation-executor", () => {
     const template = await prisma.agentTemplate.findUnique({
       where: { id: final?.templateId as string },
     });
+    // The model-produced ["model-produced-leak"] must NOT survive — the request
+    // flagged no connections, so the persisted template is stamped [].
     expect(template?.connections).toEqual([]);
   });
 

--- a/tests/agent-templates.generations-ephemeral.test.ts
+++ b/tests/agent-templates.generations-ephemeral.test.ts
@@ -54,11 +54,12 @@ const sseApiKeyHeaders = {
 const noKeyHeaders = { "Content-Type": "application/json" };
 
 // Records the args the generator was called with, so a test can assert the
-// overrides are forwarded: builderPrompt as the 5th param (systemPromptOverride)
-// and builderModel as the 6th (modelOverride).
+// overrides are forwarded: builderPrompt as the 5th param (systemPromptOverride),
+// builderModel as the 6th (modelOverride), and connections as the 7th.
 let lastCall: {
   systemPromptOverride?: string | null;
   modelOverride?: string | null;
+  connections?: string[] | null;
 } | null = null;
 
 let baseURL: string;
@@ -95,8 +96,9 @@ beforeEach(() => {
       _trace,
       systemPromptOverride,
       modelOverride,
+      connections,
     ) => {
-      lastCall = { systemPromptOverride, modelOverride };
+      lastCall = { systemPromptOverride, modelOverride, connections };
       return Promise.resolve({
         template: fakeTemplate,
         metrics: DEFAULT_TEST_METRICS,
@@ -185,6 +187,44 @@ describe("POST /generations/ephemeral — builderModel (privileged override)", (
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("is not a valid OpenRouter model");
+  });
+});
+
+describe("POST /generations/ephemeral — connections", () => {
+  test("unknown connection → 400", async () => {
+    const res = await post({
+      inputs: { idea: "x" },
+      connections: ["not_a_real_service"],
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("Unknown connection");
+  });
+
+  test("valid connections are forwarded to the generator and overlaid onto the returned template", async () => {
+    const res = await post({
+      inputs: { idea: "a scheduling helper" },
+      // Mixed case + duplicate to exercise catalog normalization + dedupe.
+      connections: ["GoogleCalendar", "googlecalendar"],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      template: { connections: string[] };
+    };
+    // Normalized canonical id forwarded to the generator (7th param)...
+    expect(lastCall?.connections).toEqual(["googlecalendar"]);
+    // ...and overlaid onto the returned (non-persisted) template.
+    expect(body.template.connections).toEqual(["googlecalendar"]);
+  });
+
+  test("no connections → generator gets [] and template stays empty", async () => {
+    const res = await post({ inputs: { idea: "a scheduling helper" } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      template: { connections: string[] };
+    };
+    expect(lastCall?.connections).toEqual([]);
+    expect(body.template.connections).toEqual([]);
   });
 });
 

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -603,6 +603,24 @@ describe("POST /generations — connections (open capability flag)", () => {
     );
     expect([200, 202]).toContain(second.status);
   });
+
+  test("same key + casing/duplicate-equivalent connections → dedupes (no spurious 409)", async () => {
+    // connections are a set: the dedupe normalizes to canonical catalog ids, so
+    // a replay differing only by casing or duplicates is the same request and
+    // must dedupe rather than 409.
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const first = await post(
+      { ...sampleBody, connections: ["GoogleCalendar", "googlecalendar"] },
+      { headers: withKey("idem-conn-normalized") },
+    );
+    expect(first.status).toBe(202);
+
+    const second = await post(
+      { ...sampleBody, connections: ["googlecalendar"] },
+      { headers: withKey("idem-conn-normalized") },
+    );
+    expect([200, 202]).toContain(second.status);
+  });
 });
 
 describe("POST /generations — SSE mode", () => {

--- a/tests/agent-templates.generations-post.test.ts
+++ b/tests/agent-templates.generations-post.test.ts
@@ -530,6 +530,81 @@ describe("POST /generations — builderModel (privileged override)", () => {
   });
 });
 
+describe("POST /generations — connections (open capability flag)", () => {
+  test("unknown connection → 400", async () => {
+    const res = await post(
+      { ...sampleBody, connections: ["not_a_real_service"] },
+      { headers: withKey("conn-unknown") },
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("Unknown connection");
+  });
+
+  test("valid connections → 202 and persist raw on the row (no auth gate)", async () => {
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    // Anonymous (no agent key): unlike builderPrompt/builderModel, stamping a
+    // connection grants nothing, so it is NOT restricted to agent-key callers.
+    const res = await post(
+      { ...sampleBody, connections: ["googlecalendar"] },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": stableUuid("conn-ok-anon"),
+        },
+      },
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { generationId: string };
+    const row = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: body.generationId },
+    });
+    expect(row?.connections).toEqual(["googlecalendar"]);
+  });
+
+  test("no connections → row.connections defaults to []", async () => {
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const res = await post(sampleBody, { headers: withKey("conn-absent") });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { generationId: string };
+    const row = await prisma.agentTemplateGeneration.findUnique({
+      where: { id: body.generationId },
+    });
+    expect(row?.connections).toEqual([]);
+  });
+
+  test("same key + different connections → 409", async () => {
+    // connections influence the generator's output (capabilities directive) and
+    // the persisted template, so they are part of the idempotent contract.
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const first = await post(
+      { ...sampleBody, connections: ["googlecalendar"] },
+      { headers: withKey("idem-conn-diff") },
+    );
+    expect(first.status).toBe(202);
+
+    const second = await post(sampleBody, {
+      headers: withKey("idem-conn-diff"),
+    });
+    expect(second.status).toBe(409);
+  });
+
+  test("same key + same connections → dedupes (no spurious 409)", async () => {
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+    const first = await post(
+      { ...sampleBody, connections: ["googlecalendar"] },
+      { headers: withKey("idem-conn-match") },
+    );
+    expect(first.status).toBe(202);
+
+    const second = await post(
+      { ...sampleBody, connections: ["googlecalendar"] },
+      { headers: withKey("idem-conn-match") },
+    );
+    expect([200, 202]).toContain(second.status);
+  });
+});
+
 describe("POST /generations — SSE mode", () => {
   test("Accept: text/event-stream emits terminal result frame", async () => {
     const res = await fetch(`${baseURL}/api/v2/agent-templates/generations`, {

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -250,6 +250,63 @@ describe("templateGen service — OpenRouter integration", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Connected-capabilities directive
+  // -----------------------------------------------------------------------
+  test("connections append a capabilities directive sourced from the catalog", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    await generateTemplate(
+      { text: "a scheduling helper" },
+      undefined,
+      null,
+      undefined,
+      null,
+      null,
+      ["googlecalendar"],
+    );
+
+    const req = getLastOpenRouterRequest();
+    const userMsg = req.body.messages[1].content as string;
+    expect(typeof userMsg).toBe("string");
+    expect(userMsg).toContain("CONNECTED CAPABILITIES");
+    // Copy comes from the catalog: displayName + the live bundle's title/desc.
+    expect(userMsg).toContain("Google Calendar");
+    expect(userMsg).toContain("Events");
+    expect(userMsg).toContain("View and edit events on all calendars");
+  });
+
+  test("no connections → no capabilities directive", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    await generateTemplate({ text: "a scheduling helper" });
+
+    const req = getLastOpenRouterRequest();
+    const userMsg = req.body.messages[1].content as string;
+    expect(userMsg).not.toContain("CONNECTED CAPABILITIES");
+  });
+
+  test("unknown connection ids contribute nothing (defensive — handler gates them)", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    await generateTemplate(
+      { text: "a scheduling helper" },
+      undefined,
+      null,
+      undefined,
+      null,
+      null,
+      ["not_a_real_service"],
+    );
+
+    const req = getLastOpenRouterRequest();
+    const userMsg = req.body.messages[1].content as string;
+    expect(userMsg).not.toContain("CONNECTED CAPABILITIES");
+  });
+
+  // -----------------------------------------------------------------------
   // Model defaults to anthropic/claude-opus-4.8-fast
   // -----------------------------------------------------------------------
   test("model defaults to anthropic/claude-opus-4.8-fast", async () => {


### PR DESCRIPTION
Closes [CON-532](https://linear.app/convos/issue/CON-532/builder-awareness-of-connection-grants).

**Stacked on #310** (`con-533`, multi-attachment inputs) → #309 (`con-527`) → `otr-dev`. Review/merge after the lower PRs.

## What & why

In the new backend-owned generation world the agent isn't deployed at build time, so a `ConnectionGrant` can't be issued at generation (no conversation, no agent inbox yet). But we still want the builder to be *aware* a connection is in play, so the generated prompt leverages it and the template records it. This is slice **A** — the buildable, self-contained slice that mirrors the shipped `prefill` work. Deferred grant issuance (slice B) is a separate downstream workstream; the `connections` array is the bridge that makes it possible.

## What changed

- **`connections` input on the generation `bodySchema`** — optional list of neutral service ids (e.g. `["googlecalendar"]`). Caller-pinned, persisted on the `AgentTemplateGeneration` row, read by the fire-and-forget executor — same shape as `prefill`.
- **Catalog validation** (`getServiceConfig`) — fail-fast **400** on an unknown service, same pattern as `builderModel` vs OpenRouter.
- **Open, not privileged** — no agent-API-key gate. Stamping a connection grants nothing; it only produces a template that *says* it uses the service. The real authz boundary is grant issuance + exec, both downstream.
- **Executor does two things:** builds a **capabilities directive** from the catalog (displayName + live bundle copy) and appends it to the generator's user message so the prompt/welcome lean on the capability; and **overlays** the connections onto the produced template's `connections` array, replacing the hardcoded `[]`.
- **Ephemeral (admin compare) endpoint** gets the same support, overlaid onto the returned non-persisted template.
- Normalize + overlay logic shared via `lib/template-connections.ts` so both generation paths stay in sync.

## Key decision: store the neutral service id, not `composio:<slug>`

Per the spec-refinement on the ticket: the template stores the **neutral service id** (`googlecalendar`), so it stays agnostic to the connection provider. The vendor binding lives only in the catalog (`bundles.config.ts`) + the exec resolver. Bare slugs on the wire; validated against the supported-services catalog.

## Idempotency

`connections` joins the dedupe contract. The column is a non-nullable array defaulting to `[]`, so an omitted `connections` compares equal to a stored `[]` — old idempotency keys replayed without connections still dedupe instead of 409ing.

## Acceptance criteria

- ✅ Generation accepts an optional `connections` list; unknown toolkits → 400.
- ✅ The generated template's `connections` array reflects the input (no longer always `[]`).
- ✅ The generated prompt is written to use the connected capability (capabilities directive verified in the user message).
- ✅ No grant is issued at generation time; idempotency / moderation / publish-status behavior unchanged.

## Tests

392 tests pass across the agent-templates + connections suites. New coverage: directive present/absent in the user message, unknown→400, anonymous valid→202 + persisted raw, dedupe 409 vs match, executor normalization/dedup (`["GoogleCalendar","googlecalendar"]` → `["googlecalendar"]`) on both the generator arg and the persisted/returned template, and the ephemeral equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784226387&installation_id=128169237&pr_number=311&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F311&signature=8fbab9c211f6b9df95c1bab7a622ec5e2fd26497488efcdc822379c2bb3b742b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add connection grants awareness to agent template generation builder
> - Adds an optional `connections` field to both the ephemeral and persisted generation endpoints; unknown service slugs return 400, and valid slugs are normalized to canonical catalog ids before storage.
> - Introduces [`template-connections.ts`](https://github.com/ephemeraHQ/convos-backend/pull/311/files#diff-f16ecb48ea9d5edab1336b36a1956abd65332d08e13e17342f4f36cfd1ee5714) with `resolveConnectionIds` and `applyConnections` helpers to normalize slugs and overlay canonical ids onto generated templates.
> - Adds `buildCapabilitiesDirective` in [`templateGen.ts`](https://github.com/ephemeraHQ/convos-backend/pull/311/files#diff-d151881c4ab5cd2005df4016ac6a564fb6094e4ce06b69fbf9529fb70e59148a) to append a `CONNECTED CAPABILITIES` block to the generation prompt when connections are provided.
> - The generation executor in [`generation-executor.ts`](https://github.com/ephemeraHQ/convos-backend/pull/311/files#diff-606bfcab4aaabc60e9aa7e0d358e823011fed37a5ab0fa8fbcaafa04b0f74e29) resolves and overlays connection ids before persisting templates.
> - Idempotency checks in [`generations-post.ts`](https://github.com/ephemeraHQ/convos-backend/pull/311/files#diff-cfa09e429c402af1c503dbdd05b6690b9fc157c69a9c4ce543a4bc481c3f5624) now include `connections`, treating omitted values as `[]` to match the DB default.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #311 opened
>
> - Modified connection comparison logic in generation request deduplication to use normalized and sorted connection identifiers [58b1627]
> - Added test coverage for idempotent behavior with connection lists that differ in casing and contain duplicates [58b1627]
> - Added test assertions to verify model-produced connections do not leak into persisted templates during generation [58b1627]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 433d5b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-template generations now support specifying service connections during creation
  * Specified connections are validated, persisted, and reflected in API responses
  * Generated agent prompts automatically incorporate relevant capabilities from connected services
  * Invalid connection requests are rejected with clear error messaging
  * Idempotency checks now account for connection differences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->