### PR TITLE
fix(credits): subscription-aware spendable balance — unblock entitled subscribers

### DIFF
--- a/src/api/v2/accounts/handlers/credits-by-id-get.ts
+++ b/src/api/v2/accounts/handlers/credits-by-id-get.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
-import { getSpendableBalance, isSpendAllowed } from "@/payments/spendable";
+import { config } from "@/payments/credits/config";
+import { getSpendableBalance } from "@/payments/spendable";
 import { prisma } from "@/utils/prisma";
 
 /**
@@ -33,7 +34,7 @@ export const creditsByIdGetHandler = async (
     }
 
     const balance = await getSpendableBalance(accountId);
-    const allowed = await isSpendAllowed(accountId);
+    const allowed = balance >= config.reservedMaxTurnCredits;
     req.log.info(
       { accountId, balance: balance.toString(), allowed },
       "credits.read.served",

--- a/src/api/v2/accounts/handlers/credits-by-id-get.ts
+++ b/src/api/v2/accounts/handlers/credits-by-id-get.ts
@@ -1,6 +1,5 @@
 import type { Request, Response } from "express";
-import { getBalance } from "@/payments";
-import { isAllowedFromBalance } from "@/payments/credits/policy";
+import { getSpendableBalance, isSpendAllowed } from "@/payments/spendable";
 import { prisma } from "@/utils/prisma";
 
 /**
@@ -33,8 +32,8 @@ export const creditsByIdGetHandler = async (
       return;
     }
 
-    const balance = await getBalance(accountId);
-    const allowed = isAllowedFromBalance(balance);
+    const balance = await getSpendableBalance(accountId);
+    const allowed = await isSpendAllowed(accountId);
     req.log.info(
       { accountId, balance: balance.toString(), allowed },
       "credits.read.served",

--- a/src/api/v2/accounts/handlers/credits-get.ts
+++ b/src/api/v2/accounts/handlers/credits-get.ts
@@ -1,39 +1,18 @@
-import { LedgerReason } from "@prisma/client";
 import type { Request, Response } from "express";
 import { getBalance } from "@/payments";
 import { config } from "@/payments/credits/config";
 import { startOfNextUtcDay } from "@/payments/daily-refill/utc";
+import { sumPeriodConsumes } from "@/payments/spendable";
 import { findCurrentByAccountId } from "@/subscriptions/repository";
 import { isEntitledSubscription } from "@/subscriptions/status";
 import { tierGrant } from "@/subscriptions/tier-config";
 import { requireSubscriptionTier } from "@/subscriptions/tiers";
-import { prisma } from "@/utils/prisma";
 
 const MONTH_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", {
   month: "long",
   year: "numeric",
   timeZone: "UTC",
 });
-
-const sumPeriodConsumes = async (
-  accountId: string,
-  since: Date,
-): Promise<number> => {
-  const agg = await prisma.creditLedger.aggregate({
-    where: {
-      accountId,
-      reason: LedgerReason.consume,
-      createdAt: { gte: since },
-    },
-    _sum: { delta: true },
-  });
-  // delta is negative for consume entries; we want the absolute total.
-  const sum = agg._sum.delta;
-  if (sum === null) return 0;
-  // BigInt → number; cap negativity and convert.
-  const positive = sum < 0n ? -sum : sum;
-  return Number(positive);
-};
 
 /**
  * GET /v2/accounts/me/credits — returns the iOS `CreditBalance` shape:

--- a/src/api/v2/accounts/handlers/credits-transactions-post.ts
+++ b/src/api/v2/accounts/handlers/credits-transactions-post.ts
@@ -5,11 +5,8 @@ import {
   transactionRequestSchema,
 } from "@/api/v2/accounts/schemas/credits-by-id";
 import { idempotencyKeySchema } from "@/api/v2/accounts/schemas/shared";
-import {
-  consume,
-  IdempotencyMismatchError,
-  InsufficientBalanceError,
-} from "@/payments";
+import { IdempotencyMismatchError, InsufficientBalanceError } from "@/payments";
+import { recordConsume } from "@/payments/spendable";
 
 /**
  * POST /v2/accounts/:accountId/credits/transactions
@@ -63,7 +60,7 @@ export const creditsTransactionsPostHandler = async (
   const { usdCostMicros, requestId, model } = bodyResult.data;
 
   try {
-    const result = await consume({
+    const result = await recordConsume({
       accountId,
       usdCostMicros,
       idempotencyKey: keyResult.data,

--- a/src/payments/ledger/repository.ts
+++ b/src/payments/ledger/repository.ts
@@ -19,6 +19,7 @@ export interface ApplyDeltaInput {
   note?: string;
   grantKindId?: GrantKindId;
   floorCheck?: { minBalance: bigint };
+  recordOnly?: boolean;
 }
 
 export interface ApplyDeltaResult {
@@ -159,6 +160,25 @@ const lockOrCreateBalance = async (
   return rows[0]?.balance ?? 0n;
 };
 
+const buildLedgerData = (input: ApplyDeltaInput, balanceAfter: bigint) => ({
+  accountId: input.accountId,
+  delta: input.delta,
+  reason: input.reason,
+  idempotencyKey: input.idempotencyKey,
+  scope: input.scope,
+  balanceAfter,
+  usdCostMicros: input.usdCostMicros ?? null,
+  markupRate:
+    input.markupRate !== undefined
+      ? new Prisma.Decimal(input.markupRate.toString())
+      : null,
+  creditsPerDollar: input.creditsPerDollar ?? null,
+  model: input.model ?? null,
+  requestId: input.requestId ?? null,
+  note: input.note ?? null,
+  grantKindId: input.grantKindId ?? null,
+});
+
 /**
  * Run the ledger mutation inside an existing transaction. Caller owns the tx.
  * Use this when the caller needs to perform additional reads/writes inside the
@@ -172,6 +192,27 @@ export const applyDeltaWithTx = async (
   input: ApplyDeltaInput,
 ): Promise<ApplyDeltaResult> => {
   assertIdempotencyKey(input.idempotencyKey);
+
+  if (input.recordOnly) {
+    if (input.floorCheck) {
+      throw new Error("recordOnly is incompatible with floorCheck");
+    }
+    const existing = await tx.userCredits.findUnique({
+      where: { accountId: input.accountId },
+      select: { balance: true },
+    });
+    const current = existing?.balance ?? 0n;
+    const created = await tx.creditLedger.create({
+      data: buildLedgerData(input, current),
+    });
+    return {
+      ledgerId: created.id,
+      replayed: false,
+      newBalance: current,
+      balanceAfter: current,
+    };
+  }
+
   const before = await lockOrCreateBalance(tx, input.accountId);
   const after = before + input.delta;
 
@@ -196,24 +237,7 @@ export const applyDeltaWithTx = async (
   }
 
   const created = await tx.creditLedger.create({
-    data: {
-      accountId: input.accountId,
-      delta: input.delta,
-      reason: input.reason,
-      idempotencyKey: input.idempotencyKey,
-      scope: input.scope, // written on every row
-      balanceAfter: after, // written on every row
-      usdCostMicros: input.usdCostMicros ?? null,
-      markupRate:
-        input.markupRate !== undefined
-          ? new Prisma.Decimal(input.markupRate.toString())
-          : null,
-      creditsPerDollar: input.creditsPerDollar ?? null,
-      model: input.model ?? null,
-      requestId: input.requestId ?? null,
-      note: input.note ?? null,
-      grantKindId: input.grantKindId ?? null,
-    },
+    data: buildLedgerData(input, after),
   });
 
   return {

--- a/src/payments/spendable.ts
+++ b/src/payments/spendable.ts
@@ -1,0 +1,47 @@
+import { LedgerReason } from "@prisma/client";
+import { getBalance } from "@/payments";
+import { config } from "@/payments/credits/config";
+import { findCurrentByAccountId } from "@/subscriptions/repository";
+import { isEntitledSubscription } from "@/subscriptions/status";
+import { tierGrant } from "@/subscriptions/tier-config";
+import { requireSubscriptionTier } from "@/subscriptions/tiers";
+import { prisma } from "@/utils/prisma";
+
+export const sumPeriodConsumes = async (
+  accountId: string,
+  since: Date,
+): Promise<number> => {
+  const agg = await prisma.creditLedger.aggregate({
+    where: {
+      accountId,
+      reason: LedgerReason.consume,
+      createdAt: { gte: since },
+    },
+    _sum: { delta: true },
+  });
+  const sum = agg._sum.delta;
+  if (sum === null) return 0;
+  return Number(sum < 0n ? -sum : sum);
+};
+
+export const getSpendableBalance = async (
+  accountId: string,
+): Promise<bigint> => {
+  const subscription = await findCurrentByAccountId(accountId);
+  if (subscription && isEntitledSubscription(subscription)) {
+    const grant = tierGrant(
+      requireSubscriptionTier(subscription.tier),
+      subscription.period,
+    );
+    const used = await sumPeriodConsumes(
+      accountId,
+      subscription.currentPeriodStart,
+    );
+    const remaining = grant.perPeriod - Math.min(used, grant.perPeriod);
+    return BigInt(remaining);
+  }
+  return getBalance(accountId);
+};
+
+export const isSpendAllowed = async (accountId: string): Promise<boolean> =>
+  (await getSpendableBalance(accountId)) >= config.reservedMaxTurnCredits;

--- a/src/payments/spendable.ts
+++ b/src/payments/spendable.ts
@@ -1,6 +1,8 @@
 import { LedgerReason } from "@prisma/client";
-import { getBalance } from "@/payments";
+import { consume, getBalance, usdToCredits } from "@/payments";
 import { config } from "@/payments/credits/config";
+import { applyDelta } from "@/payments/ledger";
+import type { ConsumeResult } from "@/payments/types";
 import { findCurrentByAccountId } from "@/subscriptions/repository";
 import { isEntitledSubscription } from "@/subscriptions/status";
 import { tierGrant } from "@/subscriptions/tier-config";
@@ -45,3 +47,32 @@ export const getSpendableBalance = async (
 
 export const isSpendAllowed = async (accountId: string): Promise<boolean> =>
   (await getSpendableBalance(accountId)) >= config.reservedMaxTurnCredits;
+
+export const recordConsume = async (args: {
+  accountId: string;
+  usdCostMicros: bigint;
+  idempotencyKey: string;
+  requestId: string;
+  model?: string;
+}): Promise<ConsumeResult> => {
+  const subscription = await findCurrentByAccountId(args.accountId);
+  if (!subscription || !isEntitledSubscription(subscription)) {
+    return consume(args);
+  }
+
+  const credits = usdToCredits(args.usdCostMicros);
+  const { replayed, newBalance, balanceAfter, ledgerId } = await applyDelta({
+    accountId: args.accountId,
+    delta: BigInt(-credits),
+    reason: LedgerReason.consume,
+    idempotencyKey: args.idempotencyKey,
+    scope: "transaction",
+    usdCostMicros: args.usdCostMicros,
+    markupRate: config.markupRate,
+    creditsPerDollar: config.creditsPerDollar,
+    model: args.model,
+    requestId: args.requestId,
+    recordOnly: true,
+  });
+  return { spent: credits, replayed, newBalance, balanceAfter, ledgerId };
+};

--- a/tests/credits/credits-by-id-get.integration.test.ts
+++ b/tests/credits/credits-by-id-get.integration.test.ts
@@ -1,5 +1,10 @@
+import { randomUUID } from "node:crypto";
+import { LedgerReason, SubscriptionPeriod } from "@prisma/client";
 import type { Express } from "express";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { tierGrant } from "@/subscriptions/tier-config";
+import { SUBSCRIPTION_TIER_PLUS } from "@/subscriptions/tiers";
+import { prisma } from "@/utils/prisma";
 import {
   agentRequest,
   buildCreditsApp,
@@ -8,6 +13,7 @@ import {
   installAgentApiKeyOverride,
   seedAccount,
   seedBalance,
+  seedPlusMonthlySubscription,
 } from "./helpers";
 
 let app: Express;
@@ -63,5 +69,51 @@ describe("GET /v2/accounts/:accountId/credits", () => {
     const res = await agentRequest(app).get("/v2/accounts/not-a-uuid/credits");
     expect(res.status).toBe(400);
     expect((res.body as { code: string }).code).toBe("invalid_account_id");
+  });
+
+  it("entitled subscriber → allowed with derived balance, even with no UserCredits row", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+
+    const perPeriod = tierGrant(
+      SUBSCRIPTION_TIER_PLUS,
+      SubscriptionPeriod.monthly,
+    ).perPeriod;
+
+    const res = await agentRequest(app).get(
+      `/v2/accounts/${accountId}/credits`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      accountId,
+      balance: String(perPeriod),
+      allowed: true,
+    });
+  });
+
+  it("entitled subscriber over cap → not allowed", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+    const perPeriod = tierGrant(
+      SUBSCRIPTION_TIER_PLUS,
+      SubscriptionPeriod.monthly,
+    ).perPeriod;
+    await prisma.creditLedger.create({
+      data: {
+        accountId,
+        delta: BigInt(-(perPeriod + 10)),
+        reason: LedgerReason.consume,
+        idempotencyKey: `c-${randomUUID()}`,
+        scope: "transaction",
+      },
+    });
+
+    const res = await agentRequest(app).get(
+      `/v2/accounts/${accountId}/credits`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId, balance: "0", allowed: false });
   });
 });

--- a/tests/credits/credits-transactions-post.integration.test.ts
+++ b/tests/credits/credits-transactions-post.integration.test.ts
@@ -1,5 +1,8 @@
+import { LedgerReason } from "@prisma/client";
 import type { Express } from "express";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { getBalance } from "@/payments";
+import { prisma } from "@/utils/prisma";
 import {
   agentRequest,
   buildCreditsApp,
@@ -8,6 +11,7 @@ import {
   installAgentApiKeyOverride,
   seedAccount,
   seedBalance,
+  seedPlusMonthlySubscription,
 } from "./helpers";
 
 let app: Express;
@@ -136,6 +140,26 @@ describe("POST /v2/accounts/:accountId/credits/transactions", () => {
     );
     expect(res.status).toBe(404);
     expect((res.body as { code: string }).code).toBe("account_not_found");
+  });
+
+  it("subscriber consume records usage without moving raw balance, never 402", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+
+    const res = await agentRequest(app).post(
+      `/v2/accounts/${accountId}/credits/transactions`,
+      `sub-${accountId}`,
+      { usdCostMicros: "1000000", requestId: "req-sub" },
+    );
+    expect(res.status).toBe(200);
+    // Raw balance untouched (record-only).
+    expect(await getBalance(accountId)).toBe(0n);
+    const row = await prisma.creditLedger.findFirst({
+      where: { accountId, reason: LedgerReason.consume },
+    });
+    expect(row).not.toBeNull();
+    expect(row?.delta).toBe(-2000n);
   });
 
   // PR-A unique constraint is still (accountId, idempotencyKey). PR-B swaps it

--- a/tests/credits/helpers.ts
+++ b/tests/credits/helpers.ts
@@ -13,6 +13,13 @@ import { jsonMiddleware } from "@/middleware/json";
 import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
 import { grant } from "@/payments";
+import {
+  AppleEnv,
+  SUBSCRIPTION_TIER_PLUS,
+  SubscriptionPeriod,
+  SubscriptionStatus,
+  upsertFromVerify,
+} from "@/subscriptions/repository";
 import { prisma } from "@/utils/prisma";
 
 export const TEST_AGENT_API_KEY =
@@ -69,8 +76,64 @@ export const seedBalance = async (
   });
 };
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const seedPlusMonthlySubscription = async (
+  accountId: string,
+): Promise<void> => {
+  const now = Date.now();
+  const start = new Date(now - 5 * DAY_MS);
+  const end = new Date(now + 25 * DAY_MS);
+  await upsertFromVerify({
+    accountId,
+    appAccountToken: randomUUID(),
+    productId: "app.convos.subs.monthly",
+    tier: SUBSCRIPTION_TIER_PLUS,
+    period: SubscriptionPeriod.monthly,
+    status: SubscriptionStatus.active,
+    originalTransactionId: `otid-${accountId}`,
+    transactionId: `tx-${accountId}`,
+    startedAt: start,
+    currentPeriodStart: start,
+    currentPeriodEnd: end,
+    willRenew: true,
+    isInTrial: false,
+    environment: AppleEnv.sandbox,
+    signedPayload: "stub.jws",
+  });
+};
+
+export const seedExpiredSubscription = async (
+  accountId: string,
+): Promise<void> => {
+  const now = Date.now();
+  const start = new Date(now - 35 * DAY_MS);
+  const end = new Date(now - 5 * DAY_MS);
+  await upsertFromVerify({
+    accountId,
+    appAccountToken: randomUUID(),
+    productId: "app.convos.subs.monthly",
+    tier: SUBSCRIPTION_TIER_PLUS,
+    period: SubscriptionPeriod.monthly,
+    status: SubscriptionStatus.expired,
+    originalTransactionId: `otid-exp-${accountId}`,
+    transactionId: `tx-exp-${accountId}`,
+    startedAt: start,
+    currentPeriodStart: start,
+    currentPeriodEnd: end,
+    willRenew: false,
+    isInTrial: false,
+    environment: AppleEnv.sandbox,
+    signedPayload: "stub.jws",
+  });
+};
+
 export const cleanupAccounts = async (accountIds: string[]): Promise<void> => {
   for (const accountId of accountIds) {
+    await prisma.appleReceipt.deleteMany({
+      where: { subscription: { accountId } },
+    });
+    await prisma.subscription.deleteMany({ where: { accountId } });
     await prisma.creditLedger.deleteMany({ where: { accountId } });
     await prisma.userCredits.deleteMany({ where: { accountId } });
     await prisma.account.deleteMany({ where: { id: accountId } });

--- a/tests/credits/ledger-record-only.integration.test.ts
+++ b/tests/credits/ledger-record-only.integration.test.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+import { LedgerReason } from "@prisma/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { applyDelta } from "@/payments/ledger";
+import { prisma } from "@/utils/prisma";
+import { cleanupAccounts, seedAccount, seedBalance } from "./helpers";
+
+const tracker: string[] = [];
+afterEach(async () => {
+  await cleanupAccounts(tracker);
+  tracker.length = 0;
+});
+
+describe("applyDelta recordOnly", () => {
+  it("writes a ledger row without moving UserCredits.balance (no row exists)", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+
+    const key = `rec-${randomUUID()}`;
+    const result = await applyDelta({
+      accountId,
+      delta: -500n,
+      reason: LedgerReason.consume,
+      idempotencyKey: key,
+      scope: "transaction",
+      recordOnly: true,
+    });
+
+    expect(result.replayed).toBe(false);
+    expect(result.balanceAfter).toBe(0n);
+    expect(result.newBalance).toBe(0n);
+
+    const row = await prisma.creditLedger.findUnique({
+      where: {
+        accountId_idempotencyKey: { accountId, idempotencyKey: key },
+      },
+    });
+    expect(row?.delta).toBe(-500n);
+    expect(row?.balanceAfter).toBe(0n);
+
+    // No balance moved → no UserCredits row created.
+    const uc = await prisma.userCredits.findUnique({ where: { accountId } });
+    expect(uc).toBeNull();
+  });
+
+  it("leaves an existing balance untouched and snapshots it", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 1000n);
+
+    const key = `rec-${randomUUID()}`;
+    await applyDelta({
+      accountId,
+      delta: -300n,
+      reason: LedgerReason.consume,
+      idempotencyKey: key,
+      scope: "transaction",
+      recordOnly: true,
+    });
+
+    const row = await prisma.creditLedger.findUnique({
+      where: { accountId_idempotencyKey: { accountId, idempotencyKey: key } },
+    });
+    expect(row?.delta).toBe(-300n);
+    expect(row?.balanceAfter).toBe(1000n);
+
+    const uc = await prisma.userCredits.findUnique({ where: { accountId } });
+    expect(uc?.balance).toBe(1000n); // unchanged
+  });
+
+  it("rejects recordOnly combined with floorCheck", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await expect(
+      applyDelta({
+        accountId,
+        delta: -100n,
+        reason: LedgerReason.consume,
+        idempotencyKey: `rec-${randomUUID()}`,
+        scope: "transaction",
+        recordOnly: true,
+        floorCheck: { minBalance: 0n },
+      }),
+    ).rejects.toThrow("recordOnly is incompatible with floorCheck");
+  });
+
+  it("is idempotent on replay (same key → prior row, still no balance move)", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const key = `rec-${randomUUID()}`;
+    const input = {
+      accountId,
+      delta: -250n,
+      reason: LedgerReason.consume,
+      idempotencyKey: key,
+      scope: "transaction" as const,
+      recordOnly: true,
+    };
+    const first = await applyDelta(input);
+    const second = await applyDelta(input);
+    expect(second.replayed).toBe(true);
+    expect(second.ledgerId).toBe(first.ledgerId);
+
+    const count = await prisma.creditLedger.count({ where: { accountId } });
+    expect(count).toBe(1);
+    const uc = await prisma.userCredits.findUnique({ where: { accountId } });
+    expect(uc).toBeNull();
+  });
+});

--- a/tests/credits/spendable.integration.test.ts
+++ b/tests/credits/spendable.integration.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { LedgerReason, SubscriptionPeriod } from "@prisma/client";
 import { afterEach, describe, expect, it } from "vitest";
-import { getBalance } from "@/payments";
+import { getBalance, getBucketedConsumption } from "@/payments";
 import { config } from "@/payments/credits/config";
 import {
   getSpendableBalance,
@@ -153,5 +153,23 @@ describe("recordConsume", () => {
       where: { accountId, reason: LedgerReason.consume },
     });
     expect(rows).toBe(1);
+  });
+
+  it("record-only subscriber consume surfaces in bucketed consumption", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const res = await recordConsume({
+      accountId,
+      usdCostMicros: 1_000_000n,
+      idempotencyKey: `u-${randomUUID()}`,
+      requestId: "req-u",
+    });
+
+    const buckets = await getBucketedConsumption(accountId, since, "day");
+    const total = buckets.reduce((n, b) => n + Number(b.consumed), 0);
+    expect(total).toBe(res.spent);
   });
 });

--- a/tests/credits/spendable.integration.test.ts
+++ b/tests/credits/spendable.integration.test.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { LedgerReason, SubscriptionPeriod } from "@prisma/client";
 import { afterEach, describe, expect, it } from "vitest";
+import { getBalance } from "@/payments";
 import { config } from "@/payments/credits/config";
-import { getSpendableBalance, isSpendAllowed } from "@/payments/spendable";
+import {
+  getSpendableBalance,
+  isSpendAllowed,
+  recordConsume,
+} from "@/payments/spendable";
 import { tierGrant } from "@/subscriptions/tier-config";
 import { SUBSCRIPTION_TIER_PLUS } from "@/subscriptions/tiers";
 import { prisma } from "@/utils/prisma";
@@ -80,5 +85,73 @@ describe("getSpendableBalance / isSpendAllowed", () => {
     await seedBalance(accountId, 1234n);
     // Subscription row exists but is not entitled → raw additive balance, not derived.
     expect(await getSpendableBalance(accountId)).toBe(1234n);
+  });
+});
+
+describe("recordConsume", () => {
+  it("subscriber → ledger row written, raw balance untouched, never throws", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+
+    const res = await recordConsume({
+      accountId,
+      usdCostMicros: 1_000_000n,
+      idempotencyKey: `t-${randomUUID()}`,
+      requestId: "req-1",
+    });
+    expect(res.spent).toBeGreaterThan(0);
+
+    // Raw balance untouched (no UserCredits row created).
+    expect(await getBalance(accountId)).toBe(0n);
+    // Usage is recorded → spendable dropped by the consumed amount.
+    expect(await getSpendableBalance(accountId)).toBe(
+      BigInt(perPeriod() - res.spent),
+    );
+    const rows = await prisma.creditLedger.count({
+      where: { accountId, reason: LedgerReason.consume },
+    });
+    expect(rows).toBe(1);
+  });
+
+  it("non-subscriber → identical to consume() (decrements raw balance)", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 5000n);
+
+    const res = await recordConsume({
+      accountId,
+      usdCostMicros: 1_000_000n,
+      idempotencyKey: `t-${randomUUID()}`,
+      requestId: "req-2",
+    });
+    expect(await getBalance(accountId)).toBe(5000n - BigInt(res.spent));
+  });
+
+  it("subscriber idempotent replay → single row, replayed: true", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+    const key = `t-${randomUUID()}`;
+
+    const first = await recordConsume({
+      accountId,
+      usdCostMicros: 1_000_000n,
+      idempotencyKey: key,
+      requestId: "req-r",
+    });
+    const second = await recordConsume({
+      accountId,
+      usdCostMicros: 1_000_000n,
+      idempotencyKey: key,
+      requestId: "req-r",
+    });
+
+    expect(second.replayed).toBe(true);
+    expect(second.ledgerId).toBe(first.ledgerId);
+    const rows = await prisma.creditLedger.count({
+      where: { accountId, reason: LedgerReason.consume },
+    });
+    expect(rows).toBe(1);
   });
 });

--- a/tests/credits/spendable.integration.test.ts
+++ b/tests/credits/spendable.integration.test.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+import { LedgerReason, SubscriptionPeriod } from "@prisma/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { config } from "@/payments/credits/config";
+import { getSpendableBalance, isSpendAllowed } from "@/payments/spendable";
+import { tierGrant } from "@/subscriptions/tier-config";
+import { SUBSCRIPTION_TIER_PLUS } from "@/subscriptions/tiers";
+import { prisma } from "@/utils/prisma";
+import {
+  cleanupAccounts,
+  seedAccount,
+  seedBalance,
+  seedExpiredSubscription,
+  seedPlusMonthlySubscription,
+} from "./helpers";
+
+const tracker: string[] = [];
+afterEach(async () => {
+  await cleanupAccounts(tracker);
+  tracker.length = 0;
+});
+
+const perPeriod = () =>
+  tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.monthly).perPeriod;
+
+const writeConsume = async (accountId: string, credits: number) => {
+  await prisma.creditLedger.create({
+    data: {
+      accountId,
+      delta: BigInt(-credits),
+      reason: LedgerReason.consume,
+      idempotencyKey: `c-${randomUUID()}`,
+      scope: "transaction",
+    },
+  });
+};
+
+describe("getSpendableBalance / isSpendAllowed", () => {
+  it("non-subscriber → raw ledger balance", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 4242n);
+    expect(await getSpendableBalance(accountId)).toBe(4242n);
+    expect(await isSpendAllowed(accountId)).toBe(true);
+  });
+
+  it("non-subscriber, no row → 0 and not allowed", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    expect(await getSpendableBalance(accountId)).toBe(0n);
+    expect(await isSpendAllowed(accountId)).toBe(false);
+  });
+
+  it("entitled subscriber → perPeriod − periodConsumes", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+    await writeConsume(accountId, 100);
+    expect(await getSpendableBalance(accountId)).toBe(
+      BigInt(perPeriod() - 100),
+    );
+    expect(await isSpendAllowed(accountId)).toBe(true);
+  });
+
+  it("entitled subscriber at/over cap → 0 and not allowed", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+    await writeConsume(accountId, perPeriod() + 50);
+    expect(await getSpendableBalance(accountId)).toBe(0n);
+    expect(await isSpendAllowed(accountId)).toBe(
+      config.reservedMaxTurnCredits <= 0n,
+    );
+  });
+
+  it("lapsed subscriber → falls through to raw ledger balance", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedExpiredSubscription(accountId);
+    await seedBalance(accountId, 1234n);
+    // Subscription row exists but is not entitled → raw additive balance, not derived.
+    expect(await getSpendableBalance(accountId)).toBe(1234n);
+  });
+});

--- a/tests/subscriptions/account-credits.test.ts
+++ b/tests/subscriptions/account-credits.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { accountsMeRouter } from "@/api/v2/accounts/accountsMeRouter";
 import { authMiddleware } from "@/middleware/auth";
 import { pinoMiddleware } from "@/middleware/pino";
+import { getSpendableBalance } from "@/payments/spendable";
 import {
   AppleEnv,
   SUBSCRIPTION_TIER_PLUS,
@@ -256,6 +257,7 @@ describe("GET /v2/accounts/me/credits", () => {
     const body = res.body as BalanceBody;
     expect(body.monthlyGrantUsed).toBe(500);
     expect(body.balance).toBe(2500 - 500);
+    expect(BigInt(body.balance)).toBe(await getSpendableBalance(accountId));
   });
 
   test("consumes before currentPeriodStart do NOT count (previous period burn)", async () => {


### PR DESCRIPTION
## Problem

Entitled subscribers can't use agents. Subscription credits are **derived, never materialized** — the agent check/consume path read the raw `UserCredits.balance` (→ 0) and gated on `isAllowedFromBalance` (0 ≥ `reservedMaxTurnCredits`=1 → false → blocked). The display path already derived correctly. Two surfaces, two sources of truth.

Confirmed in prod: acct `7a90c770-3455-44d7-afac-483af7e5fbc9` has an active/plus/monthly `Subscription` row but no `UserCredits`/`CreditLedger` rows. `broken_subscribers = 2` (small only because the feature is new — the path breaks every entitled subscriber).

## Fix (Option B)

Teach the agent path the same derivation the display already uses, via a new bridge `src/payments/spendable.ts`:

- `getSpendableBalance` — entitled subscriber → `tierGrant.perPeriod − consumeSince(currentPeriodStart)`, floored at 0; else raw `getBalance`.
- `isSpendAllowed` — spendable ≥ `reservedMaxTurnCredits`.
- `recordConsume` — entitled subscriber → balance-neutral **record-only** ledger write (usage tracked, raw balance untouched, no floor); else existing `consume()` verbatim.

The ledger core gains an opt-in `recordOnly` write: inserts a `CreditLedger` row without moving `UserCredits.balance` (non-locking snapshot, no phantom row; mutually exclusive with `floorCheck`, idempotent replay intact). The check route, consume route, and display handler all route through the bridge so all three agree on one derivation.

### Design decisions

- **Soft cap** — the pre-turn check gates; consume records usage without an atomic period cap. A subscriber may slip ~one turn past `perPeriod` under concurrency; the pool serializes turns per account, so this is effectively bounded to one turn. Acceptable for a paid tier.
- **Record-only for subscribers** — the raw `UserCredits.balance` is never moved → no phantom negative debt, clean cancel → free-tier transition.

### Non-subscriber behavior unchanged

Additive accounts (free tier, daily refill, signup bonus, manual grants) are regression-guarded: bridge else-branch = raw balance, `recordConsume` else-branch = `consume()` verbatim (decrement + floor + 402), display non-subscriber branch untouched.

## Testing

- New integration coverage (real DB): `recordOnly` primitive (incl. `floorCheck` mutual-exclusion + idempotent replay), spendable bridge (non-sub / no-row / entitled / over-cap / lapsed→raw), `recordConsume` (subscriber record-only, non-sub decrement, replay), check route (subscriber allowed / over-cap not-allowed + non-sub regression), consume route (subscriber record-only never-402 + ledger-row-written + 402 regression), usage-bucket surfacing of record-only rows, and a display↔bridge agreement assertion.
- Full suite: **1043 passed / 1 skipped**. The lone failure is the known telemetry-502 flake (#301), confirmed passing **18/18** in isolation.
- `pnpm check` clean except the pre-existing `instrumentation.ts` protobuf TS2307 errors (unrelated, documented).

## Follow-ups (not in this PR)

- **Cross-repo**: confirm which endpoint prod Hermes/pool calls pre-turn (the raw by-id route vs the removed `POST /v2/credits/check`, deleted in #247).
- **Pool contract note**: the consume `200` response `balance`/`balanceAfter` is the *raw* balance (0 for subscribers, record-only). The pool must read spendable balance via the **check** route, not the consume response.
- **Ops stopgap**: a one-off manual `grant()` unblocks the 2 currently-stuck accounts under current code; harmless leftover once this ships.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784233916&installation_id=128169237&pr_number=313&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F313&signature=a0f2cfb4ddaa9eb807460457cdc11c96482cd5e93c79e6ffd5a7774ca1a2655d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spendable balance for entitled subscribers to unblock credit spend checks
> - Introduces `getSpendableBalance()` in [`src/payments/spendable.ts`](https://github.com/ephemeraHQ/convos-backend/pull/313/files#diff-cf5530a6d3c2c580e74ad2b31329241220f537979f3564f208593eb2f404abad): for entitled subscribers, balance is derived as subscription-period grant minus period consumes (floored at zero); non-subscribers continue using raw ledger balance.
> - Replaces `consume()` with `recordConsume()` in the transactions handler so subscriber consumes write a ledger row without decrementing `UserCredits.balance`.
> - Adds `recordOnly` mode to `applyDeltaWithTx` in [`src/payments/ledger/repository.ts`](https://github.com/ephemeraHQ/convos-backend/pull/313/files#diff-69d0da1657814118e710df59d6d2f101ee40ca5c083afe604005bc9e5c630522), which writes a ledger entry without mutating the raw balance; combining `recordOnly` with `floorCheck` throws an error.
> - Updates the credits-by-id GET handler to use `getSpendableBalance()` and an inline threshold check against `config.reservedMaxTurnCredits` instead of the previous `isAllowedFromBalance()` helper.
> - Behavioral Change: entitled subscribers with an active subscription no longer require a `UserCredits` row to be considered allowed, and their reported balance reflects subscription grant minus usage rather than raw credits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75a8698.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Subscription-aware credit spending limits: Plus subscribers can now spend credits based on their monthly grant minus current period consumption
  * Credits consumption is now properly recorded and tracked against subscription entitlements
  * Spending is gated by subscription status and configured spending thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->