### PR TITLE
Light hardening of the presigned attachment flow (stacked on #310)

### DIFF
--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -853,11 +853,12 @@ export async function generationsPostHandler(req: Request, res: Response) {
       }
       if (totalBytes > BUILD_ATTACHMENTS_MAX_TOTAL_BYTES) {
         // The 400 reports the total only; log the per-attachment breakdown so
-        // an over-cap submission can be traced to the offending objects.
+        // an over-cap submission can be traced. Log a short key prefix rather
+        // than the full objectKey to avoid leaking the bucket reference.
         req.log.warn(
           {
             attachments: heads.map((h, i) => ({
-              objectKey: coalesced.attachments[i].objectKey,
+              objectKeyPrefix: coalesced.attachments[i].objectKey.slice(0, 16),
               size: h.contentLength,
             })),
             totalBytes,

--- a/src/api/v2/agent-templates/services/attachment-resolver.ts
+++ b/src/api/v2/agent-templates/services/attachment-resolver.ts
@@ -15,7 +15,10 @@
  */
 
 import { z } from "zod";
-import { BUILD_ATTACHMENTS_MAX_COUNT } from "@/config";
+import {
+  BUILD_ATTACHMENTS_MAX_COUNT,
+  BUILD_ATTACHMENTS_MAX_TOTAL_BYTES,
+} from "@/config";
 import { AppError } from "@/utils/errors";
 import {
   classifyMime,
@@ -42,10 +45,15 @@ export const attachmentRefSchema = z
 export type AttachmentRef = z.infer<typeof attachmentRefSchema>;
 
 /** The whole `attachments` field: an optional array capped at the per-
- *  generation count. */
+ *  generation count, with object keys required to be unique. */
 export const attachmentsArraySchema = z
   .array(attachmentRefSchema)
-  .max(BUILD_ATTACHMENTS_MAX_COUNT)
+  .max(BUILD_ATTACHMENTS_MAX_COUNT, {
+    message: `At most ${BUILD_ATTACHMENTS_MAX_COUNT} attachments allowed`,
+  })
+  .refine((arr) => new Set(arr.map((a) => a.objectKey)).size === arr.length, {
+    message: "Duplicate attachment objectKey",
+  })
   .optional();
 
 /** Thrown when an attachment is rejected by moderation. Carried distinctly so
@@ -76,9 +84,10 @@ export interface ResolveOpts {
   moderate: boolean;
 }
 
-type OneResult =
+type OneResult = { byteLength: number } & (
   | { kind: "attachment"; attachment: ResolvedAttachment }
-  | { kind: "transcript"; transcript: string };
+  | { kind: "transcript"; transcript: string }
+);
 
 async function resolveOne(
   ref: AttachmentRef,
@@ -113,7 +122,7 @@ async function resolveOne(
         );
       }
     }
-    return { kind: "transcript", transcript };
+    return { kind: "transcript", transcript, byteLength: bytes.length };
   }
 
   if (kind === "image" && opts.moderate) {
@@ -131,6 +140,7 @@ async function resolveOne(
     const mime = normalizeMime(ref.mimeType);
     return {
       kind: "attachment",
+      byteLength: bytes.length,
       attachment: {
         kind: "image",
         mimeType: mime,
@@ -140,6 +150,7 @@ async function resolveOne(
   }
   return {
     kind: "attachment",
+    byteLength: bytes.length,
     attachment: {
       kind: "pdf",
       filename: ref.filename || "document.pdf",
@@ -174,6 +185,16 @@ export async function resolveAttachments(
 ): Promise<ResolvedInputs> {
   if (_override) return _override(refs, opts);
   const results = await Promise.all(refs.map((ref) => resolveOne(ref, opts)));
+  // Defense-in-depth: re-check the aggregate byte size executor-side. The submit
+  // path already enforces this against HeadObject sizes; this guards against a
+  // content-swap between submit and resolve and keeps the per-file check above.
+  const totalBytes = results.reduce((sum, r) => sum + r.byteLength, 0);
+  if (totalBytes > BUILD_ATTACHMENTS_MAX_TOTAL_BYTES) {
+    throw new AppError(
+      400,
+      `Attachments exceed the total size limit of ${BUILD_ATTACHMENTS_MAX_TOTAL_BYTES} bytes`,
+    );
+  }
   const attachments: ResolvedAttachment[] = [];
   const transcripts: string[] = [];
   for (const r of results) {

--- a/src/api/v2/agent-templates/services/build-attachments.ts
+++ b/src/api/v2/agent-templates/services/build-attachments.ts
@@ -109,7 +109,9 @@ function requireBucket(): { bucket: string; client: S3Client } {
 const BUILD_KEY_RE = /^build\/[A-Za-z0-9._/-]+$/;
 
 function assertBuildKey(objectKey: string): void {
-  if (!BUILD_KEY_RE.test(objectKey)) {
+  // Reject `..` path segments defensively (not a real S3 escape, but keeps keys
+  // canonical) in addition to the prefix/charset check.
+  if (!BUILD_KEY_RE.test(objectKey) || objectKey.split("/").includes("..")) {
     throw new AppError(400, `Invalid attachment objectKey: ${objectKey}`);
   }
 }
@@ -173,11 +175,13 @@ export async function presignBuildUpload(
     ContentType: contentType,
     ContentLength: contentLength,
   });
+  // `Content-Length` is signed by the presigner by default, so S3 enforces the
+  // exact capped size — the client must send exactly these many bytes or the
+  // signature won't match. (A `signableHeaders: new Set(["content-length"])`
+  // option was removed: it is redundant here since content-length is already in
+  // the default signed-header set, verified as `content-length;host` either way.)
   const uploadUrl = await getSignedUrl(client, command, {
     expiresIn: 3600,
-    // Sign content-length so S3 enforces the body matches the capped size; the
-    // client must send exactly this many bytes or the signature won't match.
-    signableHeaders: new Set(["content-length"]),
   });
   return { objectKey, uploadUrl };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -236,10 +236,15 @@ export const BUILD_ATTACHMENTS_MAX_COUNT = Math.min(
 // caps are class-specific (image vs pdf vs audio) and live in
 // services/build-attachments.ts, set against real vision-model ceilings.
 // 100 MiB fits a full batch either way: 9 images (9 × 10 MiB) or 4 pdf/audio
-// (4 × 25 MiB).
-export const BUILD_ATTACHMENTS_MAX_TOTAL_BYTES = parsePositiveInt(
-  process.env.BUILD_ATTACHMENTS_MAX_TOTAL_BYTES,
+// (4 × 25 MiB). Clamped to the default so an env override can only lower it,
+// never raise the executor's worst-case memory footprint (mirrors the count
+// clamp above).
+export const BUILD_ATTACHMENTS_MAX_TOTAL_BYTES = Math.min(
   100 * 1024 * 1024,
+  parsePositiveInt(
+    process.env.BUILD_ATTACHMENTS_MAX_TOTAL_BYTES,
+    100 * 1024 * 1024,
+  ),
 );
 
 // Audio-capable model that transcribes voice attachments to text before

--- a/tests/attachment-resolver.service.test.ts
+++ b/tests/attachment-resolver.service.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, expect, test, vi } from "vitest";
 import {
   AttachmentModerationError,
+  attachmentsArraySchema,
   resolveAttachments,
 } from "@/api/v2/agent-templates/services/attachment-resolver";
 import { __resetImageModerationForTests } from "@/api/v2/agent-templates/services/image-moderation";
@@ -164,12 +165,46 @@ test("over-cap image → throws before any moderation", async () => {
   expect(spy).not.toHaveBeenCalled();
 });
 
+test("aggregate over the total cap → throws (executor-side re-check)", async () => {
+  // Each PDF is under the 25 MiB per-file cap, but 5 × 24 MiB = 120 MiB blows
+  // the 100 MiB aggregate cap. The stub reuses one buffer, so only 24 MiB is
+  // actually allocated.
+  stubBytes(new Uint8Array(24 * 1024 * 1024));
+  const refs = Array.from({ length: 5 }, (_, i) => ({
+    objectKey: `build/doc-${i}.pdf`,
+    mimeType: "application/pdf",
+  }));
+  await expect(resolveAttachments(refs, { moderate: false })).rejects.toThrow(
+    /total size limit/,
+  );
+});
+
 test("unsupported mime → throws", async () => {
   await expect(
     resolveAttachments([{ objectKey: "build/x.gif", mimeType: "image/gif" }], {
       moderate: false,
     }),
   ).rejects.toThrow(/Unsupported/);
+});
+
+test("attachmentsArraySchema rejects duplicate objectKeys", () => {
+  const dup = [
+    { objectKey: "build/a.png", mimeType: "image/png" },
+    { objectKey: "build/a.png", mimeType: "image/png" },
+  ];
+  const res = attachmentsArraySchema.safeParse(dup);
+  expect(res.success).toBe(false);
+  if (!res.success) {
+    expect(res.error.issues[0].message).toMatch(/Duplicate attachment/);
+  }
+});
+
+test("attachmentsArraySchema accepts distinct objectKeys", () => {
+  const ok = [
+    { objectKey: "build/a.png", mimeType: "image/png" },
+    { objectKey: "build/b.png", mimeType: "image/png" },
+  ];
+  expect(attachmentsArraySchema.safeParse(ok).success).toBe(true);
 });
 
 test("mixed batch resolves images/pdfs as blocks and audio as transcripts", async () => {

--- a/tests/build-attachments.service.test.ts
+++ b/tests/build-attachments.service.test.ts
@@ -80,7 +80,7 @@ test("maxBytesForKind caps images tighter than pdf/audio", () => {
 });
 
 describe("presignBuildUpload", () => {
-  test("mints a build/ key, sets ContentLength, and signs content-length", async () => {
+  test("mints a build/ key and sets ContentLength on the signed command", async () => {
     const { objectKey, uploadUrl } = await presignBuildUpload(
       "image/png",
       1024,
@@ -88,15 +88,13 @@ describe("presignBuildUpload", () => {
     expect(objectKey).toMatch(/^build\/[\w-]+\.png$/);
     expect(uploadUrl).toBe("https://signed.example/put");
 
-    // The exact byte count is signed so S3 caps the (anonymous) PUT itself.
-    const [, command, opts] = vi.mocked(getSignedUrl).mock
-      .calls[0] as unknown as [
+    // The exact byte count is set on the command; the presigner signs
+    // Content-Length by default, so S3 caps the (anonymous) PUT itself.
+    const [, command] = vi.mocked(getSignedUrl).mock.calls[0] as unknown as [
       unknown,
       { input: { ContentLength?: number } },
-      { signableHeaders?: Set<string> },
     ];
     expect(command.input.ContentLength).toBe(1024);
-    expect([...(opts.signableHeaders ?? [])]).toContain("content-length");
   });
 
   test("rejects an unsupported type with 400", async () => {
@@ -142,6 +140,13 @@ describe("headBuildObject", () => {
 
   test("rejects a key outside the build/ namespace without touching S3", async () => {
     await expect(headBuildObject("other/abc.png")).rejects.toMatchObject({
+      statusCode: 400,
+    });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test("rejects a key with a `..` segment under build/ without touching S3", async () => {
+    await expect(headBuildObject("build/../secret")).rejects.toMatchObject({
       statusCode: 400,
     });
     expect(mockSend).not.toHaveBeenCalled();


### PR DESCRIPTION
## Light, low-risk hardening stacked on #310

Follow-ups from the re-review of #310 (head `6ee352e`, after the size-ceiling update). Everything here is **defense-in-depth or hygiene** — no behavior change to the happy path. Kept deliberately tight so it's fast to review and safe to land alongside #310.

**Base:** `saul/con-533-multi-attachment-generation-inputs-via-presigned-upload-drop` (this stacks on #310, not on `dev`). Draft until #310 settles.

### Fixes
- **RS1 — drop dead presign option.** Removed `signableHeaders: new Set(["content-length"])` from `getSignedUrl` in `presignBuildUpload`. It's redundant: `Content-Length` is in the presigner's default signed-header set, so S3 still enforces the exact capped body size. Verified locally on `@aws-sdk/s3-request-presigner@3.1051.0` — `X-Amz-SignedHeaders` is `content-length;host` with or without the option. _(`services/build-attachments.ts`)_
- **RN2 — reject `..` in object keys.** `assertBuildKey` now also rejects any key with a `..` path segment (defensive; not a real S3 escape). _(`services/build-attachments.ts`)_
- **RS6 — reject duplicate attachments.** `attachmentsArraySchema` gains a `.refine` rejecting duplicate `objectKey`s (avoids double fetch/count/cost). Applies to both the generation and ephemeral handlers via the shared schema. _(`services/attachment-resolver.ts`)_
- **RN1 — friendly over-count message.** The over-count `.max()` now surfaces `At most N attachments allowed` instead of a raw zod issue list. _(`services/attachment-resolver.ts`)_
- **RS5 — executor-side aggregate re-check.** `resolveAttachments` now sums the resolved byte sizes and 400s if the total exceeds `BUILD_ATTACHMENTS_MAX_TOTAL_BYTES`. Submit already enforces this against `HeadObject` sizes; this is a defense-in-depth re-check on the executor side (per-file check kept). _(`services/attachment-resolver.ts`)_
- **Aggregate clamp.** `BUILD_ATTACHMENTS_MAX_TOTAL_BYTES` is now `Math.min(100 MiB, env)`, mirroring the existing count clamp, so an env override can only **lower** the aggregate — never raise the executor's worst-case memory footprint. _(`config.ts`)_
- **RN3 — scrub key in over-cap log.** The aggregate-over-cap `warn` log now records a short `objectKeyPrefix` (first 16 chars) instead of the full `objectKey`. _(`handlers/generations-post.ts`)_

Tests added: `..`-segment key rejection, duplicate-objectKey schema refine (+ distinct-keys accept), and the executor-side aggregate over-cap re-check. The presign unit test was updated to match RS1.

### #310 status
**B2 (no upload-size bound) is confirmed fixed.** The presign requires `contentLength`, the server rejects `contentLength > maxBytesForKind(kind)` before signing, and `Content-Length` lands in `X-Amz-SignedHeaders` so S3 rejects an oversized body.

### Deliberately out of scope (need their own PR / discussion)
These are the heavier findings from the re-review; each wants its own change + review and is intentionally **not** in this light PR:
- **RB1** — cap arbitrage via content-type spoofing: compare fetched S3 `ContentType` to the claimed class + magic-byte sniff before base64.
- **RB2** — memory/OOM at the 100 MiB aggregate: concurrency semaphore around resolution + a global in-flight executor ceiling + `--max-old-space-size` / container limit.
- **RS2 / RS3** — PDFs unmoderated (extract text → `checkContent`); Rekognition fail-**closed** on infra errors + assert bucket/Rekognition region parity.
- **RS4 / B1** — IDOR: `objectKey` not owner-bound at mint/submit/read.
- **RS7** — global presign-minting ceiling (storage-cost DoS).
- **RS8** — distill display-text length/charset clamp.
- The other raw-key echoes in error messages (RN3 follow-up) — left as a noted follow-up rather than churned here.

### Validation
- `pnpm typecheck`, `pnpm format:check`: pass. `pnpm lint`: 0 errors (3 pre-existing warnings in an untouched file).
- Attachment unit suites (`build-attachments.service`, `build-attachment-presigned`, `attachment-resolver.service`): 34 passing.
- `agent-templates.generations-attachments.test.ts` (HTTP integration) has 6 failures that are **pre-existing on the base SHA** (they need a DB not available in CI sandbox; verified identical on the clean base) — not a regression from this PR.
- Codex (read-only, high effort) review: clean pass, no real issues, no overreach.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784277184&installation_id=128169237&pr_number=314&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F314&signature=7ed31e4d968958100725cf609ad772ed9a21b36d2beaef8ea6e12090b7936c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden presigned attachment flow with size caps, duplicate key rejection, and path traversal checks
> - `BUILD_ATTACHMENTS_MAX_TOTAL_BYTES` in [config.ts](https://github.com/ephemeraHQ/convos-backend/pull/314/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012) is now clamped to 100 MiB via `Math.min`, preventing env overrides from raising the cap above this limit.
> - `resolveAttachments` in [attachment-resolver.ts](https://github.com/ephemeraHQ/convos-backend/pull/314/files#diff-4b3d4ea46d7a5a6dbeb246d35ae9a76c8e94ff2af11a8b66dad4d587c7b0eda3) now throws a 400 error when aggregate resolved attachment size exceeds `BUILD_ATTACHMENTS_MAX_TOTAL_BYTES`.
> - `attachmentsArraySchema` now rejects arrays with duplicate `objectKey` values and enforces a max count with a specific error message.
> - `assertBuildKey` in [build-attachments.ts](https://github.com/ephemeraHQ/convos-backend/pull/314/files#diff-012527fa6cb28f27c2e51485c3ea0a670462a291180ad2d2701e7e318ce9da44) now rejects keys containing `..` path segments to prevent path traversal.
> - Warning logs for over-cap attachments now record only the first 16 characters of `objectKey` instead of the full value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fd00a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->