### PR TITLE
feat(agents): accept and forward client timezone on agents/join

### DIFF
--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -71,6 +71,7 @@ const bodySchema = z
     name: z.string().min(1).max(256).optional(),
     profileImage: z.string().min(1).max(2048).optional(),
     options: optionsSchema.optional(),
+    timezone: z.string().min(1).max(64).optional(),
   })
   .strict()
   .refine((b) => (b.slug === undefined) !== (b.conversationId === undefined), {
@@ -139,6 +140,7 @@ const dispatchBodySchema = z
     template: z.record(z.string(), z.unknown()).nullable(),
     ownerAccountId: accountIdSchema,
     options: optionsSchema.optional(),
+    timezone: z.string().min(1).max(64).optional(),
   })
   .strict()
   .refine(
@@ -380,8 +382,15 @@ export async function joinHandler(req: Request, res: Response) {
     return;
   }
 
-  const { slug, conversationId, templateId, name, profileImage, options } =
-    parsed.data;
+  const {
+    slug,
+    conversationId,
+    templateId,
+    name,
+    profileImage,
+    options,
+    timezone,
+  } = parsed.data;
   // Avoid logging the raw slug (it's a join-token granting conversation
   // access) and the raw `options` (caller-controlled input). Log only the
   // public `templateId` reference + option keys so volumes/cardinality
@@ -575,6 +584,9 @@ export async function joinHandler(req: Request, res: Response) {
     };
     if (Object.keys(upstreamOptions).length > 0) {
       dispatchBody.options = upstreamOptions;
+    }
+    if (timezone !== undefined) {
+      dispatchBody.timezone = timezone;
     }
 
     const dispatchParse = dispatchBodySchema.safeParse(dispatchBody);

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -32,6 +32,19 @@ export function __setTemplateFinderForTests(
   _templateFinder = finder ?? defaultTemplateFinder;
 }
 
+const timezoneSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .refine((value) => {
+    try {
+      Intl.DateTimeFormat("en-US", { timeZone: value });
+      return true;
+    } catch {
+      return false;
+    }
+  }, "timezone must be a valid IANA timezone identifier");
+
 // Per-join assistant-shaping knobs, forwarded onto convos-assistants'
 // free-form `metadata: Record<string, unknown>` bag. Each field is only
 // stamped onto metadata when the caller explicitly passes it — we do
@@ -71,7 +84,7 @@ const bodySchema = z
     name: z.string().min(1).max(256).optional(),
     profileImage: z.string().min(1).max(2048).optional(),
     options: optionsSchema.optional(),
-    timezone: z.string().min(1).max(64).optional(),
+    timezone: timezoneSchema.optional(),
   })
   .strict()
   .refine((b) => (b.slug === undefined) !== (b.conversationId === undefined), {
@@ -140,7 +153,7 @@ const dispatchBodySchema = z
     template: z.record(z.string(), z.unknown()).nullable(),
     ownerAccountId: accountIdSchema,
     options: optionsSchema.optional(),
-    timezone: z.string().min(1).max(64).optional(),
+    timezone: timezoneSchema.optional(),
   })
   .strict()
   .refine(


### PR DESCRIPTION
Accepts an optional `timezone` field (IANA timezone identifier, e.g. `"America/New_York"`) on `POST /api/v2/agents/join` and forwards it to the assistant dispatch at `POST {assistant}/api/assistants`.

## Changes

- **Inbound schema** (`bodySchema`): adds `timezone: z.string().min(1).max(64).optional()` — back-compatible, older clients that omit it are unaffected.
- **Egress schema** (`dispatchBodySchema`): adds the same optional `timezone` field — required because the schema is `.strict()` and any unregistered key on the dispatch body causes a 500 on every join.
- **Dispatch body mapping**: stamps `timezone` onto the dispatch body when present (`if (timezone !== undefined) { dispatchBody.timezone = timezone; }`).

## Behaviour

The field is fully optional. Clients that send it supply the creator's device IANA timezone, which the assistant runtime uses as the per-instance baseline zone (Channel A in the cross-repo timezone design). Clients that omit it see no change in behaviour.

No Prisma schema change — creator timezone is a per-join value, not an `AgentTemplate` attribute.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784308821&installation_id=128169237&pr_number=316&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F316&signature=7f6fbb5a94348947216ccecaf8354bd1d062d8c6f02908ef7e599be6683608f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept and forward client timezone on `POST /api/v2/agents/join`
> Adds an optional `timezone` field to the `agents/join` request body, validated as a non-empty IANA timezone identifier (max 64 chars) using `Intl.DateTimeFormat`. When provided, the value is forwarded in the dispatch payload to the assistants service. Invalid timezone values are rejected with a 400 before dispatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e04aa3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional **timezone** when joining agent operations. If provided, the value is validated and then forwarded to backend services so scheduling and time-related behavior reflects the selected timezone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->