### PR TITLE
fix(agent-templates): unblock distill preview — drop unsupported array minItems/maxItems

### DIFF
--- a/src/api/v2/agent-templates/services/distill.ts
+++ b/src/api/v2/agent-templates/services/distill.ts
@@ -40,7 +40,7 @@ const DISTILL_PROMPT = loadDataPrompt("distill-prompt.txt");
 // main generate call — a hung distill must not eat the pipeline's time budget.
 const DISTILL_TIMEOUT_MS = 60_000;
 
-// The schema asks for 6–8 phrases; accept down to this floor after filtering
+// The prompt asks for 6–8 phrases; accept down to this floor after filtering
 // blanks so a near-miss still yields a usable badge rather than failing the
 // (best-effort) stage. Trim anything over the ceiling.
 const MIN_PHRASES = 4;
@@ -132,9 +132,9 @@ async function _distill(
 
   const userContent = buildDistillUserContent(text, attachments, prefill);
 
-  // `any` body so the OpenRouter extensions (per-block cache_control, the
-  // json_schema with min/maxItems) pass through the OpenAI SDK unchanged —
-  // mirrors the main generate call in templateGen.
+  // `any` body so the OpenRouter extension (the per-block cache_control on the
+  // system prompt) passes through the OpenAI SDK unchanged — mirrors the main
+  // generate call in templateGen.
   const body: any = {
     model: getModel(),
     messages: [
@@ -168,8 +168,9 @@ async function _distill(
             progressPhrases: {
               type: "array",
               items: { type: "string" },
-              minItems: 6,
-              maxItems: MAX_PHRASES,
+              // No minItems/maxItems: Anthropic's structured outputs reject any
+              // array minItems other than 0 or 1. The prompt asks for 6–8 and
+              // parseDistillResponse enforces the 4–8 bounds after the fact.
             },
           },
           required: ["agentName", "emoji", "description", "progressPhrases"],


### PR DESCRIPTION
## What

The server-side distill stage (#309) requested `progressPhrases` as a `json_schema` array with `minItems: 6, maxItems: 8`. **Anthropic's structured-output API rejects any array `minItems` other than 0 or 1**, returning:

```
output_config.format.schema: For 'array' type, 'minItems' values other than 0 or 1 are not supported (got: [6, ∞])
```

So every distill call that routes to Anthropic fails with `invalid_request_error`. The executor swallows distill failures best-effort (`[generation-executor] Distill stage failed; proceeding without preview`), leaving the `preview` / `progressPhrases` columns null — which is why the generation poll has been returning them **empty for all generations** since the feature shipped (observed on generation `ee923f98-995f-41c5-8cd5-12838b61f4ad`).

The main generate call works because its `tools` array carries no `min/maxItems`.

## Fix

Remove the array bounds from the distill schema. They were redundant:
- `data/distill-prompt.txt` already asks for "6–8 short lines".
- `parseDistillResponse` already enforces the 4–8 floor/ceiling after parsing.

Also corrected two stale comments that described the removed bounds, and added a note at the schema so the constraint isn't reintroduced.

## Verification

- `agent-templates.distill.service` (13) and `agent-templates.generation-preview` (10) unit tests pass.
- The executor integration suite requires a live `DATABASE_URL` (not available locally) and doesn't touch the schema shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784315137&installation_id=128169237&pr_number=317&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F317&signature=d29d308d202bd85d46ac22453fc355e06bae77e65a9b2038455a2d67a05de5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop unsupported `minItems`/`maxItems` constraints from distill structured output schema
> Removes `minItems` and `maxItems` from the `progressPhrases` array in the JSON schema sent to the chat completion API in [`distill.ts`](https://github.com/ephemeraHQ/convos-backend/pull/317/files#diff-275f58f94ccc137bf59443d651f7a49d89e020f0be585ee9b3bed4da36e785a1). These constraints are not supported by the structured output schema format, causing the distill preview to be blocked. Phrase count is now enforced via the prompt instead of the schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70e2b6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation and processing of progress phrases to improve system reliability and consistency in output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->