### PR TITLE
fix(agent-templates): exempt authenticated callers from presigned-upload rate limit

### DIFF
--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -59,8 +59,8 @@ agentTemplatesRouter.get(
 // bucket. Mounted before /:idOrUrlSlug so the wildcard doesn't capture
 // "attachments" as a slug-or-id. Optional auth, like the generation endpoint.
 // Auth runs before the limiter so it can read the resolved identity from
-// res.locals and exempt authenticated callers — the per-IP cap then applies
-// only to anonymous capability-token minting.
+// res.locals and exempt the agent-API-key caller (the bot) — the per-IP cap
+// then applies to everyone else (anonymous + signed-in JWT callers).
 agentTemplatesRouter.get(
   "/attachments/presigned",
   optionalAuthOrAgentApiKeyAuth,

--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -58,12 +58,13 @@ agentTemplatesRouter.get(
 // Presigned PUT for a generation attachment (image / PDF / voice) → the private
 // bucket. Mounted before /:idOrUrlSlug so the wildcard doesn't capture
 // "attachments" as a slug-or-id. Optional auth, like the generation endpoint.
-// A dedicated per-IP limiter caps capability-token minting since the endpoint
-// is optional-auth.
+// Auth runs before the limiter so it can read the resolved identity from
+// res.locals and exempt authenticated callers — the per-IP cap then applies
+// only to anonymous capability-token minting.
 agentTemplatesRouter.get(
   "/attachments/presigned",
-  buildAttachmentPresignedLimiter,
   optionalAuthOrAgentApiKeyAuth,
+  buildAttachmentPresignedLimiter,
   buildAttachmentPresignedHandler,
 );
 

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -65,19 +65,22 @@ export const agentAssetPreAuthLimiter = rateLimit({
 
 // Rate limiting for the build-attachment presigned-URL endpoint
 // (GET /api/v2/agent-templates/attachments/presigned). Each request mints an
-// S3 PUT capability token. The cap targets ANONYMOUS minting: authenticated
-// callers are accountable, so they're exempted via `skip` and only anonymous
-// traffic is held to this per-IP cap. The exemption requires the auth
-// middleware to run BEFORE this limiter so `res.locals` carries the resolved
-// identity (see the route wiring in agent-templates.router.ts).
+// S3 PUT capability token, and there's no global ceiling behind this — only the
+// per-kind size cap and the object lifecycle bound an abuser — so the per-IP cap
+// is the blast-radius limit on unbounded minting. Only the agent-API-key caller
+// (the twitter bot, which mints up to 9 presigns per multi-photo mention behind
+// one egress IP) is exempted via `skip`; anonymous and signed-in (JWT) callers
+// stay capped. The exemption requires the auth middleware to run BEFORE this
+// limiter so `res.locals` carries the resolved identity (see the route wiring in
+// agent-templates.router.ts).
 export const buildAttachmentPresignedLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   limit: 20,
   keyGenerator: (req) => req.ip || "unknown",
-  // Authenticated callers bypass the cap. `res.locals.accountId` is set for
-  // both the agent-API-key path (→ ADMIN, e.g. the twitter bot) and the JWT
-  // path; it stays undefined for anonymous requests, which remain limited.
-  skip: (_req, res) => Boolean(res.locals.accountId),
+  // Only the agent-API-key caller bypasses the cap. `res.locals.isApiKeyListener`
+  // is set exclusively on that path (→ ADMIN_ACCOUNT_ID); anonymous and JWT
+  // callers keep `isApiKeyListener` falsy and stay subject to the per-IP limit.
+  skip: (_req, res) => res.locals.isApiKeyListener === true,
   legacyHeaders: false,
   standardHeaders: "draft-8",
   message: {

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -65,13 +65,19 @@ export const agentAssetPreAuthLimiter = rateLimit({
 
 // Rate limiting for the build-attachment presigned-URL endpoint
 // (GET /api/v2/agent-templates/attachments/presigned). Each request mints an
-// S3 PUT capability token and the endpoint is optional-auth, so it needs a
-// tighter per-IP cap than the global 1000/5min — comfortably above the handful
-// of presigns a real multi-attachment build needs, far below a useful abuse rate.
+// S3 PUT capability token. The cap targets ANONYMOUS minting: authenticated
+// callers are accountable, so they're exempted via `skip` and only anonymous
+// traffic is held to this per-IP cap. The exemption requires the auth
+// middleware to run BEFORE this limiter so `res.locals` carries the resolved
+// identity (see the route wiring in agent-templates.router.ts).
 export const buildAttachmentPresignedLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   limit: 20,
   keyGenerator: (req) => req.ip || "unknown",
+  // Authenticated callers bypass the cap. `res.locals.accountId` is set for
+  // both the agent-API-key path (→ ADMIN, e.g. the twitter bot) and the JWT
+  // path; it stays undefined for anonymous requests, which remain limited.
+  skip: (_req, res) => Boolean(res.locals.accountId),
   legacyHeaders: false,
   standardHeaders: "draft-8",
   message: {

--- a/tests/build-attachment-presigned.ratelimit.test.ts
+++ b/tests/build-attachment-presigned.ratelimit.test.ts
@@ -2,8 +2,8 @@
  * Rate-limit coverage for GET /api/v2/agent-templates/attachments/presigned.
  * Mounts the real exported limiter in front of a trivial handler so the test
  * exercises its configured per-IP cap (20/min) and its auth-aware `skip`
- * without pulling in S3. The skip keys on `res.locals.accountId`, so a one-line
- * middleware that sets it stands in for the real auth chain.
+ * without pulling in S3. The skip keys on `res.locals.isApiKeyListener`, so a
+ * one-line middleware that sets it stands in for the agent-API-key auth path.
  */
 
 import express from "express";
@@ -32,11 +32,41 @@ test("anonymous: 21st presigned request in the window → 429", async () => {
   });
 });
 
-test("authenticated: requests bypass the per-IP cap", async () => {
-  // Stand in for the auth chain: set res.locals.accountId before the limiter,
-  // as optionalAuthOrAgentApiKeyAuth does for an agent-key or JWT caller.
-  const authedApp = express();
-  authedApp.get(
+test("agent API key caller: requests bypass the per-IP cap", async () => {
+  // Stand in for the auth chain: set res.locals.isApiKeyListener before the
+  // limiter, as optionalAuthOrAgentApiKeyAuth does for the agent-API-key path.
+  const apiKeyApp = express();
+  apiKeyApp.get(
+    "/presigned",
+    (_req, res, next) => {
+      res.locals.isApiKeyListener = true;
+      next();
+    },
+    buildAttachmentPresignedLimiter,
+    (_req, res) => {
+      res.json({ ok: true });
+    },
+  );
+
+  // Well past the cap of 20 — every request still passes because the limiter
+  // skips the agent-API-key caller (and never increments the counter).
+  for (let i = 0; i < 25; i++) {
+    const res = await request(apiKeyApp).get("/presigned");
+    expect(res.status).toBe(200);
+  }
+});
+
+test("signed-in (JWT) caller stays capped: 21st request → 429", async () => {
+  // A JWT caller has res.locals.accountId set but NOT isApiKeyListener, so the
+  // skip does not fire — only the agent-API-key path is exempt.
+  //
+  // The limiter store is shared across this file's apps and keyed on req.ip;
+  // the anonymous test already exhausted the loopback counter, so route this
+  // test through a distinct client IP (trust proxy + X-Forwarded-For) to get an
+  // independent counter.
+  const jwtApp = express();
+  jwtApp.set("trust proxy", true);
+  jwtApp.get(
     "/presigned",
     (_req, res, next) => {
       res.locals.accountId = "test-account-id";
@@ -48,10 +78,13 @@ test("authenticated: requests bypass the per-IP cap", async () => {
     },
   );
 
-  // Well past the anonymous cap of 20 — every request still passes because the
-  // limiter skips authenticated callers (and never increments the counter).
-  for (let i = 0; i < 25; i++) {
-    const res = await request(authedApp).get("/presigned");
+  const asJwtClient = () =>
+    request(jwtApp).get("/presigned").set("X-Forwarded-For", "203.0.113.7");
+
+  for (let i = 0; i < 20; i++) {
+    const res = await asJwtClient();
     expect(res.status).toBe(200);
   }
+  const limited = await asJwtClient();
+  expect(limited.status).toBe(429);
 });

--- a/tests/build-attachment-presigned.ratelimit.test.ts
+++ b/tests/build-attachment-presigned.ratelimit.test.ts
@@ -1,7 +1,9 @@
 /**
  * Rate-limit coverage for GET /api/v2/agent-templates/attachments/presigned.
  * Mounts the real exported limiter in front of a trivial handler so the test
- * exercises its configured per-IP cap (20/min) without pulling in S3 or auth.
+ * exercises its configured per-IP cap (20/min) and its auth-aware `skip`
+ * without pulling in S3. The skip keys on `res.locals.accountId`, so a one-line
+ * middleware that sets it stands in for the real auth chain.
  */
 
 import express from "express";
@@ -9,22 +11,47 @@ import request from "supertest";
 import { expect, test } from "vitest";
 import { buildAttachmentPresignedLimiter } from "@/middleware/rateLimit";
 
-const app = express();
-app.get("/presigned", buildAttachmentPresignedLimiter, (_req, res) => {
+const anonApp = express();
+anonApp.get("/presigned", buildAttachmentPresignedLimiter, (_req, res) => {
   res.json({ ok: true });
 });
 
-test("21st presigned request in the window → 429", async () => {
-  // supertest drives every request from the same loopback IP, so they share
-  // one counter. The first 20 are allowed; the 21st must be rejected.
+test("anonymous: 21st presigned request in the window → 429", async () => {
+  // No res.locals.accountId → the limiter does not skip. supertest drives every
+  // request from the same loopback IP, so they share one counter: the first 20
+  // are allowed; the 21st must be rejected.
   for (let i = 0; i < 20; i++) {
-    const res = await request(app).get("/presigned");
+    const res = await request(anonApp).get("/presigned");
     expect(res.status).toBe(200);
   }
 
-  const limited = await request(app).get("/presigned");
+  const limited = await request(anonApp).get("/presigned");
   expect(limited.status).toBe(429);
   expect(limited.body).toEqual({
     error: "Too many attachment upload requests, please try again later",
   });
+});
+
+test("authenticated: requests bypass the per-IP cap", async () => {
+  // Stand in for the auth chain: set res.locals.accountId before the limiter,
+  // as optionalAuthOrAgentApiKeyAuth does for an agent-key or JWT caller.
+  const authedApp = express();
+  authedApp.get(
+    "/presigned",
+    (_req, res, next) => {
+      res.locals.accountId = "test-account-id";
+      next();
+    },
+    buildAttachmentPresignedLimiter,
+    (_req, res) => {
+      res.json({ ok: true });
+    },
+  );
+
+  // Well past the anonymous cap of 20 — every request still passes because the
+  // limiter skips authenticated callers (and never increments the counter).
+  for (let i = 0; i < 25; i++) {
+    const res = await request(authedApp).get("/presigned");
+    expect(res.status).toBe(200);
+  }
 });


### PR DESCRIPTION
## Summary

The presigned-upload limiter — `GET /api/v2/agent-templates/attachments/presigned`, **20/min/IP** — exists to cap *anonymous* capability-token minting. But it was mounted **before** auth and keyed purely on IP, so it also throttled authenticated callers.

The caller that hits this is the **twitter bot**: it mints up to 9 presigns per photo mention, all from a single Cloudflare egress IP. A photo-heavy minute — or a catch-up tick after downtime, where `since_id` replays the whole backlog — can trip the 20/min cap, after which presigns 429 and attachments are silently dropped (`twitter_bot_attachment_failed`).

## Change

- Run `optionalAuthOrAgentApiKeyAuth` **before** the limiter so the resolved identity is on `res.locals`.
- Add `skip: (_req, res) => Boolean(res.locals.accountId)` to the limiter. `res.locals.accountId` is set for both the agent-API-key path (→ ADMIN, e.g. the bot) and the JWT path, and is `undefined` for anonymous.

Net effect: authenticated callers (agent key + signed-in users) bypass the per-IP cap; **anonymous traffic stays capped at 20/min/IP**, and the global `1000/5min` limiter remains a backstop for everyone.

## Tests

`tests/build-attachment-presigned.ratelimit.test.ts`:
- anonymous → still 429s on the 21st request in the window
- authenticated (`res.locals.accountId` set) → sails past the cap (25 requests, all 200)

`eslint` + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784356778&installation_id=128169237&pr_number=318&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F318&signature=47f56f0d04a49ddd608fcb0c185ad5b079e6723b0c2a2c89072daf210871324d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exempt authenticated callers from the presigned-upload rate limit
> - Reorders middleware in the `GET /api/v2/agent-templates/attachments/presigned` route so `optionalAuthOrAgentApiKeyAuth` runs before `buildAttachmentPresignedLimiter`, populating `res.locals.accountId` before the limiter executes.
> - Adds a `skip` predicate to `buildAttachmentPresignedLimiter` in [rateLimit.ts](https://github.com/ephemeraHQ/convos-backend/pull/318/files#diff-b3f285f74315ca0a0594a1319122cf3b0a5b15dcab60014c1f8bd6896818a8db) that bypasses the 20 req/min per-IP cap when `res.locals.accountId` is set.
> - Anonymous callers remain subject to the existing cap; authenticated callers are fully exempt.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #318 opened
>
> - Changed `buildAttachmentPresignedLimiter` middleware to exempt only agent-API-key authenticated requests from the per-IP rate limit by checking `res.locals.isApiKeyListener === true` instead of `res.locals.accountId`, subjecting JWT-authenticated callers to the 20-per-minute cap alongside anonymous callers [275aed4]
> - Updated rate limiter test suite to verify agent-API-key exemption using `isApiKeyListener` flag and added test case confirming JWT-authenticated callers are subject to the per-IP rate limit [275aed4]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82177b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limiting behavior for attachment presigned URL generation: only the designated agent API-key callers are exempt, while anonymous and standard authenticated JWT callers are still capped per IP.
  * Adjusted middleware ordering so the limiter can correctly apply the exemption rules.
* **Tests**
  * Expanded automated coverage to verify the 20-request cap behavior across anonymous, agent API-key, and JWT-authenticated scenarios (including the 21st request returning 429).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->