### PR TITLE
feat(credits-admin): internal credits admin portal — view + grant/adjust (CF Access)

### DIFF
--- a/prisma/migrations/20260617165659_add_admin_audit/migration.sql
+++ b/prisma/migrations/20260617165659_add_admin_audit/migration.sql
@@ -13,6 +13,9 @@ CREATE TABLE "AdminAudit" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "AdminAudit_accountId_idempotencyKey_key" ON "AdminAudit"("accountId", "idempotencyKey");
+
+-- CreateIndex
 CREATE INDEX "AdminAudit_accountId_createdAt_idx" ON "AdminAudit"("accountId", "createdAt");
 
 -- CreateIndex

--- a/prisma/migrations/20260617165659_add_admin_audit/migration.sql
+++ b/prisma/migrations/20260617165659_add_admin_audit/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "AdminAudit" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "accountId" UUID NOT NULL,
+    "actorEmail" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "deltaCredits" BIGINT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdminAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdminAudit_accountId_createdAt_idx" ON "AdminAudit"("accountId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AdminAudit_actorEmail_createdAt_idx" ON "AdminAudit"("actorEmail", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -443,3 +443,17 @@ model TelemetryBatch {
 
   @@index([receivedAt])
 }
+
+model AdminAudit {
+  id             String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  accountId      String   @db.Uuid
+  actorEmail     String
+  action         String
+  deltaCredits   BigInt
+  reason         String
+  idempotencyKey String
+  createdAt      DateTime @default(now())
+
+  @@index([accountId, createdAt])
+  @@index([actorEmail, createdAt])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -454,6 +454,7 @@ model AdminAudit {
   idempotencyKey String
   createdAt      DateTime @default(now())
 
+  @@unique([accountId, idempotencyKey])
   @@index([accountId, createdAt])
   @@index([actorEmail, createdAt])
 }

--- a/src/api/v2/credits-admin/audit-repository.ts
+++ b/src/api/v2/credits-admin/audit-repository.ts
@@ -31,7 +31,7 @@ export const listAdminAuditByAccount = async (
 ): Promise<AdminAudit[]> => {
   return prisma.adminAudit.findMany({
     where: { accountId },
-    orderBy: { createdAt: "desc" },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     take: limit,
   });
 };

--- a/src/api/v2/credits-admin/audit-repository.ts
+++ b/src/api/v2/credits-admin/audit-repository.ts
@@ -1,0 +1,28 @@
+import type { AdminAudit } from "@prisma/client";
+import { prisma } from "@/utils/prisma";
+
+export type AdminAuditAction = "grant" | "adjust";
+
+export const writeAdminAudit = async (args: {
+  accountId: string;
+  actorEmail: string;
+  action: AdminAuditAction;
+  deltaCredits: bigint;
+  reason: string;
+  idempotencyKey: string;
+}): Promise<void> => {
+  await prisma.adminAudit.create({ data: args });
+};
+
+const AUDIT_LIST_LIMIT = 50;
+
+export const listAdminAuditByAccount = async (
+  accountId: string,
+  limit: number = AUDIT_LIST_LIMIT,
+): Promise<AdminAudit[]> => {
+  return prisma.adminAudit.findMany({
+    where: { accountId },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+};

--- a/src/api/v2/credits-admin/audit-repository.ts
+++ b/src/api/v2/credits-admin/audit-repository.ts
@@ -11,7 +11,16 @@ export const writeAdminAudit = async (args: {
   reason: string;
   idempotencyKey: string;
 }): Promise<void> => {
-  await prisma.adminAudit.create({ data: args });
+  await prisma.adminAudit.upsert({
+    where: {
+      accountId_idempotencyKey: {
+        accountId: args.accountId,
+        idempotencyKey: args.idempotencyKey,
+      },
+    },
+    update: {},
+    create: args,
+  });
 };
 
 const AUDIT_LIST_LIMIT = 50;

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
 import { accountViewGetHandler } from "./handlers/account-view-get";
+import { adjustPostHandler } from "./handlers/adjust-post";
 import { grantPostHandler } from "./handlers/grant-post";
 import { searchGetHandler } from "./handlers/search-get";
 import { cfAccessHeaderMiddleware } from "./middleware/cf-access";
@@ -21,4 +22,11 @@ creditsAdminRouter.post(
   cfAccessHeaderMiddleware,
   meGuard,
   grantPostHandler,
+);
+
+creditsAdminRouter.post(
+  "/accounts/:accountId/adjust",
+  cfAccessHeaderMiddleware,
+  meGuard,
+  adjustPostHandler,
 );

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
 import { accountViewGetHandler } from "./handlers/account-view-get";
 import { adjustPostHandler } from "./handlers/adjust-post";
+import { auditGetHandler } from "./handlers/audit-get";
 import { grantPostHandler } from "./handlers/grant-post";
 import { searchGetHandler } from "./handlers/search-get";
 import { cfAccessHeaderMiddleware } from "./middleware/cf-access";
@@ -9,6 +10,8 @@ import { cfAccessHeaderMiddleware } from "./middleware/cf-access";
 export const creditsAdminRouter = Router();
 
 creditsAdminRouter.get("/search", cfAccessHeaderMiddleware, searchGetHandler);
+
+creditsAdminRouter.get("/audit", cfAccessHeaderMiddleware, auditGetHandler);
 
 creditsAdminRouter.get(
   "/accounts/:accountId",

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+
+export const creditsAdminRouter = Router();

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -1,7 +1,16 @@
 import { Router } from "express";
+import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
+import { accountViewGetHandler } from "./handlers/account-view-get";
 import { searchGetHandler } from "./handlers/search-get";
 import { cfAccessHeaderMiddleware } from "./middleware/cf-access";
 
 export const creditsAdminRouter = Router();
 
 creditsAdminRouter.get("/search", cfAccessHeaderMiddleware, searchGetHandler);
+
+creditsAdminRouter.get(
+  "/accounts/:accountId",
+  cfAccessHeaderMiddleware,
+  meGuard,
+  accountViewGetHandler,
+);

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
 import { accountViewGetHandler } from "./handlers/account-view-get";
+import { grantPostHandler } from "./handlers/grant-post";
 import { searchGetHandler } from "./handlers/search-get";
 import { cfAccessHeaderMiddleware } from "./middleware/cf-access";
 
@@ -13,4 +14,11 @@ creditsAdminRouter.get(
   cfAccessHeaderMiddleware,
   meGuard,
   accountViewGetHandler,
+);
+
+creditsAdminRouter.post(
+  "/accounts/:accountId/grant",
+  cfAccessHeaderMiddleware,
+  meGuard,
+  grantPostHandler,
 );

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -2,12 +2,15 @@ import { Router } from "express";
 import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
 import { accountViewGetHandler } from "./handlers/account-view-get";
 import { adjustPostHandler } from "./handlers/adjust-post";
+import { adminPageHandler } from "./handlers/admin-page";
 import { auditGetHandler } from "./handlers/audit-get";
 import { grantPostHandler } from "./handlers/grant-post";
 import { searchGetHandler } from "./handlers/search-get";
 import { cfAccessHeaderMiddleware } from "./middleware/cf-access";
 
 export const creditsAdminRouter = Router();
+
+creditsAdminRouter.get("/", adminPageHandler);
 
 creditsAdminRouter.get("/search", cfAccessHeaderMiddleware, searchGetHandler);
 

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -1,3 +1,7 @@
 import { Router } from "express";
+import { searchGetHandler } from "./handlers/search-get";
+import { cfAccessHeaderMiddleware } from "./middleware/cf-access";
 
 export const creditsAdminRouter = Router();
+
+creditsAdminRouter.get("/search", cfAccessHeaderMiddleware, searchGetHandler);

--- a/src/api/v2/credits-admin/handlers/account-view-get.ts
+++ b/src/api/v2/credits-admin/handlers/account-view-get.ts
@@ -1,0 +1,117 @@
+import type { CreditLedger } from "@prisma/client";
+import type { Request, Response } from "express";
+import { getBalance, getBucketedConsumption } from "@/payments";
+import { getSpendableBalance, sumPeriodConsumes } from "@/payments/spendable";
+import { findCurrentByAccountId } from "@/subscriptions/repository";
+import {
+  effectiveSubscriptionStatus,
+  ENTITLED_SUBSCRIPTION_STATUSES,
+} from "@/subscriptions/status";
+import { prisma } from "@/utils/prisma";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const LEDGER_LIMIT = 50;
+const REFILL_LIMIT = 20;
+const USAGE_WINDOW_DAYS = 30;
+
+const serializeLedger = (r: CreditLedger) => ({
+  id: r.id,
+  delta: r.delta.toString(),
+  reason: r.reason,
+  grantKindId: r.grantKindId,
+  note: r.note,
+  idempotencyKey: r.idempotencyKey,
+  balanceAfter: r.balanceAfter?.toString() ?? null,
+  createdAt: r.createdAt.toISOString(),
+});
+
+export const accountViewGetHandler = async (
+  req: Request<{ accountId: string }>,
+  res: Response,
+): Promise<void> => {
+  const accountId = req.params.accountId;
+
+  const account = await prisma.account.findUnique({
+    where: { id: accountId },
+    select: { id: true, createdAt: true },
+  });
+  if (!account) {
+    req.log.warn({ accountId }, "credits_admin.view.account_not_found");
+    res.status(404).json({ code: "account_not_found" });
+    return;
+  }
+
+  const now = new Date();
+  const subscription = await findCurrentByAccountId(accountId);
+
+  let subView: {
+    tier: string;
+    storedStatus: string;
+    effectiveStatus: string;
+    isEntitled: boolean;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+    environment: string | null;
+    willRenew: boolean;
+    isInTrial: boolean;
+  } | null = null;
+  let periodConsumesCredits = 0;
+
+  if (subscription) {
+    const effectiveStatus = effectiveSubscriptionStatus(subscription, now);
+    const isEntitled = ENTITLED_SUBSCRIPTION_STATUSES.includes(effectiveStatus);
+    if (isEntitled) {
+      periodConsumesCredits = await sumPeriodConsumes(
+        accountId,
+        subscription.currentPeriodStart,
+      );
+    }
+    subView = {
+      tier: subscription.tier,
+      storedStatus: subscription.status,
+      effectiveStatus,
+      isEntitled,
+      currentPeriodStart: subscription.currentPeriodStart.toISOString(),
+      currentPeriodEnd: subscription.currentPeriodEnd.toISOString(),
+      environment: subscription.environment ?? null,
+      willRenew: subscription.willRenew,
+      isInTrial: subscription.isInTrial,
+    };
+  }
+
+  const [spendable, raw, ledgerRows, refillRows, usage] = await Promise.all([
+    getSpendableBalance(accountId),
+    getBalance(accountId),
+    prisma.creditLedger.findMany({
+      where: { accountId },
+      orderBy: { createdAt: "desc" },
+      take: LEDGER_LIMIT,
+    }),
+    prisma.creditLedger.findMany({
+      where: { accountId, grantKindId: "daily_refill" },
+      orderBy: { createdAt: "desc" },
+      take: REFILL_LIMIT,
+    }),
+    getBucketedConsumption(
+      accountId,
+      new Date(now.getTime() - USAGE_WINDOW_DAYS * DAY_MS),
+      "day",
+    ),
+  ]);
+
+  res.status(200).json({
+    accountId,
+    accountCreatedAt: account.createdAt.toISOString(),
+    subscription: subView,
+    isEntitled: subView?.isEntitled ?? false,
+    spendableCredits: spendable.toString(),
+    rawBalanceCredits: raw.toString(),
+    periodConsumesCredits,
+    ledger: ledgerRows.map(serializeLedger),
+    dailyRefills: refillRows.map(serializeLedger),
+    usageDaily: usage.map((u) => ({
+      bucketStart: u.bucketStart,
+      consumed: u.consumed.toString(),
+    })),
+  });
+};

--- a/src/api/v2/credits-admin/handlers/adjust-post.ts
+++ b/src/api/v2/credits-admin/handlers/adjust-post.ts
@@ -41,16 +41,14 @@ export const adjustPostHandler = async (
       note: `admin:${actorEmail} — ${reason}`,
     });
 
-    if (!result.replayed) {
-      await writeAdminAudit({
-        accountId,
-        actorEmail,
-        action: "adjust",
-        deltaCredits: BigInt(delta),
-        reason,
-        idempotencyKey,
-      });
-    }
+    await writeAdminAudit({
+      accountId,
+      actorEmail,
+      action: "adjust",
+      deltaCredits: BigInt(delta),
+      reason,
+      idempotencyKey,
+    });
 
     res.status(200).json({
       applied: true,

--- a/src/api/v2/credits-admin/handlers/adjust-post.ts
+++ b/src/api/v2/credits-admin/handlers/adjust-post.ts
@@ -1,0 +1,81 @@
+import type { Request, Response } from "express";
+import {
+  adjust,
+  IdempotencyMismatchError,
+  InsufficientBalanceError,
+} from "@/payments";
+import { prisma } from "@/utils/prisma";
+import { writeAdminAudit } from "../audit-repository";
+import { adjustBodySchema } from "../schemas/requests";
+
+export const adjustPostHandler = async (
+  req: Request<{ accountId: string }>,
+  res: Response,
+): Promise<void> => {
+  const accountId = req.params.accountId;
+  const actorEmail = res.locals.actorEmail as string;
+
+  const parsed = adjustBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", details: parsed.error.errors });
+    return;
+  }
+  const { delta, reason, idempotencyKey } = parsed.data;
+
+  const account = await prisma.account.findUnique({
+    where: { id: accountId },
+    select: { id: true },
+  });
+  if (!account) {
+    res.status(404).json({ code: "account_not_found" });
+    return;
+  }
+
+  try {
+    const result = await adjust({
+      accountId,
+      delta,
+      idempotencyKey,
+      note: `admin:${actorEmail} — ${reason}`,
+    });
+
+    if (!result.replayed) {
+      await writeAdminAudit({
+        accountId,
+        actorEmail,
+        action: "adjust",
+        deltaCredits: BigInt(delta),
+        reason,
+        idempotencyKey,
+      });
+    }
+
+    res.status(200).json({
+      applied: true,
+      replayed: result.replayed,
+      balanceAfter: result.balanceAfter.toString(),
+      newBalance: result.newBalance.toString(),
+      ledgerId: result.ledgerId,
+    });
+  } catch (err) {
+    if (err instanceof InsufficientBalanceError) {
+      req.log.warn(
+        { accountId, delta },
+        "credits_admin.adjust.insufficient_balance",
+      );
+      res.status(402).json({ code: "insufficient_balance" });
+      return;
+    }
+    if (err instanceof IdempotencyMismatchError) {
+      req.log.warn(
+        { accountId, idempotencyKey },
+        "credits_admin.adjust.idempotency_mismatch",
+      );
+      res.status(409).json({ code: "idempotency_mismatch" });
+      return;
+    }
+    throw err;
+  }
+};

--- a/src/api/v2/credits-admin/handlers/admin-page.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page.ts
@@ -1,0 +1,327 @@
+import crypto from "node:crypto";
+import type { Request, Response } from "express";
+import { config } from "@/payments/credits/config";
+import { resolveActorEmail } from "../middleware/cf-access";
+
+export const adminPageHandler = (req: Request, res: Response): void => {
+  const nonce = crypto.randomBytes(16).toString("base64");
+  const resolved = resolveActorEmail(
+    req.header("Cf-Access-Authenticated-User-Email"),
+  );
+  const adminEmail = resolved.email ?? "unknown";
+  const creditsPerUsd = Number(config.creditsPerDollar);
+
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.removeHeader("Content-Security-Policy");
+  res.setHeader(
+    "Content-Security-Policy",
+    `default-src 'self'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'`,
+  );
+  res.send(buildHTML(nonce, adminEmail, creditsPerUsd));
+};
+
+function safeScriptJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e");
+}
+
+function buildHTML(
+  nonce: string,
+  adminEmail: string,
+  creditsPerUsd: number,
+): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Credits Admin — Convos</title>
+<style>
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 24px; background: #f5f5f7; color: #1d1d1f; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 16px; margin: 0 0 12px; }
+  .identity { font-size: 13px; color: #6e6e73; margin-bottom: 20px; }
+  .identity strong { color: #1d1d1f; }
+  .card { background: #fff; border-radius: 12px; padding: 20px; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  label { display: block; font-size: 13px; font-weight: 600; margin: 12px 0 4px; }
+  input, select { width: 100%; padding: 10px; border: 1px solid #d2d2d7; border-radius: 8px; font-size: 14px; }
+  button { padding: 10px 16px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; }
+  .btn-primary { background: #0071e3; color: #fff; }
+  .btn-danger { background: #d70015; color: #fff; }
+  .btn-secondary { background: #e8e8ed; color: #1d1d1f; }
+  .row { display: flex; gap: 12px; align-items: flex-end; }
+  .row > * { flex: 1; }
+  .hint { font-size: 12px; color: #6e6e73; margin-top: 4px; }
+  .balances { display: flex; gap: 24px; flex-wrap: wrap; }
+  .balance { padding: 12px 16px; border-radius: 8px; background: #f5f5f7; min-width: 160px; }
+  .balance .k { font-size: 12px; color: #6e6e73; }
+  .balance .v { font-size: 20px; font-weight: 700; }
+  .balance.spendable { background: #e3f2e8; }
+  .balance.raw { background: #eef0ff; }
+  .badge { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+  .badge-yes { background: #d1f0d6; color: #14752a; }
+  .badge-no { background: #f7d6d6; color: #a3151f; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid #ececec; }
+  th { color: #6e6e73; font-weight: 600; }
+  .hidden { display: none; }
+  .toast { position: fixed; bottom: 24px; right: 24px; padding: 12px 18px; border-radius: 8px; color: #fff; opacity: 0; transition: opacity .2s; pointer-events: none; }
+  .toast.show { opacity: 1; }
+  .toast-success { background: #14752a; }
+  .toast-error { background: #a3151f; }
+  .modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; }
+  .modal { background: #fff; border-radius: 12px; padding: 24px; max-width: 440px; width: 90%; }
+  .modal p { font-size: 14px; line-height: 1.5; }
+  .modal .actions { display: flex; gap: 12px; margin-top: 20px; }
+</style>
+</head>
+<body>
+<h1>💳 Credits Admin</h1>
+<div class="identity">Acting as <strong id="admin-email"></strong> (Cloudflare Access)</div>
+
+<div class="card">
+  <h2>Find account</h2>
+  <div class="row">
+    <div style="flex:0 0 160px">
+      <label for="search-key">Lookup by</label>
+      <select id="search-key">
+        <option value="accountId">accountId (UUID)</option>
+        <option value="wallet">wallet address</option>
+      </select>
+    </div>
+    <div>
+      <label for="search-value">Value</label>
+      <input id="search-value" placeholder="paste accountId or wallet">
+    </div>
+    <div style="flex:0 0 120px">
+      <button class="btn-primary" id="search-btn" style="width:100%">Search</button>
+    </div>
+  </div>
+</div>
+
+<div id="detail" class="hidden">
+  <div class="card">
+    <h2>Account <span id="detail-id" style="font-weight:400;font-size:13px"></span></h2>
+    <div class="balances">
+      <div class="balance spendable"><div class="k">Spendable (derived)</div><div class="v" id="b-spendable"></div></div>
+      <div class="balance raw"><div class="k">Raw parked balance</div><div class="v" id="b-raw"></div></div>
+      <div class="balance"><div class="k">Entitled</div><div class="v"><span id="b-entitled"></span></div></div>
+    </div>
+    <div id="sub-block" style="margin-top:16px"></div>
+  </div>
+
+  <div class="card">
+    <h2>Grant credits (additive)</h2>
+    <div class="row">
+      <div><label for="grant-credits">Credits</label><input id="grant-credits" type="number" min="1"><div class="hint" id="grant-hint"></div></div>
+      <div><label for="grant-reason">Reason</label><input id="grant-reason" placeholder="required"></div>
+      <div style="flex:0 0 120px"><button class="btn-primary" id="grant-btn" style="width:100%">Grant</button></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Adjust ledger (signed correction)</h2>
+    <div class="row">
+      <div><label for="adjust-delta">Delta (±credits)</label><input id="adjust-delta" type="number"><div class="hint" id="adjust-hint"></div></div>
+      <div><label for="adjust-reason">Reason</label><input id="adjust-reason" placeholder="required"></div>
+      <div style="flex:0 0 120px"><button class="btn-danger" id="adjust-btn" style="width:100%">Adjust</button></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Recent ledger</h2>
+    <div style="overflow-x:auto"><table id="ledger-table"><thead><tr><th>When</th><th>Δ</th><th>Reason</th><th>Kind</th><th>Note</th></tr></thead><tbody></tbody></table></div>
+  </div>
+
+  <div class="card">
+    <h2>Admin audit log</h2>
+    <div style="overflow-x:auto"><table id="audit-table"><thead><tr><th>When</th><th>Actor</th><th>Action</th><th>Δ</th><th>Reason</th></tr></thead><tbody></tbody></table></div>
+  </div>
+</div>
+
+<div id="modal-root"></div>
+<div class="toast" id="toast"></div>
+
+<script nonce="${nonce}">
+  var ADMIN_EMAIL = ${safeScriptJson(adminEmail)};
+  var CREDITS_PER_USD = ${safeScriptJson(creditsPerUsd)};
+  var currentAccountId = null;
+  document.getElementById("admin-email").textContent = ADMIN_EMAIL;
+
+  function apiBase() { return window.location.origin + "/api/v2/credits-admin"; }
+  function apiFetch(path, opts) {
+    opts = opts || {};
+    return fetch(apiBase() + path, Object.assign({ credentials: "include" }, opts, {
+      headers: Object.assign({ "Content-Type": "application/json" }, opts.headers || {})
+    }));
+  }
+  function toast(msg, type) {
+    var el = document.getElementById("toast");
+    el.textContent = msg;
+    el.className = "toast toast-" + (type || "success") + " show";
+    setTimeout(function () { el.className = "toast"; }, 3500);
+  }
+  function esc(s) {
+    if (s === null || s === undefined) return "";
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+  function fmtDate(iso) {
+    if (!iso) return "—";
+    var d = new Date(iso);
+    return d.toLocaleDateString() + " " + d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  function fmtCredits(n) { return Number(n).toLocaleString(); }
+  function usdHint(credits) {
+    var c = Number(credits);
+    if (!CREDITS_PER_USD || !isFinite(c) || !c) return "";
+    var usd = c / CREDITS_PER_USD;
+    return "≈ $" + usd.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  function newKey(prefix) { return prefix + "_" + crypto.randomUUID(); }
+
+  document.getElementById("grant-credits").addEventListener("input", function () {
+    document.getElementById("grant-hint").textContent = usdHint(this.value);
+  });
+  document.getElementById("adjust-delta").addEventListener("input", function () {
+    document.getElementById("adjust-hint").textContent = usdHint(Math.abs(Number(this.value)));
+  });
+
+  document.getElementById("search-btn").addEventListener("click", doSearch);
+  document.getElementById("search-value").addEventListener("keydown", function (e) { if (e.key === "Enter") doSearch(); });
+  function doSearch() {
+    var key = document.getElementById("search-key").value;
+    var value = document.getElementById("search-value").value.trim();
+    if (!value) return;
+    apiFetch("/search?key=" + encodeURIComponent(key) + "&value=" + encodeURIComponent(value))
+      .then(function (r) { return r.json(); })
+      .then(function (j) {
+        if (!j.accountId) { toast("No account found", "error"); return; }
+        loadAccount(j.accountId);
+      })
+      .catch(function () { toast("Search failed", "error"); });
+  }
+
+  function loadAccount(accountId) {
+    apiFetch("/accounts/" + encodeURIComponent(accountId))
+      .then(function (r) { if (!r.ok) throw new Error("not found"); return r.json(); })
+      .then(function (j) { currentAccountId = accountId; renderDetail(j); loadAudit(accountId); })
+      .catch(function () { toast("Account not found", "error"); });
+  }
+
+  function renderDetail(j) {
+    document.getElementById("detail").classList.remove("hidden");
+    document.getElementById("detail-id").textContent = j.accountId;
+    document.getElementById("b-spendable").textContent = fmtCredits(j.spendableCredits);
+    document.getElementById("b-raw").textContent = fmtCredits(j.rawBalanceCredits);
+    document.getElementById("b-entitled").innerHTML = j.isEntitled
+      ? '<span class="badge badge-yes">entitled</span>'
+      : '<span class="badge badge-no">not entitled</span>';
+    var sb = document.getElementById("sub-block");
+    if (j.subscription) {
+      var s = j.subscription;
+      sb.innerHTML = "<table><tbody>" +
+        "<tr><th>Tier</th><td>" + esc(s.tier) + "</td></tr>" +
+        "<tr><th>Stored status</th><td>" + esc(s.storedStatus) + "</td></tr>" +
+        "<tr><th>Effective status</th><td>" + esc(s.effectiveStatus) + "</td></tr>" +
+        "<tr><th>Period</th><td>" + fmtDate(s.currentPeriodStart) + " → " + fmtDate(s.currentPeriodEnd) + "</td></tr>" +
+        "<tr><th>Environment</th><td>" + esc(s.environment) + "</td></tr>" +
+        "<tr><th>Period consumes</th><td>" + fmtCredits(j.periodConsumesCredits) + " credits</td></tr>" +
+        "</tbody></table>";
+    } else {
+      sb.innerHTML = '<div class="hint">No subscription on record.</div>';
+    }
+    var lt = document.querySelector("#ledger-table tbody");
+    lt.innerHTML = (j.ledger || []).map(function (r) {
+      return "<tr><td>" + fmtDate(r.createdAt) + "</td><td>" + esc(r.delta) + "</td><td>" + esc(r.reason) + "</td><td>" + esc(r.grantKindId || "—") + "</td><td>" + esc(r.note || "") + "</td></tr>";
+    }).join("");
+  }
+
+  function loadAudit(accountId) {
+    apiFetch("/audit?accountId=" + encodeURIComponent(accountId))
+      .then(function (r) { return r.json(); })
+      .then(function (j) {
+        var at = document.querySelector("#audit-table tbody");
+        at.innerHTML = (j.audit || []).map(function (r) {
+          return "<tr><td>" + fmtDate(r.createdAt) + "</td><td>" + esc(r.actorEmail) + "</td><td>" + esc(r.action) + "</td><td>" + esc(r.deltaCredits) + "</td><td>" + esc(r.reason) + "</td></tr>";
+        }).join("");
+      })
+      .catch(function () { toast("Audit load failed", "error"); });
+  }
+
+  function confirmModal(message, onConfirm) {
+    var root = document.getElementById("modal-root");
+    root.innerHTML = '<div class="modal-bg"><div class="modal"><p>' + message + '</p>' +
+      '<div class="actions"><button class="btn-secondary" id="modal-cancel" style="flex:1">Cancel</button>' +
+      '<button class="btn-primary" id="modal-confirm" style="flex:1">Confirm</button></div></div></div>';
+    function close() { root.innerHTML = ""; }
+    document.getElementById("modal-cancel").addEventListener("click", close);
+    var confirmBtn = document.getElementById("modal-confirm");
+    confirmBtn.addEventListener("click", function () {
+      confirmBtn.disabled = true;
+      onConfirm(close);
+    });
+  }
+
+  document.getElementById("grant-btn").addEventListener("click", function () {
+    if (!currentAccountId) return;
+    var credits = parseInt(document.getElementById("grant-credits").value, 10);
+    var reason = document.getElementById("grant-reason").value.trim();
+    if (!credits || credits <= 0) { toast("Enter a positive credit amount", "error"); return; }
+    if (!reason) { toast("Reason is required", "error"); return; }
+    var key = newKey("admin_grant");
+    confirmModal(
+      "Grant <strong>" + fmtCredits(credits) + "</strong> credits " + esc(usdHint(credits)) +
+      " to <code>" + esc(currentAccountId) + "</code>.<br>Reason: " + esc(reason) +
+      "<br>Acting as: " + esc(ADMIN_EMAIL),
+      function (close) {
+        apiFetch("/accounts/" + encodeURIComponent(currentAccountId) + "/grant", {
+          method: "POST",
+          body: JSON.stringify({ credits: credits, reason: reason, idempotencyKey: key })
+        }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+          .then(function (res) {
+            close();
+            if (!res.ok) { toast(res.j.code === "idempotency_mismatch" ? "Idempotency mismatch" : "Grant failed", "error"); return; }
+            toast(res.j.replayed ? "Already applied (idempotent)" : "Granted", "success");
+            loadAccount(currentAccountId);
+          }).catch(function () { close(); toast("Grant failed", "error"); });
+      }
+    );
+  });
+
+  document.getElementById("adjust-btn").addEventListener("click", function () {
+    if (!currentAccountId) return;
+    var delta = parseInt(document.getElementById("adjust-delta").value, 10);
+    var reason = document.getElementById("adjust-reason").value.trim();
+    if (!delta) { toast("Enter a non-zero delta", "error"); return; }
+    if (!reason) { toast("Reason is required", "error"); return; }
+    var key = newKey("admin_adjust");
+    confirmModal(
+      "Adjust ledger by <strong>" + (delta > 0 ? "+" : "") + fmtCredits(delta) + "</strong> credits " + esc(usdHint(Math.abs(delta))) +
+      " on <code>" + esc(currentAccountId) + "</code>.<br>Reason: " + esc(reason) +
+      "<br>Acting as: " + esc(ADMIN_EMAIL),
+      function (close) {
+        apiFetch("/accounts/" + encodeURIComponent(currentAccountId) + "/adjust", {
+          method: "POST",
+          body: JSON.stringify({ delta: delta, reason: reason, idempotencyKey: key })
+        }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+          .then(function (res) {
+            close();
+            if (!res.ok) {
+              var msg = res.j.code === "insufficient_balance" ? "Below minimum balance floor" :
+                        res.j.code === "idempotency_mismatch" ? "Idempotency mismatch" : "Adjust failed";
+              toast(msg, "error"); return;
+            }
+            toast(res.j.replayed ? "Already applied (idempotent)" : "Adjusted", "success");
+            loadAccount(currentAccountId);
+          }).catch(function () { close(); toast("Adjust failed", "error"); });
+      }
+    );
+  });
+</script>
+</body>
+</html>`;
+}

--- a/src/api/v2/credits-admin/handlers/audit-get.ts
+++ b/src/api/v2/credits-admin/handlers/audit-get.ts
@@ -1,0 +1,28 @@
+import type { Request, Response } from "express";
+import { listAdminAuditByAccount } from "../audit-repository";
+import { auditQuerySchema } from "../schemas/requests";
+
+export const auditGetHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const parsed = auditQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", details: parsed.error.errors });
+    return;
+  }
+  const rows = await listAdminAuditByAccount(parsed.data.accountId);
+  res.status(200).json({
+    audit: rows.map((r) => ({
+      id: r.id,
+      actorEmail: r.actorEmail,
+      action: r.action,
+      deltaCredits: r.deltaCredits.toString(),
+      reason: r.reason,
+      idempotencyKey: r.idempotencyKey,
+      createdAt: r.createdAt.toISOString(),
+    })),
+  });
+};

--- a/src/api/v2/credits-admin/handlers/grant-post.ts
+++ b/src/api/v2/credits-admin/handlers/grant-post.ts
@@ -39,16 +39,14 @@ export const grantPostHandler = async (
       requestId: idempotencyKey,
     });
 
-    if (!result.replayed) {
-      await writeAdminAudit({
-        accountId,
-        actorEmail,
-        action: "grant",
-        deltaCredits: BigInt(credits),
-        reason,
-        idempotencyKey,
-      });
-    }
+    await writeAdminAudit({
+      accountId,
+      actorEmail,
+      action: "grant",
+      deltaCredits: BigInt(credits),
+      reason,
+      idempotencyKey,
+    });
 
     res.status(200).json({
       applied: true,

--- a/src/api/v2/credits-admin/handlers/grant-post.ts
+++ b/src/api/v2/credits-admin/handlers/grant-post.ts
@@ -1,0 +1,72 @@
+import type { Request, Response } from "express";
+import { grant, IdempotencyMismatchError } from "@/payments";
+import { prisma } from "@/utils/prisma";
+import { writeAdminAudit } from "../audit-repository";
+import { grantBodySchema } from "../schemas/requests";
+
+export const grantPostHandler = async (
+  req: Request<{ accountId: string }>,
+  res: Response,
+): Promise<void> => {
+  const accountId = req.params.accountId;
+  const actorEmail = res.locals.actorEmail as string;
+
+  const parsed = grantBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", details: parsed.error.errors });
+    return;
+  }
+  const { credits, reason, idempotencyKey } = parsed.data;
+
+  const account = await prisma.account.findUnique({
+    where: { id: accountId },
+    select: { id: true },
+  });
+  if (!account) {
+    res.status(404).json({ code: "account_not_found" });
+    return;
+  }
+
+  try {
+    const result = await grant({
+      accountId,
+      credits,
+      kind: "manual",
+      idempotencyKey,
+      note: `admin:${actorEmail} — ${reason}`,
+      requestId: idempotencyKey,
+    });
+
+    if (!result.replayed) {
+      await writeAdminAudit({
+        accountId,
+        actorEmail,
+        action: "grant",
+        deltaCredits: BigInt(credits),
+        reason,
+        idempotencyKey,
+      });
+    }
+
+    res.status(200).json({
+      applied: true,
+      replayed: result.replayed,
+      granted: result.granted,
+      balanceAfter: result.balanceAfter.toString(),
+      newBalance: result.newBalance.toString(),
+      ledgerId: result.ledgerId,
+    });
+  } catch (err) {
+    if (err instanceof IdempotencyMismatchError) {
+      req.log.warn(
+        { accountId, idempotencyKey },
+        "credits_admin.grant.idempotency_mismatch",
+      );
+      res.status(409).json({ code: "idempotency_mismatch" });
+      return;
+    }
+    throw err;
+  }
+};

--- a/src/api/v2/credits-admin/handlers/search-get.ts
+++ b/src/api/v2/credits-admin/handlers/search-get.ts
@@ -1,0 +1,37 @@
+import type { Request, Response } from "express";
+import { accountIdSchema } from "@/utils/account-id";
+import { prisma } from "@/utils/prisma";
+import { searchQuerySchema } from "../schemas/requests";
+
+export const searchGetHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const parsed = searchQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", details: parsed.error.errors });
+    return;
+  }
+  const { key, value } = parsed.data;
+
+  if (key === "accountId") {
+    if (!accountIdSchema.safeParse(value).success) {
+      res.status(200).json({ accountId: null });
+      return;
+    }
+    const account = await prisma.account.findUnique({
+      where: { id: value },
+      select: { id: true },
+    });
+    res.status(200).json({ accountId: account?.id ?? null });
+    return;
+  }
+
+  const authMethod = await prisma.authMethod.findUnique({
+    where: { type_externalKey: { type: "SIWE", externalKey: value } },
+    select: { accountId: true },
+  });
+  res.status(200).json({ accountId: authMethod?.accountId ?? null });
+};

--- a/src/api/v2/credits-admin/middleware/cf-access.ts
+++ b/src/api/v2/credits-admin/middleware/cf-access.ts
@@ -1,0 +1,50 @@
+import type { NextFunction, Request, Response } from "express";
+import { IS_DEVELOPMENT } from "@/config";
+
+export const CF_ACCESS_EMAIL_HEADER = "Cf-Access-Authenticated-User-Email";
+export const CF_ACCESS_DEV_FALLBACK_EMAIL = "local-dev@convos.invalid";
+
+let _devFallbackOverride: boolean | undefined = undefined;
+export function __setCfAccessDevFallbackForTests(
+  value: boolean | undefined,
+): void {
+  _devFallbackOverride = value;
+}
+function devFallbackEnabled(): boolean {
+  return _devFallbackOverride ?? IS_DEVELOPMENT;
+}
+
+type ResolvedActor =
+  | { email: string; usedDevFallback: boolean }
+  | { email: null; usedDevFallback: false };
+
+export function resolveActorEmail(
+  headerValue: string | undefined,
+): ResolvedActor {
+  const trimmed = (headerValue ?? "").trim();
+  if (trimmed) {
+    return { email: trimmed, usedDevFallback: false };
+  }
+  if (devFallbackEnabled()) {
+    return { email: CF_ACCESS_DEV_FALLBACK_EMAIL, usedDevFallback: true };
+  }
+  return { email: null, usedDevFallback: false };
+}
+
+export const cfAccessHeaderMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const resolved = resolveActorEmail(req.header(CF_ACCESS_EMAIL_HEADER));
+  if (!resolved.email) {
+    req.log.warn("cf_access.missing_header");
+    res.status(401).json({ code: "unauthorized" });
+    return;
+  }
+  if (resolved.usedDevFallback) {
+    req.log.warn("cf_access.dev_fallback_identity");
+  }
+  res.locals.actorEmail = resolved.email;
+  next();
+};

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { idempotencyKeySchema } from "@/payments/ledger/idempotency-key";
+import { accountIdSchema } from "@/utils/account-id";
+
+export const MAX_ADMIN_GRANT_CREDITS = 100_000_000;
+
+export const searchQuerySchema = z.object({
+  key: z.enum(["accountId", "wallet"]),
+  value: z.string().trim().min(1).max(256),
+});
+
+export const auditQuerySchema = z.object({
+  accountId: accountIdSchema,
+});
+
+export const grantBodySchema = z.object({
+  credits: z.number().int().positive().max(MAX_ADMIN_GRANT_CREDITS),
+  reason: z.string().trim().min(1).max(256),
+  idempotencyKey: idempotencyKeySchema,
+});
+
+export const adjustBodySchema = z.object({
+  delta: z
+    .number()
+    .int()
+    .refine((v) => v !== 0, { message: "delta_must_be_nonzero" })
+    .refine((v) => Math.abs(v) <= MAX_ADMIN_GRANT_CREDITS, {
+      message: "delta_out_of_range",
+    }),
+  reason: z.string().trim().min(1).max(256),
+  idempotencyKey: idempotencyKeySchema,
+});

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -35,6 +35,7 @@ import { authRouter } from "./auth/auth.router";
 import { composioRouter } from "./composio/composio.router";
 import { connectionsRouter } from "./connections/connections.router";
 import { servicesGetHandler } from "./connections/handlers/services-get";
+import { creditsAdminRouter } from "./credits-admin/credits-admin.router";
 import { dailyRefillRouter } from "./credits/daily.router";
 import { devRouter } from "./dev/dev.router";
 import { deviceRouter } from "./device/device.router";
@@ -60,6 +61,7 @@ v2Router.use("/agent-templates", agentTemplatesRouter);
 
 v2Router.use("/invites", invitesV2Router);
 
+v2Router.use("/credits-admin", creditsAdminRouter);
 // Invite codes: admin page + API (auth applied per-route inside the router)
 v2Router.use("/invite-codes/admin", inviteCodesAdminRouter);
 // Invite codes: client redemption (JWT-authenticated)

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -12,5 +12,6 @@ declare namespace Express {
     jwtMetadata?: {
       notificationExtensionOnly?: boolean;
     };
+    actorEmail?: string;
   }
 }

--- a/tests/credits-admin/account-view.integration.test.ts
+++ b/tests/credits-admin/account-view.integration.test.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from "node:crypto";
+import type { Express } from "express";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  adminRequest,
+  buildCreditsAdminApp,
+  cleanupAdminAccounts,
+  seedAccount,
+  seedBalance,
+  seedPlusMonthlySubscription,
+} from "./helpers";
+
+type AccountViewBody = {
+  accountId: string;
+  accountCreatedAt: string;
+  subscription: {
+    tier: string;
+    storedStatus: string;
+    effectiveStatus: string;
+    isEntitled: boolean;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+    environment: string | null;
+    willRenew: boolean;
+    isInTrial: boolean;
+  } | null;
+  isEntitled: boolean;
+  spendableCredits: string;
+  rawBalanceCredits: string;
+  periodConsumesCredits: number;
+  ledger: {
+    id: string;
+    delta: string;
+    reason: string;
+    grantKindId: string | null;
+    note: string | null;
+    balanceAfter: string | null;
+    idempotencyKey: string;
+    createdAt: string;
+  }[];
+  dailyRefills: unknown[];
+  usageDaily: unknown[];
+};
+
+describe("GET /api/v2/credits-admin/accounts/:accountId", () => {
+  let app: Express;
+  const tracker: string[] = [];
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("entitled subscriber → derived spendable + raw + isEntitled true", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedPlusMonthlySubscription(accountId);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${accountId}`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as AccountViewBody;
+    expect(body.isEntitled).toBe(true);
+    expect(body.subscription?.effectiveStatus).toBe("active");
+    expect(body.rawBalanceCredits).toBe("0");
+    expect(BigInt(body.spendableCredits)).toBeGreaterThan(0n);
+  });
+
+  it("non-subscriber → no subscription, spendable equals raw", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 1_000n);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${accountId}`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as AccountViewBody;
+    expect(body.subscription).toBeNull();
+    expect(body.isEntitled).toBe(false);
+    expect(body.rawBalanceCredits).toBe("1000");
+    expect(body.spendableCredits).toBe("1000");
+    expect(body.ledger.length).toBeGreaterThanOrEqual(1);
+    expect(body.ledger[0].delta).toBe("1000");
+  });
+
+  it("unknown account → 404", async () => {
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${randomUUID()}`,
+    );
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ code: "account_not_found" });
+  });
+
+  it("invalid uuid param → 400 (meGuard)", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts/not-a-uuid",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_account_id" });
+  });
+});

--- a/tests/credits-admin/adjust.integration.test.ts
+++ b/tests/credits-admin/adjust.integration.test.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from "node:crypto";
+import type { Express } from "express";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { getBalance } from "@/payments";
+import { prisma } from "@/utils/prisma";
+import {
+  adminRequest,
+  buildCreditsAdminApp,
+  cleanupAdminAccounts,
+  seedAccount,
+  seedBalance,
+} from "./helpers";
+
+describe("POST /api/v2/credits-admin/accounts/:accountId/adjust", () => {
+  let app: Express;
+  const tracker: string[] = [];
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("positive delta: applies, writes audit with signed delta + admin note", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 1_000n);
+    const idempotencyKey = `admin_adjust_${randomUUID()}`;
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/adjust`,
+      { delta: 250, reason: "correction up", idempotencyKey },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      applied: true,
+      replayed: false,
+      balanceAfter: "1250",
+    });
+    expect(await getBalance(accountId)).toBe(1_250n);
+    const audit = await prisma.adminAudit.findFirst({
+      where: { accountId, idempotencyKey },
+    });
+    expect(audit?.action).toBe("adjust");
+    expect(audit?.deltaCredits).toBe(250n);
+    const ledger = await prisma.creditLedger.findFirst({
+      where: { accountId, idempotencyKey },
+    });
+    expect(ledger?.note).toBe("admin:admin@convos.test — correction up");
+  });
+
+  it("negative delta within floor: applies down", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 1_000n);
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/adjust`,
+      {
+        delta: -300,
+        reason: "clawback",
+        idempotencyKey: `admin_adjust_${randomUUID()}`,
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(await getBalance(accountId)).toBe(700n);
+    const audit = await prisma.adminAudit.findFirst({ where: { accountId } });
+    expect(audit?.deltaCredits).toBe(-300n);
+  });
+
+  it("unknown account → 404", async () => {
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${randomUUID()}/adjust`,
+      {
+        delta: 100,
+        reason: "x",
+        idempotencyKey: `admin_adjust_${randomUUID()}`,
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("negative delta breaching minBalance floor → 402, no write", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 100n);
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/adjust`,
+      {
+        delta: -5_000,
+        reason: "too much",
+        idempotencyKey: `admin_adjust_${randomUUID()}`,
+      },
+    );
+    expect(res.status).toBe(402);
+    expect(res.body).toMatchObject({ code: "insufficient_balance" });
+    expect(await getBalance(accountId)).toBe(100n);
+    expect(await prisma.adminAudit.count({ where: { accountId } })).toBe(0);
+  });
+
+  it("delta = 0 → 400", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/adjust`,
+      {
+        delta: 0,
+        reason: "noop",
+        idempotencyKey: `admin_adjust_${randomUUID()}`,
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("idempotent replay: no double-apply, single audit row", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await seedBalance(accountId, 1_000n);
+    const body = {
+      delta: 100,
+      reason: "dup",
+      idempotencyKey: `admin_adjust_${randomUUID()}`,
+    };
+    await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/adjust`,
+      body,
+    );
+    const res2 = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/adjust`,
+      body,
+    );
+    expect(res2.body).toMatchObject({ replayed: true });
+    expect(await getBalance(accountId)).toBe(1_100n);
+    expect(await prisma.adminAudit.count({ where: { accountId } })).toBe(1);
+  });
+});

--- a/tests/credits-admin/adjust.integration.test.ts
+++ b/tests/credits-admin/adjust.integration.test.ts
@@ -120,10 +120,12 @@ describe("POST /api/v2/credits-admin/accounts/:accountId/adjust", () => {
       reason: "dup",
       idempotencyKey: `admin_adjust_${randomUUID()}`,
     };
-    await adminRequest(app).post(
+    const res1 = await adminRequest(app).post(
       `/api/v2/credits-admin/accounts/${accountId}/adjust`,
       body,
     );
+    expect(res1.status).toBe(200);
+    expect(res1.body).toMatchObject({ replayed: false });
     const res2 = await adminRequest(app).post(
       `/api/v2/credits-admin/accounts/${accountId}/adjust`,
       body,

--- a/tests/credits-admin/admin-audit-model.test.ts
+++ b/tests/credits-admin/admin-audit-model.test.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { prisma } from "@/utils/prisma";
+
+describe("AdminAudit model", () => {
+  const created: string[] = [];
+  afterEach(async () => {
+    for (const id of created) {
+      await prisma.adminAudit.deleteMany({ where: { id } });
+    }
+    created.length = 0;
+  });
+
+  it("persists and reads back a row with a server-generated uuid", async () => {
+    const row = await prisma.adminAudit.create({
+      data: {
+        accountId: randomUUID(),
+        actorEmail: "admin@convos.test",
+        action: "grant",
+        deltaCredits: 500_000n,
+        reason: "manual top-up",
+        idempotencyKey: `admin_grant_${randomUUID()}`,
+      },
+    });
+    created.push(row.id);
+    expect(row.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(row.actorEmail).toBe("admin@convos.test");
+    expect(row.action).toBe("grant");
+    expect(row.reason).toBe("manual top-up");
+    expect(row.deltaCredits).toBe(500_000n);
+    expect(row.createdAt).toBeInstanceOf(Date);
+  });
+});

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -1,0 +1,41 @@
+import type { Express } from "express";
+import { beforeAll, describe, expect, it } from "vitest";
+import { adminRequest, buildCreditsAdminApp } from "./helpers";
+
+describe("GET /api/v2/credits-admin/ (admin page)", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("serves HTML with CSP nonce, no-store, noindex, and echoes the CF Access identity", async () => {
+    const res = await adminRequest(app, "ops@convos.test").get(
+      "/api/v2/credits-admin/",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.headers["cache-control"]).toBe("no-store");
+    const csp = res.headers["content-security-policy"];
+    expect(csp).toMatch(/script-src 'nonce-/);
+    const text = res.text;
+    expect(text).toContain('content="noindex, nofollow"');
+    expect(text).toContain("ops@convos.test");
+    const headerNonce = /script-src 'nonce-([^']+)'/.exec(csp)?.[1];
+    expect(headerNonce).toBeTruthy();
+    expect(text).toContain(`<script nonce="${headerNonce}">`);
+  });
+
+  it("page route does NOT require the CF Access header (perimeter gates it)", async () => {
+    const res = await adminRequest(app, null).get("/api/v2/credits-admin/");
+    expect(res.status).toBe(200);
+  });
+
+  it("escapes angle brackets in the injected identity (no <script> breakout)", async () => {
+    const res = await adminRequest(app, "evil</script><script>x").get(
+      "/api/v2/credits-admin/",
+    );
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain("evil</script>");
+    expect(res.text).toContain("evil\\u003c/script\\u003e");
+  });
+});

--- a/tests/credits-admin/audit-repository.test.ts
+++ b/tests/credits-admin/audit-repository.test.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listAdminAuditByAccount,
+  writeAdminAudit,
+} from "@/api/v2/credits-admin/audit-repository";
+import { prisma } from "@/utils/prisma";
+
+describe("AdminAudit repository", () => {
+  const accounts: string[] = [];
+  afterEach(async () => {
+    for (const accountId of accounts) {
+      await prisma.adminAudit.deleteMany({ where: { accountId } });
+    }
+    accounts.length = 0;
+  });
+
+  it("writes a row and lists it back, newest first", async () => {
+    const accountId = randomUUID();
+    accounts.push(accountId);
+
+    await writeAdminAudit({
+      accountId,
+      actorEmail: "admin@convos.test",
+      action: "grant",
+      deltaCredits: 500_000n,
+      reason: "first",
+      idempotencyKey: `admin_grant_${randomUUID()}`,
+    });
+    await writeAdminAudit({
+      accountId,
+      actorEmail: "admin@convos.test",
+      action: "adjust",
+      deltaCredits: -100n,
+      reason: "second",
+      idempotencyKey: `admin_adjust_${randomUUID()}`,
+    });
+
+    const rows = await listAdminAuditByAccount(accountId);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].reason).toBe("second");
+    expect(rows[0].action).toBe("adjust");
+    expect(rows[0].deltaCredits).toBe(-100n);
+    expect(rows[1].reason).toBe("first");
+  });
+});

--- a/tests/credits-admin/audit-repository.test.ts
+++ b/tests/credits-admin/audit-repository.test.ts
@@ -38,9 +38,13 @@ describe("AdminAudit repository", () => {
 
     const rows = await listAdminAuditByAccount(accountId);
     expect(rows).toHaveLength(2);
-    expect(rows[0].reason).toBe("second");
-    expect(rows[0].action).toBe("adjust");
-    expect(rows[0].deltaCredits).toBe(-100n);
-    expect(rows[1].reason).toBe("first");
+    expect(rows[0].createdAt.getTime()).toBeGreaterThanOrEqual(
+      rows[1].createdAt.getTime(),
+    );
+    const first = rows.find((r) => r.reason === "first");
+    const second = rows.find((r) => r.reason === "second");
+    expect(first?.action).toBe("grant");
+    expect(second?.action).toBe("adjust");
+    expect(second?.deltaCredits).toBe(-100n);
   });
 });

--- a/tests/credits-admin/audit.integration.test.ts
+++ b/tests/credits-admin/audit.integration.test.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from "node:crypto";
+import type { Express } from "express";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  adminRequest,
+  buildCreditsAdminApp,
+  cleanupAdminAccounts,
+  seedAccount,
+} from "./helpers";
+
+type AuditRow = {
+  id: string;
+  actorEmail: string;
+  action: string;
+  deltaCredits: string;
+  reason: string;
+  idempotencyKey: string;
+  createdAt: string;
+};
+
+describe("GET /api/v2/credits-admin/audit", () => {
+  let app: Express;
+  const tracker: string[] = [];
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("returns admin actions for an account, newest first, deltaCredits as string", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      {
+        credits: 500,
+        reason: "first",
+        idempotencyKey: `admin_grant_${randomUUID()}`,
+      },
+    );
+    await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/adjust`,
+      {
+        delta: -100,
+        reason: "second",
+        idempotencyKey: `admin_adjust_${randomUUID()}`,
+      },
+    );
+
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/audit?accountId=${accountId}`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { audit: AuditRow[] };
+    expect(body.audit).toHaveLength(2);
+    expect(body.audit[0].reason).toBe("second");
+    expect(body.audit[0].deltaCredits).toBe("-100");
+    expect(body.audit[1].deltaCredits).toBe("500");
+  });
+
+  it("invalid accountId query → 400", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/audit?accountId=not-a-uuid",
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/credits-admin/cf-access.test.ts
+++ b/tests/credits-admin/cf-access.test.ts
@@ -1,0 +1,62 @@
+import express, { type Express } from "express";
+import supertest from "supertest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  __setCfAccessDevFallbackForTests,
+  CF_ACCESS_DEV_FALLBACK_EMAIL,
+  CF_ACCESS_EMAIL_HEADER,
+  cfAccessHeaderMiddleware,
+} from "@/api/v2/credits-admin/middleware/cf-access";
+import { errorHandlerMiddleware } from "@/middleware/errorHandler";
+import { pinoMiddleware } from "@/middleware/pino";
+
+const buildProbeApp = (): Express => {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.get("/probe", cfAccessHeaderMiddleware, (_req, res) => {
+    res.status(200).json({ actorEmail: res.locals.actorEmail });
+  });
+  app.use(errorHandlerMiddleware);
+  return app;
+};
+
+describe("cfAccessHeaderMiddleware", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildProbeApp();
+  });
+  afterEach(() => {
+    __setCfAccessDevFallbackForTests(undefined);
+  });
+
+  it("passes and exposes actorEmail when header present", async () => {
+    const res = await supertest(app)
+      .get("/probe")
+      .set(CF_ACCESS_EMAIL_HEADER, "admin@convos.test");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ actorEmail: "admin@convos.test" });
+  });
+
+  it("non-dev: missing header → 401, no actorEmail", async () => {
+    __setCfAccessDevFallbackForTests(false);
+    const res = await supertest(app).get("/probe");
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: "unauthorized" });
+  });
+
+  it("dev: missing header → fallback label, 200", async () => {
+    __setCfAccessDevFallbackForTests(true);
+    const res = await supertest(app).get("/probe");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ actorEmail: CF_ACCESS_DEV_FALLBACK_EMAIL });
+  });
+
+  it("treats whitespace-only header as missing (non-dev → 401)", async () => {
+    __setCfAccessDevFallbackForTests(false);
+    const res = await supertest(app)
+      .get("/probe")
+      .set(CF_ACCESS_EMAIL_HEADER, "   ");
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: "unauthorized" });
+  });
+});

--- a/tests/credits-admin/grant.integration.test.ts
+++ b/tests/credits-admin/grant.integration.test.ts
@@ -78,10 +78,12 @@ describe("POST /api/v2/credits-admin/accounts/:accountId/grant", () => {
     tracker.push(accountId);
     const idempotencyKey = `admin_grant_${randomUUID()}`;
     const body = { credits: 1_000, reason: "dup", idempotencyKey };
-    await adminRequest(app).post(
+    const res1 = await adminRequest(app).post(
       `/api/v2/credits-admin/accounts/${accountId}/grant`,
       body,
     );
+    expect(res1.status).toBe(200);
+    expect(res1.body).toMatchObject({ replayed: false });
     const res2 = await adminRequest(app).post(
       `/api/v2/credits-admin/accounts/${accountId}/grant`,
       body,

--- a/tests/credits-admin/grant.integration.test.ts
+++ b/tests/credits-admin/grant.integration.test.ts
@@ -93,6 +93,25 @@ describe("POST /api/v2/credits-admin/accounts/:accountId/grant", () => {
     expect(audit).toHaveLength(1);
   });
 
+  it("replay re-creates a missing audit row (idempotent upsert closes the gap)", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const idempotencyKey = `admin_grant_${randomUUID()}`;
+    const body = { credits: 100, reason: "recover", idempotencyKey };
+    await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      body,
+    );
+    await prisma.adminAudit.deleteMany({ where: { accountId } });
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      body,
+    );
+    expect(res.body).toMatchObject({ replayed: true });
+    const audit = await prisma.adminAudit.findMany({ where: { accountId } });
+    expect(audit).toHaveLength(1);
+  });
+
   it("missing reason → 400, no ledger/audit write", async () => {
     const accountId = await seedAccount();
     tracker.push(accountId);

--- a/tests/credits-admin/grant.integration.test.ts
+++ b/tests/credits-admin/grant.integration.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto";
+import { LedgerReason } from "@prisma/client";
+import type { Express } from "express";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { __setCfAccessDevFallbackForTests } from "@/api/v2/credits-admin/middleware/cf-access";
+import { getBalance } from "@/payments";
+import { prisma } from "@/utils/prisma";
+import {
+  adminRequest,
+  buildCreditsAdminApp,
+  cleanupAdminAccounts,
+  seedAccount,
+} from "./helpers";
+
+describe("POST /api/v2/credits-admin/accounts/:accountId/grant", () => {
+  let app: Express;
+  const tracker: string[] = [];
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    __setCfAccessDevFallbackForTests(undefined);
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("grants via grant(): kind=manual ledger, admin note, AdminAudit row", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const idempotencyKey = `admin_grant_${randomUUID()}`;
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      { credits: 500_000, reason: "support top-up", idempotencyKey },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      applied: true,
+      replayed: false,
+      balanceAfter: "500000",
+      newBalance: "500000",
+    });
+    expect(await getBalance(accountId)).toBe(500_000n);
+
+    const ledger = await prisma.creditLedger.findFirst({
+      where: { accountId, idempotencyKey },
+    });
+    expect(ledger?.grantKindId).toBe("manual");
+    expect(ledger?.reason).toBe(LedgerReason.grant);
+    expect(ledger?.note).toBe("admin:admin@convos.test — support top-up");
+
+    const audit = await prisma.adminAudit.findMany({ where: { accountId } });
+    expect(audit).toHaveLength(1);
+    expect(audit[0].actorEmail).toBe("admin@convos.test");
+    expect(audit[0].action).toBe("grant");
+    expect(audit[0].deltaCredits).toBe(500_000n);
+    expect(audit[0].reason).toBe("support top-up");
+    expect(audit[0].idempotencyKey).toBe(idempotencyKey);
+  });
+
+  it("idempotency mismatch (same key, different payload) → 409", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const idempotencyKey = `admin_grant_${randomUUID()}`;
+    await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      { credits: 100, reason: "first", idempotencyKey },
+    );
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      { credits: 999, reason: "first", idempotencyKey },
+    );
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "idempotency_mismatch" });
+  });
+
+  it("idempotent replay: second call replays, no second audit row", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const idempotencyKey = `admin_grant_${randomUUID()}`;
+    const body = { credits: 1_000, reason: "dup", idempotencyKey };
+    await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      body,
+    );
+    const res2 = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      body,
+    );
+    expect(res2.status).toBe(200);
+    expect(res2.body).toMatchObject({ replayed: true });
+    expect(await getBalance(accountId)).toBe(1_000n);
+    const audit = await prisma.adminAudit.findMany({ where: { accountId } });
+    expect(audit).toHaveLength(1);
+  });
+
+  it("missing reason → 400, no ledger/audit write", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      { credits: 100, idempotencyKey: `admin_grant_${randomUUID()}` },
+    );
+    expect(res.status).toBe(400);
+    expect(await getBalance(accountId)).toBe(0n);
+    expect(await prisma.adminAudit.count({ where: { accountId } })).toBe(0);
+  });
+
+  it("non-dev: missing CF Access header → 401, no write", async () => {
+    __setCfAccessDevFallbackForTests(false);
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app, null).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      {
+        credits: 100,
+        reason: "x",
+        idempotencyKey: `admin_grant_${randomUUID()}`,
+      },
+    );
+    expect(res.status).toBe(401);
+    expect(await getBalance(accountId)).toBe(0n);
+    expect(await prisma.adminAudit.count({ where: { accountId } })).toBe(0);
+  });
+
+  it("dev fallback: missing header → uses fallback label, audit written", async () => {
+    __setCfAccessDevFallbackForTests(true);
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app, null).post(
+      `/api/v2/credits-admin/accounts/${accountId}/grant`,
+      {
+        credits: 100,
+        reason: "devrun",
+        idempotencyKey: `admin_grant_${randomUUID()}`,
+      },
+    );
+    expect(res.status).toBe(200);
+    const audit = await prisma.adminAudit.findFirst({ where: { accountId } });
+    expect(audit?.actorEmail).toBe("local-dev@convos.invalid");
+  });
+
+  it("unknown account → 404", async () => {
+    const res = await adminRequest(app).post(
+      `/api/v2/credits-admin/accounts/${randomUUID()}/grant`,
+      {
+        credits: 100,
+        reason: "x",
+        idempotencyKey: `admin_grant_${randomUUID()}`,
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/credits-admin/helpers.ts
+++ b/tests/credits-admin/helpers.ts
@@ -1,0 +1,63 @@
+import express, { type Express } from "express";
+import supertest from "supertest";
+import { creditsAdminRouter } from "@/api/v2/credits-admin/credits-admin.router";
+import { CF_ACCESS_EMAIL_HEADER } from "@/api/v2/credits-admin/middleware/cf-access";
+import { errorHandlerMiddleware } from "@/middleware/errorHandler";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+import { cleanupAccounts } from "../credits/helpers";
+
+export {
+  seedAccount,
+  seedBalance,
+  seedPlusMonthlySubscription,
+} from "../credits/helpers";
+
+export const DEFAULT_ADMIN_EMAIL = "admin@convos.test";
+
+export const buildCreditsAdminApp = (): Express => {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use(jsonMiddleware);
+  app.use("/api/v2/credits-admin", creditsAdminRouter);
+  app.use(noRouteMiddleware);
+  app.use(errorHandlerMiddleware);
+  return app;
+};
+
+export const adminRequest = (
+  app: Express,
+  email: string | null = DEFAULT_ADMIN_EMAIL,
+) => ({
+  get: (path: string) => {
+    const r = supertest(app).get(path);
+    return email === null ? r : r.set(CF_ACCESS_EMAIL_HEADER, email);
+  },
+  post: (path: string, body: unknown) => {
+    const r = supertest(app)
+      .post(path)
+      .send(body as object);
+    return email === null ? r : r.set(CF_ACCESS_EMAIL_HEADER, email);
+  },
+});
+
+export const seedSiweAuthMethod = async (
+  accountId: string,
+  externalKey: string,
+): Promise<void> => {
+  await prisma.authMethod.create({
+    data: { accountId, type: "SIWE", externalKey },
+  });
+};
+
+export const cleanupAdminAccounts = async (
+  accountIds: string[],
+): Promise<void> => {
+  for (const accountId of accountIds) {
+    await prisma.adminAudit.deleteMany({ where: { accountId } });
+    await prisma.authMethod.deleteMany({ where: { accountId } });
+  }
+  await cleanupAccounts(accountIds);
+};

--- a/tests/credits-admin/mount.test.ts
+++ b/tests/credits-admin/mount.test.ts
@@ -1,0 +1,17 @@
+import type { Express } from "express";
+import { beforeAll, describe, expect, it } from "vitest";
+import { adminRequest, buildCreditsAdminApp } from "./helpers";
+
+describe("credits-admin mount", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("router is mounted (unknown path under mount → 404 from noRoute, not a crash)", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/does-not-exist",
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/credits-admin/search.integration.test.ts
+++ b/tests/credits-admin/search.integration.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Express } from "express";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { __setCfAccessDevFallbackForTests } from "@/api/v2/credits-admin/middleware/cf-access";
 import {
   adminRequest,
   buildCreditsAdminApp,
@@ -16,6 +17,7 @@ describe("GET /api/v2/credits-admin/search", () => {
     app = buildCreditsAdminApp();
   });
   afterEach(async () => {
+    __setCfAccessDevFallbackForTests(undefined);
     await cleanupAdminAccounts(tracker);
     tracker.length = 0;
   });
@@ -67,13 +69,10 @@ describe("GET /api/v2/credits-admin/search", () => {
   });
 
   it("missing CF Access header (non-dev) → 401", async () => {
-    const { __setCfAccessDevFallbackForTests } =
-      await import("@/api/v2/credits-admin/middleware/cf-access");
     __setCfAccessDevFallbackForTests(false);
     const res = await adminRequest(app, null).get(
       "/api/v2/credits-admin/search?key=accountId&value=x",
     );
-    __setCfAccessDevFallbackForTests(undefined);
     expect(res.status).toBe(401);
   });
 });

--- a/tests/credits-admin/search.integration.test.ts
+++ b/tests/credits-admin/search.integration.test.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from "node:crypto";
+import type { Express } from "express";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  adminRequest,
+  buildCreditsAdminApp,
+  cleanupAdminAccounts,
+  seedAccount,
+  seedSiweAuthMethod,
+} from "./helpers";
+
+describe("GET /api/v2/credits-admin/search", () => {
+  let app: Express;
+  const tracker: string[] = [];
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("resolves by accountId", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/search?key=accountId&value=${accountId}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId });
+  });
+
+  it("resolves by wallet externalKey", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const wallet = `0xWALLET_${randomUUID()}`;
+    await seedSiweAuthMethod(accountId, wallet);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/search?key=wallet&value=${encodeURIComponent(wallet)}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId });
+  });
+
+  it("clean miss → accountId null, 200", async () => {
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/search?key=accountId&value=${randomUUID()}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId: null });
+  });
+
+  it("non-uuid accountId value → null (treated as miss, not 500)", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/search?key=accountId&value=not-a-uuid",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId: null });
+  });
+
+  it("invalid key → 400", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/search?key=UNKNOWN&value=x",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_request" });
+  });
+
+  it("missing CF Access header (non-dev) → 401", async () => {
+    const { __setCfAccessDevFallbackForTests } =
+      await import("@/api/v2/credits-admin/middleware/cf-access");
+    __setCfAccessDevFallbackForTests(false);
+    const res = await adminRequest(app, null).get(
+      "/api/v2/credits-admin/search?key=accountId&value=x",
+    );
+    __setCfAccessDevFallbackForTests(undefined);
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,8 @@
 // vi.mock for firebase-admin lives in __mocks__/ + per-test-file vi.mock()
 // declarations.
 
+import { afterAll } from "vitest";
+
 // Local dev: load DATABASE_URL (and any other vars) from .env when the shell
 // hasn't already provided it. CI sets DATABASE_URL as a real env var, so this
 // no-ops there. vitest does not read .env on its own, unlike the prisma CLI.
@@ -76,3 +78,8 @@ process.env.PAYMENTS_CRON_API_KEY =
 // number is set by ops via env in each deploy environment.
 process.env.PAYMENTS_GRANT_PLUS_MONTHLY =
   process.env.PAYMENTS_GRANT_PLUS_MONTHLY || "2500";
+
+afterAll(async () => {
+  const { prisma } = await import("@/utils/prisma");
+  await prisma.$disconnect();
+});


### PR DESCRIPTION
## Summary

Internal admin portal to inspect and fix an account's credit/subscription state — replaces the hand-written prod SQL + unaudited manual `grant()` calls used during the subscription-spendable investigation.

- **Server-rendered HTML page** at `GET /api/v2/credits-admin/` (CSP nonce, `no-store`, `noindex`, no build step) reusing the invite-codes page *chrome* but with NO password login — Cloudflare Access is the perimeter and the page echoes the CF Access admin identity.
- **JSON endpoints** (all behind an in-app `cfAccessHeaderMiddleware` backstop):
  - `GET /search?key=accountId|wallet&value=` → resolve to an accountId (clean miss → `{accountId:null}`, never 500).
  - `GET /accounts/:id` → derived **spendable** vs raw **parked** balance vs date-aware **entitlement**, period consumes, recent ledger, daily-refill history, 30-day usage.
  - `POST /accounts/:id/grant` → additive `grant({kind:"manual"})`, mandatory typed reason, page-generated idempotency key.
  - `POST /accounts/:id/adjust` → signed ledger correction; floor breach → 402.
  - `GET /audit?accountId=` → recent admin actions.
- **`AdminAudit` table** (no FK — survives account deletion) + an `admin:<email> — <reason>` ledger note on every mutation. Audit row written once per action (skipped on idempotent replay; the ledger note is the durable backstop).

### Auth model
Cloudflare Access is the perimeter (same as the convos-assistant admin). The in-app backstop requires `Cf-Access-Authenticated-User-Email` → **401 in non-dev**, dev-only fallback label when `NODE_ENV=development`. Verifying the signed `Cf-Access-Jwt-Assertion` in-app is named later hardening. Residual header-forgery risk (direct backend network access) is accepted for v1. The injected admin identity is `<`/`>`-escaped to prevent `</script>` breakout.

### Reuse (no payment-semantics changes)
`getSpendableBalance`/`sumPeriodConsumes`, `getBalance`/`getBucketedConsumption`, `findCurrentByAccountId`/`effectiveSubscriptionStatus`, `grant`/`adjust` — all unchanged.

### Drive-by test-infra fix
`tests/setup.ts` now `$disconnect()`s prisma after each isolated test file. Under `pool:forks` + `isolate:true` each file instantiates its own PrismaClient and the pools were never released, so connections accumulated across files and crossed the local Postgres `max_connections` once this suite was added.

## Test Plan

Automated (real-DB integration, no prisma mock):
- [x] credits-admin suite green (search / view / grant / adjust / audit / page / middleware / model / repo).
- [x] Full suite green modulo the pre-existing known telemetry-502 race flake (`telemetry-metrics.test.ts:230`, passes 18/18 in isolation).
- [x] `pnpm typecheck` + `eslint` + `prettier` clean on all changed files.

Manual browser walk (the human gate for the page's interactions — run locally with `NODE_ENV=development`):
- [ ] CF Access identity always visible in the header.
- [ ] Search by accountId and by wallet → detail view; second search replaces state cleanly.
- [ ] Spendable (green) / Raw parked (blue) / Entitled badge are visually distinct (no "489 vs 500k" ambiguity).
- [ ] Grant `500000` → unit hint shows "≈ \$500.00"; confirmation modal previews amount + unit + target + reason + identity; Cancel changes nothing; Confirm applies and refreshes ledger + audit.
- [ ] Reason empty → blocked with a toast.
- [ ] Double-click Confirm does not double-apply (one balance change, one audit row).
- [ ] Adjust up/down; floor breach → "Below minimum balance floor" toast, no write.

## Deploy prerequisite
Reachability in deployed environments requires Cloudflare Access configured at the perimeter (infra/Terraform, out of this repo). No new app env vars (USD hint uses existing `PAYMENTS_CREDITS_PER_USD`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784357285&installation_id=128169237&pr_number=319&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F319&signature=ba682b032299196d2c72e0ea71a4af0930cbe46d84661147f1c47e3fef7cc903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add internal credits admin portal with grant, adjust, and audit under CF Access
> - Adds a new Express router at `/api/v2/credits-admin` serving an HTML admin UI and JSON endpoints for viewing account credit state, granting credits, adjusting balances, searching accounts, and listing audit history.
> - Protects all non-page routes with [cf-access.ts](https://github.com/ephemeraHQ/convos-backend/pull/319/files#diff-1d0c5f527a4845a2e4a8b4fdd92f9b785b4b7852e63c1350a031244cda358fdd) middleware that requires the `Cf-Access-Authenticated-User-Email` header (with a dev fallback mode), setting `res.locals.actorEmail` for downstream handlers.
> - Adds a new `AdminAudit` table (via Prisma migration) that records every grant/adjust action with actor email, delta, reason, and idempotency key.
> - Grant and adjust handlers enforce idempotency semantics and return structured errors (400/402/404/409) for validation failures, insufficient balance, missing accounts, or idempotency mismatches.
> - The admin UI is served as a nonce-protected HTML page with a strict CSP; the embedded JS drives all search, view, and mutation flows against the JSON APIs.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #319 opened
>
> - Implemented idempotent audit logging for admin credit operations by adding a composite unique constraint on `AdminAudit(accountId, idempotencyKey)` in the database schema and Prisma model, changing `writeAdminAudit` to use `upsert` with the composite key as the `where` clause, and removing conditional guards in `adjustPostHandler` and `grantPostHandler` so they unconditionally attempt to write audit records [f9435b2]
> - Modified `audit-repository.listAdminAuditByAccount` to sort results using compound ordering [8ee3e79]
> - Updated idempotency replay tests to capture and assert on initial response properties [8ee3e79]
> - Updated audit repository test assertions to verify sort order and locate rows by reason [8ee3e79]
> - Changed CF Access dev fallback function import from dynamic to top-level [8ee3e79]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5cd7f55. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Credits Admin interface for searching accounts, viewing account details, and reviewing admin audit history.
  * Introduced admin actions to grant or adjust credits with idempotency and automatic audit logging.
* **Database**
  * Added persistent Admin Audit records with deduplication and time-based lookup indexes.
* **Tests**
  * Expanded integration test coverage for admin page, account view, grant/adjust behavior (including replay and error cases), audit retrieval, authentication gating, and audit model correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->