### PR TITLE
feat(agent-templates): let twitter photo mentions skip the intent gate

### DIFF
--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -38,7 +38,7 @@
  *  12.                  → existing different body               → 409
  *  13. Attachment bytes — existence + size caps (fresh submit)  → 400
  *  14. Content moderation (text only)                           → 422 (content)
- *  15. Twitter intent moderation (when twitterContext present)  → 422 (intent)
+ *  15. Twitter intent moderation (twitterContext, no attachment) → 422 (intent)
  *  16. Persist row + fire executor + respondPerMode
  *
  * Idempotent replays go through the SAME respondPerMode path as the original
@@ -774,10 +774,12 @@ export async function generationsPostHandler(req: Request, res: Response) {
       : undefined;
 
   // 6a. The twitter intent classifier needs text to run on, so a twitter
-  //     submission must carry either `inputs.text` or `twitterContext.idea`.
-  //     Checked here — before any S3/LLM work — so a text-less twitter request
-  //     fails fast rather than after fetching attachment bytes.
-  if (body.twitterContext) {
+  //     submission must carry either `inputs.text` or `twitterContext.idea` —
+  //     unless it carries an attachment. An attachment is itself a deliberate
+  //     build request, so it stands in for the intent text (step 14 skips the
+  //     classifier in that case). Checked here — before any S3/LLM work — so a
+  //     text-less, attachment-less twitter request fails fast.
+  if (body.twitterContext && coalesced.attachments.length === 0) {
     const intentText = twitterIdea ?? coalesced.text;
     if (!intentText || intentText.trim().length === 0) {
       res.status(400).json({
@@ -981,9 +983,14 @@ export async function generationsPostHandler(req: Request, res: Response) {
     }
   }
 
-  // 14. Twitter intent gate — only when twitterContext is present. The
-  //     presence of usable intent text was already enforced in step 6a.
-  if (body.twitterContext) {
+  // 14. Twitter intent gate — only when twitterContext is present AND there's no
+  //     attachment. An attached image/PDF/audio is itself a deliberate build
+  //     request and stands in for the text intent signal (which the classifier
+  //     never sees), so a photo mention whose only "text" is the photo's own
+  //     t.co link isn't rejected as not_agent_request. Binary attachments are
+  //     still moderated off the request path in the executor (Rekognition for
+  //     images, a transcript check for audio).
+  if (body.twitterContext && coalesced.attachments.length === 0) {
     const intentInput = twitterIdea ?? coalesced.text ?? "";
     const intent = await checkTwitterIntent(intentInput, moderationTrace);
     if (!intent.allowed) {

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -11,7 +11,15 @@
  *   - composeReply LLM failure → deterministic fallback text still written
  */
 
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import {
   __resetComposeReplyForTests,
   buildDeterministicFallback,
@@ -38,6 +46,41 @@ import {
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
 import { makeFakeTemplate } from "./agent-templates.generation.helpers";
+
+// S3 is mocked so attachment-bearing submits clear the existence/size check
+// (step 12a) without real S3. HeadObject returns a size well under every cap;
+// no other S3 op is exercised on the submit path.
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class {
+    send(cmd: { constructor: { name: string } }) {
+      if (cmd.constructor.name === "HeadObjectCommand") {
+        return Promise.resolve({
+          ContentLength: 1_000,
+          ContentType: "image/png",
+        });
+      }
+      return Promise.resolve({});
+    }
+  },
+  PutObjectCommand: class {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  },
+  HeadObjectCommand: class {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  },
+  GetObjectCommand: class {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  },
+}));
 
 const TEST_PORT = 4078;
 const TEST_SOURCE = "generations-twitter-test";
@@ -173,28 +216,34 @@ describe("POST /generations — twitterContext validation", () => {
     expect(res.status).toBe(400);
   });
 
-  test("twitterContext + attachment-only inputs (no text, no idea) → 400", async () => {
-    // When the caller sends twitterContext but provides only an attachment AND
-    // no `twitterContext.idea`, there's no text for the intent moderation check
-    // to operate on. The handler rejects with 400 (in step 6a, before any S3
-    // work) rather than proceeding with empty intent text.
+  test("twitterContext + attachment-only inputs (no text, no idea) → builds", async () => {
+    // An attachment is itself a deliberate build request, so a twitter
+    // submission carrying one is exempt from the text-required check (step 6a)
+    // and the intent classifier (step 14). Intent is forced to reject here to
+    // prove it's skipped, not merely passing.
+    __resetTwitterIntentForTests(() =>
+      Promise.resolve({ allowed: false, reason: "not_agent_request" }),
+    );
+    __resetGenerationExecutorForTests(() => Promise.resolve());
     const body = {
       source: TEST_SOURCE,
       inputs: {
-        attachments: [
-          { objectKey: "build/doc.pdf", mimeType: "application/pdf" },
-        ],
+        attachments: [{ objectKey: "build/photo.png", mimeType: "image/png" }],
       },
       twitterContext: {
         twitterHandle: "@some_user",
         tweetId: "1789432100123456789",
-        // no `idea`
+        // no text, no idea — the photo is the request
       },
     };
-    const res = await post(body, { headers: withKey("tw-binary-no-idea") });
-    expect(res.status).toBe(400);
-    const errBody = (await res.json()) as { error: string };
-    expect(errBody.error.toLowerCase()).toContain("twittercontext.idea");
+    const res = await post(body, { headers: withKey("tw-attachment-only") });
+    expect(res.status).toBe(202);
+
+    const rows = await prisma.agentTemplateGeneration.findMany({
+      where: { source: TEST_SOURCE, ownerAccountId: ADMIN_ACCOUNT_ID },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].twitterContext).toBeTruthy();
   });
 });
 
@@ -262,6 +311,37 @@ describe("POST /generations — twitter intent moderation", () => {
     expect(res.status).toBe(422);
     const body = (await res.json()) as { reason: string; category: string };
     expect(body.category).toBe("content");
+    expect(intentCalls).toBe(0);
+  });
+
+  test("attachment present → intent gate skipped (photo is the request)", async () => {
+    // A photo mention whose only text is the photo's own t.co link would be
+    // classified not_agent_request, but the attachment makes intent moot — the
+    // gate is skipped entirely (not just passed), so the build proceeds.
+    let intentCalls = 0;
+    __resetTwitterIntentForTests(() => {
+      intentCalls += 1;
+      return Promise.resolve({ allowed: false, reason: "not_agent_request" });
+    });
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+
+    const res = await post(
+      {
+        source: TEST_SOURCE,
+        inputs: {
+          text: "https://t.co/y8VfTXPY7f",
+          attachments: [
+            { objectKey: "build/photo.png", mimeType: "image/png" },
+          ],
+        },
+        twitterContext: {
+          twitterHandle: "@some_user",
+          tweetId: "1789432100123456789",
+        },
+      },
+      { headers: withKey("tw-attachment-skips-intent") },
+    );
+    expect(res.status).toBe(202);
     expect(intentCalls).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

A twitter photo mention was being rejected as `not_agent_request` even though the photo was uploaded fine.

The twitter intent classifier (`generations-post.ts` step 14) judges **text only** — it never sees an attached image. When a user @mentions the bot with a photo, Twitter appends a `t.co` link for the native media, and that link becomes the only "text" in the seed. The classifier sees a bare URL, returns `not_agent_request`, and the build is killed — discarding the image, which was the actual request.

(Confirmed from the LLM trace: the intent input was just `https://t.co/… / Linked tweet from @…: @bot https://t.co/…`, with no image anywhere in the prompt.)

## Change

When the generation carries an attachment, **skip the intent classifier (step 14) and waive the text-required check (step 6a)**. An attachment is itself a deliberate build request and stands in for the text intent signal the classifier can't see.

This relaxes **only** the agent-vs-not-agent intent filter:
- Text content moderation (step 13) still runs.
- Binary attachments are still moderated off the request path in the executor (Rekognition for images, a transcript check for audio).

Consequence worth noting: any twitter mention with a photo now bypasses the intent filter, so low-effort image mentions will build. For an image-to-agent flow that's the intended behavior.

## Tests

`tests/agent-templates.generations-twitter.test.ts` (S3 `HeadObject` mocked so attachment submits clear step 12a):
- attachment-only twitter submit → builds (intent forced to reject, proving it's skipped rather than passing)
- photo mention with URL-only text → builds, and the intent classifier is never called

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784360378&installation_id=128169237&pr_number=320&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F320&signature=6d16dbcaf71d3a91d42de86c184bfef995c3d4def4691c08126ea9172af99953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip the twitter intent gate for photo mentions with attachments in agent-template generations
> - Twitter context submissions that include attachments no longer require `text` or `idea` fields, and skip the intent classifier gate entirely.
> - In [generations-post.ts](https://github.com/ephemeraHQ/convos-backend/pull/320/files#diff-cfa09e429c402af1c503dbdd05b6690b9fc157c69a9c4ce543a4bc481c3f5624), both the early input validation (step 6a) and the intent moderation gate (step 14) are now conditioned on `twitterContext` being present **and** no attachments being present.
> - Behavioral Change: `POST /api/v2/agent-templates/generations` now returns 202 (instead of 400) for `twitterContext` payloads that have attachments but no `text` or `idea`, and the intent classifier is never invoked for those requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 054d0db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->