### PR TITLE
Deal with invalid JSON from the LLM

### DIFF
--- a/data/template-generator-prompt.txt
+++ b/data/template-generator-prompt.txt
@@ -299,7 +299,7 @@ From the input you receive (an idea, content, URL extract, document, or image), 
 
 **Write the `prompt` field first** — decide who the character is, give SOUL its opening `Character: {Name} {Emoji}` line, flesh out every Blueprint layer, and write the WELCOME MESSAGE. Then copy the Name into `agentName`, the emoji into `emoji`, summarize into `description`, pick a `category`, and choose `tools`. The other fields are derived from the prompt — never the other way around.
 
-Respond with ONLY a JSON object (no markdown fences, no explanation). Keep this field order:
+Respond with ONLY a complete, parseable JSON object (no markdown fences, no explanation). The JSON must close every string, array, and object; never stop mid-field or rely on the runtime to repair partial output. Keep `prompt` concise enough that the full object can finish cleanly. Keep this field order:
 
 ```
 {

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -9,7 +9,9 @@
  * pool's asymmetry preserved verbatim).
  *
  * OpenRouter raw fetch to https://openrouter.ai/api/v1/chat/completions with
- * strict response_format json_schema, temp 0.7, no max_tokens.
+ * strict response_format json_schema, temp 0.7, no max_tokens. If the provider
+ * returns truncated/malformed JSON despite structured output, retry once at a
+ * lower temperature with an explicit concise-JSON reminder.
  * Helper calls run at temp 0.2 without response_format: the GitHub-instructions
  * selector uses the main model; the content-classifier uses the cheap
  * BUILDER_CLASSIFIER_MODEL and passes content through on two routes: it is
@@ -90,6 +92,11 @@ const DEFAULT_MODEL = "anthropic/claude-opus-4.8-fast";
 // so the same wallclock cap covers both. If the runtime ever streams chunks
 // from upstream, that path needs a separate per-chunk inactivity timer.
 const OPENROUTER_TIMEOUT_MS = 120_000;
+const GENERATE_JSON_RETRY_TEMPERATURE = 0.2;
+const GENERATE_JSON_RETRY_DIRECTIVE =
+  "Retry the same generation. Return only one valid JSON object matching the " +
+  "schema. Keep the prompt concise enough to fit completely; do not include " +
+  "markdown fences or commentary.";
 
 // ---------------------------------------------------------------------------
 // LLM error classification
@@ -126,6 +133,37 @@ function describeLlmError(err: unknown): string {
   }
   if (isHttpStatusError(err)) return `HTTP ${err.status}`;
   return err instanceof Error ? err.message : String(err);
+}
+
+function isJsonParseFailure(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    /^Failed to parse (?:LLM response as JSON|extracted JSON):/.test(
+      err.message,
+    )
+  );
+}
+
+function summarizeLlmContent(content: string): Record<string, unknown> {
+  return {
+    contentLength: content.length,
+    contentStart: content.slice(0, 300),
+    contentEnd: content.slice(Math.max(0, content.length - 300)),
+  };
+}
+
+function buildGenerateRetryBody(reqBody: any): any {
+  return {
+    ...reqBody,
+    temperature: GENERATE_JSON_RETRY_TEMPERATURE,
+    messages: [
+      ...reqBody.messages,
+      {
+        role: "user",
+        content: GENERATE_JSON_RETRY_DIRECTIVE,
+      },
+    ],
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1617,10 +1655,10 @@ export async function generateTemplate(
     }
     throw err;
   }
-  const latencyMs = Math.round(performance.now() - t0);
-  const promptTokens = Number(data?.usage?.prompt_tokens ?? 0);
-  const completionTokens = Number(data?.usage?.completion_tokens ?? 0);
-  const responseModel = String(data?.model ?? model);
+  let latencyMs = Math.round(performance.now() - t0);
+  let promptTokens = Number(data?.usage?.prompt_tokens ?? 0);
+  let completionTokens = Number(data?.usage?.completion_tokens ?? 0);
+  let responseModel = String(data?.model ?? model);
   console.log(
     `[templateGen] generate ok: model=${responseModel}, latencyMs=${latencyMs}, prompt=${promptTokens}, completion=${completionTokens}`,
   );
@@ -1638,7 +1676,96 @@ export async function generateTemplate(
     throw new Error("No content in LLM response");
   }
 
-  const parsed = parseTemplateResponse(content);
+  let parsed: Omit<GeneratedTemplate, "connections">;
+  try {
+    parsed = parseTemplateResponse(content);
+  } catch (err) {
+    if (!isJsonParseFailure(err)) throw err;
+
+    const finishReason = data?.choices?.[0]?.finish_reason;
+    console.warn("[templateGen] Invalid LLM JSON; retrying generate once", {
+      model: responseModel,
+      finishReason,
+      error: err instanceof Error ? err.message : String(err),
+      ...summarizeLlmContent(content),
+    });
+
+    const retryStarted = performance.now();
+    let retryData: any;
+    try {
+      retryData = await openRouterChatCompletion({
+        apiKey,
+        stage: "generate",
+        body: buildGenerateRetryBody(reqBody),
+        signal: externalSignal,
+        timeoutMs: OPENROUTER_TIMEOUT_MS,
+        trace,
+      });
+    } catch (retryErr) {
+      if (isTimeoutOrAbort(retryErr)) {
+        throw new AppError(
+          504,
+          `OpenRouter request timed out after ${OPENROUTER_TIMEOUT_MS}ms`,
+        );
+      }
+      if (isHttpStatusError(retryErr)) {
+        console.error(
+          "[templateGen] OpenRouter retry error:",
+          retryErr.status,
+          retryErr.message.slice(0, 500),
+        );
+        throw new Error(`OpenRouter API error ${retryErr.status}`);
+      }
+      throw retryErr;
+    }
+
+    if (retryData?.error) {
+      throw new Error(
+        `LLM error after JSON retry: ${retryData.error.message || "unknown"}`,
+      );
+    }
+
+    const retryContent = retryData?.choices?.[0]?.message?.content;
+    const retryFinishReason = retryData?.choices?.[0]?.finish_reason;
+    const retryModel = String(retryData?.model ?? responseModel);
+    if (!retryContent) {
+      console.error(
+        "[templateGen] Empty LLM retry response:",
+        JSON.stringify(retryData).slice(0, 500),
+      );
+      throw new Error("No content in LLM retry response");
+    }
+
+    try {
+      parsed = parseTemplateResponse(retryContent);
+    } catch (retryParseErr) {
+      console.error("[templateGen] Invalid LLM JSON after retry", {
+        model: retryModel,
+        finishReason: retryFinishReason,
+        error:
+          retryParseErr instanceof Error
+            ? retryParseErr.message
+            : String(retryParseErr),
+        ...summarizeLlmContent(retryContent),
+      });
+      throw new Error(
+        `Invalid structured JSON after retry: ${
+          retryParseErr instanceof Error
+            ? retryParseErr.message
+            : String(retryParseErr)
+        }`,
+      );
+    }
+
+    const retryLatencyMs = Math.round(performance.now() - retryStarted);
+    latencyMs = Math.round(performance.now() - t0);
+    promptTokens = Number(retryData?.usage?.prompt_tokens ?? 0);
+    completionTokens = Number(retryData?.usage?.completion_tokens ?? 0);
+    responseModel = retryModel;
+    console.log(
+      `[templateGen] generate retry ok: model=${retryModel}, latencyMs=${retryLatencyMs}, prompt=${retryData?.usage?.prompt_tokens}, completion=${retryData?.usage?.completion_tokens}`,
+    );
+  }
   // Server-injects connections: [] on every successful return
   const withConnections = { ...parsed, connections: [] as string[] };
   const finalTemplate = appendBrevityRail(withConnections);

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -27,7 +27,11 @@ type CapturedRequest = {
 let capturedRequests: CapturedRequest[] = [];
 const fetchMockResponses: Map<
   string,
-  { status: number; body: any; headers?: Record<string, string> }
+  {
+    status: number;
+    body: unknown;
+    headers?: Record<string, string>;
+  }
 > = new Map();
 
 const originalFetch = globalThis.fetch;
@@ -77,7 +81,9 @@ function mockFetch(input: any, init?: RequestInit): Response {
   // Check for mock responses
   for (const [pattern, response] of fetchMockResponses) {
     if (url.includes(pattern)) {
-      return new Response(JSON.stringify(response.body), {
+      const responseBody =
+        typeof response.body === "function" ? response.body() : response.body;
+      return new Response(JSON.stringify(responseBody), {
         status: response.status,
         headers: { "Content-Type": "application/json", ...response.headers },
       });
@@ -117,6 +123,42 @@ const TEST_API_KEY = "test-or-key-1234567890";
 
 function setOpenRouterResponse(body: any, status = 200) {
   fetchMockResponses.set("openrouter.ai", { status, body });
+}
+
+function templateResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    model: "@preset/assistants-pro",
+    choices: [
+      {
+        finish_reason: "stop",
+        message: {
+          content: JSON.stringify({
+            prompt: "BODY",
+            agentName: "TestAgent",
+            emoji: "🤖",
+            description: "A test agent",
+            category: "Work",
+            tools: ["Search"],
+            ...overrides,
+          }),
+        },
+      },
+    ],
+    usage: { prompt_tokens: 100, completion_tokens: 50 },
+  };
+}
+
+function setOpenRouterResponseQueue(bodies: any[]) {
+  const queue = [...bodies];
+  fetchMockResponses.set("openrouter.ai", {
+    status: 200,
+    body: () => {
+      if (queue.length === 0) {
+        throw new Error("OpenRouter response queue exhausted");
+      }
+      return queue.shift();
+    },
+  });
 }
 
 function _setGitHubRepoResponse(repoData: any) {
@@ -523,6 +565,111 @@ describe("templateGen service — OpenRouter integration", () => {
     for (const key of forbiddenKeys) {
       expect(req.body[key]).toBeUndefined();
     }
+  });
+
+  test("retries main generation once when structured output is malformed JSON", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    setOpenRouterResponseQueue([
+      {
+        model: "@preset/assistants-pro",
+        choices: [
+          {
+            finish_reason: "length",
+            message: {
+              content: '{"prompt":"Character: Page Two',
+            },
+          },
+        ],
+        usage: { prompt_tokens: 100, completion_tokens: 20 },
+      },
+      templateResponse({
+        agentName: "RetryBot",
+        prompt: "Recovered prompt",
+        description: "Recovered description",
+      }),
+    ]);
+
+    const result = await generateTemplate({ text: "Build me a helper" });
+
+    expect(result.template.agentName).toBe("RetryBot");
+    expect(result.template.prompt).toContain("Recovered prompt");
+
+    const reqs = getOpenRouterRequests();
+    expect(reqs).toHaveLength(2);
+    expect(reqs[0].body.temperature).toBe(0.7);
+    expect(reqs[1].body.temperature).toBe(0.2);
+    expect(reqs[1].body.response_format).toEqual(reqs[0].body.response_format);
+    const firstMessages = reqs[0].body.messages as unknown[];
+    const retryMessages = reqs[1].body.messages as unknown[];
+    expect(retryMessages).toHaveLength(firstMessages.length + 1);
+    expect(retryMessages.at(-1)).toMatchObject({
+      role: "user",
+      content: expect.stringContaining("Return only one valid JSON object"),
+    });
+  });
+
+  test("does not retry when structured JSON is valid but missing required fields", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    setOpenRouterResponse({
+      model: "@preset/assistants-pro",
+      choices: [
+        {
+          finish_reason: "stop",
+          message: {
+            content: JSON.stringify({
+              agentName: "Bot",
+              emoji: "🤖",
+              description: "desc",
+              category: "Work",
+              tools: [],
+            }),
+          },
+        },
+      ],
+      usage: { prompt_tokens: 100, completion_tokens: 20 },
+    });
+
+    await expect(
+      generateTemplate({ text: "Build me a helper" }),
+    ).rejects.toThrow(/missing prompt/i);
+    expect(getOpenRouterRequests()).toHaveLength(1);
+  });
+
+  test("fails with a clear error when malformed JSON retry is also malformed", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+
+    setOpenRouterResponseQueue([
+      {
+        model: "@preset/assistants-pro",
+        choices: [
+          {
+            finish_reason: "length",
+            message: { content: '{"prompt":"unterminated' },
+          },
+        ],
+        usage: { prompt_tokens: 100, completion_tokens: 20 },
+      },
+      {
+        model: "@preset/assistants-pro",
+        choices: [
+          {
+            finish_reason: "length",
+            message: { content: '{"prompt":"still unterminated' },
+          },
+        ],
+        usage: { prompt_tokens: 100, completion_tokens: 20 },
+      },
+    ]);
+
+    await expect(
+      generateTemplate({ text: "Build me a helper" }),
+    ).rejects.toThrow(/Invalid structured JSON after retry/i);
+    expect(getOpenRouterRequests()).toHaveLength(2);
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This makes agent-template generation more resilient when the LLM returns truncated or malformed structured output.

- Retries the main OpenRouter `generate` call once when the returned content cannot be parsed as JSON.
- Keeps the same strict `json_schema` response format on retry, lowers temperature to `0.2`, and appends a concise valid-JSON-only reminder.
- Logs parse-failure context (`finish_reason`, model, content length, content head/tail) before retrying and if the retry also fails.
- Updates retry metrics so successful retry results report the retry model/tokens and full two-call latency.
- Strengthens the default builder prompt to ask for a complete, parseable JSON object that does not stop mid-field.

## Why

Datadog showed generation failures where the model output ended mid-string, producing errors like `Failed to parse LLM response as JSON`. These should be recoverable without persisting a corrupted template.

## Validation

- `pnpm vitest run tests/template-prompt.test.ts tests/template-gen.service.test.ts tests/template-gen.openrouter-errors.test.ts`
- `pnpm typecheck`
- `pnpm lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784487819&installation_id=128169237&pr_number=322&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F322&signature=fe1fed2006e92e2dcb207e2a0d461d76a94626d2a978b680e7550835a1ff5d34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry template generation with a lower temperature when the LLM returns invalid JSON
> - When `generateTemplate` receives malformed or truncated JSON from OpenRouter, it now issues a single retry at temperature 0.2 with an appended directive instructing the model to return a concise, complete JSON object.
> - The prompt template in [template-generator-prompt.txt](https://github.com/ephemeraHQ/convos-backend/pull/322/files#diff-8408ab304a047f82462fe0860f5216764b22621a10c4c60818c26efb14737052) is updated to explicitly require a fully closed, parseable JSON object.
> - On a successful retry, latency, token, and model metrics are updated from the retry response and logged separately.
> - If the retry also returns malformed JSON, the service throws a clear error indicating failure after retry.
> - Behavioral Change: a single LLM call may now become two calls when the first response contains invalid JSON.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0439e76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced template generation reliability with automatic retry handling for malformed responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
