### PR TITLE
docs(agent-templates): reframe the cron-mechanics note as a positive boundary

### DIFF
--- a/data/template-generator-prompt.txt
+++ b/data/template-generator-prompt.txt
@@ -205,7 +205,7 @@ Ask it specifically, ask it once — and ask it *after* the first artifact has l
 
 If THE HOOK is *how the agent offers* to come back, THE SCHEDULE is *how it actually comes back*. Most agents you design will have 2-4 concrete scheduled sends — weekly digests, monthly summaries, countdown pings, condition-triggered alerts. Your prompt must describe them specifically.
 
-The runtime already handles cron delivery mechanics — in a cron session the agent's final response IS the message (no tool call, no meta-preface), cron jobs run until explicitly removed (no auto-expiry, no self-scheduled cleanup jobs), and each firing is a fresh session with no conversation history. Those are taught by the platform's injected CRON context — **do not re-teach them inside your generated prompt.** Focus on cron *strategy*.
+Cron delivery mechanics are runtime-injected — your job is cron *strategy*: trigger, skip condition, opt-in, pause lever.
 
 For every scheduled send your prompt introduces, specify all four:
 


### PR DESCRIPTION
## Summary

Follow-up to #327. Reframes the one remaining piece of expository "what NOT to bake in" meta in `THE SCHEDULE` as a positive, forward-pointing boundary, matching how `THE CLOCK` now reads after #327.

**Before:**
> The runtime already handles cron delivery mechanics — … Those are taught by the platform's injected CRON context — **do not re-teach them inside your generated prompt.** Focus on cron *strategy*.

**After:**
> Cron delivery mechanics are runtime-injected — your job is cron *strategy*: trigger, skip condition, opt-in, pause lever.

Stops phrasing the boundary as a prohibition and previews the exact four strategy items the next bullets define (Trigger / Skip condition / Opt-in script / Pause lever).

The two terse echoes of this rule — the `prompt` field spec and the verification checklist item — are left as-is, since negative pass/fail phrasing reads naturally there.

No behavior change; 1 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eaXsznx8qEHweKq3TXiCi


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reframe cron mechanics note as a strategy directive in agent template prompt
> Replaces a detailed paragraph enumerating cron runtime behaviors and prohibitions in [template-generator-prompt.txt](https://github.com/ephemeraHQ/convos-backend/pull/328/files#diff-8408ab304a047f82462fe0860f5216764b22621a10c4c60818c26efb14737052) with a single concise directive focused on four cron strategy elements: trigger, skip condition, opt-in, and pause lever.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 358e0cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->