### PR TITLE
fix(agents): only register a direct-add agent once it's past "starting"

### DIFF
--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -283,7 +283,7 @@ function pollUntilJoined(
 // Direct-add mode waits only for Herald registration (inboxId lands in the
 // status row), not for the join itself — the join happens after the caller
 // adds the inbox to the group.
-function pollUntilRegistered(
+function pollUntilRegisteredAndReady(
   args: Omit<
     Parameters<typeof pollAssistantStatus<RegisteredOutcome>>[0],
     "check"
@@ -295,7 +295,13 @@ function pollUntilRegistered(
       if (status.joinStatus === "failed") {
         return { kind: "failed", reason: status.joinFailureReason ?? null };
       }
-      if (status.inboxId)
+      // Only treat the agent as registered once it has progressed past
+      // "starting" — an inboxId can land in the status row before the
+      // assistant is far enough along to be added to the group.
+      const registered = ["pending_acceptance", "joined", "ready"].includes(
+        status.joinStatus,
+      );
+      if (registered && status.inboxId)
         return { kind: "registered", inboxId: status.inboxId };
       return null;
     },
@@ -704,7 +710,7 @@ export async function joinHandler(req: Request, res: Response) {
   // inboxId to add to the group; the join completes when the runtime
   // observes the group welcome their addMembers produces.
   if (slug === undefined) {
-    const outcome = await pollUntilRegistered({
+    const outcome = await pollUntilRegisteredAndReady({
       assistantBaseUrl,
       instanceId,
       authHeader,

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -197,7 +197,7 @@ describe("agents join (assistant API)", () => {
         return Promise.resolve(
           jsonResponse(200, {
             instanceId: "inst-direct",
-            joinStatus: "starting",
+            joinStatus: "pending_acceptance",
             inboxId: "inbox-direct-1",
           }),
         );
@@ -228,12 +228,23 @@ describe("agents join (assistant API)", () => {
           );
         }
         pollCount += 1;
+        // While still "starting" the inboxId hasn't been earned yet; only once
+        // the assistant reaches "pending_acceptance" does registration land.
         return Promise.resolve(
-          jsonResponse(200, {
-            instanceId: "inst-direct-2",
-            joinStatus: "starting",
-            inboxId: pollCount < 3 ? null : "inbox-direct-2",
-          }),
+          jsonResponse(
+            200,
+            pollCount < 3
+              ? {
+                  instanceId: "inst-direct-2",
+                  joinStatus: "starting",
+                  inboxId: null,
+                }
+              : {
+                  instanceId: "inst-direct-2",
+                  joinStatus: "pending_acceptance",
+                  inboxId: "inbox-direct-2",
+                },
+          ),
         );
       };
 
@@ -242,6 +253,37 @@ describe("agents join (assistant API)", () => {
       const data = (await res.json()) as { inboxId: string | null };
       expect(data.inboxId).toBe("inbox-direct-2");
       expect(pollCount).toBeGreaterThanOrEqual(3);
+    });
+
+    test("direct-add → 'starting' with an inboxId does NOT register; waits for progression", async () => {
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-direct-early" }),
+          );
+        }
+        // inboxId is present but joinStatus is still "starting" — the assistant
+        // isn't far enough along to be added to the group, so the poll must not
+        // treat this as registered. It outlasts the wait budget → inboxId:null.
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-direct-early",
+            joinStatus: "starting",
+            inboxId: "inbox-direct-early",
+          }),
+        );
+      };
+
+      const res = await post({ conversationId: DIRECT_ADD_CONVERSATION_ID });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        success: boolean;
+        joined: boolean;
+        inboxId: string | null;
+      };
+      expect(data.success).toBe(true);
+      expect(data.joined).toBe(false);
+      expect(data.inboxId).toBeNull();
     });
 
     test("direct-add → inboxId:null when registration outlasts the wait budget", async () => {
@@ -957,7 +999,7 @@ describe("agents join (assistant API)", () => {
         return Promise.resolve(
           jsonResponse(200, {
             instanceId: "inst-uuid-owner",
-            joinStatus: "starting",
+            joinStatus: "pending_acceptance",
             inboxId: "inbox-uuid-owner",
           }),
         );


### PR DESCRIPTION
## What

Gate the direct-add registration poll on `joinStatus`, not just the presence of an `inboxId`.

## Why

In direct-add mode, the join handler polls the assistant runtime until the agent is "registered," then returns its `inboxId` so the caller can `addMembers` it to the group. The old `pollUntilRegistered` returned `registered` **as soon as an `inboxId` appeared** in the status row.

But the runtime can stamp an `inboxId` while `joinStatus` is still `"starting"` — before the assistant is far enough along to be safely added to the group. The caller would then add the inbox too early.

## Change

`pollUntilRegistered` → **`pollUntilRegisteredAndReady`**. It now reports `registered` only when **both**:
- `joinStatus` is one of `pending_acceptance`, `joined`, or `ready`, **and**
- an `inboxId` is present.

The `failed` short-circuit (→ 502 `AGENT_PROVISION_FAILED`) is unchanged. When the agent never progresses past `starting` within the wait budget, the handler responds as before with `inboxId: null` (caller polls `GET /api/v2/agents/join/:instanceId`).

## Tests

- Updated the three cases that relied on `"starting"` + `inboxId` registering (now use `pending_acceptance`).
- Reworked `polls past a null inboxId` to stay `starting`/`null` then transition to `pending_acceptance` + `inboxId`, proving both signals are required.
- **Added** a case pinning that `"starting"` *with* an `inboxId` does **not** register — it waits out the budget and returns `inboxId: null`.

All 49 tests in `tests/agents-join.test.ts` pass; `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix direct-add agent registration to require progression past 'starting' status
> Previously, `pollUntilRegistered` in [join.ts](https://github.com/ephemeraHQ/convos-backend/pull/331/files#diff-56b3806a78b9509421cf23cd82891715d11c219bad27f45a5a9ff9665a18cd7c) treated an agent as registered as soon as `inboxId` was present, even if `joinStatus` was `'starting'`. Now, registration only completes when `joinStatus` is one of `['pending_acceptance', 'joined', 'ready']` and `inboxId` is non-null. The function is renamed to `pollUntilRegisteredAndReady` to reflect the stricter check. A new test covers the case where `'starting'` with a non-null `inboxId` correctly does not trigger registration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 879e8f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct-add join handling so a conversation is treated as ready only after it has fully progressed, reducing premature success responses.
  * Updated polling behavior to keep waiting when an ID appears too early, returning a pending result until the join is actually ready.
  * Refined join status handling to better reflect the transition from initial setup to a usable state.

* **Tests**
  * Expanded coverage for direct-add join flows, including delayed readiness and cases where an ID exists before the join is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->