### PR TITLE
fix(jwt): normalize PEM env keys (literal \n + wrapping quotes)

### DIFF
--- a/src/api/v2/notifications/apns-push.service.ts
+++ b/src/api/v2/notifications/apns-push.service.ts
@@ -2,6 +2,7 @@ import http2 from "node:http2";
 import type { ApnsEnvironment, PushTokenType } from "@prisma/client";
 import jwt from "jsonwebtoken";
 import logger from "@/utils/logger";
+import { normalizePemKey } from "@/utils/pem";
 import type {
   AnyNotificationPayloadWithJWT,
   NotificationPayload,
@@ -350,8 +351,7 @@ export function createApnsService(): ApnsPushService | null {
     return null;
   }
 
-  // Convert \n escape sequences to actual newlines
-  const formattedPrivateKey = privateKey.replace(/\\n/g, "\n");
+  const formattedPrivateKey = normalizePemKey(privateKey);
 
   logger.info({ teamId, keyId, bundleId }, "[APNS] Initialising APNS service");
 

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -5,6 +5,7 @@ import { accountIdSchema } from "@/utils/account-id";
 import { deviceIdSchema } from "@/utils/device-id";
 import { AppError } from "@/utils/errors";
 import logger from "@/utils/logger";
+import { normalizePemKey } from "@/utils/pem";
 import { tryCatch } from "@/utils/try-catch";
 
 // Maximum size in bytes for JWT metadata to prevent token bloat.
@@ -48,7 +49,10 @@ const loadPrivateKey = (): Promise<jose.KeyLike> => {
         ),
       );
     }
-    privateKeyPromise = jose.importPKCS8(JWT_PRIVATE_KEY, "ES256");
+    privateKeyPromise = jose.importPKCS8(
+      normalizePemKey(JWT_PRIVATE_KEY),
+      "ES256",
+    );
   }
   return privateKeyPromise;
 };
@@ -66,7 +70,10 @@ const loadPublicKey = (): Promise<jose.KeyLike> => {
         ),
       );
     }
-    publicKeyPromise = jose.importSPKI(JWT_PUBLIC_KEY, "ES256");
+    publicKeyPromise = jose.importSPKI(
+      normalizePemKey(JWT_PUBLIC_KEY),
+      "ES256",
+    );
   }
   return publicKeyPromise;
 };

--- a/src/utils/pem.ts
+++ b/src/utils/pem.ts
@@ -1,0 +1,6 @@
+export const normalizePemKey = (raw: string): string =>
+  raw
+    .trim()
+    .replace(/^(['"])([\s\S]*)\1$/, "$2")
+    .replace(/\\r\\n/g, "\n")
+    .replace(/\\n/g, "\n");

--- a/tests/pem.test.ts
+++ b/tests/pem.test.ts
@@ -1,0 +1,35 @@
+import * as jose from "jose";
+import { describe, expect, test } from "vitest";
+import { normalizePemKey } from "@/utils/pem";
+
+describe("normalizePemKey", () => {
+  test("imports an ES256 key delivered as a single-line literal-\\n string", async () => {
+    const { privateKey } = await jose.generateKeyPair("ES256", {
+      extractable: true,
+    });
+    const pem = await jose.exportPKCS8(privateKey);
+
+    const escaped = pem.trimEnd().replace(/\n/g, "\\n");
+    const infisicalStyle = `"${escaped}"`;
+
+    await expect(jose.importPKCS8(infisicalStyle, "ES256")).rejects.toThrow();
+
+    const key = await jose.importPKCS8(
+      normalizePemKey(infisicalStyle),
+      "ES256",
+    );
+    expect(key).toBeDefined();
+  });
+
+  test("strips wrapping quotes and CRLF escapes", () => {
+    const out = normalizePemKey(
+      `'-----BEGIN-----\\r\\nbody\\r\\n-----END-----'`,
+    );
+    expect(out).toBe("-----BEGIN-----\nbody\n-----END-----");
+  });
+
+  test("leaves a real multi-line PEM untouched", () => {
+    const pem = "-----BEGIN-----\nbody\n-----END-----";
+    expect(normalizePemKey(pem)).toBe(pem);
+  });
+});


### PR DESCRIPTION
## Summary
- Secret-store migration TF → Infisical broke ES256 key load with `ERR_OSSL_ASN1_TOO_LONG`. **TF HCL** expands `\n` to real newlines on inject; **Infisical** passes the literal `\n` (and may keep wrapping quotes). `jose.importPKCS8`/`importSPKI` then decode corrupt DER → ASN1 "too long".
- New canonical `src/utils/pem.ts` `normalizePemKey`: trim → strip wrapping `'`/`"` quotes → convert `\r\n` and `\n` escapes to real newlines.
- Routed all 3 PEM-bearing env keys through it: `JWT_PRIVATE_KEY` + `JWT_PUBLIC_KEY` (`src/utils/jwt.ts`), `APNS_PRIVATE_KEY` (`src/api/v2/notifications/apns-push.service.ts`, replacing a weaker inline `.replace` that lacked quote-stripping).
- **No-op on already-clean multiline keys** → backward compatible with the prior TF-injected format and the new real-multiline Infisical values.

Not affected: `FIREBASE_SERVICE_ACCOUNT` (JSON.parse handles `\n` natively), `JWT_SECRET` (HS256 raw bytes), other `*_API_KEY`/`*_TOKEN`/`*_SECRET` (opaque, no PEM parse).

## Test Plan
- [x] `tests/pem.test.ts` (new): un-normalized Infisical-format key `rejects.toThrow()`, normalized one imports clean; quote+CRLF strip; real-multiline no-op.
- [x] `tests/jwt.test.ts` + `tests/apns-push-service.test.ts` green (18/18 across the 3 affected non-DB suites).
- [x] lint + prettier clean; typecheck clean on changed files (2 pre-existing `@/gen/*_pb` errors unrelated).
- [ ] Full integration suite — runs in CI (local run needs Postgres up; change touches zero DB code).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784916935&installation_id=128169237&pr_number=332&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F332&signature=b4c44badbe2324c75aa3bb36bb7310c437839c834d2334673749a5682cdb8b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize PEM env keys with escaped newlines and wrapping quotes in JWT and APNS services
> - Adds `normalizePemKey` in [`src/utils/pem.ts`](https://github.com/ephemeraHQ/convos-backend/pull/332/files#diff-33c5dc407d98f3d14d420c4ac900f86f29013379adf5c0cb01e9600a8e1e3c72) that strips wrapping quotes and converts literal `\n`/`\r\n` escape sequences into real newlines.
> - Applies `normalizePemKey` to `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` in [`src/utils/jwt.ts`](https://github.com/ephemeraHQ/convos-backend/pull/332/files#diff-bc3253061283423c721c833f262624f2ba8b6073381c5122cc6671b500cfc743) before passing to `jose.importPKCS8`/`jose.importSPKI`.
> - Applies `normalizePemKey` to the APNS private key in [`src/api/v2/notifications/apns-push.service.ts`](https://github.com/ephemeraHQ/convos-backend/pull/332/files#diff-fe0e5d0fa93539414a2a3e4aa999cabebec32ff49e88ba83daced03a400150d0), replacing the previous manual `.replace(/\\n/g, "\n")` call.
> - Behavioral Change: PEM env vars that were previously rejected due to escaped newlines or surrounding quotes will now be accepted silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e8fe20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PEM-formatted keys so signed tokens and push notifications work correctly when keys are stored with quotes or escaped line breaks.
  * Normalized key formatting before loading signing and verification credentials, reducing import failures with malformed key values.

* **Tests**
  * Added coverage for key normalization, including quoted strings, escaped newlines, and already valid PEM content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->