### PR TITLE
feat: per-PR agent variants — convos-backend (CON-576)

### DIFF
--- a/prisma/migrations/20260624182517_add_agent_variant/migration.sql
+++ b/prisma/migrations/20260624182517_add_agent_variant/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "AgentVariant" (
+    "slug" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "whatToTest" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'building',
+    "assistantWorkerUrl" TEXT,
+    "builderPromptSlug" TEXT,
+    "prUrl" TEXT NOT NULL,
+    "branch" TEXT NOT NULL,
+    "commit" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentVariant_pkey" PRIMARY KEY ("slug")
+);
+
+-- CreateIndex
+CREATE INDEX "AgentVariant_status_createdAt_idx" ON "AgentVariant"("status", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -478,3 +478,34 @@ model AdminAudit {
   @@index([accountId, createdAt])
   @@index([actorEmail, createdAt])
 }
+
+/// Per-PR agent variant (dev XMTP network only). A named bundle pinning an
+/// ephemeral runtime (assistantWorkerUrl, Axis A) and/or a bench builder-prompt
+/// slug (builderPromptSlug, Axis B). Written only by the convos-assistants
+/// variant CI (agent API key + dev-only route gate); read by the dev app picker
+/// and applied server-side at generation + join. `slug` is the
+/// natural key — the PR slug (e.g. "pr-1234"); the ephemeral host is
+/// ephemeral-<slug>.convos.fun. Ownerless: there is no Account relation because
+/// variants are infrastructure, not user content.
+model AgentVariant {
+  slug               String    @id
+  label              String
+  whatToTest         String    @db.Text
+  /// Lifecycle: building | ready | failed | stale. Plain string (no Postgres
+  /// enum) — validated in app code via AgentVariantStatusSchema, matching the
+  /// project's move away from non-transactional enum migrations (see the
+  /// AuthMethod.type / Subscription.tier comments).
+  status             String    @default("building")
+  /// Axis A — the ephemeral runtime base URL, or null for the default dev runtime.
+  assistantWorkerUrl String?
+  /// Axis B — a bench/Braintrust prompt slug, or null for the canonical generator.
+  builderPromptSlug  String?
+  prUrl              String
+  branch             String
+  commit             String
+  expiresAt          DateTime?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  @@index([status, createdAt])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -480,8 +480,8 @@ model AdminAudit {
 }
 
 /// Per-PR agent variant (dev XMTP network only). A named bundle pinning an
-/// ephemeral runtime (assistantWorkerUrl, Axis A) and/or a bench builder-prompt
-/// slug (builderPromptSlug, Axis B). Written only by the convos-assistants
+/// ephemeral runtime (assistantWorkerUrl) and/or a bench builder-prompt slug
+/// (builderPromptSlug). Written only by the convos-assistants
 /// variant CI (agent API key + dev-only route gate); read by the dev app picker
 /// and applied server-side at generation + join. `slug` is the
 /// natural key — the PR slug (e.g. "pr-1234"); the ephemeral host is
@@ -496,9 +496,9 @@ model AgentVariant {
   /// project's move away from non-transactional enum migrations (see the
   /// AuthMethod.type / Subscription.tier comments).
   status             String    @default("building")
-  /// Axis A — the ephemeral runtime base URL, or null for the default dev runtime.
+  /// The ephemeral runtime base URL, or null for the default dev runtime.
   assistantWorkerUrl String?
-  /// Axis B — a bench/Braintrust prompt slug, or null for the canonical generator.
+  /// A bench/Braintrust prompt slug, or null for the canonical generator.
   builderPromptSlug  String?
   prUrl              String
   branch             String

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -71,6 +71,7 @@ import {
   attachmentsArraySchema,
   type AttachmentRef,
 } from "@/api/v2/agent-templates/services/attachment-resolver";
+import { loadBenchPromptText } from "@/api/v2/agent-templates/services/bench-prompt";
 import {
   classifyMime,
   headBuildObject,
@@ -85,7 +86,7 @@ import { type TraceContext } from "@/api/v2/agent-templates/services/openrouter-
 import { isKnownOpenRouterModel } from "@/api/v2/agent-templates/services/openrouter-models";
 import { resolveActor } from "@/api/v2/agent-templates/services/posthog";
 import { getServiceConfig } from "@/api/v2/connections/bundles.config";
-import { BUILD_ATTACHMENTS_MAX_TOTAL_BYTES } from "@/config";
+import { BUILD_ATTACHMENTS_MAX_TOTAL_BYTES, XMTP_ENV } from "@/config";
 import { accountIdSchema } from "@/utils/account-id";
 import { getEffectiveOwnerId } from "@/utils/auth-helpers";
 import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
@@ -210,7 +211,7 @@ const TemplatePrefillSchema = z
   })
   .strict();
 
-const bodySchema = z
+export const bodySchema = z
   .object({
     source: z.string().min(1, "source is required"),
     inputs: inputsSchema,
@@ -264,6 +265,13 @@ const bodySchema = z
     // ignored for JWT (JWT account always wins) and anonymous (falls
     // back to ADMIN). See the owner-resolution block below.
     ownerAccountId: accountIdSchema.optional(),
+    // Per-PR agent variant (Axis B), dev-only. Selects a registered variant
+    // whose builder-prompt slug the backend resolves server-side into this
+    // generation's builderPrompt. Optional + ignored off-dev, so it stays
+    // backwards-compatible for shipped clients; the slug is never client-
+    // supplied (only the variantId), so the privileged override stays
+    // admin-authored.
+    variantId: z.string().trim().min(1).max(64).optional(),
   })
   .strict();
 
@@ -651,6 +659,42 @@ async function respondPerMode(args: {
   res.status(httpStatus).json(toResponse(row));
 }
 
+/**
+ * Resolve a registered variant's builder prompt (Axis B). Returns the prompt
+ * text when the variant exists and pins a bench slug that resolves; returns
+ * null (→ canonical generator) when the variant is unknown, pins no slug
+ * (an Axis-A-only / runtime variant), or the bench lookup fails. Never throws —
+ * a variant degrades, it never fails the build.
+ */
+async function resolveVariantBuilderPrompt(
+  req: Request,
+  variantId: string,
+): Promise<string | null> {
+  try {
+    const variant = await prisma.agentVariant.findUnique({
+      where: { slug: variantId },
+      select: { builderPromptSlug: true },
+    });
+    if (!variant) {
+      req.log.warn(
+        { variantId },
+        "agent variant not found; using canonical generator",
+      );
+      return null;
+    }
+    if (!variant.builderPromptSlug) {
+      return null;
+    }
+    return await loadBenchPromptText(variant.builderPromptSlug);
+  } catch (err) {
+    req.log.warn(
+      { err, variantId },
+      "agent variant builder-prompt resolve failed; using canonical generator",
+    );
+    return null;
+  }
+}
+
 export async function generationsPostHandler(req: Request, res: Response) {
   // Track client disconnect so all blocking paths (SSE poll, wait_ms long-poll)
   // can bail early when nobody is listening.
@@ -836,6 +880,25 @@ export async function generationsPostHandler(req: Request, res: Response) {
         });
         return;
       }
+    }
+  }
+
+  // 9c. Agent variant (Axis B), dev-only. A variantId selects a registered
+  //     variant; if it pins a bench builder-prompt slug, resolve that slug to
+  //     text and use it as this generation's builderPrompt. The slug comes from
+  //     the trusted registry (admin-authored), so this is the one path that sets
+  //     a builder-prompt override for a non-agent-key caller — the privileged
+  //     gate above only rejects a *client-supplied* builderPrompt. Resolved
+  //     BEFORE the dedupe so a replay with the same variantId matches; degrades
+  //     to the canonical generator on any miss/error (never fails the build).
+  //     Off-dev the field is ignored.
+  if (body.variantId && XMTP_ENV !== "production") {
+    const variantPrompt = await resolveVariantBuilderPrompt(
+      req,
+      body.variantId,
+    );
+    if (variantPrompt !== null) {
+      body.builderPrompt = variantPrompt;
     }
   }
 

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -265,7 +265,7 @@ export const bodySchema = z
     // ignored for JWT (JWT account always wins) and anonymous (falls
     // back to ADMIN). See the owner-resolution block below.
     ownerAccountId: accountIdSchema.optional(),
-    // Per-PR agent variant (Axis B), dev-only. Selects a registered variant
+    // Per-PR agent variant builder prompt, dev-only. Selects a registered variant
     // whose builder-prompt slug the backend resolves server-side into this
     // generation's builderPrompt. Optional + ignored off-dev, so it stays
     // backwards-compatible for shipped clients; the slug is never client-
@@ -660,10 +660,10 @@ async function respondPerMode(args: {
 }
 
 /**
- * Resolve a registered variant's builder prompt (Axis B). Returns the prompt
- * text when the variant exists and pins a bench slug that resolves; returns
- * null (→ canonical generator) when the variant is unknown, pins no slug
- * (an Axis-A-only / runtime variant), or the bench lookup fails. Never throws —
+ * Resolve a registered variant's builder prompt. Returns the prompt text when
+ * the variant exists and pins a bench slug that resolves; returns null
+ * (→ canonical generator) when the variant is unknown, pins no slug
+ * (a runtime-only variant), or the bench lookup fails. Never throws —
  * a variant degrades, it never fails the build.
  */
 async function resolveVariantBuilderPrompt(
@@ -883,7 +883,7 @@ export async function generationsPostHandler(req: Request, res: Response) {
     }
   }
 
-  // 9c. Agent variant (Axis B), dev-only. A variantId selects a registered
+  // 9c. Agent variant builder prompt, dev-only. A variantId selects a registered
   //     variant; if it pins a bench builder-prompt slug, resolve that slug to
   //     text and use it as this generation's builderPrompt. The slug comes from
   //     the trusted registry (admin-authored), so this is the one path that sets

--- a/src/api/v2/agent-templates/services/bench-prompt.ts
+++ b/src/api/v2/agent-templates/services/bench-prompt.ts
@@ -1,0 +1,96 @@
+import { BRAINTRUST_API_KEY } from "@/config";
+
+// The bench prompt store is Braintrust's native versioned Prompts, slug-
+// addressable over the public REST API. Variant builder prompts (Axis B) are
+// authored there (project "convos-agent-bench") and resolved live at generation
+// time — editing a bench prompt takes effect on the next build with no re-push.
+const BT_REST = "https://api.braintrust.dev/v1";
+const BENCH_PROJECT = "convos-agent-bench";
+const REST_TIMEOUT_MS = 15_000;
+
+function restObjects(body: unknown): Record<string, unknown>[] {
+  if (typeof body !== "object" || body === null || !("objects" in body)) {
+    return [];
+  }
+  const objs: unknown = body.objects;
+  if (!Array.isArray(objs)) return [];
+  return objs.filter(
+    (o): o is Record<string, unknown> => typeof o === "object" && o !== null,
+  );
+}
+
+/**
+ * Pull the builder text out of a Braintrust `prompt_data` payload — either a
+ * completion `content`/`prompt` string or the joined chat `messages`. Pure, so
+ * the parsing is unit-testable without hitting the API.
+ */
+export function extractPromptText(promptData: unknown): string {
+  if (typeof promptData !== "object" || promptData === null) return "";
+  const p = (promptData as { prompt?: unknown }).prompt;
+  if (typeof p !== "object" || p === null) return "";
+  const prompt = p as Record<string, unknown>;
+  if (typeof prompt.content === "string") return prompt.content;
+  if (typeof prompt.prompt === "string") return prompt.prompt;
+  if (Array.isArray(prompt.messages)) {
+    return prompt.messages
+      .map((m: unknown) =>
+        typeof m === "object" &&
+        m !== null &&
+        typeof (m as { content?: unknown }).content === "string"
+          ? (m as { content: string }).content
+          : "",
+      )
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+export type BenchPromptLoader = (slug: string) => Promise<string>;
+let _loaderOverride: BenchPromptLoader | null = null;
+
+/**
+ * Install a test override for `loadBenchPromptText` (the only network call in
+ * this module). Pass `null` to restore normal Braintrust REST behaviour. Mirrors
+ * the `__reset*ForTests` seam the other generation services expose, so tests
+ * stay hermetic without module mocks.
+ */
+export function __resetBenchPromptLoaderForTests(
+  override: BenchPromptLoader | null,
+): void {
+  _loaderOverride = override;
+}
+
+/**
+ * Resolve a bench/Braintrust prompt slug to its latest text. Throws on a missing
+ * key, an unreachable/erroring API, an unknown slug, or empty text — the
+ * generation seam catches and falls back to the canonical generator, so a
+ * variant degrades rather than fails the build.
+ */
+export async function loadBenchPromptText(slug: string): Promise<string> {
+  if (_loaderOverride) {
+    return _loaderOverride(slug);
+  }
+  if (!BRAINTRUST_API_KEY) {
+    throw new Error("BRAINTRUST_API_KEY not configured");
+  }
+  const res = await fetch(
+    `${BT_REST}/prompt?project_name=${encodeURIComponent(BENCH_PROJECT)}&slug=${encodeURIComponent(slug)}`,
+    {
+      headers: { Authorization: `Bearer ${BRAINTRUST_API_KEY}` },
+      signal: AbortSignal.timeout(REST_TIMEOUT_MS),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Braintrust prompt lookup failed (${res.status})`);
+  }
+  const first = restObjects(await res.json()).at(0);
+  if (!first) {
+    throw new Error(`bench prompt "${slug}" not found`);
+  }
+  const text = extractPromptText(first.prompt_data);
+  if (!text) {
+    throw new Error(`bench prompt "${slug}" carries no text`);
+  }
+  return text;
+}

--- a/src/api/v2/agent-templates/services/bench-prompt.ts
+++ b/src/api/v2/agent-templates/services/bench-prompt.ts
@@ -19,25 +19,46 @@ function restObjects(body: unknown): Record<string, unknown>[] {
   );
 }
 
+// A Braintrust message `content` is either a plain string or an array of typed
+// parts (e.g. [{ type: "text", text: "..." }] for multimodal prompts). Join the
+// text parts and ignore the rest; anything else yields "".
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === "object" &&
+        part !== null &&
+        (part as { type?: unknown }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string"
+          ? (part as { text: string }).text
+          : "",
+      )
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
 /**
  * Pull the builder text out of a Braintrust `prompt_data` payload — either a
- * completion `content`/`prompt` string or the joined chat `messages`. Pure, so
- * the parsing is unit-testable without hitting the API.
+ * completion `content`/`prompt` string or the joined chat `messages`. A message
+ * `content` may be a plain string or an array of typed parts. Pure, so the
+ * parsing is unit-testable without hitting the API.
  */
 export function extractPromptText(promptData: unknown): string {
   if (typeof promptData !== "object" || promptData === null) return "";
   const p = (promptData as { prompt?: unknown }).prompt;
   if (typeof p !== "object" || p === null) return "";
   const prompt = p as Record<string, unknown>;
-  if (typeof prompt.content === "string") return prompt.content;
+  const direct = contentToText(prompt.content);
+  if (direct) return direct;
   if (typeof prompt.prompt === "string") return prompt.prompt;
   if (Array.isArray(prompt.messages)) {
     return prompt.messages
       .map((m: unknown) =>
-        typeof m === "object" &&
-        m !== null &&
-        typeof (m as { content?: unknown }).content === "string"
-          ? (m as { content: string }).content
+        typeof m === "object" && m !== null
+          ? contentToText((m as { content?: unknown }).content)
           : "",
       )
       .filter(Boolean)

--- a/src/api/v2/agent-templates/services/bench-prompt.ts
+++ b/src/api/v2/agent-templates/services/bench-prompt.ts
@@ -99,6 +99,10 @@ export async function loadBenchPromptText(slug: string): Promise<string> {
     `${BT_REST}/prompt?project_name=${encodeURIComponent(BENCH_PROJECT)}&slug=${encodeURIComponent(slug)}`,
     {
       headers: { Authorization: `Bearer ${BRAINTRUST_API_KEY}` },
+      // Don't follow redirects: a 3xx to another host would replay the
+      // Authorization bearer off-origin. A redirect throws here and degrades to
+      // the canonical generator like any other lookup failure.
+      redirect: "error",
       signal: AbortSignal.timeout(REST_TIMEOUT_MS),
     },
   );

--- a/src/api/v2/agent-templates/services/bench-prompt.ts
+++ b/src/api/v2/agent-templates/services/bench-prompt.ts
@@ -1,7 +1,7 @@
 import { BRAINTRUST_API_KEY } from "@/config";
 
 // The bench prompt store is Braintrust's native versioned Prompts, slug-
-// addressable over the public REST API. Variant builder prompts (Axis B) are
+// addressable over the public REST API. Variant builder prompts are
 // authored there (project "convos-agent-bench") and resolved live at generation
 // time — editing a bench prompt takes effect on the next build with no re-push.
 const BT_REST = "https://api.braintrust.dev/v1";

--- a/src/api/v2/agent-variants/agent-variants.router.ts
+++ b/src/api/v2/agent-variants/agent-variants.router.ts
@@ -1,0 +1,48 @@
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
+import { XMTP_ENV } from "@/config";
+import { agentApiKeyAuth } from "@/middleware/agentAuth";
+import { authMiddleware } from "@/middleware/auth";
+import { deleteAgentVariantHandler } from "./handlers/delete";
+import { listAgentVariantsHandler } from "./handlers/list";
+import { upsertAgentVariantHandler } from "./handlers/upsert";
+
+export const agentVariantsRouter = Router();
+
+// Variants are a dev-network-only feature. The write routes 404 on prod even if
+// the registry token were somehow configured there — defense in depth on top of
+// the token being unset. (The GET returns [] off-dev instead of 404 so the
+// app's picker gets the documented empty-list contract.)
+function requireDevBackend(_req: Request, res: Response, next: NextFunction) {
+  if (XMTP_ENV === "production") {
+    res.status(404).json({ error: "Not found" });
+    return;
+  }
+  next();
+}
+
+// Read by the dev app picker (internal builds). authMiddleware keeps it to
+// signed-in clients; the handler returns [] off-dev.
+agentVariantsRouter.get("/", authMiddleware, listAgentVariantsHandler);
+
+// Written only by the convos-assistants variant CI, authenticating with the
+// agent API key (X-Agent-API-Key) — the same machine→backend credential the
+// worker uses. The container can't smuggle a write through the worker's
+// convos.internal proxy: that path is denylisted in the proxy (outbound.ts).
+// requireDevBackend runs first so prod 404s before auth even evaluates.
+agentVariantsRouter.post(
+  "/",
+  requireDevBackend,
+  agentApiKeyAuth,
+  upsertAgentVariantHandler,
+);
+agentVariantsRouter.delete(
+  "/:slug",
+  requireDevBackend,
+  agentApiKeyAuth,
+  deleteAgentVariantHandler,
+);

--- a/src/api/v2/agent-variants/agent-variants.router.ts
+++ b/src/api/v2/agent-variants/agent-variants.router.ts
@@ -5,8 +5,7 @@ import {
   type Response,
 } from "express";
 import { XMTP_ENV } from "@/config";
-import { agentApiKeyAuth } from "@/middleware/agentAuth";
-import { authMiddleware } from "@/middleware/auth";
+import { agentApiKeyAuth, authOrAgentApiKeyAuth } from "@/middleware/agentAuth";
 import { deleteAgentVariantHandler } from "./handlers/delete";
 import { listAgentVariantsHandler } from "./handlers/list";
 import { upsertAgentVariantHandler } from "./handlers/upsert";
@@ -25,9 +24,10 @@ function requireDevBackend(_req: Request, res: Response, next: NextFunction) {
   next();
 }
 
-// Read by the dev app picker (internal builds). authMiddleware keeps it to
-// signed-in clients; the handler returns [] off-dev.
-agentVariantsRouter.get("/", authMiddleware, listAgentVariantsHandler);
+// Read by the dev app picker (a signed-in client's JWT) and by the
+// convos-assistants variant-sweep CI (the agent API key) — authOrAgentApiKeyAuth
+// accepts either. Non-sensitive dev-only data, and the handler returns [] off-dev.
+agentVariantsRouter.get("/", authOrAgentApiKeyAuth, listAgentVariantsHandler);
 
 // Written only by the convos-assistants variant CI, authenticating with the
 // agent API key (X-Agent-API-Key) — the same machine→backend credential the

--- a/src/api/v2/agent-variants/handlers/delete.ts
+++ b/src/api/v2/agent-variants/handlers/delete.ts
@@ -28,6 +28,7 @@ export async function deleteAgentVariantHandler(req: Request, res: Response) {
   try {
     await prisma.agentVariant.deleteMany({ where: { slug: parsed.data.slug } });
     res.status(204).end();
+    return;
   } catch (error) {
     req.log.error(
       {
@@ -38,5 +39,6 @@ export async function deleteAgentVariantHandler(req: Request, res: Response) {
       "Failed to delete agent variant",
     );
     res.status(500).json({ error: "Failed to delete agent variant" });
+    return;
   }
 }

--- a/src/api/v2/agent-variants/handlers/delete.ts
+++ b/src/api/v2/agent-variants/handlers/delete.ts
@@ -1,0 +1,42 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const paramsSchema = z.object({
+  slug: z
+    .string()
+    .trim()
+    .min(1)
+    .max(64)
+    .regex(/^[a-z0-9-]+$/),
+});
+
+/**
+ * DELETE /v2/agent-variants/:slug — drop a variant row (auth + dev-gate on the
+ * route). Idempotent by design: teardown fires on PR close/unlabel and may
+ * target a slug that was never registered (a default-runtime variant) or one
+ * already removed, so a missing row is a 204, not a 404. `deleteMany` makes
+ * the zero-row case a no-op instead of a throw.
+ */
+export async function deleteAgentVariantHandler(req: Request, res: Response) {
+  const parsed = paramsSchema.safeParse(req.params);
+  if (!parsed.success) {
+    res.status(400).json({ error: "Invalid slug" });
+    return;
+  }
+
+  try {
+    await prisma.agentVariant.deleteMany({ where: { slug: parsed.data.slug } });
+    res.status(204).end();
+  } catch (error) {
+    req.log.error(
+      {
+        error,
+        slug: parsed.data.slug,
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+      "Failed to delete agent variant",
+    );
+    res.status(500).json({ error: "Failed to delete agent variant" });
+  }
+}

--- a/src/api/v2/agent-variants/handlers/list.ts
+++ b/src/api/v2/agent-variants/handlers/list.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from "express";
+import { XMTP_ENV } from "@/config";
+import { prisma } from "@/utils/prisma";
+import { serializeAgentVariant } from "../serialize";
+
+/**
+ * GET /v2/agent-variants — the dev app picker's source of truth. Returns the
+ * ready/building variants, newest first. Variants exist only on the dev XMTP
+ * network, so off-dev the list is empty by contract (the picker treats [] as
+ * "no variants"); this is the single environment gate §7.1 calls for.
+ */
+export async function listAgentVariantsHandler(req: Request, res: Response) {
+  if (XMTP_ENV === "production") {
+    res.status(200).json({ data: [] });
+    return;
+  }
+
+  try {
+    const variants = await prisma.agentVariant.findMany({
+      where: { status: { in: ["ready", "building"] } },
+      orderBy: { createdAt: "desc" },
+    });
+    res.status(200).json({ data: variants.map(serializeAgentVariant) });
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to list agent variants",
+    );
+    res.status(500).json({ error: "Failed to list agent variants" });
+  }
+}

--- a/src/api/v2/agent-variants/handlers/list.ts
+++ b/src/api/v2/agent-variants/handlers/list.ts
@@ -7,7 +7,7 @@ import { serializeAgentVariant } from "../serialize";
  * GET /v2/agent-variants — the dev app picker's source of truth. Returns the
  * ready/building variants, newest first. Variants exist only on the dev XMTP
  * network, so off-dev the list is empty by contract (the picker treats [] as
- * "no variants"); this is the single environment gate §7.1 calls for.
+ * "no variants"); this is the single dev-only environment gate.
  */
 export async function listAgentVariantsHandler(req: Request, res: Response) {
   if (XMTP_ENV === "production") {

--- a/src/api/v2/agent-variants/handlers/list.ts
+++ b/src/api/v2/agent-variants/handlers/list.ts
@@ -21,11 +21,13 @@ export async function listAgentVariantsHandler(req: Request, res: Response) {
       orderBy: { createdAt: "desc" },
     });
     res.status(200).json({ data: variants.map(serializeAgentVariant) });
+    return;
   } catch (error) {
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to list agent variants",
     );
     res.status(500).json({ error: "Failed to list agent variants" });
+    return;
   }
 }

--- a/src/api/v2/agent-variants/handlers/upsert.ts
+++ b/src/api/v2/agent-variants/handlers/upsert.ts
@@ -1,0 +1,38 @@
+import type { Request, Response } from "express";
+import { prisma } from "@/utils/prisma";
+import { AgentVariantUpsertSchema } from "../schemas";
+import { serializeAgentVariant } from "../serialize";
+
+/**
+ * POST /v2/agent-variants — create or update a variant, keyed on slug. Called
+ * only by the convos-assistants variant CI with the agent API key (auth +
+ * dev-gate live on the route). `synchronize` redeploys reuse this to refresh
+ * commit/status, so it's an upsert rather than a create.
+ */
+export async function upsertAgentVariantHandler(req: Request, res: Response) {
+  const parsed = AgentVariantUpsertSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: "Invalid request body",
+      message: parsed.error.issues[0]?.message ?? "Invalid body",
+    });
+    return;
+  }
+
+  const { slug, ...rest } = parsed.data;
+
+  try {
+    const variant = await prisma.agentVariant.upsert({
+      where: { slug },
+      create: { slug, ...rest },
+      update: rest,
+    });
+    res.status(200).json(serializeAgentVariant(variant));
+  } catch (error) {
+    req.log.error(
+      { error, slug, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to upsert agent variant",
+    );
+    res.status(500).json({ error: "Failed to upsert agent variant" });
+  }
+}

--- a/src/api/v2/agent-variants/handlers/upsert.ts
+++ b/src/api/v2/agent-variants/handlers/upsert.ts
@@ -28,11 +28,13 @@ export async function upsertAgentVariantHandler(req: Request, res: Response) {
       update: rest,
     });
     res.status(200).json(serializeAgentVariant(variant));
+    return;
   } catch (error) {
     req.log.error(
       { error, slug, stack: error instanceof Error ? error.stack : undefined },
       "Failed to upsert agent variant",
     );
     res.status(500).json({ error: "Failed to upsert agent variant" });
+    return;
   }
 }

--- a/src/api/v2/agent-variants/schemas.ts
+++ b/src/api/v2/agent-variants/schemas.ts
@@ -30,15 +30,20 @@ export const AgentVariantUpsertSchema = z
       ),
     label: z.string().trim().min(1).max(40),
     whatToTest: z.string().trim().min(1).max(500),
-    status: AgentVariantStatusSchema.default("building"),
+    // Optional, NOT defaulted: an omitted field stays `undefined` so a partial
+    // re-POST (the upsert spreads `...rest` into the Prisma `update`) preserves
+    // the stored value instead of clobbering it with a default. Omitted fields
+    // on create fall back to the Prisma column defaults (`status` → "building",
+    // the nullable URL/slug/date columns → null).
+    status: AgentVariantStatusSchema.optional(),
     // The ephemeral runtime base URL, or null for the default dev runtime.
-    assistantWorkerUrl: z.string().url().nullable().default(null),
+    assistantWorkerUrl: z.string().url().nullable().optional(),
     // A bench/Braintrust prompt slug, or null for the canonical generator.
-    builderPromptSlug: z.string().trim().min(1).nullable().default(null),
+    builderPromptSlug: z.string().trim().min(1).nullable().optional(),
     prUrl: z.string().url(),
     branch: z.string().trim().min(1).max(255),
     commit: z.string().trim().min(1).max(64),
-    expiresAt: z.coerce.date().nullable().default(null),
+    expiresAt: z.coerce.date().nullable().optional(),
   })
   .strict();
 export type AgentVariantUpsert = z.infer<typeof AgentVariantUpsertSchema>;

--- a/src/api/v2/agent-variants/schemas.ts
+++ b/src/api/v2/agent-variants/schemas.ts
@@ -31,9 +31,9 @@ export const AgentVariantUpsertSchema = z
     label: z.string().trim().min(1).max(40),
     whatToTest: z.string().trim().min(1).max(500),
     status: AgentVariantStatusSchema.default("building"),
-    // Axis A — ephemeral runtime base URL, or null for the default dev runtime.
+    // The ephemeral runtime base URL, or null for the default dev runtime.
     assistantWorkerUrl: z.string().url().nullable().default(null),
-    // Axis B — bench/Braintrust prompt slug, or null for the canonical generator.
+    // A bench/Braintrust prompt slug, or null for the canonical generator.
     builderPromptSlug: z.string().trim().min(1).nullable().default(null),
     prUrl: z.string().url(),
     branch: z.string().trim().min(1).max(255),

--- a/src/api/v2/agent-variants/schemas.ts
+++ b/src/api/v2/agent-variants/schemas.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+// Variant lifecycle. Plain-string column in Prisma (no Postgres enum); this is
+// the single source of valid values, validated on write and used by the GET
+// filter. building → ready/failed as CI deploys; stale is reserved for a future
+// reconciler.
+export const AGENT_VARIANT_STATUSES = [
+  "building",
+  "ready",
+  "failed",
+  "stale",
+] as const;
+export const AgentVariantStatusSchema = z.enum(AGENT_VARIANT_STATUSES);
+export type AgentVariantStatus = z.infer<typeof AgentVariantStatusSchema>;
+
+// Write body for POST /v2/agent-variants. Server-to-server only (the variant CI
+// holds the scoped registry token), so `.strict()` is safe here — this is NOT a
+// shipped-client contract. `slug` is the natural key; an upsert keys on it.
+export const AgentVariantUpsertSchema = z
+  .object({
+    // PR slug, e.g. "pr-1234" → ephemeral-pr-1234.convos.fun.
+    slug: z
+      .string()
+      .trim()
+      .min(1)
+      .max(64)
+      .regex(
+        /^[a-z0-9-]+$/,
+        "slug must be lowercase alphanumerics and hyphens",
+      ),
+    label: z.string().trim().min(1).max(40),
+    whatToTest: z.string().trim().min(1).max(500),
+    status: AgentVariantStatusSchema.default("building"),
+    // Axis A — ephemeral runtime base URL, or null for the default dev runtime.
+    assistantWorkerUrl: z.string().url().nullable().default(null),
+    // Axis B — bench/Braintrust prompt slug, or null for the canonical generator.
+    builderPromptSlug: z.string().trim().min(1).nullable().default(null),
+    prUrl: z.string().url(),
+    branch: z.string().trim().min(1).max(255),
+    commit: z.string().trim().min(1).max(64),
+    expiresAt: z.coerce.date().nullable().default(null),
+  })
+  .strict();
+export type AgentVariantUpsert = z.infer<typeof AgentVariantUpsertSchema>;

--- a/src/api/v2/agent-variants/serialize.ts
+++ b/src/api/v2/agent-variants/serialize.ts
@@ -1,0 +1,19 @@
+import type { AgentVariant } from "@prisma/client";
+
+// Wire shape the dev app picker reads. Dates are emitted as ISO strings;
+// everything else rides verbatim.
+export function serializeAgentVariant(variant: AgentVariant) {
+  return {
+    slug: variant.slug,
+    label: variant.label,
+    whatToTest: variant.whatToTest,
+    status: variant.status,
+    assistantWorkerUrl: variant.assistantWorkerUrl,
+    builderPromptSlug: variant.builderPromptSlug,
+    prUrl: variant.prUrl,
+    branch: variant.branch,
+    commit: variant.commit,
+    expiresAt: variant.expiresAt ? variant.expiresAt.toISOString() : null,
+    createdAt: variant.createdAt.toISOString(),
+  };
+}

--- a/src/api/v2/agents/handlers/join-status.ts
+++ b/src/api/v2/agents/handlers/join-status.ts
@@ -1,5 +1,7 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
+import { resolveVariantWorkerOrigin } from "@/api/v2/agents/lib/variant-routing";
+import { XMTP_ENV } from "@/config";
 import {
   assistantStatusSchema,
   getAssistantApiKey,
@@ -69,7 +71,18 @@ export async function joinStatusHandler(req: Request, res: Response) {
   }
 
   const { instanceId } = parsed.data;
-  const assistantBaseUrl = assistantApiUrl.replace(/\/+$/, "");
+
+  // A join routed to a variant worker returns an instanceId that lives there, not
+  // on the default worker, so the client carries the variantId back here to poll
+  // the right runtime. Re-resolve the variant's ephemeral origin (dev-only, live +
+  // allowlisted); anything else falls back to the default worker.
+  let assistantBaseUrl = assistantApiUrl.replace(/\/+$/, "");
+  const variantId =
+    typeof req.query.variantId === "string" ? req.query.variantId : null;
+  if (variantId && XMTP_ENV !== "production") {
+    const origin = await resolveVariantWorkerOrigin(variantId);
+    if (origin) assistantBaseUrl = origin;
+  }
 
   const headers: Record<string, string> = {};
   if (assistantApiKey) {

--- a/src/api/v2/agents/handlers/join-status.ts
+++ b/src/api/v2/agents/handlers/join-status.ts
@@ -15,6 +15,13 @@ const paramsSchema = z.object({
   instanceId: z.string().trim().min(1, "instanceId is required").max(256),
 });
 
+// Optional dev-only variant routing hint. A malformed value (array, blank,
+// over-long) parses away to undefined and the poll falls back to the default
+// worker rather than 400ing — the status read still works.
+const querySchema = z.object({
+  variantId: z.string().trim().min(1).max(64).optional(),
+});
+
 const ERRORS = {
   STATUS_FAILED: {
     status: 502,
@@ -77,8 +84,7 @@ export async function joinStatusHandler(req: Request, res: Response) {
   // the right runtime. Re-resolve the variant's ephemeral origin (dev-only, live +
   // allowlisted); anything else falls back to the default worker.
   let assistantBaseUrl = assistantApiUrl.replace(/\/+$/, "");
-  const variantId =
-    typeof req.query.variantId === "string" ? req.query.variantId : null;
+  const variantId = querySchema.safeParse(req.query).data?.variantId;
   if (variantId && XMTP_ENV !== "production") {
     const origin = await resolveVariantWorkerOrigin(variantId);
     if (origin) assistantBaseUrl = origin;

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { buildJoinPayload } from "@/api/v2/agents/lib/build-join-payload";
-import { XMTP_ENV } from "@/config";
+import { EPHEMERAL_CREATE_SECRET, XMTP_ENV } from "@/config";
 import { accountIdSchema } from "@/utils/account-id";
 import { prisma } from "@/utils/prisma";
 import {
@@ -53,6 +53,11 @@ const optionsSchema = z
   .object({
     skipGreeting: z.boolean().optional(),
     onboarding: z.string().min(1).max(64).optional(),
+    // Per-PR agent variant (dev-only). Selects a registered variant; the backend
+    // consumes it here (Axis-A routing + the metadata stamp) and does NOT forward
+    // it to the runtime. Optional + ignored off-dev, so it stays backwards-
+    // compatible for shipped clients.
+    variantId: z.string().trim().min(1).max(64).optional(),
   })
   .strict();
 
@@ -68,7 +73,7 @@ const optionsSchema = z
 // carries the agent's `inboxId`, the caller adds it to the declared group
 // with addMembers, and the runtime attaches when it observes the resulting
 // group welcome. No confirmation call exists.
-const bodySchema = z
+export const bodySchema = z
   .object({
     slug: z.string().min(1, "slug must not be empty").max(2048).optional(),
     // Normalized to lowercase: the runtime forwards this to Herald, whose
@@ -154,6 +159,10 @@ const dispatchBodySchema = z
     ownerAccountId: accountIdSchema,
     options: optionsSchema.optional(),
     timezone: timezoneSchema.optional(),
+    // Free-form XMTP-profile metadata seed forwarded to the worker. Used to
+    // carry the per-PR variant descriptor ({ variant: <json> }), which the
+    // worker stamps onto the agent's profile at Herald-join.
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict()
   .refine(
@@ -422,6 +431,29 @@ export async function joinHandler(req: Request, res: Response) {
     "Agent join request received",
   );
 
+  // Per-PR agent variant (dev-only). When the join carries a variantId for a
+  // registered variant, route provisioning to its ephemeral worker (Axis A,
+  // when one is pinned) and stamp the variant descriptor onto the agent's
+  // profile via `metadata` (the worker emits it at Herald-join). The builder-
+  // prompt side (Axis B) was already applied at generation. `variantId` is
+  // consumed here and never forwarded to the runtime. A missing/invalid variant
+  // (or off-dev) falls through to the default worker with no stamp.
+  const variant =
+    options?.variantId && XMTP_ENV !== "production"
+      ? await prisma.agentVariant.findUnique({
+          where: { slug: options.variantId },
+          select: {
+            slug: true,
+            label: true,
+            whatToTest: true,
+            prUrl: true,
+            assistantWorkerUrl: true,
+          },
+        })
+      : null;
+  const effectiveAssistantApiUrl =
+    variant?.assistantWorkerUrl ?? assistantApiUrl;
+
   // `/api/v2/agents/join` is mounted behind `authMiddleware` (401s any
   // request without a valid JWT) and gated by `requireAccount` (403s a
   // valid-but-account-less JWT), so under normal routing `accountId` is
@@ -546,7 +578,7 @@ export async function joinHandler(req: Request, res: Response) {
     }
   }
 
-  const assistantBaseUrl = assistantApiUrl.replace(/\/+$/, "");
+  const assistantBaseUrl = effectiveAssistantApiUrl.replace(/\/+$/, "");
   const authHeader = assistantApiKey ? `Bearer ${assistantApiKey}` : undefined;
 
   let instanceId: string;
@@ -555,6 +587,11 @@ export async function joinHandler(req: Request, res: Response) {
       "Content-Type": "application/json",
     };
     if (authHeader) dispatchHeaders.Authorization = authHeader;
+    // Ephemeral variant workers gate their create route on a shared secret (F7);
+    // present it when routing to one. The default/canonical worker ignores it.
+    if (variant?.assistantWorkerUrl && EPHEMERAL_CREATE_SECRET) {
+      dispatchHeaders["x-ephemeral-create-secret"] = EPHEMERAL_CREATE_SECRET;
+    }
 
     // Forward each option only when the caller explicitly passed it —
     // no defaults at this layer. `options` is omitted entirely from the
@@ -606,6 +643,19 @@ export async function joinHandler(req: Request, res: Response) {
     }
     if (timezone !== undefined) {
       dispatchBody.timezone = timezone;
+    }
+    // Stamp the variant onto the agent: the worker reads metadata.variant at
+    // Herald-join and emits it into the XMTP profile so every participant sees
+    // the banner. Carries only the public descriptor — never the runtime URL.
+    if (variant) {
+      dispatchBody.metadata = {
+        variant: JSON.stringify({
+          slug: variant.slug,
+          label: variant.label,
+          whatToTest: variant.whatToTest,
+          prUrl: variant.prUrl,
+        }),
+      };
     }
 
     const dispatchParse = dispatchBodySchema.safeParse(dispatchBody);

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -15,6 +15,31 @@ import {
 
 const AGENT_BUILDER_ONBOARDING = "agent-builder";
 
+// The public variant descriptor + optional ephemeral runtime URL read from the
+// registry for a dev-only per-PR variant join.
+type VariantDescriptor = {
+  slug: string;
+  label: string;
+  whatToTest: string;
+  prUrl: string;
+  assistantWorkerUrl: string | null;
+};
+
+// Variant rows store a free-form URL; only our HTTPS dev ephemeral origins
+// (ephemeral-<slug>.convos.fun) may receive the join dispatch and its bearer
+// token. Anything else falls back to the default worker.
+function isAllowedVariantWorkerUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "https:" &&
+      /^ephemeral-[a-z0-9-]+\.convos\.fun$/.test(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 type TemplateRow = Awaited<ReturnType<typeof prisma.agentTemplate.findUnique>>;
 type TemplateFinder = (id: string) => Promise<TemplateRow>;
 
@@ -438,21 +463,48 @@ export async function joinHandler(req: Request, res: Response) {
   // already applied at generation. `variantId` is
   // consumed here and never forwarded to the runtime. A missing/invalid variant
   // (or off-dev) falls through to the default worker with no stamp.
-  const variant =
-    options?.variantId && XMTP_ENV !== "production"
-      ? await prisma.agentVariant.findUnique({
-          where: { slug: options.variantId },
-          select: {
-            slug: true,
-            label: true,
-            whatToTest: true,
-            prUrl: true,
-            assistantWorkerUrl: true,
-          },
-        })
-      : null;
-  const effectiveAssistantApiUrl =
-    variant?.assistantWorkerUrl ?? assistantApiUrl;
+  let variant: VariantDescriptor | null = null;
+  if (options?.variantId && XMTP_ENV !== "production") {
+    try {
+      variant = await prisma.agentVariant.findUnique({
+        where: { slug: options.variantId },
+        select: {
+          slug: true,
+          label: true,
+          whatToTest: true,
+          prUrl: true,
+          assistantWorkerUrl: true,
+        },
+      });
+    } catch (error) {
+      // A transient DB error on this optional dev-only lookup must not 500 the
+      // join — degrade to the default worker with no variant stamp.
+      req.log.error(
+        { error, variantId: options.variantId },
+        "Variant lookup failed; falling back to the default worker",
+      );
+    }
+  }
+
+  // The variant row carries a free-form URL. Before routing the join — and its
+  // `Authorization: Bearer` — at it, confirm it's one of our HTTPS dev ephemeral
+  // origins; a bad or compromised row otherwise turns this into an SSRF /
+  // credential-leak path. A non-matching URL falls back to the default worker
+  // (the descriptor stamp still applies, exactly as a default-runtime variant).
+  let effectiveAssistantApiUrl = assistantApiUrl;
+  if (variant?.assistantWorkerUrl) {
+    if (isAllowedVariantWorkerUrl(variant.assistantWorkerUrl)) {
+      effectiveAssistantApiUrl = variant.assistantWorkerUrl;
+    } else {
+      req.log.warn(
+        {
+          variantId: variant.slug,
+          assistantWorkerUrl: variant.assistantWorkerUrl,
+        },
+        "Variant assistantWorkerUrl is not an allowed dev ephemeral origin; using the default worker",
+      );
+    }
+  }
 
   // `/api/v2/agents/join` is mounted behind `authMiddleware` (401s any
   // request without a valid JWT) and gated by `requireAccount` (403s a

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -26,20 +26,24 @@ type VariantDescriptor = {
 };
 
 // Variant rows store a free-form URL; only our HTTPS dev ephemeral origins
-// (ephemeral-<slug>.convos.fun) may receive the join dispatch and its bearer
-// token. Anything else falls back to the default worker. This pattern is a
-// cross-repo contract with the convos-assistants ephemeral host (EPHEMERAL_PREFIX
-// + ROUTE_ZONE in scripts/ephemeral.ts, registered by variant.yml) — keep the
-// two in lockstep or variant joins silently fall back.
-function isAllowedVariantWorkerUrl(url: string): boolean {
+// (ephemeral-<slug>.convos.fun, default port) may receive the join dispatch and
+// its bearer token. Returns the canonical origin (scheme + host only) to dispatch
+// at, or null to fall back to the default worker — normalizing to the origin
+// means an injected port, path, or query on an otherwise-trusted host can't
+// redirect the bearer. This pattern is a cross-repo contract with the
+// convos-assistants ephemeral host (EPHEMERAL_PREFIX + ROUTE_ZONE in
+// scripts/ephemeral.ts, registered by variant.yml) — keep the two in lockstep or
+// variant joins silently fall back.
+function allowedVariantWorkerOrigin(url: string): string | null {
   try {
     const parsed = new URL(url);
-    return (
+    const allowed =
       parsed.protocol === "https:" &&
-      /^ephemeral-[a-z0-9-]+\.convos\.fun$/.test(parsed.hostname)
-    );
+      (parsed.port === "" || parsed.port === "443") &&
+      /^ephemeral-[a-z0-9-]+\.convos\.fun$/.test(parsed.hostname);
+    return allowed ? parsed.origin : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -496,8 +500,11 @@ export async function joinHandler(req: Request, res: Response) {
   // (the descriptor stamp still applies, exactly as a default-runtime variant).
   let effectiveAssistantApiUrl = assistantApiUrl;
   if (variant?.assistantWorkerUrl) {
-    if (isAllowedVariantWorkerUrl(variant.assistantWorkerUrl)) {
-      effectiveAssistantApiUrl = variant.assistantWorkerUrl;
+    const allowedOrigin = allowedVariantWorkerOrigin(
+      variant.assistantWorkerUrl,
+    );
+    if (allowedOrigin) {
+      effectiveAssistantApiUrl = allowedOrigin;
     } else {
       req.log.warn(
         {

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { buildJoinPayload } from "@/api/v2/agents/lib/build-join-payload";
-import { EPHEMERAL_CREATE_SECRET, XMTP_ENV } from "@/config";
+import { XMTP_ENV } from "@/config";
 import { accountIdSchema } from "@/utils/account-id";
 import { prisma } from "@/utils/prisma";
 import {
@@ -587,11 +587,6 @@ export async function joinHandler(req: Request, res: Response) {
       "Content-Type": "application/json",
     };
     if (authHeader) dispatchHeaders.Authorization = authHeader;
-    // Ephemeral variant workers gate their create route on a shared secret (F7);
-    // present it when routing to one. The default/canonical worker ignores it.
-    if (variant?.assistantWorkerUrl && EPHEMERAL_CREATE_SECRET) {
-      dispatchHeaders["x-ephemeral-create-secret"] = EPHEMERAL_CREATE_SECRET;
-    }
 
     // Forward each option only when the caller explicitly passed it —
     // no defaults at this layer. `options` is omitted entirely from the

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -1,6 +1,10 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { buildJoinPayload } from "@/api/v2/agents/lib/build-join-payload";
+import {
+  allowedVariantWorkerOrigin,
+  liveVariantWhere,
+} from "@/api/v2/agents/lib/variant-routing";
 import { XMTP_ENV } from "@/config";
 import { accountIdSchema } from "@/utils/account-id";
 import { prisma } from "@/utils/prisma";
@@ -24,28 +28,6 @@ type VariantDescriptor = {
   prUrl: string;
   assistantWorkerUrl: string | null;
 };
-
-// Variant rows store a free-form URL; only our HTTPS dev ephemeral origins
-// (ephemeral-<slug>.convos.fun, default port) may receive the join dispatch and
-// its bearer token. Returns the canonical origin (scheme + host only) to dispatch
-// at, or null to fall back to the default worker — normalizing to the origin
-// means an injected port, path, or query on an otherwise-trusted host can't
-// redirect the bearer. This pattern is a cross-repo contract with the
-// convos-assistants ephemeral host (EPHEMERAL_PREFIX + ROUTE_ZONE in
-// scripts/ephemeral.ts, registered by variant.yml) — keep the two in lockstep or
-// variant joins silently fall back.
-function allowedVariantWorkerOrigin(url: string): string | null {
-  try {
-    const parsed = new URL(url);
-    const allowed =
-      parsed.protocol === "https:" &&
-      (parsed.port === "" || parsed.port === "443") &&
-      /^ephemeral-[a-z0-9-]+\.convos\.fun$/.test(parsed.hostname);
-    return allowed ? parsed.origin : null;
-  } catch {
-    return null;
-  }
-}
 
 type TemplateRow = Awaited<ReturnType<typeof prisma.agentTemplate.findUnique>>;
 type TemplateFinder = (id: string) => Promise<TemplateRow>;
@@ -477,11 +459,7 @@ export async function joinHandler(req: Request, res: Response) {
       // rows (mirrors the picker's ready/building filter) so a client can't pin a
       // retired runtime by slug. A miss falls through to the default worker.
       variant = await prisma.agentVariant.findFirst({
-        where: {
-          slug: options.variantId,
-          status: { in: ["ready", "building"] },
-          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
-        },
+        where: liveVariantWhere(options.variantId),
         select: {
           slug: true,
           label: true,

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -54,7 +54,7 @@ const optionsSchema = z
     skipGreeting: z.boolean().optional(),
     onboarding: z.string().min(1).max(64).optional(),
     // Per-PR agent variant (dev-only). Selects a registered variant; the backend
-    // consumes it here (Axis-A routing + the metadata stamp) and does NOT forward
+    // consumes it here (runtime routing + the metadata stamp) and does NOT forward
     // it to the runtime. Optional + ignored off-dev, so it stays backwards-
     // compatible for shipped clients.
     variantId: z.string().trim().min(1).max(64).optional(),
@@ -432,10 +432,10 @@ export async function joinHandler(req: Request, res: Response) {
   );
 
   // Per-PR agent variant (dev-only). When the join carries a variantId for a
-  // registered variant, route provisioning to its ephemeral worker (Axis A,
-  // when one is pinned) and stamp the variant descriptor onto the agent's
-  // profile via `metadata` (the worker emits it at Herald-join). The builder-
-  // prompt side (Axis B) was already applied at generation. `variantId` is
+  // registered variant, route provisioning to its ephemeral worker (when one is
+  // pinned) and stamp the variant descriptor onto the agent's profile via
+  // `metadata` (the worker emits it at Herald-join). The builder-prompt side was
+  // already applied at generation. `variantId` is
   // consumed here and never forwarded to the runtime. A missing/invalid variant
   // (or off-dev) falls through to the default worker with no stamp.
   const variant =

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -4,6 +4,7 @@ import { buildJoinPayload } from "@/api/v2/agents/lib/build-join-payload";
 import {
   allowedVariantWorkerOrigin,
   liveVariantWhere,
+  variantWorkerHostname,
 } from "@/api/v2/agents/lib/variant-routing";
 import { XMTP_ENV } from "@/config";
 import { accountIdSchema } from "@/utils/account-id";
@@ -487,6 +488,7 @@ export async function joinHandler(req: Request, res: Response) {
   if (variant?.assistantWorkerUrl) {
     const allowedOrigin = allowedVariantWorkerOrigin(
       variant.assistantWorkerUrl,
+      variantWorkerHostname(variant.slug),
     );
     if (allowedOrigin) {
       effectiveAssistantApiUrl = allowedOrigin;

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -473,8 +473,15 @@ export async function joinHandler(req: Request, res: Response) {
   let variant: VariantDescriptor | null = null;
   if (options?.variantId && XMTP_ENV !== "production") {
     try {
-      variant = await prisma.agentVariant.findUnique({
-        where: { slug: options.variantId },
+      // Only a live variant routes + stamps: exclude failed/stale and expired
+      // rows (mirrors the picker's ready/building filter) so a client can't pin a
+      // retired runtime by slug. A miss falls through to the default worker.
+      variant = await prisma.agentVariant.findFirst({
+        where: {
+          slug: options.variantId,
+          status: { in: ["ready", "building"] },
+          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+        },
         select: {
           slug: true,
           label: true,

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -27,7 +27,10 @@ type VariantDescriptor = {
 
 // Variant rows store a free-form URL; only our HTTPS dev ephemeral origins
 // (ephemeral-<slug>.convos.fun) may receive the join dispatch and its bearer
-// token. Anything else falls back to the default worker.
+// token. Anything else falls back to the default worker. This pattern is a
+// cross-repo contract with the convos-assistants ephemeral host (EPHEMERAL_PREFIX
+// + ROUTE_ZONE in scripts/ephemeral.ts, registered by variant.yml) — keep the
+// two in lockstep or variant joins silently fall back.
 function isAllowedVariantWorkerUrl(url: string): boolean {
   try {
     const parsed = new URL(url);

--- a/src/api/v2/agents/lib/variant-routing.ts
+++ b/src/api/v2/agents/lib/variant-routing.ts
@@ -11,22 +11,30 @@ export function liveVariantWhere(slug: string) {
   };
 }
 
-// Variant rows store a free-form URL; only our HTTPS dev ephemeral origins
-// (ephemeral-<slug>.convos.fun, default port) may receive a dispatch/poll and its
-// bearer token. Returns the canonical origin (scheme + host only) to route at, or
-// null to fall back to the default worker — normalizing to the origin means an
-// injected port, path, or query on an otherwise-trusted host can't redirect the
-// bearer. This pattern is a cross-repo contract with the convos-assistants
-// ephemeral host (EPHEMERAL_PREFIX + ROUTE_ZONE in scripts/ephemeral.ts,
-// registered by variant.yml) — keep the two in lockstep or variant routing
-// silently falls back.
-export function allowedVariantWorkerOrigin(url: string): string | null {
+// The ephemeral worker host for a variant slug. Cross-repo contract with the
+// convos-assistants ephemeral host (EPHEMERAL_PREFIX + ROUTE_ZONE in
+// scripts/ephemeral.ts, registered by variant.yml) — keep the two in lockstep or
+// variant routing silently falls back.
+export function variantWorkerHostname(slug: string): string {
+  return `ephemeral-${slug}.convos.fun`;
+}
+
+// A variant's dispatch/poll and its bearer token may go ONLY to the variant's
+// own HTTPS ephemeral origin (default port). Binding to the exact expected
+// hostname — not just the ephemeral-*.convos.fun shape — stops a bad/mismatched
+// row (e.g. pr-123 pointing at pr-999's worker) from leaking the bearer to
+// another PR's runtime; returning the canonical origin (scheme + host only)
+// strips any injected port/path/query.
+export function allowedVariantWorkerOrigin(
+  url: string,
+  expectedHostname: string,
+): string | null {
   try {
     const parsed = new URL(url);
     const allowed =
       parsed.protocol === "https:" &&
       (parsed.port === "" || parsed.port === "443") &&
-      /^ephemeral-[a-z0-9-]+\.convos\.fun$/.test(parsed.hostname);
+      parsed.hostname === expectedHostname;
     return allowed ? parsed.origin : null;
   } catch {
     return null;
@@ -45,7 +53,10 @@ export async function resolveVariantWorkerOrigin(
       select: { assistantWorkerUrl: true },
     });
     if (!variant?.assistantWorkerUrl) return null;
-    return allowedVariantWorkerOrigin(variant.assistantWorkerUrl);
+    return allowedVariantWorkerOrigin(
+      variant.assistantWorkerUrl,
+      variantWorkerHostname(slug),
+    );
   } catch {
     return null;
   }

--- a/src/api/v2/agents/lib/variant-routing.ts
+++ b/src/api/v2/agents/lib/variant-routing.ts
@@ -1,0 +1,52 @@
+import { prisma } from "@/utils/prisma";
+
+// A variant is live — routable + stampable — only while ready/building and not
+// expired. Mirrors the picker's GET filter so a client can't pin a failed/stale/
+// expired slug by passing it directly.
+export function liveVariantWhere(slug: string) {
+  return {
+    slug,
+    status: { in: ["ready", "building"] },
+    OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+  };
+}
+
+// Variant rows store a free-form URL; only our HTTPS dev ephemeral origins
+// (ephemeral-<slug>.convos.fun, default port) may receive a dispatch/poll and its
+// bearer token. Returns the canonical origin (scheme + host only) to route at, or
+// null to fall back to the default worker — normalizing to the origin means an
+// injected port, path, or query on an otherwise-trusted host can't redirect the
+// bearer. This pattern is a cross-repo contract with the convos-assistants
+// ephemeral host (EPHEMERAL_PREFIX + ROUTE_ZONE in scripts/ephemeral.ts,
+// registered by variant.yml) — keep the two in lockstep or variant routing
+// silently falls back.
+export function allowedVariantWorkerOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const allowed =
+      parsed.protocol === "https:" &&
+      (parsed.port === "" || parsed.port === "443") &&
+      /^ephemeral-[a-z0-9-]+\.convos\.fun$/.test(parsed.hostname);
+    return allowed ? parsed.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+// Resolve a variant slug to the allowed ephemeral worker origin to route at, or
+// null (unknown / retired / expired / off-host → default worker). A DB error
+// degrades to null rather than throwing. Callers gate on the dev network.
+export async function resolveVariantWorkerOrigin(
+  slug: string,
+): Promise<string | null> {
+  try {
+    const variant = await prisma.agentVariant.findFirst({
+      where: liveVariantWhere(slug),
+      select: { assistantWorkerUrl: true },
+    });
+    if (!variant?.assistantWorkerUrl) return null;
+    return allowedVariantWorkerOrigin(variant.assistantWorkerUrl);
+  } catch {
+    return null;
+  }
+}

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -23,6 +23,7 @@ import { accountsByIdRouter } from "./accounts/accountsByIdRouter";
 import { accountsMeRouter } from "./accounts/accountsMeRouter";
 import { meGuard } from "./accounts/middleware/meGuard";
 import { agentTemplatesRouter } from "./agent-templates/agent-templates.router";
+import { agentVariantsRouter } from "./agent-variants/agent-variants.router";
 import { agentsRouter } from "./agents/agents.router";
 import { agentAssetsRouter } from "./agents/assets/agent-assets.router";
 import { assetsRouter } from "./assets/assets.router";
@@ -58,6 +59,10 @@ if (process.env.XMTP_ENV !== "production") {
 }
 
 v2Router.use("/agent-templates", agentTemplatesRouter);
+
+// Per-PR agent variants. Per-route auth: GET is app-facing (authMiddleware,
+// dev-gated to []), POST/DELETE require the agent API key + dev-gate.
+v2Router.use("/agent-variants", agentVariantsRouter);
 
 v2Router.use("/invites", invitesV2Router);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,6 +147,12 @@ export const CONTENT_MODERATION_MODEL =
 export const BUILDER_EXA_SERVICE_KEY =
   process.env.BUILDER_EXA_SERVICE_KEY?.trim() || "";
 
+// Braintrust bench prompt store — backs per-PR agent variant builder-prompt
+// resolution (Axis B), project "convos-agent-bench". Optional: when unset,
+// variant builder-prompt resolution fails open and the generation falls back
+// to the canonical generator. Dev-only feature; never set on prod.
+export const BRAINTRUST_API_KEY = process.env.BRAINTRUST_API_KEY?.trim() || "";
+
 // Twitter reply composition (optional — only fires when twitterContext is
 // present on a generation). The twitter intent check reuses
 // CONTENT_MODERATION_MODEL (both are the same cheap-classifier knob).

--- a/src/config.ts
+++ b/src/config.ts
@@ -148,7 +148,7 @@ export const BUILDER_EXA_SERVICE_KEY =
   process.env.BUILDER_EXA_SERVICE_KEY?.trim() || "";
 
 // Braintrust bench prompt store — backs per-PR agent variant builder-prompt
-// resolution (Axis B), project "convos-agent-bench". Optional: when unset,
+// resolution, project "convos-agent-bench". Optional: when unset,
 // variant builder-prompt resolution fails open and the generation falls back
 // to the canonical generator. Dev-only feature; never set on prod.
 export const BRAINTRUST_API_KEY = process.env.BRAINTRUST_API_KEY?.trim() || "";

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,14 +66,6 @@ if (parsedAssistantUrl.protocol !== "https:" && !isLocalHost) {
   );
 }
 
-// Shared secret presented on the create route of ephemeral variant workers
-// (ephemeral-<slug>.convos.fun — the Axis-A runtime of a per-PR variant), which
-// gate that route on it. Must match the EPHEMERAL_CREATE_SECRET set on those
-// workers. Only used when a join routes to a variant's ephemeral worker; the
-// default/canonical worker ignores it. Dev-only; unset elsewhere.
-export const EPHEMERAL_CREATE_SECRET =
-  process.env.EPHEMERAL_CREATE_SECRET?.trim() || "";
-
 // Agent asset upload auth (optional — endpoint returns 503 if not configured)
 export const AGENT_ASSETS_API_KEY = process.env.AGENT_ASSETS_API_KEY || "";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,14 @@ if (parsedAssistantUrl.protocol !== "https:" && !isLocalHost) {
   );
 }
 
+// Shared secret presented on the create route of ephemeral variant workers
+// (ephemeral-<slug>.convos.fun — the Axis-A runtime of a per-PR variant), which
+// gate that route on it. Must match the EPHEMERAL_CREATE_SECRET set on those
+// workers. Only used when a join routes to a variant's ephemeral worker; the
+// default/canonical worker ignores it. Dev-only; unset elsewhere.
+export const EPHEMERAL_CREATE_SECRET =
+  process.env.EPHEMERAL_CREATE_SECRET?.trim() || "";
+
 // Agent asset upload auth (optional — endpoint returns 503 if not configured)
 export const AGENT_ASSETS_API_KEY = process.env.AGENT_ASSETS_API_KEY || "";
 

--- a/tests/agent-templates.bench-prompt.test.ts
+++ b/tests/agent-templates.bench-prompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { extractPromptText } from "@/api/v2/agent-templates/services/bench-prompt";
+
+describe("extractPromptText", () => {
+  test("reads a completion `content` string", () => {
+    expect(extractPromptText({ prompt: { content: "you are a bot" } })).toBe(
+      "you are a bot",
+    );
+  });
+
+  test("reads a completion `prompt` string", () => {
+    expect(extractPromptText({ prompt: { prompt: "system text" } })).toBe(
+      "system text",
+    );
+  });
+
+  test("joins chat `messages`, skipping non-string content", () => {
+    expect(
+      extractPromptText({
+        prompt: {
+          messages: [
+            { role: "system", content: "line one" },
+            { role: "user", content: "line two" },
+            { role: "assistant", content: { parts: ["ignored"] } },
+          ],
+        },
+      }),
+    ).toBe("line one\nline two");
+  });
+
+  test("returns empty string for missing/unknown shapes", () => {
+    expect(extractPromptText(null)).toBe("");
+    expect(extractPromptText({})).toBe("");
+    expect(extractPromptText({ prompt: {} })).toBe("");
+    expect(extractPromptText({ prompt: { messages: [] } })).toBe("");
+  });
+});

--- a/tests/agent-templates.bench-prompt.test.ts
+++ b/tests/agent-templates.bench-prompt.test.ts
@@ -28,6 +28,34 @@ describe("extractPromptText", () => {
     ).toBe("line one\nline two");
   });
 
+  test("reads array message `content`, joining text parts and skipping non-text", () => {
+    expect(
+      extractPromptText({
+        prompt: {
+          messages: [
+            {
+              role: "system",
+              content: [
+                { type: "text", text: "part one" },
+                { type: "image_url", image_url: { url: "ignored" } },
+                { type: "text", text: "part two" },
+              ],
+            },
+            { role: "user", content: "plain string still works" },
+          ],
+        },
+      }),
+    ).toBe("part one\npart two\nplain string still works");
+  });
+
+  test("reads a completion `content` array", () => {
+    expect(
+      extractPromptText({
+        prompt: { content: [{ type: "text", text: "you are a bot" }] },
+      }),
+    ).toBe("you are a bot");
+  });
+
   test("returns empty string for missing/unknown shapes", () => {
     expect(extractPromptText(null)).toBe("");
     expect(extractPromptText({})).toBe("");

--- a/tests/agent-templates.generations-contract.test.ts
+++ b/tests/agent-templates.generations-contract.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { bodySchema } from "@/api/v2/agent-templates/handlers/generations-post";
+import { assertLegacyShapeValidates } from "./helpers/assertLegacyShapeValidates";
+
+// Backwards-compatibility CONTRACT test for the generations request schema
+// (CLAUDE.md append-only rule). Adding `variantId` must not reject the shapes
+// shipped iOS builds already send. A future re-tightening fails CI here instead
+// of breaking users whose app can't be force-updated.
+describe("generations POST body schema — legacy client contract", () => {
+  test("legacy ios-app body (no variantId) still validates", () => {
+    const legacy = {
+      source: "ios-app",
+      inputs: { text: "make me a daily-trivia agent" },
+      clientDeviceId: "0192f0a1-1111-7222-8333-444455556666",
+      publishStatus: "unlisted",
+    };
+    assertLegacyShapeValidates(
+      bodySchema,
+      legacy,
+      "legacy ios-app generations body (no variantId)",
+    );
+  });
+
+  test("variantId is optional and accepted when present", () => {
+    const parsed = bodySchema.safeParse({
+      source: "ios-app",
+      inputs: { text: "x" },
+      variantId: "pr-1234",
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.variantId).toBe("pr-1234");
+    }
+  });
+
+  test("an unknown top-level key is still rejected (schema stays strict)", () => {
+    const parsed = bodySchema.safeParse({
+      source: "ios-app",
+      inputs: { text: "x" },
+      bogus: 1,
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/tests/agent-templates.generations-variant.test.ts
+++ b/tests/agent-templates.generations-variant.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the agent-variant (Axis B) seam in POST /generations.
+ *
+ * A `variantId` selects a registered variant; when it pins a bench builder-
+ * prompt slug, the backend resolves that slug to text (here via the bench-loader
+ * test override) and persists it as the generation row's `builderPrompt`. A
+ * variant with no slug, or an unknown variantId, degrades to the canonical
+ * generator (builderPrompt stays null). XMTP_ENV is "local" under tests/setup,
+ * so the dev-gate is open.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { __resetBenchPromptLoaderForTests } from "@/api/v2/agent-templates/services/bench-prompt";
+import { __resetGenerationExecutorForTests } from "@/api/v2/agent-templates/services/generation-executor";
+import { __resetModerationForTests } from "@/api/v2/agent-templates/services/moderation";
+import { __setOpenRouterModelsForTests } from "@/api/v2/agent-templates/services/openrouter-models";
+import { __resetPostHogForTests } from "@/api/v2/agent-templates/services/posthog";
+import {
+  __resetGenerateTemplateForTests,
+  DEFAULT_TEST_METRICS,
+} from "@/api/v2/agent-templates/services/templateGen";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  stableUuid,
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+import { makeFakeTemplate } from "./agent-templates.generation.helpers";
+
+const TEST_PORT = 4078;
+const TEST_SOURCE = "generations-variant-test";
+const SLUG_PREFIX = "pr-test-variant-gen-";
+const VARIANT_WITH_PROMPT = `${SLUG_PREFIX}axisb`;
+const VARIANT_RUNTIME_ONLY = `${SLUG_PREFIX}axisa`;
+const BENCH_SLUG = "qa-flow-v2";
+
+const fakeTemplate = makeFakeTemplate({
+  agentName: "Variant Test Agent",
+  description: "desc",
+  prompt: "prompt",
+});
+
+const headers = (key: string) => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+  "Idempotency-Key": stableUuid(key),
+});
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const post = (body: unknown, key: string) =>
+  fetch(`${baseURL}/api/v2/agent-templates/generations`, {
+    method: "POST",
+    headers: headers(key),
+    body: JSON.stringify(body),
+  });
+
+// The handler's create() omits builderPrompt from its select, so read it back
+// off the persisted row.
+async function latestBuilderPrompt(): Promise<string | null> {
+  const row = await prisma.agentTemplateGeneration.findFirst({
+    where: { ownerAccountId: ADMIN_ACCOUNT_ID, source: TEST_SOURCE },
+    select: { builderPrompt: true },
+    orderBy: { createdAt: "desc" },
+  });
+  return row?.builderPrompt ?? null;
+}
+
+async function cleanupGenerations() {
+  await prisma.agentTemplateGeneration.deleteMany({
+    where: { ownerAccountId: ADMIN_ACCOUNT_ID, source: TEST_SOURCE },
+  });
+}
+
+beforeAll(async () => {
+  __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+  __resetPostHogForTests(() => {});
+  __resetModerationForTests(() => Promise.resolve({ allowed: true }));
+  __setOpenRouterModelsForTests(["anthropic/claude-opus-4.8"]);
+  __resetGenerateTemplateForTests(() =>
+    Promise.resolve({ template: fakeTemplate, metrics: DEFAULT_TEST_METRICS }),
+  );
+  // Echo the bench slug so a test can assert which slug was resolved, without
+  // hitting Braintrust.
+  __resetBenchPromptLoaderForTests((slug) =>
+    Promise.resolve(`BUILDER PROMPT for ${slug}`),
+  );
+
+  await prisma.agentVariant.deleteMany({
+    where: { slug: { startsWith: SLUG_PREFIX } },
+  });
+  await prisma.agentVariant.createMany({
+    data: [
+      {
+        slug: VARIANT_WITH_PROMPT,
+        label: "Q+A",
+        whatToTest: "asks first",
+        status: "ready",
+        assistantWorkerUrl: `https://ephemeral-${VARIANT_WITH_PROMPT}.convos.fun`,
+        builderPromptSlug: BENCH_SLUG,
+        prUrl: "https://github.com/x/y/pull/1",
+        branch: "b",
+        commit: "c",
+      },
+      {
+        slug: VARIANT_RUNTIME_ONLY,
+        label: "Runtime",
+        whatToTest: "runtime only",
+        status: "ready",
+        assistantWorkerUrl: `https://ephemeral-${VARIANT_RUNTIME_ONLY}.convos.fun`,
+        builderPromptSlug: null,
+        prUrl: "https://github.com/x/y/pull/2",
+        branch: "b",
+        commit: "c",
+      },
+    ],
+  });
+
+  const server = await startAgentTemplatesServer(TEST_PORT);
+  baseURL = server.baseURL;
+  closeServer = server.close;
+});
+
+afterEach(async () => {
+  __resetGenerationExecutorForTests(null);
+  await cleanupGenerations();
+});
+
+afterAll(async () => {
+  __resetBenchPromptLoaderForTests(null);
+  __resetGenerateTemplateForTests(null);
+  __resetPostHogForTests(null);
+  __resetModerationForTests(null);
+  __setOpenRouterModelsForTests(null);
+  __setAgentAssetsApiKeyOverrideForTests(undefined);
+  await prisma.agentVariant.deleteMany({
+    where: { slug: { startsWith: SLUG_PREFIX } },
+  });
+  await closeServer();
+});
+
+describe("POST /generations — agent variant (Axis B)", () => {
+  test("a variant pinning a bench slug resolves into builderPrompt", async () => {
+    const res = await post(
+      {
+        source: TEST_SOURCE,
+        inputs: { text: "build me a trivia bot" },
+        variantId: VARIANT_WITH_PROMPT,
+      },
+      "variant-resolves",
+    );
+    expect([200, 202]).toContain(res.status);
+    expect(await latestBuilderPrompt()).toBe(
+      `BUILDER PROMPT for ${BENCH_SLUG}`,
+    );
+  });
+
+  test("a runtime-only variant (no slug) leaves builderPrompt null (canonical)", async () => {
+    const res = await post(
+      {
+        source: TEST_SOURCE,
+        inputs: { text: "build me a trivia bot" },
+        variantId: VARIANT_RUNTIME_ONLY,
+      },
+      "variant-runtime-only",
+    );
+    expect([200, 202]).toContain(res.status);
+    expect(await latestBuilderPrompt()).toBeNull();
+  });
+
+  test("an unknown variantId degrades to the canonical generator", async () => {
+    const res = await post(
+      {
+        source: TEST_SOURCE,
+        inputs: { text: "build me a trivia bot" },
+        variantId: `${SLUG_PREFIX}does-not-exist`,
+      },
+      "variant-unknown",
+    );
+    expect([200, 202]).toContain(res.status);
+    expect(await latestBuilderPrompt()).toBeNull();
+  });
+});

--- a/tests/agent-templates.generations-variant.test.ts
+++ b/tests/agent-templates.generations-variant.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the agent-variant (Axis B) seam in POST /generations.
+ * Tests for the agent-variant builder-prompt seam in POST /generations.
  *
  * A `variantId` selects a registered variant; when it pins a bench builder-
  * prompt slug, the backend resolves that slug to text (here via the bench-loader
@@ -142,7 +142,7 @@ afterAll(async () => {
   await closeServer();
 });
 
-describe("POST /generations — agent variant (Axis B)", () => {
+describe("POST /generations — agent variant builder prompt", () => {
   test("a variant pinning a bench slug resolves into builderPrompt", async () => {
     const res = await post(
       {

--- a/tests/agent-templates.generations-variant.test.ts
+++ b/tests/agent-templates.generations-variant.test.ts
@@ -183,4 +183,29 @@ describe("POST /generations — agent variant builder prompt", () => {
     expect([200, 202]).toContain(res.status);
     expect(await latestBuilderPrompt()).toBeNull();
   });
+
+  test("a bench-loader failure degrades to the canonical generator", async () => {
+    // The variant pins a bench slug, but resolving it throws (e.g. a Braintrust
+    // outage or a redirect). The generation must fall back to canonical, not 500.
+    __resetBenchPromptLoaderForTests(() =>
+      Promise.reject(new Error("braintrust unreachable")),
+    );
+    try {
+      const res = await post(
+        {
+          source: TEST_SOURCE,
+          inputs: { text: "build me a trivia bot" },
+          variantId: VARIANT_WITH_PROMPT,
+        },
+        "variant-loader-fail",
+      );
+      expect([200, 202]).toContain(res.status);
+      expect(await latestBuilderPrompt()).toBeNull();
+    } finally {
+      // Restore the success loader for any remaining tests.
+      __resetBenchPromptLoaderForTests((slug) =>
+        Promise.resolve(`BUILDER PROMPT for ${slug}`),
+      );
+    }
+  });
 });

--- a/tests/agent-variants.routes.test.ts
+++ b/tests/agent-variants.routes.test.ts
@@ -96,20 +96,55 @@ describe("POST /v2/agent-variants", () => {
 
   test("upserts (second POST on the same slug updates, not duplicates)", async () => {
     const slug = `${SLUG_PREFIX}upsert`;
-    await fetch(`${baseURL}/api/v2/agent-variants`, {
+    const first = await fetch(`${baseURL}/api/v2/agent-variants`, {
       method: "POST",
       headers: registryHeaders(AGENT_KEY),
       body: JSON.stringify(body(slug, { status: "building", commit: "old" })),
     });
+    expect(first.status).toBe(200);
     const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
       method: "POST",
       headers: registryHeaders(AGENT_KEY),
       body: JSON.stringify(body(slug, { status: "ready", commit: "new" })),
     });
     expect(res.status).toBe(200);
+    expect(await prisma.agentVariant.count({ where: { slug } })).toBe(1);
     const row = await prisma.agentVariant.findUnique({ where: { slug } });
     expect(row?.commit).toBe("new");
     expect(row?.status).toBe("ready");
+  });
+
+  test("a partial update preserves omitted optional fields (no clobber)", async () => {
+    const slug = `${SLUG_PREFIX}partial`;
+    const full = body(slug);
+    const created = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders(AGENT_KEY),
+      body: JSON.stringify(full),
+    });
+    expect(created.status).toBe(200);
+
+    // Re-POST omitting assistantWorkerUrl + builderPromptSlug. With the schema
+    // defaulting removed they stay undefined and Prisma leaves them untouched,
+    // rather than nulling out the stored runtime URL.
+    const updated = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders(AGENT_KEY),
+      body: JSON.stringify({
+        slug: full.slug,
+        label: full.label,
+        whatToTest: full.whatToTest,
+        prUrl: full.prUrl,
+        branch: full.branch,
+        commit: full.commit,
+        status: "building",
+      }),
+    });
+    expect(updated.status).toBe(200);
+    const row = await prisma.agentVariant.findUnique({ where: { slug } });
+    expect(row?.assistantWorkerUrl).toBe(full.assistantWorkerUrl);
+    expect(row?.builderPromptSlug).toBe("qa-flow-v2");
+    expect(row?.status).toBe("building");
   });
 
   test("401 without the registry key", async () => {

--- a/tests/agent-variants.routes.test.ts
+++ b/tests/agent-variants.routes.test.ts
@@ -1,0 +1,205 @@
+import type { Server } from "node:http";
+import express from "express";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { agentVariantsRouter } from "@/api/v2/agent-variants/agent-variants.router";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+// XMTP_ENV is "local" under tests/setup.ts, so the dev-gate is open — these
+// tests exercise the dev path (GET returns rows, mutations reach the auth
+// check). The prod branch (GET → [], mutations → 404) is a single
+// XMTP_ENV === "production" guard and isn't worth a module-mock here.
+
+const AGENT_KEY = "test-agent-api-key-that-is-at-least-32-characters";
+const SLUG_PREFIX = "pr-test-variant-";
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use("/api/v2/agent-variants", agentVariantsRouter);
+app.use(noRouteMiddleware);
+
+let server: Server;
+const baseURL = "http://localhost:4071";
+
+const cleanup = () =>
+  prisma.agentVariant.deleteMany({
+    where: { slug: { startsWith: SLUG_PREFIX } },
+  });
+
+const registryHeaders = (key: string | null) => ({
+  "Content-Type": "application/json",
+  ...(key === null ? {} : { "X-Agent-API-Key": key }),
+});
+
+const jwtHeaders = async () => ({
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-agent-variants",
+    accountId: ADMIN_ACCOUNT_ID,
+  }),
+});
+
+const body = (slug: string, over: Record<string, unknown> = {}) => ({
+  slug,
+  label: "Q+A",
+  whatToTest: "Asks clarifying questions first.",
+  status: "ready",
+  assistantWorkerUrl: `https://ephemeral-${slug}.convos.fun`,
+  builderPromptSlug: "qa-flow-v2",
+  prUrl: "https://github.com/xmtplabs/convos-assistants/pull/1",
+  branch: "saul/qa",
+  commit: "abc1234",
+  ...over,
+});
+
+beforeAll(async () => {
+  __setAgentAssetsApiKeyOverrideForTests(AGENT_KEY);
+  await new Promise<void>((resolve) => {
+    server = app.listen(4071, () => {
+      resolve();
+    });
+  });
+  await cleanup();
+});
+
+afterEach(cleanup);
+
+afterAll(async () => {
+  __setAgentAssetsApiKeyOverrideForTests(undefined);
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+});
+
+describe("POST /v2/agent-variants", () => {
+  test("creates a variant with the scoped registry key", async () => {
+    const slug = `${SLUG_PREFIX}create`;
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders(AGENT_KEY),
+      body: JSON.stringify(body(slug)),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.slug).toBe(slug);
+    expect(json.status).toBe("ready");
+    expect("updatedAt" in json).toBe(false);
+  });
+
+  test("upserts (second POST on the same slug updates, not duplicates)", async () => {
+    const slug = `${SLUG_PREFIX}upsert`;
+    await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders(AGENT_KEY),
+      body: JSON.stringify(body(slug, { status: "building", commit: "old" })),
+    });
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders(AGENT_KEY),
+      body: JSON.stringify(body(slug, { status: "ready", commit: "new" })),
+    });
+    expect(res.status).toBe(200);
+    const row = await prisma.agentVariant.findUnique({ where: { slug } });
+    expect(row?.commit).toBe("new");
+    expect(row?.status).toBe("ready");
+  });
+
+  test("401 without the registry key", async () => {
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders(null),
+      body: JSON.stringify(body(`${SLUG_PREFIX}noauth`)),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("401 with a wrong registry key", async () => {
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders("wrong-key-but-also-at-least-32-characters!!"),
+      body: JSON.stringify(body(`${SLUG_PREFIX}wrong`)),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("400 on an invalid body (unknown key)", async () => {
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      method: "POST",
+      headers: registryHeaders(AGENT_KEY),
+      body: JSON.stringify({ ...body(`${SLUG_PREFIX}bad`), bogus: 1 }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /v2/agent-variants", () => {
+  test("returns ready+building newest-first, excludes failed", async () => {
+    await prisma.agentVariant.createMany({
+      data: [
+        {
+          ...body(`${SLUG_PREFIX}old`, { status: "ready" }),
+          createdAt: new Date("2026-06-01T00:00:00.000Z"),
+        },
+        {
+          ...body(`${SLUG_PREFIX}new`, { status: "building" }),
+          createdAt: new Date("2026-06-20T00:00:00.000Z"),
+        },
+        { ...body(`${SLUG_PREFIX}gone`, { status: "failed" }) },
+      ],
+    });
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      headers: await jwtHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { slug: string }[] };
+    const slugs = json.data
+      .filter((v) => v.slug.startsWith(SLUG_PREFIX))
+      .map((v) => v.slug);
+    expect(slugs).toEqual([`${SLUG_PREFIX}new`, `${SLUG_PREFIX}old`]);
+    expect(slugs).not.toContain(`${SLUG_PREFIX}gone`);
+  });
+
+  test("401 without a JWT", async () => {
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /v2/agent-variants/:slug", () => {
+  test("deletes an existing variant (204) and is idempotent on a missing one", async () => {
+    const slug = `${SLUG_PREFIX}del`;
+    await prisma.agentVariant.create({ data: body(slug) });
+
+    const first = await fetch(`${baseURL}/api/v2/agent-variants/${slug}`, {
+      method: "DELETE",
+      headers: registryHeaders(AGENT_KEY),
+    });
+    expect(first.status).toBe(204);
+    expect(
+      await prisma.agentVariant.findUnique({ where: { slug } }),
+    ).toBeNull();
+
+    // Re-delete a now-missing slug — teardown is idempotent.
+    const second = await fetch(`${baseURL}/api/v2/agent-variants/${slug}`, {
+      method: "DELETE",
+      headers: registryHeaders(AGENT_KEY),
+    });
+    expect(second.status).toBe(204);
+  });
+
+  test("401 without the registry key", async () => {
+    const res = await fetch(
+      `${baseURL}/api/v2/agent-variants/${SLUG_PREFIX}x`,
+      { method: "DELETE", headers: registryHeaders(null) },
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/agent-variants.routes.test.ts
+++ b/tests/agent-variants.routes.test.ts
@@ -167,9 +167,21 @@ describe("GET /v2/agent-variants", () => {
     expect(slugs).not.toContain(`${SLUG_PREFIX}gone`);
   });
 
-  test("401 without a JWT", async () => {
+  test("401 without any credentials", async () => {
     const res = await fetch(`${baseURL}/api/v2/agent-variants`);
     expect(res.status).toBe(401);
+  });
+
+  test("also accepts the agent API key (the CI sweep's path)", async () => {
+    await prisma.agentVariant.create({
+      data: body(`${SLUG_PREFIX}agentkey`, { status: "ready" }),
+    });
+    const res = await fetch(`${baseURL}/api/v2/agent-variants`, {
+      headers: { "X-Agent-API-Key": AGENT_KEY },
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { slug: string }[] };
+    expect(json.data.map((v) => v.slug)).toContain(`${SLUG_PREFIX}agentkey`);
   });
 });
 

--- a/tests/agent-variants.schema.test.ts
+++ b/tests/agent-variants.schema.test.ts
@@ -21,10 +21,15 @@ describe("AgentVariantUpsertSchema", () => {
     expect(parsed.assistantWorkerUrl).toBe(
       "https://ephemeral-pr-1234.convos.fun",
     );
-    expect(parsed.expiresAt).toBeNull();
+    // expiresAt is omitted from `valid`; optional fields are not defaulted.
+    expect(parsed.expiresAt).toBeUndefined();
   });
 
-  test("defaults status, nullable axes, and expiresAt when omitted", () => {
+  test("leaves omitted optional fields undefined (not defaulted)", () => {
+    // Optional, NOT defaulted: omitted fields stay undefined so a partial upsert
+    // preserves the stored value (the handler spreads ...rest into the Prisma
+    // update, which skips undefined). Create-time gaps fall back to the Prisma
+    // column defaults instead.
     const parsed = AgentVariantUpsertSchema.parse({
       slug: "pr-1",
       label: "X",
@@ -33,10 +38,10 @@ describe("AgentVariantUpsertSchema", () => {
       branch: "b",
       commit: "c",
     });
-    expect(parsed.status).toBe("building");
-    expect(parsed.assistantWorkerUrl).toBeNull();
-    expect(parsed.builderPromptSlug).toBeNull();
-    expect(parsed.expiresAt).toBeNull();
+    expect(parsed.status).toBeUndefined();
+    expect(parsed.assistantWorkerUrl).toBeUndefined();
+    expect(parsed.builderPromptSlug).toBeUndefined();
+    expect(parsed.expiresAt).toBeUndefined();
   });
 
   test("rejects an unknown key (strict; server-to-server route)", () => {

--- a/tests/agent-variants.schema.test.ts
+++ b/tests/agent-variants.schema.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "vitest";
+import { AgentVariantUpsertSchema } from "@/api/v2/agent-variants/schemas";
+import { serializeAgentVariant } from "@/api/v2/agent-variants/serialize";
+
+const valid = {
+  slug: "pr-1234",
+  label: "Q+A",
+  whatToTest: "Agent asks clarifying questions before building.",
+  status: "ready",
+  assistantWorkerUrl: "https://ephemeral-pr-1234.convos.fun",
+  builderPromptSlug: "qa-flow-v2",
+  prUrl: "https://github.com/xmtplabs/convos-assistants/pull/1234",
+  branch: "saul/qa-flow",
+  commit: "b9adb65",
+};
+
+describe("AgentVariantUpsertSchema", () => {
+  test("accepts a full valid body", () => {
+    const parsed = AgentVariantUpsertSchema.parse(valid);
+    expect(parsed.slug).toBe("pr-1234");
+    expect(parsed.assistantWorkerUrl).toBe(
+      "https://ephemeral-pr-1234.convos.fun",
+    );
+    expect(parsed.expiresAt).toBeNull();
+  });
+
+  test("defaults status, nullable axes, and expiresAt when omitted", () => {
+    const parsed = AgentVariantUpsertSchema.parse({
+      slug: "pr-1",
+      label: "X",
+      whatToTest: "y",
+      prUrl: "https://github.com/x/y/pull/1",
+      branch: "b",
+      commit: "c",
+    });
+    expect(parsed.status).toBe("building");
+    expect(parsed.assistantWorkerUrl).toBeNull();
+    expect(parsed.builderPromptSlug).toBeNull();
+    expect(parsed.expiresAt).toBeNull();
+  });
+
+  test("rejects an unknown key (strict; server-to-server route)", () => {
+    expect(() =>
+      AgentVariantUpsertSchema.parse({ ...valid, bogus: 1 }),
+    ).toThrow();
+  });
+
+  test("rejects an out-of-set status", () => {
+    expect(() =>
+      AgentVariantUpsertSchema.parse({ ...valid, status: "live" }),
+    ).toThrow();
+  });
+
+  test("rejects a non-url assistantWorkerUrl and prUrl", () => {
+    expect(() =>
+      AgentVariantUpsertSchema.parse({ ...valid, assistantWorkerUrl: "nope" }),
+    ).toThrow();
+    expect(() =>
+      AgentVariantUpsertSchema.parse({ ...valid, prUrl: "nope" }),
+    ).toThrow();
+  });
+
+  test("rejects a slug with illegal characters", () => {
+    expect(() =>
+      AgentVariantUpsertSchema.parse({ ...valid, slug: "PR_1234" }),
+    ).toThrow();
+  });
+
+  test("coerces expiresAt to a Date", () => {
+    const parsed = AgentVariantUpsertSchema.parse({
+      ...valid,
+      expiresAt: "2026-07-01T00:00:00.000Z",
+    });
+    expect(parsed.expiresAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("serializeAgentVariant", () => {
+  test("emits ISO date strings and preserves nulls", () => {
+    const out = serializeAgentVariant({
+      slug: "pr-9",
+      label: "L",
+      whatToTest: "w",
+      status: "building",
+      assistantWorkerUrl: null,
+      builderPromptSlug: null,
+      prUrl: "https://github.com/x/y/pull/9",
+      branch: "b",
+      commit: "c",
+      expiresAt: null,
+      createdAt: new Date("2026-06-24T12:00:00.000Z"),
+      updatedAt: new Date("2026-06-24T12:00:00.000Z"),
+    });
+    expect(out.assistantWorkerUrl).toBeNull();
+    expect(out.expiresAt).toBeNull();
+    expect(out.createdAt).toBe("2026-06-24T12:00:00.000Z");
+    // updatedAt is internal — not part of the wire shape.
+    expect("updatedAt" in out).toBe(false);
+  });
+});

--- a/tests/agents-join-contract.test.ts
+++ b/tests/agents-join-contract.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { bodySchema } from "@/api/v2/agents/handlers/join";
+import { assertLegacyShapeValidates } from "./helpers/assertLegacyShapeValidates";
+
+// Backwards-compatibility CONTRACT test for the agents/join request schema
+// (CLAUDE.md append-only rule). Adding `options.variantId` must not reject the
+// shapes shipped iOS builds already send. A future re-tightening fails CI here
+// instead of breaking users whose app can't be force-updated.
+describe("agents/join body schema — legacy client contract", () => {
+  test("legacy invite join (slug + options, no variantId) still validates", () => {
+    assertLegacyShapeValidates(
+      bodySchema,
+      {
+        slug: "join-token-abc123",
+        options: { skipGreeting: true, onboarding: "agent-builder" },
+      },
+      "legacy join body (no variantId)",
+    );
+  });
+
+  test("legacy direct-add join (conversationId only) still validates", () => {
+    assertLegacyShapeValidates(
+      bodySchema,
+      { conversationId: "deadbeefcafe1234" },
+      "legacy direct-add join body",
+    );
+  });
+
+  test("variantId is optional and accepted on options", () => {
+    const parsed = bodySchema.safeParse({
+      slug: "join-token-abc123",
+      options: { variantId: "pr-1234" },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("an unknown option key is still rejected (options stays strict)", () => {
+    const parsed = bodySchema.safeParse({
+      slug: "join-token-abc123",
+      options: { bogus: 1 },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -314,9 +314,12 @@ describe("POST /agents/join — agent variant runtime routing", () => {
   });
 
   test("a variant lookup DB error degrades to the default worker (no 500)", async () => {
+    // Reject only the single lookup this join makes (mockRejectedValueOnce): the
+    // spy then calls through to the real findFirst, so later tests aren't left
+    // with a rejecting mock if mockRestore is unreliable for the prisma method.
     const findFirstSpy = vi
       .spyOn(prisma.agentVariant, "findFirst")
-      .mockRejectedValue(new Error("db unreachable"));
+      .mockRejectedValueOnce(new Error("db unreachable"));
     try {
       const res = await post({
         slug: "join-token-jkl",

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -36,7 +36,13 @@ const VARIANT_SLUG = "pr-test-join-variant";
 const VARIANT_URL = `https://ephemeral-${VARIANT_SLUG}.convos.fun`;
 const RUNTIME_DEFAULT_SLUG = "pr-test-join-axisb";
 const BAD_URL_SLUG = "pr-test-join-badurl";
-const ALL_SLUGS = [VARIANT_SLUG, RUNTIME_DEFAULT_SLUG, BAD_URL_SLUG];
+const FAILED_SLUG = "pr-test-join-failed";
+const ALL_SLUGS = [
+  VARIANT_SLUG,
+  RUNTIME_DEFAULT_SLUG,
+  BAD_URL_SLUG,
+  FAILED_SLUG,
+];
 const DEFAULT_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 
 type RecordedCall = {
@@ -156,6 +162,18 @@ beforeAll(async () => {
         branch: "b",
         commit: "c",
       },
+      {
+        // A non-live (failed) variant must be ignored even with a valid URL.
+        slug: FAILED_SLUG,
+        label: "Failed",
+        whatToTest: "retired runtime",
+        status: "failed",
+        assistantWorkerUrl: `https://ephemeral-${FAILED_SLUG}.convos.fun`,
+        builderPromptSlug: null,
+        prUrl: "https://github.com/x/y/pull/4",
+        branch: "b",
+        commit: "c",
+      },
     ],
   });
   await new Promise<void>((resolve) => {
@@ -251,6 +269,20 @@ describe("POST /agents/join — agent variant runtime routing", () => {
     expect(JSON.parse(meta?.variant ?? "{}")).toMatchObject({
       slug: BAD_URL_SLUG,
     });
+  });
+
+  test("a non-live (failed) variant is ignored and routes to the default", async () => {
+    const res = await post({
+      slug: "join-token-mno",
+      options: { variantId: FAILED_SLUG },
+    });
+    expect(res.status).toBeLessThan(500);
+
+    const dispatch = postDispatch();
+    if (!dispatch) throw new Error("no POST dispatch recorded");
+    // Filtered out by status, so no routing and no descriptor stamp.
+    expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
+    expect(dispatch.body?.metadata).toBeUndefined();
   });
 
   test("a variant lookup DB error degrades to the default worker (no 500)", async () => {

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -286,8 +286,8 @@ describe("POST /agents/join — agent variant runtime routing", () => {
   });
 
   test("a variant lookup DB error degrades to the default worker (no 500)", async () => {
-    const findUniqueSpy = vi
-      .spyOn(prisma.agentVariant, "findUnique")
+    const findFirstSpy = vi
+      .spyOn(prisma.agentVariant, "findFirst")
       .mockRejectedValue(new Error("db unreachable"));
     try {
       const res = await post({
@@ -300,7 +300,43 @@ describe("POST /agents/join — agent variant runtime routing", () => {
       expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
       expect(dispatch.body?.metadata).toBeUndefined();
     } finally {
-      findUniqueSpy.mockRestore();
+      findFirstSpy.mockRestore();
     }
+  });
+});
+
+describe("GET /agents/join/:instanceId — variant status routing", () => {
+  test("polls the variant worker when the client carries variantId", async () => {
+    const res = await originalFetch(
+      `${baseURL}/api/v2/agents/join/inst-x?variantId=${VARIANT_SLUG}`,
+    );
+    expect(res.status).toBe(200);
+    const statusGet = calls.find(
+      (c) => c.method === "GET" && c.url.includes("/api/assistants/inst-x"),
+    );
+    if (!statusGet) throw new Error("no status GET recorded");
+    expect(statusGet.url).toBe(`${VARIANT_URL}/api/assistants/inst-x`);
+  });
+
+  test("polls the default worker without variantId", async () => {
+    const res = await originalFetch(`${baseURL}/api/v2/agents/join/inst-y`);
+    expect(res.status).toBe(200);
+    const statusGet = calls.find(
+      (c) => c.method === "GET" && c.url.includes("/api/assistants/inst-y"),
+    );
+    if (!statusGet) throw new Error("no status GET recorded");
+    expect(statusGet.url).toBe(`${DEFAULT_URL}/api/assistants/inst-y`);
+  });
+
+  test("falls back to the default worker for a non-live variant", async () => {
+    const res = await originalFetch(
+      `${baseURL}/api/v2/agents/join/inst-z?variantId=${FAILED_SLUG}`,
+    );
+    expect(res.status).toBe(200);
+    const statusGet = calls.find(
+      (c) => c.method === "GET" && c.url.includes("/api/assistants/inst-z"),
+    );
+    if (!statusGet) throw new Error("no status GET recorded");
+    expect(statusGet.url).toBe(`${DEFAULT_URL}/api/assistants/inst-z`);
   });
 });

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -312,28 +312,6 @@ describe("POST /agents/join — agent variant runtime routing", () => {
     // Host is a valid ephemeral but not THIS variant's — bearer stays on default.
     expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
   });
-
-  test("a variant lookup DB error degrades to the default worker (no 500)", async () => {
-    // Reject only the single lookup this join makes (mockRejectedValueOnce): the
-    // spy then calls through to the real findFirst, so later tests aren't left
-    // with a rejecting mock if mockRestore is unreliable for the prisma method.
-    const findFirstSpy = vi
-      .spyOn(prisma.agentVariant, "findFirst")
-      .mockRejectedValueOnce(new Error("db unreachable"));
-    try {
-      const res = await post({
-        slug: "join-token-jkl",
-        options: { variantId: VARIANT_SLUG },
-      });
-      expect(res.status).toBeLessThan(500);
-      const dispatch = postDispatch();
-      if (!dispatch) throw new Error("no POST dispatch recorded");
-      expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
-      expect(dispatch.body?.metadata).toBeUndefined();
-    } finally {
-      findFirstSpy.mockRestore();
-    }
-  });
 });
 
 describe("GET /agents/join/:instanceId — variant status routing", () => {
@@ -369,5 +347,31 @@ describe("GET /agents/join/:instanceId — variant status routing", () => {
     );
     if (!statusGet) throw new Error("no status GET recorded");
     expect(statusGet.url).toBe(`${DEFAULT_URL}/api/assistants/inst-z`);
+  });
+});
+
+// Placed last on purpose: this spies the shared prisma.agentVariant.findFirst,
+// and mockRestore is unreliable for the prisma delegate method here — so running
+// it before the routing tests leaks a stubbed findFirst into them. With it last,
+// no test runs after, and the file isolation (singleFork + isolate) keeps it
+// from bleeding into other files.
+describe("POST /agents/join — variant lookup degradation", () => {
+  test("a DB error on the variant lookup degrades to the default worker", async () => {
+    const findFirstSpy = vi
+      .spyOn(prisma.agentVariant, "findFirst")
+      .mockRejectedValueOnce(new Error("db unreachable"));
+    try {
+      const res = await post({
+        slug: "join-token-jkl",
+        options: { variantId: VARIANT_SLUG },
+      });
+      expect(res.status).toBeLessThan(500);
+      const dispatch = postDispatch();
+      if (!dispatch) throw new Error("no POST dispatch recorded");
+      expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
+      expect(dispatch.body?.metadata).toBeUndefined();
+    } finally {
+      findFirstSpy.mockRestore();
+    }
   });
 });

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -22,6 +22,7 @@ import {
   describe,
   expect,
   test,
+  vi,
 } from "vitest";
 import { __setAssistantConfigOverridesForTests } from "@/api/v2/agents/handlers/assistant-config";
 import { joinHandler } from "@/api/v2/agents/handlers/join";
@@ -253,11 +254,9 @@ describe("POST /agents/join — agent variant runtime routing", () => {
   });
 
   test("a variant lookup DB error degrades to the default worker (no 500)", async () => {
-    const variantModel = prisma.agentVariant as unknown as {
-      findUnique: (...args: unknown[]) => Promise<unknown>;
-    };
-    const original = variantModel.findUnique;
-    variantModel.findUnique = () => Promise.reject(new Error("db unreachable"));
+    const findUniqueSpy = vi
+      .spyOn(prisma.agentVariant, "findUnique")
+      .mockRejectedValue(new Error("db unreachable"));
     try {
       const res = await post({
         slug: "join-token-jkl",
@@ -269,7 +268,7 @@ describe("POST /agents/join — agent variant runtime routing", () => {
       expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
       expect(dispatch.body?.metadata).toBeUndefined();
     } finally {
-      variantModel.findUnique = original;
+      findUniqueSpy.mockRestore();
     }
   });
 });

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -34,6 +34,8 @@ const DEFAULT_URL = "https://assistants.test.local";
 const VARIANT_SLUG = "pr-test-join-variant";
 const VARIANT_URL = `https://ephemeral-${VARIANT_SLUG}.convos.fun`;
 const RUNTIME_DEFAULT_SLUG = "pr-test-join-axisb";
+const BAD_URL_SLUG = "pr-test-join-badurl";
+const ALL_SLUGS = [VARIANT_SLUG, RUNTIME_DEFAULT_SLUG, BAD_URL_SLUG];
 const DEFAULT_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 
 type RecordedCall = {
@@ -113,7 +115,7 @@ const postDispatch = () => calls.find((c) => c.method === "POST");
 
 beforeAll(async () => {
   await prisma.agentVariant.deleteMany({
-    where: { slug: { in: [VARIANT_SLUG, RUNTIME_DEFAULT_SLUG] } },
+    where: { slug: { in: ALL_SLUGS } },
   });
   await prisma.agentVariant.createMany({
     data: [
@@ -140,6 +142,19 @@ beforeAll(async () => {
         branch: "b",
         commit: "c",
       },
+      {
+        // Untrusted worker URL (not an ephemeral-*.convos.fun origin) → the join
+        // must NOT send the bearer there; it falls back to the default worker.
+        slug: BAD_URL_SLUG,
+        label: "Bad URL",
+        whatToTest: "untrusted worker origin",
+        status: "ready",
+        assistantWorkerUrl: "https://evil.example.com",
+        builderPromptSlug: null,
+        prUrl: "https://github.com/x/y/pull/3",
+        branch: "b",
+        commit: "c",
+      },
     ],
   });
   await new Promise<void>((resolve) => {
@@ -158,7 +173,7 @@ afterAll(async () => {
   globalThis.fetch = originalFetch;
   __setAssistantConfigOverridesForTests({});
   await prisma.agentVariant.deleteMany({
-    where: { slug: { in: [VARIANT_SLUG, RUNTIME_DEFAULT_SLUG] } },
+    where: { slug: { in: ALL_SLUGS } },
   });
   await new Promise<void>((resolve) => {
     server.close(() => {
@@ -217,5 +232,44 @@ describe("POST /agents/join — agent variant runtime routing", () => {
     const dispatch = postDispatch();
     if (!dispatch) throw new Error("no POST dispatch recorded");
     expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
+  });
+
+  test("a non-allowlisted worker URL routes to the default and still stamps", async () => {
+    const res = await post({
+      slug: "join-token-ghi",
+      options: { variantId: BAD_URL_SLUG },
+    });
+    expect(res.status).toBeLessThan(500);
+
+    const dispatch = postDispatch();
+    if (!dispatch) throw new Error("no POST dispatch recorded");
+    // The untrusted URL never receives the dispatch (nor its bearer token).
+    expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
+    // The descriptor stamp still applies, as for a default-runtime variant.
+    const meta = dispatch.body?.metadata as { variant?: string } | undefined;
+    expect(JSON.parse(meta?.variant ?? "{}")).toMatchObject({
+      slug: BAD_URL_SLUG,
+    });
+  });
+
+  test("a variant lookup DB error degrades to the default worker (no 500)", async () => {
+    const variantModel = prisma.agentVariant as unknown as {
+      findUnique: (...args: unknown[]) => Promise<unknown>;
+    };
+    const original = variantModel.findUnique;
+    variantModel.findUnique = () => Promise.reject(new Error("db unreachable"));
+    try {
+      const res = await post({
+        slug: "join-token-jkl",
+        options: { variantId: VARIANT_SLUG },
+      });
+      expect(res.status).toBeLessThan(500);
+      const dispatch = postDispatch();
+      if (!dispatch) throw new Error("no POST dispatch recorded");
+      expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
+      expect(dispatch.body?.metadata).toBeUndefined();
+    } finally {
+      variantModel.findUnique = original;
+    }
   });
 });

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -3,10 +3,10 @@
  *
  * When a join carries options.variantId for a registered variant with an
  * ephemeral worker, the dispatch must (1) route to the variant's worker instead
- * of the default, (2) present the ephemeral create secret (F7), (3) carry
- * metadata.variant for the profile stamp, and (4) NOT forward variantId in the
- * options the runtime sees. XMTP_ENV is "local" under tests/setup, so the
- * dev-gate is open. Needs the test DB (the variant row); runs in CI.
+ * of the default, (2) carry metadata.variant for the profile stamp, and (3) NOT
+ * forward variantId in the options the runtime sees. XMTP_ENV is "local" under
+ * tests/setup, so the dev-gate is open. Needs the test DB (the variant row);
+ * runs in CI.
  */
 
 import type { Server } from "node:http";
@@ -34,7 +34,6 @@ const DEFAULT_URL = "https://assistants.test.local";
 const VARIANT_SLUG = "pr-test-join-variant";
 const VARIANT_URL = `https://ephemeral-${VARIANT_SLUG}.convos.fun`;
 const RUNTIME_DEFAULT_SLUG = "pr-test-join-axisb";
-const EXPECTED_SECRET = "test-ephemeral-create-secret"; // tests/setup.ts default
 const DEFAULT_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 
 type RecordedCall = {
@@ -182,7 +181,7 @@ beforeEach(() => {
 });
 
 describe("POST /agents/join — agent variant routing (Axis A)", () => {
-  test("routes to the variant worker, presents the secret, stamps metadata, strips variantId", async () => {
+  test("routes to the variant worker, stamps metadata, strips variantId", async () => {
     const res = await post({
       slug: "join-token-abc",
       options: { variantId: VARIANT_SLUG, skipGreeting: true },
@@ -194,9 +193,7 @@ describe("POST /agents/join — agent variant routing (Axis A)", () => {
 
     // (1) routed to the variant's ephemeral worker, not the default
     expect(dispatch.url).toBe(`${VARIANT_URL}/api/assistants`);
-    // (2) presented the ephemeral create secret (F7)
-    expect(dispatch.headers["x-ephemeral-create-secret"]).toBe(EXPECTED_SECRET);
-    // (3) carried the variant descriptor for the profile stamp
+    // (2) carried the variant descriptor for the profile stamp
     const meta = dispatch.body?.metadata as { variant?: string } | undefined;
     expect(meta?.variant).toBeTruthy();
     expect(JSON.parse(meta?.variant ?? "{}")).toMatchObject({
@@ -204,13 +201,13 @@ describe("POST /agents/join — agent variant routing (Axis A)", () => {
       label: "Q+A",
       prUrl: "https://github.com/x/y/pull/1",
     });
-    // (4) variantId is NOT forwarded to the runtime; skipGreeting still is
+    // (3) variantId is NOT forwarded to the runtime; skipGreeting still is
     const opts = (dispatch.body?.options ?? {}) as Record<string, unknown>;
     expect(opts).not.toHaveProperty("variantId");
     expect(opts.skipGreeting).toBe(true);
   });
 
-  test("an Axis-B-only variant (no worker) routes to the default, no secret", async () => {
+  test("an Axis-B-only variant (no worker) routes to the default", async () => {
     const res = await post({
       slug: "join-token-def",
       options: { variantId: RUNTIME_DEFAULT_SLUG },
@@ -220,6 +217,5 @@ describe("POST /agents/join — agent variant routing (Axis A)", () => {
     const dispatch = postDispatch();
     if (!dispatch) throw new Error("no POST dispatch recorded");
     expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
-    expect(dispatch.headers["x-ephemeral-create-secret"]).toBeUndefined();
   });
 });

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the agent-variant (Axis A) routing seam in POST /agents/join.
+ *
+ * When a join carries options.variantId for a registered variant with an
+ * ephemeral worker, the dispatch must (1) route to the variant's worker instead
+ * of the default, (2) present the ephemeral create secret (F7), (3) carry
+ * metadata.variant for the profile stamp, and (4) NOT forward variantId in the
+ * options the runtime sees. XMTP_ENV is "local" under tests/setup, so the
+ * dev-gate is open. Needs the test DB (the variant row); runs in CI.
+ */
+
+import type { Server } from "node:http";
+import express, {
+  type Response as ExpressResponse,
+  type NextFunction,
+  type Request,
+} from "express";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { __setAssistantConfigOverridesForTests } from "@/api/v2/agents/handlers/assistant-config";
+import { joinHandler } from "@/api/v2/agents/handlers/join";
+import { joinStatusHandler } from "@/api/v2/agents/handlers/join-status";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+
+const DEFAULT_URL = "https://assistants.test.local";
+const VARIANT_SLUG = "pr-test-join-variant";
+const VARIANT_URL = `https://ephemeral-${VARIANT_SLUG}.convos.fun`;
+const RUNTIME_DEFAULT_SLUG = "pr-test-join-axisb";
+const EXPECTED_SECRET = "test-ephemeral-create-secret"; // tests/setup.ts default
+const DEFAULT_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+
+type RecordedCall = {
+  url: string;
+  method?: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown> | null;
+};
+const calls: RecordedCall[] = [];
+
+let mockFetchImpl: (url: string, init?: RequestInit) => Promise<Response>;
+const originalFetch = globalThis.fetch;
+
+function testAccountMiddleware(
+  _req: Request,
+  res: ExpressResponse,
+  next: NextFunction,
+) {
+  res.locals.accountId = DEFAULT_ACCOUNT_ID;
+  next();
+}
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use(testAccountMiddleware);
+app.post("/api/v2/agents/join", joinHandler);
+app.get("/api/v2/agents/join/:instanceId", joinStatusHandler);
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function record(url: string, init?: RequestInit): void {
+  calls.push({
+    url,
+    method: init?.method,
+    headers: (init?.headers ?? {}) as Record<string, string>,
+    body:
+      typeof init?.body === "string"
+        ? (JSON.parse(init.body) as Record<string, unknown>)
+        : null,
+  });
+}
+
+// Record every call, then respond: POST → { instanceId }, GET (status poll) →
+// joined, so the handler completes.
+function defaultMock(url: string, init?: RequestInit): Promise<Response> {
+  record(url, init);
+  if (init?.method === "POST") {
+    return Promise.resolve(jsonResponse(200, { instanceId: "inst-variant" }));
+  }
+  return Promise.resolve(
+    jsonResponse(200, {
+      instanceId: "inst-variant",
+      joinStatus: "joined",
+      inboxId: "inbox-variant",
+      conversationId: "conv-variant",
+    }),
+  );
+}
+
+let server: Server;
+let baseURL: string;
+
+const post = (body: unknown) =>
+  originalFetch(`${baseURL}/api/v2/agents/join`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const postDispatch = () => calls.find((c) => c.method === "POST");
+
+beforeAll(async () => {
+  await prisma.agentVariant.deleteMany({
+    where: { slug: { in: [VARIANT_SLUG, RUNTIME_DEFAULT_SLUG] } },
+  });
+  await prisma.agentVariant.createMany({
+    data: [
+      {
+        slug: VARIANT_SLUG,
+        label: "Q+A",
+        whatToTest: "asks first",
+        status: "ready",
+        assistantWorkerUrl: VARIANT_URL,
+        builderPromptSlug: "qa-flow-v2",
+        prUrl: "https://github.com/x/y/pull/1",
+        branch: "b",
+        commit: "c",
+      },
+      {
+        // Axis-B-only variant: no ephemeral worker → routes to the default.
+        slug: RUNTIME_DEFAULT_SLUG,
+        label: "Prompt only",
+        whatToTest: "builder prompt only",
+        status: "ready",
+        assistantWorkerUrl: null,
+        builderPromptSlug: "qa-flow-v2",
+        prUrl: "https://github.com/x/y/pull/2",
+        branch: "b",
+        commit: "c",
+      },
+    ],
+  });
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("Failed to resolve test server address");
+      }
+      baseURL = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  globalThis.fetch = originalFetch;
+  __setAssistantConfigOverridesForTests({});
+  await prisma.agentVariant.deleteMany({
+    where: { slug: { in: [VARIANT_SLUG, RUNTIME_DEFAULT_SLUG] } },
+  });
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+});
+
+beforeEach(() => {
+  calls.length = 0;
+  __setAssistantConfigOverridesForTests({
+    assistantApiUrl: DEFAULT_URL,
+    assistantApiKey: "test-assistant-key",
+    joinWaitBudgetMs: 200,
+    joinPollIntervalMs: 20,
+  });
+  mockFetchImpl = defaultMock;
+  globalThis.fetch = ((url: string, init?: RequestInit) =>
+    mockFetchImpl(url, init)) as typeof fetch;
+});
+
+describe("POST /agents/join — agent variant routing (Axis A)", () => {
+  test("routes to the variant worker, presents the secret, stamps metadata, strips variantId", async () => {
+    const res = await post({
+      slug: "join-token-abc",
+      options: { variantId: VARIANT_SLUG, skipGreeting: true },
+    });
+    expect(res.status).toBeLessThan(500);
+
+    const dispatch = postDispatch();
+    if (!dispatch) throw new Error("no POST dispatch recorded");
+
+    // (1) routed to the variant's ephemeral worker, not the default
+    expect(dispatch.url).toBe(`${VARIANT_URL}/api/assistants`);
+    // (2) presented the ephemeral create secret (F7)
+    expect(dispatch.headers["x-ephemeral-create-secret"]).toBe(EXPECTED_SECRET);
+    // (3) carried the variant descriptor for the profile stamp
+    const meta = dispatch.body?.metadata as { variant?: string } | undefined;
+    expect(meta?.variant).toBeTruthy();
+    expect(JSON.parse(meta?.variant ?? "{}")).toMatchObject({
+      slug: VARIANT_SLUG,
+      label: "Q+A",
+      prUrl: "https://github.com/x/y/pull/1",
+    });
+    // (4) variantId is NOT forwarded to the runtime; skipGreeting still is
+    const opts = (dispatch.body?.options ?? {}) as Record<string, unknown>;
+    expect(opts).not.toHaveProperty("variantId");
+    expect(opts.skipGreeting).toBe(true);
+  });
+
+  test("an Axis-B-only variant (no worker) routes to the default, no secret", async () => {
+    const res = await post({
+      slug: "join-token-def",
+      options: { variantId: RUNTIME_DEFAULT_SLUG },
+    });
+    expect(res.status).toBeLessThan(500);
+
+    const dispatch = postDispatch();
+    if (!dispatch) throw new Error("no POST dispatch recorded");
+    expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
+    expect(dispatch.headers["x-ephemeral-create-secret"]).toBeUndefined();
+  });
+});

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -37,11 +37,13 @@ const VARIANT_URL = `https://ephemeral-${VARIANT_SLUG}.convos.fun`;
 const RUNTIME_DEFAULT_SLUG = "pr-test-join-axisb";
 const BAD_URL_SLUG = "pr-test-join-badurl";
 const FAILED_SLUG = "pr-test-join-failed";
+const MISMATCH_SLUG = "pr-test-join-mismatch";
 const ALL_SLUGS = [
   VARIANT_SLUG,
   RUNTIME_DEFAULT_SLUG,
   BAD_URL_SLUG,
   FAILED_SLUG,
+  MISMATCH_SLUG,
 ];
 const DEFAULT_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -174,6 +176,19 @@ beforeAll(async () => {
         branch: "b",
         commit: "c",
       },
+      {
+        // Valid ephemeral host, but for a DIFFERENT slug — the bearer must not
+        // go cross-PR, so this routes to the default worker.
+        slug: MISMATCH_SLUG,
+        label: "Mismatch",
+        whatToTest: "host points at another slug",
+        status: "ready",
+        assistantWorkerUrl: "https://ephemeral-pr-test-join-other.convos.fun",
+        builderPromptSlug: null,
+        prUrl: "https://github.com/x/y/pull/5",
+        branch: "b",
+        commit: "c",
+      },
     ],
   });
   await new Promise<void>((resolve) => {
@@ -283,6 +298,19 @@ describe("POST /agents/join — agent variant runtime routing", () => {
     // Filtered out by status, so no routing and no descriptor stamp.
     expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
     expect(dispatch.body?.metadata).toBeUndefined();
+  });
+
+  test("a variant whose worker host is a different slug routes to the default", async () => {
+    const res = await post({
+      slug: "join-token-pqr",
+      options: { variantId: MISMATCH_SLUG },
+    });
+    expect(res.status).toBeLessThan(500);
+
+    const dispatch = postDispatch();
+    if (!dispatch) throw new Error("no POST dispatch recorded");
+    // Host is a valid ephemeral but not THIS variant's — bearer stays on default.
+    expect(dispatch.url).toBe(`${DEFAULT_URL}/api/assistants`);
   });
 
   test("a variant lookup DB error degrades to the default worker (no 500)", async () => {

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the agent-variant (Axis A) routing seam in POST /agents/join.
+ * Tests for the agent-variant runtime-routing seam in POST /agents/join.
  *
  * When a join carries options.variantId for a registered variant with an
  * ephemeral worker, the dispatch must (1) route to the variant's worker instead
@@ -129,7 +129,7 @@ beforeAll(async () => {
         commit: "c",
       },
       {
-        // Axis-B-only variant: no ephemeral worker → routes to the default.
+        // Builder-prompt-only variant: no ephemeral worker → routes to the default.
         slug: RUNTIME_DEFAULT_SLUG,
         label: "Prompt only",
         whatToTest: "builder prompt only",
@@ -180,7 +180,7 @@ beforeEach(() => {
     mockFetchImpl(url, init)) as typeof fetch;
 });
 
-describe("POST /agents/join — agent variant routing (Axis A)", () => {
+describe("POST /agents/join — agent variant runtime routing", () => {
   test("routes to the variant worker, stamps metadata, strips variantId", async () => {
     const res = await post({
       slug: "join-token-abc",
@@ -207,7 +207,7 @@ describe("POST /agents/join — agent variant routing (Axis A)", () => {
     expect(opts.skipGreeting).toBe(true);
   });
 
-  test("an Axis-B-only variant (no worker) routes to the default", async () => {
+  test("a builder-prompt-only variant (no worker) routes to the default", async () => {
     const res = await post({
       slug: "join-token-def",
       options: { variantId: RUNTIME_DEFAULT_SLUG },

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -34,10 +34,6 @@ process.env.ASSISTANT_API_URL =
   process.env.ASSISTANT_API_URL || "https://assistants.test.local";
 process.env.ASSISTANT_API_KEY =
   process.env.ASSISTANT_API_KEY || "test-assistant-key";
-// Presented to ephemeral variant workers on join dispatch (F7); the variant
-// routing test asserts it rides the dispatch headers.
-process.env.EPHEMERAL_CREATE_SECRET =
-  process.env.EPHEMERAL_CREATE_SECRET || "test-ephemeral-create-secret";
 // Shrink the server-side join wait so tests don't burn 25s each.
 process.env.ASSISTANT_JOIN_WAIT_BUDGET_MS =
   process.env.ASSISTANT_JOIN_WAIT_BUDGET_MS || "200";

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -34,6 +34,10 @@ process.env.ASSISTANT_API_URL =
   process.env.ASSISTANT_API_URL || "https://assistants.test.local";
 process.env.ASSISTANT_API_KEY =
   process.env.ASSISTANT_API_KEY || "test-assistant-key";
+// Presented to ephemeral variant workers on join dispatch (F7); the variant
+// routing test asserts it rides the dispatch headers.
+process.env.EPHEMERAL_CREATE_SECRET =
+  process.env.EPHEMERAL_CREATE_SECRET || "test-ephemeral-create-secret";
 // Shrink the server-side join wait so tests don't burn 25s each.
 process.env.ASSISTANT_JOIN_WAIT_BUDGET_MS =
   process.env.ASSISTANT_JOIN_WAIT_BUDGET_MS || "200";


### PR DESCRIPTION
## Summary

The `convos-backend` half of the Per-PR Agent Variants epic ([CON-576](https://linear.app/convos/issue/CON-576/per-pr-agent-variants)). Targets `otr-dev`. Dev-network only; pairs with the convos-assistants PR.

- **AgentVariant registry (CON-580):** Prisma `AgentVariant` model (slug PK) + migration; `GET /v2/agent-variants` (app-facing, `authMiddleware`, returns `[]` off-dev) and `POST`/`DELETE` (agent API key + dev-gate, idempotent delete).
- **Generation seam — builder prompt (CON-581):** optional `variantId` on the generations schema (append-only, contract-tested); on dev, resolves the variant's bench `builderPromptSlug` → text and applies it through the existing `builderPrompt` → `systemPromptOverride` path, **before** the idempotency dedupe; canonical fallback on any miss. Adds `BRAINTRUST_API_KEY` + a bench-prompt loader.
- **Join seam — runtime routing (CON-582):** optional `options.variantId` (append-only, contract-tested); routes provisioning to `variant.assistantWorkerUrl ?? default`, forwards `metadata.variant` for the profile stamp, and never forwards `variantId` to the runtime.

Variant ephemerals are credit-checked (paired convos-assistants PR), so there's no bespoke create secret — the owner/credit gate backstops the ephemeral create route. DB-backed integration tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFyBqhbGyuY4CNy8hHUZtp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added v2 API support for agent variants (create/upsert, list, delete) with dev-gated writes and non-production listing of ready/building variants.
  * Enabled dev-only, per-request agent variant selection for generations, join dispatch, and join status polling (including `metadata.variant` stamping when applicable).
  * Added Braintrust builder-prompt resolution from prompt slugs, configurable via `BRAINTRUST_API_KEY`.
* **Bug Fixes**
  * Improved resilience: missing/invalid variants or prompt resolution failures now safely fall back to canonical behavior without breaking requests.
  * Preserved backward compatibility by accepting legacy payloads and keeping request schemas strict.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-PR agent variant routing and management endpoints to convos-backend
> - Adds a new `AgentVariant` database model and REST API (`/api/v2/agent-variants`) with list, upsert, and delete endpoints; all mutating endpoints are dev-only (404 in production).
> - On non-production, the `join` handler accepts an optional `options.variantId` to route agent provisioning to an ephemeral variant worker, stamping `metadata.variant` on the dispatch payload; falls back to the default worker if the variant is unknown, not live, or has an invalid URL.
> - The generations POST endpoint accepts an optional `variantId` to resolve a Braintrust bench prompt via the new `loadBenchPromptText` loader, overriding `builderPrompt` before idempotency checks; only active in non-production.
> - Variant worker URLs are validated against an allowlisted HTTPS ephemeral hostname before any routing override is applied.
> - Risk: Braintrust prompt resolution requires `BRAINTRUST_API_KEY` to be set; missing or misconfigured keys will cause `loadBenchPromptText` to throw, degrading gracefully to the default generator via the `resolveVariantBuilderPrompt` wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e11a9e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->