### PR TITLE
feat(agent-templates): sharpen generated persona/group-chat voice + cap length

### DIFF
--- a/data/template-generator-prompt.txt
+++ b/data/template-generator-prompt.txt
@@ -291,6 +291,26 @@ The **Character Name + Emoji** is the single identity that flows through every f
 - **No Generic Names**: Never "Assistant" or "Helper" or "Bot." These have no personality.
 - **No Descriptive Titles**: Never "The Group Treasurer" or "Dinner Club Concierge." The Name is a handle, not a description — the `description` field handles the "what it does" part.
 
+## Raise the Bar on Voice and Group Dynamics
+
+A memorable agent beats a merely competent one on two axes most generations under-deliver. Push past competent:
+
+**VOICE (SOUL)** — make it unmistakable, not a trope:
+- Write 2-3 verbatim one-liners only THIS agent could say, each anchored to a concrete specific (a named member, a real number, a precise moment). "Marcus started a guy on a bye. In Week 11. Sir." beats "That's a you problem."
+- Give the humor a target AND a limit — who it punches at, and the line it won't cross (it "reads who can take it"). Calibrated beats generically witty.
+- Pick one distinctive speech tic, cadence, or signature move and use it consistently across the examples.
+- Banned: interchangeable archetype blurbs ("the friend who's organized but fun"), hype-y exclamation energy, any line that could belong to a different agent.
+
+**GROUP DYNAMICS (BRAIN + HEART)** — model the room, not just the job:
+- Write Decision Logic as event→reaction rules keyed to what MEMBERS do: "When someone brags, verify before amplifying. When someone whines, needle don't coddle. When someone shares a result, react with a take, not a stat dump."
+- Name 1-2 recurring rituals the agent runs, so the group has bits to look forward to.
+- Spell out proactive in-the-moment moves: when to stir the pot, when to nudge a specific member by name, when to stay silent and let the room cook. Silence-by-default is the floor, not the whole story.
+- Track per-person texture (signature moves, rivalries, who never follows through) and use it by name.
+
+Show, don't summarize. Concrete, named, and specific wins every time.
+
+**Length discipline** — specific is not longer. The named lines and event→reaction rules above REPLACE generic prose; they don't add to it. Hold the whole prompt to ~800 words (≤1000).
+
 ---
 
 ## Your Task


### PR DESCRIPTION
## What

Appends one section to the template-generator prompt (`data/template-generator-prompt.txt`, +20 lines) — the **persona/group-dynamics reinforcement we A/B-validated, reproduced verbatim**, plus a single length-guardrail paragraph.

## Why

An LLM-judge rubric eval (`gpt-5.5`, the 6-dimension rubric the convos-assistants bench mirrors) showed generated agents lose almost entirely on **persona_quality** and **group_chat_fit / specificity** — blueprint-complete but generic. The validated block targets exactly those: named verbatim one-liners over archetype blurbs, humor with a target and a limit, a signature move, event→reaction decision logic keyed to member behavior, recurring rituals, per-person texture, and a banned-generic list.

In testing, this block **raised absolute rubric scores for both the production model and an alternative**, and lifted persona/specificity in pairwise judging.

## Fidelity note

The section is the **exact block from the A/B** — only the `VOICE` / `GROUP DYNAMICS` sub-labels are bolded to match the prompt's style. The single addition beyond the tested text is the trailing **Length discipline** paragraph, because the persona push on its own grew generated prompts ~7–14% and dipped constraint_compliance: it states the named examples *replace* generic prose rather than add to it, and restates the ~800-word (≤1000) cap. Length is controlled via the prompt, deliberately **not** a `max_tokens` cap (which would truncate the JSON).

## Validation

The block is validated; the length paragraph is the one new variable. Confirm before merge with the harness's built-in prompt A/B:

```
pnpm eval:prompt   # base-branch prompt vs this branch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sharpen agent template voice and cap generated prompt length to ~800 words
> Updates [template-generator-prompt.txt](https://github.com/ephemeraHQ/convos-backend/pull/334/files#diff-8408ab304a047f82462fe0860f5216764b22621a10c4c60818c26efb14737052) with a new 'Raise the Bar on Voice and Group Dynamics' guidance section to improve persona quality in generated agent templates.
>
> - Adds VOICE directives requiring 2-3 concrete one-liner examples, a distinctive speech tic, and a ban on generic archetypes
> - Adds GROUP DYNAMICS rules with event→reaction decision logic, recurring rituals, proactive silence, and per-person texture tracking
> - Adds a 'Show, don't summarize' instruction to reduce abstract descriptions
> - Caps generated prompt length to ~800 words (≤1000), with new specifics replacing generic prose rather than adding to it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afb7c52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved guidance for generating more distinct, consistent agent voices and group dynamics.
  * Added clearer direction for using concrete details, recurring speech patterns, and situation-based responses.
  * Encourages more specific, concise, and natural-sounding output with better humor boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->