### PR TITLE
fix(notifications): heal NULL DeviceRegistration.accountId push drops

### DIFF
--- a/src/api/v2/notifications/handlers/subscribe.ts
+++ b/src/api/v2/notifications/handlers/subscribe.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { hexToUint8Array } from "uint8array-extras";
 import { z } from "zod";
@@ -5,6 +6,86 @@ import { createNotificationClient } from "@/notifications/client";
 import { verifyDeviceOwnership } from "@/utils/auth-guards";
 import { deviceIdSchema } from "@/utils/device-id";
 import { prisma } from "@/utils/prisma";
+
+/**
+ * The subset of a Prisma transaction client this module needs. Declared
+ * structurally so the persistence logic can be unit-tested against a tiny
+ * fake without standing up a real DB / `$transaction`.
+ */
+export interface SubscriptionIdentityTx {
+  clientIdentifier: {
+    upsert: (args: Prisma.ClientIdentifierUpsertArgs) => Promise<unknown>;
+  };
+  deviceRegistration: {
+    updateMany: (
+      args: Prisma.DeviceRegistrationUpdateManyArgs,
+    ) => Promise<{ count: number }>;
+  };
+}
+
+/**
+ * Persist the subscribing client's identity in ONE transaction: upsert the
+ * ClientIdentifier and (when authenticated) adopt the subscriber's account
+ * onto the device.
+ *
+ * Why also stamp DeviceRegistration.accountId here:
+ * The webhook delivery guard (isAccountIdMismatch) fails closed unless
+ * ClientIdentifier.accountId === DeviceRegistration.accountId (both non-null).
+ * `/v2/device/register` is AppCheck-only and never writes accountId, and the
+ * `/auth/token` backfill no-ops when the device row doesn't exist yet, so a
+ * device can sit with accountId = NULL indefinitely — silently dropping every
+ * push. A subscribe carrying a verified accountId is a fresh authenticated
+ * signal that *this* account currently owns the device, so we adopt it
+ * ("current-subscriber-wins"): set device.accountId when it is NULL OR differs
+ * from the subscriber.
+ *
+ * Safety: the guard fails closed, so a wrong/stale device.accountId can only
+ * ever DROP a push, never deliver to the wrong account — no cross-account leak.
+ * Shared-device thrash: two accounts actively subscribing on one physical
+ * device will flip device.accountId back and forth; each flip self-corrects on
+ * the next subscribe, and the loser merely misses pushes until it re-subscribes.
+ * Only an accountId-bearing JWT mutates anything — legacy/non-SIWE builds
+ * (accountId undefined) leave BOTH columns untouched so a backfilled or prior
+ * SIWE value is never clobbered.
+ *
+ * Exported for unit testing.
+ */
+export async function persistSubscriptionIdentity(args: {
+  tx: SubscriptionIdentityTx;
+  clientId: string;
+  deviceId: string;
+  accountId: string | undefined;
+}) {
+  const { tx, clientId, deviceId, accountId } = args;
+
+  await tx.clientIdentifier.upsert({
+    where: { id: clientId },
+    create: {
+      id: clientId,
+      deviceId,
+      ...(accountId !== undefined ? { accountId } : {}),
+    },
+    update: {
+      deviceId,
+      ...(accountId !== undefined ? { accountId } : {}),
+    },
+  });
+
+  // Adopt the authenticated subscriber's account onto the device when it is
+  // missing or stale. `updateMany` with the `not` predicate is a single
+  // conditional UPDATE (no read-modify-write race) that touches the row only
+  // when it actually needs changing. Skipped entirely for unauthenticated
+  // (legacy) subscribes.
+  if (accountId !== undefined) {
+    await tx.deviceRegistration.updateMany({
+      where: {
+        deviceId,
+        OR: [{ accountId: null }, { accountId: { not: accountId } }],
+      },
+      data: { accountId },
+    });
+  }
+}
 
 const subscribeRequestSchema = z.object({
   deviceId: deviceIdSchema,
@@ -138,27 +219,26 @@ export async function subscribe(
       }
     }
 
-    // Create or update client identifier record. accountId is sourced
-    // from the JWT and is what the webhook delivery guard compares
-    // against the joined DeviceRegistration.accountId before sending a
-    // push. Older iOS builds that authenticate without SIWE produce a
-    // JWT with no accountId; leave the field untouched in that case so
-    // the migration backfill value (or a prior accountId from a SIWE
-    // authentication on the same row) is not clobbered.
+    // Create or update client identifier record and (when authenticated)
+    // adopt the subscriber's account onto the device. accountId is sourced
+    // from the JWT and is what the webhook delivery guard compares against
+    // the joined DeviceRegistration.accountId before sending a push. Older
+    // iOS builds that authenticate without SIWE produce a JWT with no
+    // accountId; leave both fields untouched in that case so the migration
+    // backfill value (or a prior accountId from a SIWE authentication on
+    // the same row) is not clobbered. Both writes share one transaction so
+    // the ClientIdentifier and DeviceRegistration never disagree mid-flight.
+    // See persistSubscriptionIdentity for the full rationale + safety notes.
     const accountId = res.locals.accountId;
     try {
-      await prisma.clientIdentifier.upsert({
-        where: { id: body.clientId },
-        create: {
-          id: body.clientId,
+      await prisma.$transaction((tx) =>
+        persistSubscriptionIdentity({
+          tx,
+          clientId: body.clientId,
           deviceId: body.deviceId,
           accountId,
-        },
-        update: {
-          deviceId: body.deviceId,
-          ...(accountId !== undefined ? { accountId } : {}),
-        },
-      });
+        }),
+      );
     } catch (dbErr) {
       // Compensate: delete installation to maintain consistency (only if we created one)
       if (device.pushToken) {

--- a/tests/notifications-subscribe-identity.test.ts
+++ b/tests/notifications-subscribe-identity.test.ts
@@ -1,0 +1,222 @@
+import type { Prisma } from "@prisma/client";
+import { describe, expect, test, vi } from "vitest";
+import {
+  persistSubscriptionIdentity,
+  type SubscriptionIdentityTx,
+} from "@/api/v2/notifications/handlers/subscribe";
+
+// Unit tests for the subscribe-time identity persistence. These pin the
+// "current-subscriber-wins" device.accountId adoption contract that keeps the
+// webhook delivery guard from silently dropping pushes on NULL-accountId
+// devices, while never clobbering anything for unauthenticated legacy builds.
+
+const ACCOUNT_A = "00000000-0000-0000-0000-0000000000aa";
+const ACCOUNT_B = "00000000-0000-0000-0000-0000000000bb";
+const CLIENT_ID = "11111111-1111-1111-1111-111111111111";
+const DEVICE_ID = "device-xyz";
+
+type UpsertFn = (args: Prisma.ClientIdentifierUpsertArgs) => Promise<unknown>;
+type UpdateManyFn = (
+  args: Prisma.DeviceRegistrationUpdateManyArgs,
+) => Promise<{ count: number }>;
+
+function makeTx(): {
+  tx: SubscriptionIdentityTx;
+  upsert: ReturnType<typeof vi.fn<UpsertFn>>;
+  updateMany: ReturnType<typeof vi.fn<UpdateManyFn>>;
+} {
+  const upsert = vi.fn<UpsertFn>().mockResolvedValue(undefined);
+  const updateMany = vi.fn<UpdateManyFn>().mockResolvedValue({ count: 1 });
+  const tx: SubscriptionIdentityTx = {
+    clientIdentifier: { upsert },
+    deviceRegistration: { updateMany },
+  };
+  return { tx, upsert, updateMany };
+}
+
+describe("persistSubscriptionIdentity", () => {
+  test("authenticated subscribe stamps ClientIdentifier and adopts device.accountId", async () => {
+    const { tx, upsert, updateMany } = makeTx();
+
+    await persistSubscriptionIdentity({
+      tx,
+      clientId: CLIENT_ID,
+      deviceId: DEVICE_ID,
+      accountId: ACCOUNT_A,
+    });
+
+    // ClientIdentifier upsert carries the accountId on both create and update.
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const upsertArg = upsert.mock.calls[0][0];
+    expect(upsertArg.where).toEqual({ id: CLIENT_ID });
+    expect(upsertArg.create).toEqual({
+      id: CLIENT_ID,
+      deviceId: DEVICE_ID,
+      accountId: ACCOUNT_A,
+    });
+    expect(upsertArg.update).toEqual({
+      deviceId: DEVICE_ID,
+      accountId: ACCOUNT_A,
+    });
+
+    // Device adoption: conditional UPDATE only when NULL or differing.
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    const updateArg = updateMany.mock.calls[0][0];
+    expect(updateArg.where).toEqual({
+      deviceId: DEVICE_ID,
+      OR: [{ accountId: null }, { accountId: { not: ACCOUNT_A } }],
+    });
+    expect(updateArg.data).toEqual({ accountId: ACCOUNT_A });
+  });
+
+  test("device.accountId adoption WHERE matches NULL and differing accounts", async () => {
+    // The single conditional updateMany covers both the NULL case (device never
+    // got an account) and the differing case (device.accountId = ACCOUNT_B but
+    // current subscriber is ACCOUNT_A => current-subscriber-wins). We assert the
+    // predicate captures both without a read-modify-write.
+    const { tx, updateMany } = makeTx();
+
+    await persistSubscriptionIdentity({
+      tx,
+      clientId: CLIENT_ID,
+      deviceId: DEVICE_ID,
+      accountId: ACCOUNT_A,
+    });
+
+    const where = updateMany.mock.calls[0][0].where;
+    expect(where).toBeDefined();
+    const orClauses = where?.OR;
+    expect(orClauses).toContainEqual({ accountId: null });
+    expect(orClauses).toContainEqual({ accountId: { not: ACCOUNT_A } });
+    // A device already on ACCOUNT_A is excluded by `not: ACCOUNT_A` (no-op write
+    // avoided); a device on ACCOUNT_B is matched by it (gets re-stamped).
+    expect(orClauses).not.toContainEqual({ accountId: { not: ACCOUNT_B } });
+  });
+
+  test("unauthenticated subscribe (no accountId) leaves device untouched and does not clobber ClientIdentifier.accountId", async () => {
+    const { tx, upsert, updateMany } = makeTx();
+
+    await persistSubscriptionIdentity({
+      tx,
+      clientId: CLIENT_ID,
+      deviceId: DEVICE_ID,
+      accountId: undefined,
+    });
+
+    // No device write at all.
+    expect(updateMany).not.toHaveBeenCalled();
+
+    // ClientIdentifier create passes accountId: undefined (=> column stays/NULL),
+    // and both create AND update OMIT accountId so a prior/backfilled value is
+    // preserved (legacy/non-SIWE builds never write the column).
+    const upsertArg = upsert.mock.calls[0][0];
+    expect(upsertArg.create).toEqual({
+      id: CLIENT_ID,
+      deviceId: DEVICE_ID,
+    });
+    expect("accountId" in upsertArg.create).toBe(false);
+    expect(upsertArg.update).toEqual({ deviceId: DEVICE_ID });
+    expect("accountId" in upsertArg.update).toBe(false);
+  });
+
+  test("both writes go through the SAME transaction client", async () => {
+    // Both calls must land on the injected tx (not the global prisma), proving
+    // the handler runs them inside one $transaction.
+    const { tx, upsert, updateMany } = makeTx();
+
+    await persistSubscriptionIdentity({
+      tx,
+      clientId: CLIENT_ID,
+      deviceId: DEVICE_ID,
+      accountId: ACCOUNT_A,
+    });
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    // The fake tx's own fns received the calls => same-tx guarantee.
+    expect(tx.clientIdentifier.upsert).toBe(upsert);
+    expect(tx.deviceRegistration.updateMany).toBe(updateMany);
+  });
+});
+
+// Handler-level test: proves subscribe() actually wraps the ClientIdentifier
+// upsert + DeviceRegistration adoption in a single prisma.$transaction. The
+// unit tests above pin persistSubscriptionIdentity's behavior on an injected
+// tx, but would still pass if the handler stopped wrapping it in a
+// transaction. This guards that wiring.
+const txClient = {
+  clientIdentifier: {
+    upsert: vi.fn().mockResolvedValue(undefined),
+  },
+  deviceRegistration: {
+    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+  },
+};
+const transactionMock = vi.fn((cb: (tx: typeof txClient) => Promise<unknown>) =>
+  cb(txClient),
+);
+
+vi.mock("@/utils/prisma", () => ({
+  prisma: {
+    // device exists, not disabled, no push token (skips the remote calls)
+    deviceRegistration: {
+      findUnique: vi.fn().mockResolvedValue({
+        deviceId: "device-xyz",
+        disabled: false,
+        pushToken: null,
+        pushTokenType: "apns",
+        apnsEnv: "production",
+      }),
+    },
+    get $transaction() {
+      return transactionMock;
+    },
+    // Present so the global afterAll teardown (tests/setup.ts) can call it.
+    $disconnect: vi.fn().mockResolvedValue(undefined),
+    $connect: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/notifications/client", () => ({
+  createNotificationClient: () => ({
+    registerInstallation: vi.fn(),
+    subscribeWithMetadata: vi.fn(),
+    deleteInstallation: vi.fn(),
+  }),
+}));
+
+vi.mock("@/utils/auth-guards", () => ({
+  verifyDeviceOwnership: () => true,
+}));
+
+describe("subscribe handler transaction wiring", () => {
+  test("wraps both writes in a single prisma.$transaction", async () => {
+    const { subscribe } =
+      await import("@/api/v2/notifications/handlers/subscribe");
+
+    const req = {
+      body: {
+        deviceId: DEVICE_ID,
+        clientId: CLIENT_ID,
+        topics: [{ topic: "/xmtp/mls/1/g-x/proto", hmacKeys: [] }],
+      },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as unknown as Parameters<typeof subscribe>[0];
+
+    const send = vi.fn();
+    const res = {
+      locals: { deviceId: DEVICE_ID, accountId: ACCOUNT_A },
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      send,
+    } as unknown as Parameters<typeof subscribe>[1];
+
+    await subscribe(req, res);
+
+    // Exactly one transaction opened, and BOTH writes ran on that tx client.
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(txClient.clientIdentifier.upsert).toHaveBeenCalledTimes(1);
+    expect(txClient.deviceRegistration.updateMany).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Push notifications: heal NULL `DeviceRegistration.accountId` drops

**Problem:** pushes were silently dropped for devices whose `DeviceRegistration.accountId` is NULL — the `isAccountIdMismatch` guard (added in #272, fails closed) drops them. ~121 active devices affected (prod DB), plus a legacy tail.

**Root cause:** `accountId` was never reliably written to `DeviceRegistration` — `/v2/device/register` is AppCheck-only and doesn't set it, and the `/auth/token` SIWE backfill `updateMany` no-ops when the device row doesn't exist yet (register/auth are independent and unordered).

**Fix:** `subscribe.ts` stamps `DeviceRegistration.accountId` from the authenticated subscriber, in the same transaction as the `ClientIdentifier` upsert (current-subscriber-wins; fails closed; no request-schema change → backwards-compatible). Self-heals every active device on its next authenticated subscribe.

**Backfill migration intentionally dropped:** an earlier revision included a one-shot data migration to backfill existing NULLs; it was removed because inferring current ownership from historical `ClientIdentifier` rows is unsound under iOS token recycling (cross-account delivery risk flagged by macroscope + the Claude review). We rely on the leak-safe subscribe-side self-heal instead.

**Guard unchanged** (kept fail-closed). Tests added; `tsc` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785072872&installation_id=128169237&pr_number=335&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F335&signature=2de734918c7baca097f436df099c8096498e56b5d7f708b6771008a80b93644e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix NULL `DeviceRegistration.accountId` by stamping account during push subscription
> - Adds `persistSubscriptionIdentity` in [`subscribe.ts`](https://github.com/ephemeraHQ/convos-backend/pull/335/files#diff-ceb1529a284486613f3b036bdbc51ee98edad2a540aaf02fca7bfa8bac4715cc) to upsert `ClientIdentifier` and conditionally update `DeviceRegistration.accountId` where it is NULL or stale, within a single transaction.
> - The `subscribe` handler now wraps both writes in `prisma.$transaction`, ensuring the account adoption and identity upsert are atomic.
> - `accountId` is omitted from `ClientIdentifier` create/update when undefined, preventing unguarded NULL writes.
> - A new test suite in [`notifications-subscribe-identity.test.ts`](https://github.com/ephemeraHQ/convos-backend/pull/335/files#diff-f46e953883c941b506ae77077ca159fcf597553dbf24213b585e77ea7be71cbd) covers authenticated/unauthenticated paths and verifies transactional wrapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b126653.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification subscription handling to save subscription and device identity together in one transaction.
  * When signed in, device records are now linked to the current account more reliably, reducing mismatched subscription ownership.
  * Added stronger validation around transaction behavior to ensure both updates use the same database session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->