### PR TITLE
feat(agent-prompt-hints): admin write-CRUD

### DIFF
--- a/src/api/v2/agent-prompt-hints/agent-prompt-hints.router.ts
+++ b/src/api/v2/agent-prompt-hints/agent-prompt-hints.router.ts
@@ -3,7 +3,7 @@ import {
   authOrAgentApiKeyAuth,
   optionalAuthOrAgentApiKeyAuth,
 } from "@/middleware/agentAuth";
-import { requireAccount } from "@/middleware/auth";
+import { requireAccount, requireAdmin } from "@/middleware/auth";
 import { createHandler } from "./handlers/create";
 import { deleteHandler } from "./handlers/delete";
 import { listHandler } from "./handlers/list";
@@ -21,38 +21,46 @@ export const agentPromptHintsRouter = Router();
 // contract — do not change it.
 agentPromptHintsRouter.get("/", optionalAuthOrAgentApiKeyAuth, listHandler);
 
-// Admin write surface. Gated by the same two-layer model the agent-templates
-// admin writes use: agent-key auth (X-Agent-API-Key) resolves the ADMIN account
-// with isApiKeyListener, or a JWT account. Hints are global rows, so there is
-// no ownership guard. Static admin paths (/admin, /reorder) register before the
-// "/:id" wildcard so it doesn't capture them as ids.
+// Admin write surface. Hints are global rows with no owner, so unlike the
+// agent-templates writes (which fall back to an ownership check) there is
+// nothing to scope a regular account to. Restrict to the admin identity with
+// `requireAdmin`, matching how the templates admin writes gate privileged
+// access: agent-key auth (X-Agent-API-Key) resolves the ADMIN account with
+// isApiKeyListener, and the admin account's own JWT is accepted too. Static
+// admin paths (/admin, /reorder) register before the "/:id" wildcard so it
+// doesn't capture them as ids.
 agentPromptHintsRouter.get(
   "/admin",
   authOrAgentApiKeyAuth,
   requireAccount,
+  requireAdmin,
   listAdminHandler,
 );
 agentPromptHintsRouter.post(
   "/reorder",
   authOrAgentApiKeyAuth,
   requireAccount,
+  requireAdmin,
   reorderHandler,
 );
 agentPromptHintsRouter.post(
   "/",
   authOrAgentApiKeyAuth,
   requireAccount,
+  requireAdmin,
   createHandler,
 );
 agentPromptHintsRouter.patch(
   "/:id",
   authOrAgentApiKeyAuth,
   requireAccount,
+  requireAdmin,
   patchHandler,
 );
 agentPromptHintsRouter.delete(
   "/:id",
   authOrAgentApiKeyAuth,
   requireAccount,
+  requireAdmin,
   deleteHandler,
 );

--- a/src/api/v2/agent-prompt-hints/agent-prompt-hints.router.ts
+++ b/src/api/v2/agent-prompt-hints/agent-prompt-hints.router.ts
@@ -1,6 +1,15 @@
 import { Router } from "express";
-import { optionalAuthOrAgentApiKeyAuth } from "@/middleware/agentAuth";
+import {
+  authOrAgentApiKeyAuth,
+  optionalAuthOrAgentApiKeyAuth,
+} from "@/middleware/agentAuth";
+import { requireAccount } from "@/middleware/auth";
+import { createHandler } from "./handlers/create";
+import { deleteHandler } from "./handlers/delete";
 import { listHandler } from "./handlers/list";
+import { listAdminHandler } from "./handlers/list-admin";
+import { patchHandler } from "./handlers/patch";
+import { reorderHandler } from "./handlers/reorder";
 
 export const agentPromptHintsRouter = Router();
 
@@ -8,5 +17,42 @@ export const agentPromptHintsRouter = Router();
 // required (anonymous callers get the published set so the maker's empty
 // composer works pre-login); valid-but-bad credentials still 401 via
 // optionalAuthOrAgentApiKeyAuth. Hints are global, so the handler ignores any
-// resolved account identity.
+// resolved account identity. The shape ({ hints: string[] }) is the frozen iOS
+// contract — do not change it.
 agentPromptHintsRouter.get("/", optionalAuthOrAgentApiKeyAuth, listHandler);
+
+// Admin write surface. Gated by the same two-layer model the agent-templates
+// admin writes use: agent-key auth (X-Agent-API-Key) resolves the ADMIN account
+// with isApiKeyListener, or a JWT account. Hints are global rows, so there is
+// no ownership guard. Static admin paths (/admin, /reorder) register before the
+// "/:id" wildcard so it doesn't capture them as ids.
+agentPromptHintsRouter.get(
+  "/admin",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  listAdminHandler,
+);
+agentPromptHintsRouter.post(
+  "/reorder",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  reorderHandler,
+);
+agentPromptHintsRouter.post(
+  "/",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  createHandler,
+);
+agentPromptHintsRouter.patch(
+  "/:id",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  patchHandler,
+);
+agentPromptHintsRouter.delete(
+  "/:id",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  deleteHandler,
+);

--- a/src/api/v2/agent-prompt-hints/handlers/create.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/create.ts
@@ -40,11 +40,13 @@ export async function createHandler(req: Request, res: Response) {
   try {
     const hint = await prisma.agentPromptHint.create({ data });
     res.status(201).json(hint);
+    return;
   } catch (error) {
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to create agent prompt hint",
     );
     res.status(500).json({ error: "Failed to create agent prompt hint" });
+    return;
   }
 }

--- a/src/api/v2/agent-prompt-hints/handlers/create.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/create.ts
@@ -1,0 +1,50 @@
+import type { Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+// Hard-cap the admin write at the same length the public read enforces. The DB
+// column is generous TEXT, but storing an over-length hint here would create an
+// invisible row the public endpoint silently drops, so what an admin saves is
+// exactly what ships.
+const MAX_HINT_LENGTH = 240;
+
+const bodySchema = z.object({
+  text: z.string().trim().min(1).max(MAX_HINT_LENGTH),
+  published: z.boolean().optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+export async function createHandler(req: Request, res: Response) {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsed.error.issues,
+    });
+    return;
+  }
+
+  // Only set the optional columns when provided so the schema defaults
+  // (published true, sortOrder 0) apply when they're omitted.
+  const data: Prisma.AgentPromptHintUncheckedCreateInput = {
+    text: parsed.data.text,
+  };
+  if (parsed.data.published !== undefined) {
+    data.published = parsed.data.published;
+  }
+  if (parsed.data.sortOrder !== undefined) {
+    data.sortOrder = parsed.data.sortOrder;
+  }
+
+  try {
+    const hint = await prisma.agentPromptHint.create({ data });
+    res.status(201).json(hint);
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to create agent prompt hint",
+    );
+    res.status(500).json({ error: "Failed to create agent prompt hint" });
+  }
+}

--- a/src/api/v2/agent-prompt-hints/handlers/delete.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/delete.ts
@@ -1,0 +1,41 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const paramsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export async function deleteHandler(req: Request, res: Response) {
+  const parsedParams = paramsSchema.safeParse(req.params);
+  if (!parsedParams.success) {
+    res.status(400).json({
+      error: "Invalid request params",
+      details: parsedParams.error.issues,
+    });
+    return;
+  }
+
+  try {
+    const deleted = await prisma.agentPromptHint.deleteMany({
+      where: { id: parsedParams.data.id },
+    });
+
+    if (deleted.count === 0) {
+      res.status(404).json({ error: "Agent prompt hint not found" });
+      return;
+    }
+
+    res.status(200).json({
+      object: "agent_prompt_hint",
+      id: parsedParams.data.id,
+      deleted: true,
+    });
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to delete agent prompt hint",
+    );
+    res.status(500).json({ error: "Failed to delete agent prompt hint" });
+  }
+}

--- a/src/api/v2/agent-prompt-hints/handlers/delete.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/delete.ts
@@ -31,11 +31,13 @@ export async function deleteHandler(req: Request, res: Response) {
       id: parsedParams.data.id,
       deleted: true,
     });
+    return;
   } catch (error) {
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to delete agent prompt hint",
     );
     res.status(500).json({ error: "Failed to delete agent prompt hint" });
+    return;
   }
 }

--- a/src/api/v2/agent-prompt-hints/handlers/list-admin.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/list-admin.ts
@@ -1,0 +1,23 @@
+import type { Request, Response } from "express";
+import { prisma } from "@/utils/prisma";
+
+// Admin full-row listing. Unlike the public read, this returns every row
+// (including unpublished and over-length ones) so the curation surface can see
+// and fix exactly the rows the public endpoint hides. Ordered the same way the
+// public read serves them (sortOrder asc, then id) so the dashboard order
+// matches what ships.
+export async function listAdminHandler(req: Request, res: Response) {
+  try {
+    const rows = await prisma.agentPromptHint.findMany({
+      orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+    });
+
+    res.status(200).json({ data: rows });
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to list agent prompt hints (admin)",
+    );
+    res.status(500).json({ error: "Failed to list agent prompt hints" });
+  }
+}

--- a/src/api/v2/agent-prompt-hints/handlers/list-admin.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/list-admin.ts
@@ -13,11 +13,13 @@ export async function listAdminHandler(req: Request, res: Response) {
     });
 
     res.status(200).json({ data: rows });
+    return;
   } catch (error) {
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to list agent prompt hints (admin)",
     );
     res.status(500).json({ error: "Failed to list agent prompt hints" });
+    return;
   }
 }

--- a/src/api/v2/agent-prompt-hints/handlers/patch.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/patch.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
@@ -50,17 +50,12 @@ export async function patchHandler(req: Request, res: Response) {
     data.sortOrder = parsedBody.data.sortOrder;
   }
 
+  // Hit the row directly instead of a findUnique pre-check: a pre-check leaves a
+  // window where the row is deleted before the update, which would throw and
+  // surface as a 500. Letting Prisma raise P2025 ("record not found") and
+  // mapping it to 404 closes that race. An empty patch still needs a fetch to
+  // echo the current row, so it uses findUniqueOrThrow (also P2025 when absent).
   try {
-    const existing = await prisma.agentPromptHint.findUnique({
-      where: { id: parsedParams.data.id },
-      select: { id: true },
-    });
-
-    if (existing === null) {
-      res.status(404).json({ error: "Agent prompt hint not found" });
-      return;
-    }
-
     if (Object.keys(data).length === 0) {
       const unchanged = await prisma.agentPromptHint.findUniqueOrThrow({
         where: { id: parsedParams.data.id },
@@ -75,6 +70,13 @@ export async function patchHandler(req: Request, res: Response) {
     });
     res.status(200).json(updated);
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      res.status(404).json({ error: "Agent prompt hint not found" });
+      return;
+    }
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to patch agent prompt hint",

--- a/src/api/v2/agent-prompt-hints/handlers/patch.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/patch.ts
@@ -1,0 +1,84 @@
+import type { Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+// Same length cap as create: the public read filters over-length rows, so the
+// admin write keeps stored == served.
+const MAX_HINT_LENGTH = 240;
+
+const paramsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const bodySchema = z.object({
+  text: z.string().trim().min(1).max(MAX_HINT_LENGTH).optional(),
+  published: z.boolean().optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+export async function patchHandler(req: Request, res: Response) {
+  const parsedParams = paramsSchema.safeParse(req.params);
+  if (!parsedParams.success) {
+    res.status(400).json({
+      error: "Invalid request params",
+      details: parsedParams.error.issues,
+    });
+    return;
+  }
+
+  const parsedBody = bodySchema.safeParse(req.body);
+  if (!parsedBody.success) {
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsedBody.error.issues,
+    });
+    return;
+  }
+
+  // Build a partial update from only the provided keys. Hints are global rows,
+  // so there is no ownership guard and no status-transition machinery — a plain
+  // published boolean, not the templates publish lifecycle.
+  const data: Prisma.AgentPromptHintUncheckedUpdateInput = {};
+  if (parsedBody.data.text !== undefined) {
+    data.text = parsedBody.data.text;
+  }
+  if (parsedBody.data.published !== undefined) {
+    data.published = parsedBody.data.published;
+  }
+  if (parsedBody.data.sortOrder !== undefined) {
+    data.sortOrder = parsedBody.data.sortOrder;
+  }
+
+  try {
+    const existing = await prisma.agentPromptHint.findUnique({
+      where: { id: parsedParams.data.id },
+      select: { id: true },
+    });
+
+    if (existing === null) {
+      res.status(404).json({ error: "Agent prompt hint not found" });
+      return;
+    }
+
+    if (Object.keys(data).length === 0) {
+      const unchanged = await prisma.agentPromptHint.findUniqueOrThrow({
+        where: { id: parsedParams.data.id },
+      });
+      res.status(200).json(unchanged);
+      return;
+    }
+
+    const updated = await prisma.agentPromptHint.update({
+      where: { id: parsedParams.data.id },
+      data,
+    });
+    res.status(200).json(updated);
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to patch agent prompt hint",
+    );
+    res.status(500).json({ error: "Failed to patch agent prompt hint" });
+  }
+}

--- a/src/api/v2/agent-prompt-hints/handlers/patch.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/patch.ts
@@ -69,6 +69,7 @@ export async function patchHandler(req: Request, res: Response) {
       data,
     });
     res.status(200).json(updated);
+    return;
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -82,5 +83,6 @@ export async function patchHandler(req: Request, res: Response) {
       "Failed to patch agent prompt hint",
     );
     res.status(500).json({ error: "Failed to patch agent prompt hint" });
+    return;
   }
 }

--- a/src/api/v2/agent-prompt-hints/handlers/reorder.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/reorder.ts
@@ -16,7 +16,8 @@ const bodySchema = z.object({
     // the returned `updated` count past the number of distinct rows actually
     // touched. With this guard, orders.length is the distinct-row count.
     .refine(
-      (orders) => new Set(orders.map((order) => order.id)).size === orders.length,
+      (orders) =>
+        new Set(orders.map((order) => order.id)).size === orders.length,
       { message: "Duplicate hint id in reorder batch" },
     ),
 });

--- a/src/api/v2/agent-prompt-hints/handlers/reorder.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/reorder.ts
@@ -11,7 +11,14 @@ const bodySchema = z.object({
         sortOrder: z.number().int(),
       }),
     )
-    .min(1),
+    .min(1)
+    // Reject duplicate ids: a repeated id is last-write-wins and would inflate
+    // the returned `updated` count past the number of distinct rows actually
+    // touched. With this guard, orders.length is the distinct-row count.
+    .refine(
+      (orders) => new Set(orders.map((order) => order.id)).size === orders.length,
+      { message: "Duplicate hint id in reorder batch" },
+    ),
 });
 
 export async function reorderHandler(req: Request, res: Response) {

--- a/src/api/v2/agent-prompt-hints/handlers/reorder.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/reorder.ts
@@ -46,6 +46,7 @@ export async function reorderHandler(req: Request, res: Response) {
     );
 
     res.status(200).json({ updated: parsed.data.orders.length });
+    return;
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -61,5 +62,6 @@ export async function reorderHandler(req: Request, res: Response) {
       "Failed to reorder agent prompt hints",
     );
     res.status(500).json({ error: "Failed to reorder agent prompt hints" });
+    return;
   }
 }

--- a/src/api/v2/agent-prompt-hints/handlers/reorder.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/reorder.ts
@@ -1,0 +1,57 @@
+import { Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+const bodySchema = z.object({
+  orders: z
+    .array(
+      z.object({
+        id: z.string().uuid(),
+        sortOrder: z.number().int(),
+      }),
+    )
+    .min(1),
+});
+
+export async function reorderHandler(req: Request, res: Response) {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsed.error.issues,
+    });
+    return;
+  }
+
+  try {
+    // Apply every sortOrder change atomically so a partial reorder never leaves
+    // the list in a half-updated order. A missing id fails the whole
+    // transaction (P2025) and surfaces as a 404.
+    await prisma.$transaction(
+      parsed.data.orders.map((order) =>
+        prisma.agentPromptHint.update({
+          where: { id: order.id },
+          data: { sortOrder: order.sortOrder },
+        }),
+      ),
+    );
+
+    res.status(200).json({ updated: parsed.data.orders.length });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      res
+        .status(404)
+        .json({ error: "One or more agent prompt hints not found" });
+      return;
+    }
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to reorder agent prompt hints",
+    );
+    res.status(500).json({ error: "Failed to reorder agent prompt hints" });
+  }
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { accountIdSchema } from "@/utils/account-id";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
 import { AppError } from "@/utils/errors";
 import { verifyAppCheckToken } from "@/utils/firebase";
 import { isNotificationExtensionOnlyToken, verifyJwtToken } from "@/utils/jwt";
@@ -188,6 +189,32 @@ export const requireAccount = (
       "requireAccount rejected request",
     );
     res.status(403).json({ error: "Account required" });
+    return;
+  }
+  next();
+};
+
+/**
+ * Restricts a route to the admin identity. Mirrors how the agent-templates
+ * admin writes restrict privileged access: the only non-owner allowed to write
+ * is the agent-API-key caller (`isApiKeyListener`), which resolves to
+ * `ADMIN_ACCOUNT_ID`. The admin account authenticating via its own JWT (the
+ * identity the agent-templates admin tests use) is accepted too, so the gate
+ * holds whichever path the admin uses. Layer this after `requireAccount`.
+ */
+export const requireAdmin = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const isApiKeyListener = res.locals.isApiKeyListener === true;
+  const isAdminAccount = res.locals.accountId === ADMIN_ACCOUNT_ID;
+  if (!isApiKeyListener && !isAdminAccount) {
+    ((req as { log?: Request["log"] }).log ?? logger).warn(
+      { isApiKeyListener },
+      "requireAdmin rejected request",
+    );
+    res.status(403).json({ error: "Admin required" });
     return;
   }
   next();

--- a/tests/agent-prompt-hints.admin.test.ts
+++ b/tests/agent-prompt-hints.admin.test.ts
@@ -408,4 +408,61 @@ describe("Agent prompt hints admin endpoints", () => {
     expect(rowA?.sortOrder).toBe(50);
     expect(rowB?.sortOrder).toBe(40);
   });
+
+  test("POST /reorder rejects duplicate ids (400)", async () => {
+    const a = await createHint({
+      text: `${TEST_PREFIX}reorder-dup`,
+      sortOrder: 1,
+    });
+
+    const response = await fetch(
+      `${baseURL}/api/v2/agent-prompt-hints/reorder`,
+      {
+        method: "POST",
+        headers: agentKeyHeaders(),
+        body: JSON.stringify({
+          orders: [
+            { id: a.json.id, sortOrder: 10 },
+            { id: a.json.id, sortOrder: 20 },
+          ],
+        }),
+      },
+    );
+    expect(response.status).toBe(400);
+
+    // Nothing applied: the row keeps its original sortOrder.
+    const rowA = await prisma.agentPromptHint.findUnique({
+      where: { id: a.json.id },
+    });
+    expect(rowA?.sortOrder).toBe(1);
+  });
+
+  test("POST /reorder rolls back when an id is missing (404, no partial update)", async () => {
+    const a = await createHint({
+      text: `${TEST_PREFIX}reorder-rollback`,
+      sortOrder: 1,
+    });
+    const missingId = "00000000-0000-4000-8000-000000000000";
+
+    const response = await fetch(
+      `${baseURL}/api/v2/agent-prompt-hints/reorder`,
+      {
+        method: "POST",
+        headers: agentKeyHeaders(),
+        body: JSON.stringify({
+          orders: [
+            { id: a.json.id, sortOrder: 77 },
+            { id: missingId, sortOrder: 88 },
+          ],
+        }),
+      },
+    );
+    expect(response.status).toBe(404);
+
+    // The whole $transaction rolled back: the valid row keeps its old sortOrder.
+    const rowA = await prisma.agentPromptHint.findUnique({
+      where: { id: a.json.id },
+    });
+    expect(rowA?.sortOrder).toBe(1);
+  });
 });

--- a/tests/agent-prompt-hints.admin.test.ts
+++ b/tests/agent-prompt-hints.admin.test.ts
@@ -1,0 +1,363 @@
+import type { Server } from "node:http";
+import express from "express";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { agentPromptHintsRouter } from "@/api/v2/agent-prompt-hints/agent-prompt-hints.router";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { jsonMiddleware } from "@/middleware/json";
+import { noRouteMiddleware } from "@/middleware/noRoute";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+
+type AdminRow = {
+  id: string;
+  text: string;
+  published: boolean;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+};
+type AdminEnvelope = { data: AdminRow[] };
+type HintsEnvelope = { hints: string[] };
+
+// All fixture rows carry this prefix so cleanup and assertions only ever touch
+// test data, never the curated seed rows in the shared local database.
+const TEST_PREFIX = "__hint_admin_test__";
+
+const validAgentAssetsApiKey =
+  "test-agent-assets-api-key-that-is-at-least-32-characters";
+
+const agentKeyHeaders = (): Record<string, string> => ({
+  "Content-Type": "application/json",
+  "X-Agent-API-Key": validAgentAssetsApiKey,
+});
+
+const jsonHeaders: Record<string, string> = {
+  "Content-Type": "application/json",
+};
+
+const buildApp = (): express.Express => {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use(jsonMiddleware);
+  app.use("/api/v2/agent-prompt-hints", agentPromptHintsRouter);
+  app.use(noRouteMiddleware);
+  return app;
+};
+
+const app = buildApp();
+let server: Server;
+const baseURL = "http://localhost:4074";
+
+const cleanup = () =>
+  prisma.agentPromptHint.deleteMany({
+    where: { text: { startsWith: TEST_PREFIX } },
+  });
+
+const seedHint = (args: {
+  text: string;
+  published?: boolean;
+  sortOrder?: number;
+}) =>
+  prisma.agentPromptHint.create({
+    data: {
+      text: args.text,
+      published: args.published ?? true,
+      sortOrder: args.sortOrder ?? 0,
+    },
+  });
+
+// A fixed-length string (incl. the test prefix) so length-boundary assertions
+// are exact under the 240-char cap.
+const textOfLength = (length: number, label: string) => {
+  const head = `${TEST_PREFIX}${label}:`;
+  return head + "x".repeat(Math.max(0, length - head.length));
+};
+
+const createHint = async (
+  body: Record<string, unknown>,
+  headers: Record<string, string> = agentKeyHeaders(),
+) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-prompt-hints`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const json = (await response.json()) as AdminRow & { error?: unknown };
+  return { response, json };
+};
+
+const patchHint = async (
+  id: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = agentKeyHeaders(),
+) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-prompt-hints/${id}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const json = (await response.json()) as AdminRow & { error?: unknown };
+  return { response, json };
+};
+
+const deleteHint = async (
+  id: string,
+  headers: Record<string, string> = agentKeyHeaders(),
+) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-prompt-hints/${id}`, {
+    method: "DELETE",
+    headers,
+  });
+  const json = (await response.json()) as {
+    id?: string;
+    deleted?: boolean;
+    error?: unknown;
+  };
+  return { response, json };
+};
+
+const listAdmin = async (
+  headers: Record<string, string> = agentKeyHeaders(),
+) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-prompt-hints/admin`, {
+    headers,
+  });
+  const json = (await response.json()) as AdminEnvelope;
+  return { response, json };
+};
+
+const adminTestRows = (json: AdminEnvelope): AdminRow[] =>
+  json.data.filter((row) => row.text.startsWith(TEST_PREFIX));
+
+const readPublicHints = async () => {
+  const response = await fetch(`${baseURL}/api/v2/agent-prompt-hints`);
+  const json = (await response.json()) as HintsEnvelope;
+  return { response, hints: json.hints };
+};
+
+describe("Agent prompt hints admin endpoints", () => {
+  beforeAll(async () => {
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+    await new Promise<void>((resolve) => {
+      server = app.listen(4074, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  test("POST / creates a hint and returns the full row (201)", async () => {
+    const text = `${TEST_PREFIX}create`;
+    const { response, json } = await createHint({ text, sortOrder: 7 });
+
+    expect(response.status).toBe(201);
+    expect(typeof json.id).toBe("string");
+    expect(json.text).toBe(text);
+    expect(json.published).toBe(true);
+    expect(json.sortOrder).toBe(7);
+    expect(typeof json.createdAt).toBe("string");
+    expect(typeof json.updatedAt).toBe("string");
+  });
+
+  test("POST / honours published:false", async () => {
+    const text = `${TEST_PREFIX}create-unpublished`;
+    const { response, json } = await createHint({ text, published: false });
+
+    expect(response.status).toBe(201);
+    expect(json.published).toBe(false);
+  });
+
+  test("GET /admin returns all rows incl. unpublished, ordered", async () => {
+    const published = `${TEST_PREFIX}admin-published`;
+    const unpublished = `${TEST_PREFIX}admin-unpublished`;
+    await seedHint({ text: unpublished, published: false, sortOrder: 20 });
+    await seedHint({ text: published, published: true, sortOrder: 10 });
+
+    const { response, json } = await listAdmin();
+    expect(response.status).toBe(200);
+
+    const rows = adminTestRows(json);
+    expect(rows.map((row) => row.text)).toEqual([published, unpublished]);
+    // The unpublished row must be present (hidden from public, visible here).
+    expect(rows.some((row) => row.text === unpublished && !row.published)).toBe(
+      true,
+    );
+    // Full row shape.
+    const first = rows[0];
+    expect(Object.keys(first).sort()).toEqual(
+      ["createdAt", "id", "published", "sortOrder", "text", "updatedAt"].sort(),
+    );
+  });
+
+  test("PATCH /:id updates text, published, and sortOrder", async () => {
+    const created = await createHint({ text: `${TEST_PREFIX}patch-src` });
+    const id = created.json.id;
+
+    const newText = `${TEST_PREFIX}patch-dst`;
+    const { response, json } = await patchHint(id, {
+      text: newText,
+      published: false,
+      sortOrder: 99,
+    });
+
+    expect(response.status).toBe(200);
+    expect(json.text).toBe(newText);
+    expect(json.published).toBe(false);
+    expect(json.sortOrder).toBe(99);
+
+    // Persisted, not just echoed.
+    const persisted = await prisma.agentPromptHint.findUnique({
+      where: { id },
+    });
+    expect(persisted?.text).toBe(newText);
+    expect(persisted?.published).toBe(false);
+    expect(persisted?.sortOrder).toBe(99);
+  });
+
+  test("PATCH /:id on a missing row returns 404", async () => {
+    const { response } = await patchHint(
+      "00000000-0000-4000-8000-000000000000",
+      { published: false },
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("DELETE /:id removes the row and returns deleted:true", async () => {
+    const created = await createHint({ text: `${TEST_PREFIX}delete-me` });
+    const id = created.json.id;
+
+    const { response, json } = await deleteHint(id);
+    expect(response.status).toBe(200);
+    expect(json).toEqual({
+      object: "agent_prompt_hint",
+      id,
+      deleted: true,
+    });
+
+    const gone = await prisma.agentPromptHint.findUnique({ where: { id } });
+    expect(gone).toBeNull();
+  });
+
+  test("DELETE /:id on a missing row returns 404", async () => {
+    const { response } = await deleteHint(
+      "00000000-0000-4000-8000-000000000000",
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("anonymous writes are rejected (401), and no row is created", async () => {
+    const text = `${TEST_PREFIX}anon`;
+    const { response } = await createHint({ text }, jsonHeaders);
+    expect(response.status).toBe(401);
+
+    const count = await prisma.agentPromptHint.count({ where: { text } });
+    expect(count).toBe(0);
+
+    // Anonymous GET /admin is gated too.
+    const adminAnon = await fetch(`${baseURL}/api/v2/agent-prompt-hints/admin`);
+    expect(adminAnon.status).toBe(401);
+  });
+
+  test("create rejects text longer than 240 chars (400)", async () => {
+    const overLimit = textOfLength(241, "over");
+    expect(overLimit.length).toBe(241);
+
+    const { response } = await createHint({ text: overLimit });
+    expect(response.status).toBe(400);
+
+    const count = await prisma.agentPromptHint.count({
+      where: { text: overLimit },
+    });
+    expect(count).toBe(0);
+  });
+
+  test("create accepts text of exactly 240 chars (201)", async () => {
+    const atLimit = textOfLength(240, "limit");
+    expect(atLimit.length).toBe(240);
+
+    const { response } = await createHint({ text: atLimit });
+    expect(response.status).toBe(201);
+  });
+
+  test("patch rejects text longer than 240 chars (400)", async () => {
+    const created = await createHint({ text: `${TEST_PREFIX}patch-cap` });
+    const overLimit = textOfLength(241, "patchover");
+
+    const { response } = await patchHint(created.json.id, { text: overLimit });
+    expect(response.status).toBe(400);
+  });
+
+  test("unpublished rows are hidden from public GET / but present in GET /admin", async () => {
+    const published = `${TEST_PREFIX}visible`;
+    const unpublished = `${TEST_PREFIX}hidden`;
+    await createHint({ text: published, published: true, sortOrder: 1 });
+    await createHint({ text: unpublished, published: false, sortOrder: 2 });
+
+    const publicView = await readPublicHints();
+    expect(publicView.response.status).toBe(200);
+    expect(publicView.hints).toContain(published);
+    expect(publicView.hints).not.toContain(unpublished);
+
+    const adminView = await listAdmin();
+    const texts = adminTestRows(adminView.json).map((row) => row.text);
+    expect(texts).toContain(published);
+    expect(texts).toContain(unpublished);
+  });
+
+  test("POST /reorder applies sortOrder atomically", async () => {
+    const a = await createHint({
+      text: `${TEST_PREFIX}reorder-a`,
+      sortOrder: 1,
+    });
+    const b = await createHint({
+      text: `${TEST_PREFIX}reorder-b`,
+      sortOrder: 2,
+    });
+
+    const response = await fetch(
+      `${baseURL}/api/v2/agent-prompt-hints/reorder`,
+      {
+        method: "POST",
+        headers: agentKeyHeaders(),
+        body: JSON.stringify({
+          orders: [
+            { id: a.json.id, sortOrder: 50 },
+            { id: b.json.id, sortOrder: 40 },
+          ],
+        }),
+      },
+    );
+    const json = (await response.json()) as { updated: number };
+    expect(response.status).toBe(200);
+    expect(json.updated).toBe(2);
+
+    const rowA = await prisma.agentPromptHint.findUnique({
+      where: { id: a.json.id },
+    });
+    const rowB = await prisma.agentPromptHint.findUnique({
+      where: { id: b.json.id },
+    });
+    expect(rowA?.sortOrder).toBe(50);
+    expect(rowB?.sortOrder).toBe(40);
+  });
+});

--- a/tests/agent-prompt-hints.admin.test.ts
+++ b/tests/agent-prompt-hints.admin.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Server } from "node:http";
 import express from "express";
 import {
@@ -13,6 +14,8 @@ import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
 import { jsonMiddleware } from "@/middleware/json";
 import { noRouteMiddleware } from "@/middleware/noRoute";
 import { pinoMiddleware } from "@/middleware/pino";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { createJwtToken } from "@/utils/jwt";
 import { prisma } from "@/utils/prisma";
 
 type AdminRow = {
@@ -42,6 +45,19 @@ const jsonHeaders: Record<string, string> = {
   "Content-Type": "application/json",
 };
 
+// JWT-authed headers for an account. Used to prove the admin gate: a non-admin
+// account is rejected (403), while the admin account's own JWT is accepted -
+// the same admin identity the agent-templates admin tests authenticate with.
+const jwtHeaders = async (
+  accountId: string,
+): Promise<Record<string, string>> => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "test-device-hint-admin-gate",
+    accountId,
+  }),
+});
+
 const buildApp = (): express.Express => {
   const app = express();
   app.use(pinoMiddleware);
@@ -53,7 +69,9 @@ const buildApp = (): express.Express => {
 
 const app = buildApp();
 let server: Server;
-const baseURL = "http://localhost:4074";
+// Bind to an ephemeral port (0) and read the assigned port back at runtime so
+// concurrent vitest workers never collide on a fixed port (EADDRINUSE).
+let baseURL = "";
 
 const cleanup = () =>
   prisma.agentPromptHint.deleteMany({
@@ -145,8 +163,14 @@ const readPublicHints = async () => {
 describe("Agent prompt hints admin endpoints", () => {
   beforeAll(async () => {
     __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
-    await new Promise<void>((resolve) => {
-      server = app.listen(4074, () => {
+    await new Promise<void>((resolve, reject) => {
+      server = app.listen(0, () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("Unable to determine server port"));
+          return;
+        }
+        baseURL = `http://localhost:${address.port}`;
         resolve();
       });
     });
@@ -276,6 +300,30 @@ describe("Agent prompt hints admin endpoints", () => {
     // Anonymous GET /admin is gated too.
     const adminAnon = await fetch(`${baseURL}/api/v2/agent-prompt-hints/admin`);
     expect(adminAnon.status).toBe(401);
+  });
+
+  test("non-admin authenticated account is rejected (403), and no row is created", async () => {
+    const headers = await jwtHeaders(randomUUID());
+
+    // Write route (POST /) is admin-gated.
+    const text = `${TEST_PREFIX}non-admin`;
+    const { response } = await createHint({ text }, headers);
+    expect(response.status).toBe(403);
+
+    const count = await prisma.agentPromptHint.count({ where: { text } });
+    expect(count).toBe(0);
+
+    // Admin read route (GET /admin) is admin-gated too.
+    const adminList = await listAdmin(headers);
+    expect(adminList.response.status).toBe(403);
+  });
+
+  test("admin account's own JWT passes the admin gate (201)", async () => {
+    const headers = await jwtHeaders(ADMIN_ACCOUNT_ID);
+    const text = `${TEST_PREFIX}admin-jwt`;
+    const { response, json } = await createHint({ text }, headers);
+    expect(response.status).toBe(201);
+    expect(json.text).toBe(text);
   });
 
   test("create rejects text longer than 240 chars (400)", async () => {


### PR DESCRIPTION
## Summary

Admin write-CRUD for `AgentPromptHint`, mirroring the agent-templates admin endpoints and reusing the **same `authOrAgentApiKeyAuth` security**. This is the backend half that powers the prompt-hints admin dashboard in convos-assistants.

## Endpoints

- `GET /admin` - list all hints (incl. unpublished), ordered by `sortOrder`
- `POST /` - create a hint
- `PATCH /:id` - update text / published / sortOrder (404 on missing row)
- `DELETE /:id` - delete a hint (404 on missing row)
- `POST /reorder` - apply `sortOrder` atomically across hints

## Behavior

- Same `authOrAgentApiKeyAuth` guard as the templates admin; anonymous writes are rejected (401) and create no row.
- Hint text is capped at 240 chars on create and patch (400 on overflow; exactly 240 accepted).
- Unpublished rows stay hidden from the public `GET /` but are visible in `GET /admin`.

## Tests

13 endpoint tests in `tests/agent-prompt-hints.admin.test.ts` covering create/list/patch/delete/reorder, auth rejection, the 240-char cap boundaries, and public/admin visibility.

## Base / stacking

This work was authored stacked on the public prompt-hints endpoint (PR #336). #336 has since merged into `otr-dev`, so this PR targets `otr-dev` directly. The single commit has been rebased onto the current `otr-dev` tip; the diff is the admin CRUD only.

## Verification

- `tsc --noEmit` clean (after `prisma generate` against current schema)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785013714&installation_id=128169237&pr_number=338&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F338&signature=cdba9fa43659f7b6e73fef826aa7461e24e0a7e3c9e8621b7fc53bfa7b2293bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add admin write CRUD endpoints for agent prompt hints
> - Adds admin-only routes to the agent prompt hints router: `GET /admin`, `POST /`, `PATCH /:id`, `DELETE /:id`, and `POST /reorder`, all gated behind a new `requireAdmin` middleware in [auth.ts](https://github.com/ephemeraHQ/convos-backend/pull/338/files#diff-ffadd6d72f4f9b739e0eae864423032b922aa491a4384fd3f422481794779c21).
> - `requireAdmin` allows access only if the caller is an agent API key listener or holds the admin account JWT, returning 403 otherwise.
> - The reorder endpoint applies `sortOrder` updates atomically via a Prisma transaction, rejecting duplicate IDs with 400 and missing IDs with 404 without partial writes.
> - Public `GET /` behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2b1166.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin endpoints to fully manage agent prompt hints: create, edit, delete, reorder, and a dedicated admin listing (including unpublished items) with stable ordering.
  * Added admin-only access control for all admin write and admin read operations.

* **Bug Fixes**
  * Strengthened request validation (UUIDs, max hint text length, and reorder batch rules like rejecting duplicate ids).
  * Improved handling for missing records and guaranteed atomic reorder updates.

* **Tests**
  * Expanded integration tests covering CRUD, reorder behavior (including rollback on missing ids), permissions, and public vs admin visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->