### PR TITLE
feat(pii): default redaction model to anthropic/claude-sonnet-5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,9 @@ POSTHOG_PROJECT_TOKEN=
 POSTHOG_HOST=
 # Content moderation model override (default: google/gemini-3.1-flash-lite)
 CONTENT_MODERATION_MODEL=
+# PII redaction model override (default: anthropic/claude-sonnet-5). Persist-time
+# scan that fails CLOSED, so recall is prioritized over cost.
+PII_REDACTION_MODEL=
 # Audio-capable model that transcribes voice attachments before generation
 # (default: google/gemini-3.1-flash-lite). The builder model can't take audio.
 BUILD_TRANSCRIBE_MODEL=

--- a/src/config.ts
+++ b/src/config.ts
@@ -145,12 +145,12 @@ export const CONTENT_MODERATION_MODEL =
   process.env.CONTENT_MODERATION_MODEL?.trim() ||
   "google/gemini-3.1-flash-lite";
 // PII redaction scan run at persist time over the generated template
-// (agentName/description/prompt). Cheap classifier — concrete OpenRouter id so
-// PostHog can price it. Unlike moderation this stage fails CLOSED (see
-// services/pii-redaction.ts): a shared/persisted artifact must never carry
-// un-scanned PII, so a scan failure fails the generation.
+// (agentName/description/prompt). Concrete OpenRouter id so PostHog can price
+// it. Uses a stronger model than moderation because this stage fails CLOSED
+// (see services/pii-redaction.ts): a shared/persisted artifact must never
+// carry un-scanned PII, so recall matters more than cost here.
 export const PII_REDACTION_MODEL =
-  process.env.PII_REDACTION_MODEL?.trim() || "google/gemini-3.1-flash-lite";
+  process.env.PII_REDACTION_MODEL?.trim() || "anthropic/claude-sonnet-5";
 export const BUILDER_EXA_SERVICE_KEY =
   process.env.BUILDER_EXA_SERVICE_KEY?.trim() || "";
 


### PR DESCRIPTION
## Summary

Bumps the default PII-redaction model from `google/gemini-3.1-flash-lite` to `anthropic/claude-sonnet-5`.

The redaction stage added in #315 runs at **persist time** over user-authored template fields and **fails closed** — a scan miss means un-scanned PII lands in a shareable/cloneable row. Given that failure mode, recall matters more than the per-scan cost that motivated the original cheap-classifier pick. Sonnet 5 is the stronger detector.

Still fully overridable via the `PII_REDACTION_MODEL` env var — now also documented in `.env.example` (it was missing there).

## Trade-off

Sonnet 5 is pricier and somewhat slower than Flash-Lite (#315 measured ~1s p50 on Flash-Lite) on the create/fork/edit hot path. Deliberate: recall on a fail-closed, persisted-artifact scan is worth the cost. Cost is capped by the env-var escape hatch if it proves too heavy.

## Changes

- `src/config.ts` — default flipped to `anthropic/claude-sonnet-5`; comment updated to reflect recall-over-cost rationale
- `.env.example` — document `PII_REDACTION_MODEL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785610143&installation_id=128169237&pr_number=339&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F339&signature=35710d6a60255e3060599e64c72ffa843d262428356bbed76b2b2349884ebd75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default PII redaction model to `anthropic/claude-sonnet-5`
> Changes the default value of `PII_REDACTION_MODEL` in [config.ts](https://github.com/ephemeraHQ/convos-backend/pull/339/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012) from `google/gemini-3.1-flash-lite` to `anthropic/claude-sonnet-5`. Also adds `PII_REDACTION_MODEL` to [.env.example](https://github.com/ephemeraHQ/convos-backend/pull/339/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c) with comments noting this is a persist-time scan that fails closed and prioritizes recall. Risk: any deployment relying on the previous default will silently switch models on next deploy if `PII_REDACTION_MODEL` is not explicitly set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7894bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional environment setting to override the redaction model used during scans.
  * Updated the default scan model to improve reliability and provide a better fallback behavior when scans fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->