### PR TITLE
feat(agent-prompt-hints): raise hint length cap 240 to 350

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -207,7 +207,7 @@ model AgentTemplate {
 // Short, quirky prompt suggestions served to the maker's empty composer.
 // Dedicated table, intentionally separate from published AgentTemplates: a
 // hint is just a string, with no owner, slug, avatar, tools, or connections.
-// The public read endpoint enforces the API contract (<= 240 chars, capped
+// The public read endpoint enforces the API contract (<= 350 chars, capped
 // item count); the DB column stays generous TEXT so curation isn't lossy.
 model AgentPromptHint {
   id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid

--- a/src/api/v2/agent-prompt-hints/handlers/create.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/create.ts
@@ -7,7 +7,7 @@ import { prisma } from "@/utils/prisma";
 // column is generous TEXT, but storing an over-length hint here would create an
 // invisible row the public endpoint silently drops, so what an admin saves is
 // exactly what ships.
-const MAX_HINT_LENGTH = 240;
+const MAX_HINT_LENGTH = 350;
 
 const bodySchema = z.object({
   text: z.string().trim().min(1).max(MAX_HINT_LENGTH),

--- a/src/api/v2/agent-prompt-hints/handlers/list.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/list.ts
@@ -5,9 +5,9 @@ import { prisma } from "@/utils/prisma";
 // The API serves each hint as a short string under `hints`. The DB column is
 // generous TEXT so curation is never lossy, so the read path is where the
 // published contract is enforced: never serve an over-length hint (clients
-// budget for <= 240 characters) and cap the payload size. Filtering and the
+// budget for <= 350 characters) and cap the payload size. Filtering and the
 // limit run in SQL so the cap counts only contract-valid rows.
-const MAX_HINT_LENGTH = 240;
+const MAX_HINT_LENGTH = 350;
 const MAX_HINTS = 1000;
 
 export async function listHandler(req: Request, res: Response) {

--- a/src/api/v2/agent-prompt-hints/handlers/patch.ts
+++ b/src/api/v2/agent-prompt-hints/handlers/patch.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/utils/prisma";
 
 // Same length cap as create: the public read filters over-length rows, so the
 // admin write keeps stored == served.
-const MAX_HINT_LENGTH = 240;
+const MAX_HINT_LENGTH = 350;
 
 const paramsSchema = z.object({
   id: z.string().uuid(),

--- a/tests/agent-prompt-hints.admin.test.ts
+++ b/tests/agent-prompt-hints.admin.test.ts
@@ -92,7 +92,7 @@ const seedHint = (args: {
   });
 
 // A fixed-length string (incl. the test prefix) so length-boundary assertions
-// are exact under the 240-char cap.
+// are exact under the 350-char cap.
 const textOfLength = (length: number, label: string) => {
   const head = `${TEST_PREFIX}${label}:`;
   return head + "x".repeat(Math.max(0, length - head.length));
@@ -326,9 +326,9 @@ describe("Agent prompt hints admin endpoints", () => {
     expect(json.text).toBe(text);
   });
 
-  test("create rejects text longer than 240 chars (400)", async () => {
-    const overLimit = textOfLength(241, "over");
-    expect(overLimit.length).toBe(241);
+  test("create rejects text longer than 350 chars (400)", async () => {
+    const overLimit = textOfLength(351, "over");
+    expect(overLimit.length).toBe(351);
 
     const { response } = await createHint({ text: overLimit });
     expect(response.status).toBe(400);
@@ -339,17 +339,17 @@ describe("Agent prompt hints admin endpoints", () => {
     expect(count).toBe(0);
   });
 
-  test("create accepts text of exactly 240 chars (201)", async () => {
-    const atLimit = textOfLength(240, "limit");
-    expect(atLimit.length).toBe(240);
+  test("create accepts text of exactly 350 chars (201)", async () => {
+    const atLimit = textOfLength(350, "limit");
+    expect(atLimit.length).toBe(350);
 
     const { response } = await createHint({ text: atLimit });
     expect(response.status).toBe(201);
   });
 
-  test("patch rejects text longer than 240 chars (400)", async () => {
+  test("patch rejects text longer than 350 chars (400)", async () => {
     const created = await createHint({ text: `${TEST_PREFIX}patch-cap` });
-    const overLimit = textOfLength(241, "patchover");
+    const overLimit = textOfLength(351, "patchover");
 
     const { response } = await patchHint(created.json.id, { text: overLimit });
     expect(response.status).toBe(400);

--- a/tests/agent-prompt-hints.list.test.ts
+++ b/tests/agent-prompt-hints.list.test.ts
@@ -122,11 +122,11 @@ describe("Agent prompt hints list endpoint", () => {
     expect(hints).not.toContain(unpublished);
   });
 
-  test("excludes hints longer than 240 characters, includes 240 exactly", async () => {
-    const atLimit = textOfLength(240, "limit");
-    const overLimit = textOfLength(241, "over");
-    expect(atLimit.length).toBe(240);
-    expect(overLimit.length).toBe(241);
+  test("excludes hints longer than 350 characters, includes 350 exactly", async () => {
+    const atLimit = textOfLength(350, "limit");
+    const overLimit = textOfLength(351, "over");
+    expect(atLimit.length).toBe(350);
+    expect(overLimit.length).toBe(351);
 
     await createHint({ text: atLimit, sortOrder: 1 });
     await createHint({ text: overLimit, sortOrder: 2 });


### PR DESCRIPTION
Raise the per-hint character cap for the curated dice prompt hints from 240 to 350. This is the source of truth: admin `create`/`patch` validation (`MAX_HINT_LENGTH`) and the public `GET /v2/agent-prompt-hints` read filter both move to 350, so what an admin can save equals what ships. Boundary tests updated to the new limit.

Part of a coordinated 4-repo change (backend gate, convos-assistants admin UI, convos-ios + convos-client client clamps). **Merge this first** — it's the write/read gate; older shipped mobile builds keep clamping to 240 until users update, and the website renders full-length immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2NeQiZiBavQCgyPZVZKd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785946552&installation_id=128169237&pr_number=340&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F340&signature=3fbf140ad4f5e598f5c6c445d8868331fdda17aae91c0a2a523345c9a461ede0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `AgentPromptHint` hint length cap from 240 to 350 characters
> Updates `MAX_HINT_LENGTH` from 240 to 350 in the create, patch, and list handlers. The create and patch endpoints now accept hints up to 350 characters; the list endpoint now includes hints up to 350 characters instead of filtering them out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e79f315.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum allowed length for agent prompt hints from 240 to 350 characters across create, update, and list behavior.
  * Longer hints can now be submitted and returned without being rejected by validation.
  * Updated boundary handling so 350-character hints are accepted, while anything longer is still blocked.
* **Tests**
  * Adjusted validation coverage to match the new 350-character limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->