### PR TITLE
fix(generations): skip twitter intent gate for shared X Articles

### DIFF
--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -195,7 +195,10 @@ const twitterContextSchema = z
      *  the real path nothing and stops a caller asserting `hasArticle` on an
      *  empty body. Caller-asserted like the rest of `twitterContext` (handle,
      *  idea) — trusted because the field is agent-API-key-gated; content
-     *  moderation still runs regardless. */
+     *  moderation still runs regardless. The caller MUST set it only when it
+     *  actually folded an article body into `inputs.text`; the server can't
+     *  verify (it has no Twitter access), so asserting it falsely only skips the
+     *  build-intent classifier, never content safety. */
     hasArticle: z.boolean().optional(),
   })
   .strict();

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -187,9 +187,15 @@ const twitterContextSchema = z
     /** True when the caller folded a shared X Article's body into `inputs.text`.
      *  A referenced article is itself a deliberate build request (the user
      *  pointed the bot at long-form content), so it stands in for the intent
-     *  signal — the intent classifier is skipped for it, exactly as it is for an
-     *  attachment. Otherwise a bare `@bot` + article, whose text is the article
-     *  body with no "make an agent" words, gets classified `not_agent_request`. */
+     *  signal — the intent *classifier* (step 14) is skipped for it, exactly as
+     *  it is for an attachment. Otherwise a bare `@bot` + article, whose text is
+     *  the article body with no "make an agent" words, is classified
+     *  `not_agent_request`. It does NOT skip the text-requirement (step 6a): an
+     *  article always carries its body in `inputs.text`, so requiring text costs
+     *  the real path nothing and stops a caller asserting `hasArticle` on an
+     *  empty body. Caller-asserted like the rest of `twitterContext` (handle,
+     *  idea) — trusted because the field is agent-API-key-gated; content
+     *  moderation still runs regardless. */
     hasArticle: z.boolean().optional(),
   })
   .strict();
@@ -824,22 +830,22 @@ export async function generationsPostHandler(req: Request, res: Response) {
       ? body.twitterContext.idea
       : undefined;
 
-  // A shared X Article stands in for the intent signal the same way an
-  // attachment does (see step 14), so it skips both the fast-fail below and the
-  // classifier.
+  // A shared X Article stands in for the intent SIGNAL the same way an
+  // attachment does, so it skips the classifier (step 14). It does NOT skip the
+  // text-requirement fast-fail below — an article always folds its body into
+  // `inputs.text`, so requiring text costs the real path nothing while stopping
+  // a caller from asserting `hasArticle` to push a text-less build through.
   const twitterHasArticle = body.twitterContext?.hasArticle === true;
 
   // 6a. The twitter intent classifier needs text to run on, so a twitter
   //     submission must carry either `inputs.text` or `twitterContext.idea` —
-  //     unless it carries an attachment or a shared article. Either is itself a
-  //     deliberate build request, so it stands in for the intent text (step 14
-  //     skips the classifier in that case). Checked here — before any S3/LLM
-  //     work — so a text-less, signal-less twitter request fails fast.
-  if (
-    body.twitterContext &&
-    coalesced.attachments.length === 0 &&
-    !twitterHasArticle
-  ) {
+  //     unless it carries an attachment. An attachment is itself a deliberate
+  //     build request, so it stands in for the intent text (step 14 skips the
+  //     classifier in that case). A shared article is NOT exempt here: it always
+  //     carries its body in `inputs.text`, so the text requirement is already
+  //     satisfied. Checked here — before any S3/LLM work — so a text-less,
+  //     attachment-less twitter request fails fast.
+  if (body.twitterContext && coalesced.attachments.length === 0) {
     const intentText = twitterIdea ?? coalesced.text;
     if (!intentText || intentText.trim().length === 0) {
       res.status(400).json({

--- a/src/api/v2/agent-templates/handlers/generations-post.ts
+++ b/src/api/v2/agent-templates/handlers/generations-post.ts
@@ -38,7 +38,7 @@
  *  12.                  → existing different body               → 409
  *  13. Attachment bytes — existence + size caps (fresh submit)  → 400
  *  14. Content moderation (text only)                           → 422 (content)
- *  15. Twitter intent moderation (twitterContext, no attachment) → 422 (intent)
+ *  15. Twitter intent moderation (twitterContext, no attachment/article) → 422 (intent)
  *  16. Persist row + fire executor + respondPerMode
  *
  * Idempotent replays go through the SAME respondPerMode path as the original
@@ -184,6 +184,13 @@ const twitterContextSchema = z
     }),
     /** Optional override for the moderation/reply input. Defaults to inputs.text. */
     idea: z.string().optional(),
+    /** True when the caller folded a shared X Article's body into `inputs.text`.
+     *  A referenced article is itself a deliberate build request (the user
+     *  pointed the bot at long-form content), so it stands in for the intent
+     *  signal — the intent classifier is skipped for it, exactly as it is for an
+     *  attachment. Otherwise a bare `@bot` + article, whose text is the article
+     *  body with no "make an agent" words, gets classified `not_agent_request`. */
+    hasArticle: z.boolean().optional(),
   })
   .strict();
 
@@ -817,13 +824,22 @@ export async function generationsPostHandler(req: Request, res: Response) {
       ? body.twitterContext.idea
       : undefined;
 
+  // A shared X Article stands in for the intent signal the same way an
+  // attachment does (see step 14), so it skips both the fast-fail below and the
+  // classifier.
+  const twitterHasArticle = body.twitterContext?.hasArticle === true;
+
   // 6a. The twitter intent classifier needs text to run on, so a twitter
   //     submission must carry either `inputs.text` or `twitterContext.idea` —
-  //     unless it carries an attachment. An attachment is itself a deliberate
-  //     build request, so it stands in for the intent text (step 14 skips the
-  //     classifier in that case). Checked here — before any S3/LLM work — so a
-  //     text-less, attachment-less twitter request fails fast.
-  if (body.twitterContext && coalesced.attachments.length === 0) {
+  //     unless it carries an attachment or a shared article. Either is itself a
+  //     deliberate build request, so it stands in for the intent text (step 14
+  //     skips the classifier in that case). Checked here — before any S3/LLM
+  //     work — so a text-less, signal-less twitter request fails fast.
+  if (
+    body.twitterContext &&
+    coalesced.attachments.length === 0 &&
+    !twitterHasArticle
+  ) {
     const intentText = twitterIdea ?? coalesced.text;
     if (!intentText || intentText.trim().length === 0) {
       res.status(400).json({
@@ -1047,13 +1063,21 @@ export async function generationsPostHandler(req: Request, res: Response) {
   }
 
   // 14. Twitter intent gate — only when twitterContext is present AND there's no
-  //     attachment. An attached image/PDF/audio is itself a deliberate build
-  //     request and stands in for the text intent signal (which the classifier
-  //     never sees), so a photo mention whose only "text" is the photo's own
-  //     t.co link isn't rejected as not_agent_request. Binary attachments are
-  //     still moderated off the request path in the executor (Rekognition for
-  //     images, a transcript check for audio).
-  if (body.twitterContext && coalesced.attachments.length === 0) {
+  //     attachment or shared article. An attached image/PDF/audio is itself a
+  //     deliberate build request and stands in for the text intent signal (which
+  //     the classifier never sees), so a photo mention whose only "text" is the
+  //     photo's own t.co link isn't rejected as not_agent_request. A folded X
+  //     Article is the same case: the user pointed the bot at long-form content,
+  //     but the seed is the article body with no "make an agent" words, so the
+  //     classifier would wrongly reject it — the deliberate reference stands in
+  //     for the intent signal instead. Binary attachments are still moderated
+  //     off the request path in the executor (Rekognition for images, a
+  //     transcript check for audio).
+  if (
+    body.twitterContext &&
+    coalesced.attachments.length === 0 &&
+    !twitterHasArticle
+  ) {
     const intentInput = twitterIdea ?? coalesced.text ?? "";
     const intent = await checkTwitterIntent(intentInput, moderationTrace);
     if (!intent.allowed) {

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -374,6 +374,37 @@ describe("POST /generations — twitter intent moderation", () => {
     expect(res.status).toBe(202);
     expect(intentCalls).toBe(0);
   });
+
+  test("hasArticle skips intent but content moderation still runs", async () => {
+    // hasArticle exempts only the intent classifier — the article body still
+    // goes through content moderation, so disallowed article text is rejected
+    // (422 content), and the intent classifier is never reached.
+    let intentCalls = 0;
+    __resetModerationForTests(() =>
+      Promise.resolve({ allowed: false, reason: "blocked" }),
+    );
+    __resetTwitterIntentForTests(() => {
+      intentCalls += 1;
+      return Promise.resolve({ allowed: true });
+    });
+
+    const res = await post(
+      {
+        source: TEST_SOURCE,
+        inputs: { text: "Shared article from @author: disallowed content" },
+        twitterContext: {
+          twitterHandle: "@some_user",
+          tweetId: "1789432100123456791",
+          hasArticle: true,
+        },
+      },
+      { headers: withKey("tw-article-content-mod") },
+    );
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { reason: string; category: string };
+    expect(body.category).toBe("content");
+    expect(intentCalls).toBe(0);
+  });
 });
 
 describe("POST /generations — twitter happy path", () => {

--- a/tests/agent-templates.generations-twitter.test.ts
+++ b/tests/agent-templates.generations-twitter.test.ts
@@ -344,6 +344,36 @@ describe("POST /generations — twitter intent moderation", () => {
     expect(res.status).toBe(202);
     expect(intentCalls).toBe(0);
   });
+
+  test("hasArticle → intent gate skipped (article is the request)", async () => {
+    // A `@bot` + shared X Article whose seed is the article body carries no
+    // "make an agent" words, so the classifier would reject it — but the folded
+    // article is a deliberate build request, so the gate is skipped entirely
+    // (like an attachment) and the build proceeds.
+    let intentCalls = 0;
+    __resetTwitterIntentForTests(() => {
+      intentCalls += 1;
+      return Promise.resolve({ allowed: false, reason: "not_agent_request" });
+    });
+    __resetGenerationExecutorForTests(() => Promise.resolve());
+
+    const res = await post(
+      {
+        source: TEST_SOURCE,
+        inputs: {
+          text: 'Shared article from @author: "How I built an app"\nA long article body with no explicit build request in it.',
+        },
+        twitterContext: {
+          twitterHandle: "@some_user",
+          tweetId: "1789432100123456790",
+          hasArticle: true,
+        },
+      },
+      { headers: withKey("tw-article-skips-intent") },
+    );
+    expect(res.status).toBe(202);
+    expect(intentCalls).toBe(0);
+  });
 });
 
 describe("POST /generations — twitter happy path", () => {


### PR DESCRIPTION
## Summary

A `@bot` mention that shares an X Article (long-form) seeds the generation with the article body but no explicit "make an agent" words. The Twitter intent classifier then classifies it `not_agent_request` and returns 422 (intent), so no agent is built and the bot posts no reply.

This treats a folded article the same way the intent gate already treats an attachment: a deliberate build request that stands in for the intent signal. The caller sets `twitterContext.hasArticle: true` when it folds an article into `inputs.text`, and the handler skips the intent gate — both the fast-fail text requirement and the classifier call — for it.

## Why

Observed in dev: a mention sharing @anshuc's X Article resolved the full article body into the seed and passed content moderation (`safe`), but the intent classifier returned `not_agent_request` because the seed was article text with no build directive. An article the user deliberately pointed the bot at is not noise — it is the request.

## Notes

- Pairs with convos-assistants twitter-bot PR #2459, which resolves the article body and now sends `hasArticle`. **Deploy ordering:** this backend change must ship first — `twitterContextSchema` is `.strict()`, so a bot sending `hasArticle` to a backend that doesn't yet accept the field would 400.
- DB-backed tests were not run locally (no isolated test DB; only the shared dev Postgres is up, which the suite's setup would truncate). Typecheck passes; the added test mirrors the existing attachment-skips-intent case. CI runs the suite against an ephemeral DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ma39x7cV569dp4XhLQi2b

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964282&installation_id=128169237&pr_number=342&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F342&signature=37345b91340915a7975893e6ba3b9e92a68f981be5c3719ad329e640afb573a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Twitter intent gate for shared X Articles when `twitterContext.hasArticle` is true
> - Adds an optional `hasArticle` boolean field to `twitterContextSchema` in [generations-post.ts](https://github.com/ephemeraHQ/convos-backend/pull/342/files#diff-cfa09e429c402af1c503dbdd05b6690b9fc157c69a9c4ce543a4bc481c3f5624); when `true`, it signals that a shared X Article's body has been folded into `inputs.text`.
> - Modifies the intent gate (step 14) to skip the Twitter intent classifier when `twitterContext.hasArticle` is `true` and there are no attachments; content moderation still runs and can block with a 422.
> - The `hasArticle` field is caller-asserted and gated behind an agent API key.
> - Adds tests covering both the skipped intent gate (202) and the still-active content moderation (422) paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9106aa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests can now mark Twitter/X inputs as a shared article, allowing the system to treat article-based submissions differently during moderation.

* **Bug Fixes**
  * Improved moderation handling so article-based Twitter/X requests skip unnecessary intent checks when no attachments are present.
  * Added coverage to ensure these requests continue through generation successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->