### PR TITLE
fix(moderation): classify agent showcases as not_agent_request

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "tsx watch --env-file=.env src/index.ts",
     "eval:models": "tsx tests/evals/run.ts",
     "eval:prompt": "tsx tests/evals/compare-prompts.ts",
+    "eval:twitter-intent": "tsx tests/evals/twitter-intent.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "generate:key": "tsx dev/scripts/generateDbKey.ts",

--- a/src/api/v2/agent-templates/services/moderation.ts
+++ b/src/api/v2/agent-templates/services/moderation.ts
@@ -122,18 +122,18 @@ export function __resetTwitterIntentForTests(
 function buildTwitterIntentPrompt(input: string): string {
   return `You are an intent classifier for a Twitter bot that builds AI assistants when users @mention it with requests like "Build me a math tutor bot".
 
-The input below has already passed a separate content-safety check; you are ONLY judging whether the author is genuinely asking the bot to BUILD AN AGENT for them.
+The input below has already passed a separate content-safety check; you are ONLY judging whether the author is genuinely asking the bot to BUILD AN AGENT.
 
-The deciding question is who the tweet is FOR: is the author asking the bot to make them an agent (agent_request), or are they talking about / showing off an agent (not_agent_request)?
+The deciding question: is the author ASKING for an agent to be built (for themselves OR for someone else), or are they TALKING ABOUT / showing off an agent that already exists?
 
 Classify into exactly one of two categories:
 
-- "agent_request": The author is directly asking for an AI agent / assistant / bot to be built for them — an imperative or first-person request. Examples: "Build me a math tutor", "Create a recipe assistant", "Make me a travel planner bot", "I need a bot that helps with coding".
+- "agent_request": The author is asking for an AI agent / assistant / bot to be built — for themselves or on someone else's behalf. Examples: "Build me a math tutor", "Create a recipe assistant", "Make me a travel planner bot", "Build my dad a medication-reminder bot", "I need a bot that helps my students with homework".
 
 - "not_agent_request": Anything else. This includes:
   • Greetings, chit-chat, and spam: "follow me back", "retweet this", "hi", "good morning", "@bot what's up", "lol".
   • Requests for the bot to do something other than build an agent.
-  • Tweets that TALK ABOUT, DESCRIBE, ANNOUNCE, SHOWCASE, or PROMOTE an agent rather than ask for one — usually third-person ("Someone built…", "Check out this agent", "Here's the agent <link>") and often linking an agent that already exists. Describing in detail what an agent does — even listing its features — is NOT a request to build one; a showcase or announcement is not a build request.
+  • Tweets that TALK ABOUT, DESCRIBE, ANNOUNCE, SHOWCASE, or PROMOTE an agent that already exists rather than ask for a new one — e.g. reporting what someone already built ("Someone built a live music agent…") or pointing at a finished agent ("Check out this agent", "Here's the agent <link>"). Describing in detail what an agent does — even listing its features — is NOT a request to build one.
 
 Respond with ONLY the classification label, nothing else. No quotes, no explanation, no extra text.
 

--- a/src/api/v2/agent-templates/services/moderation.ts
+++ b/src/api/v2/agent-templates/services/moderation.ts
@@ -122,13 +122,18 @@ export function __resetTwitterIntentForTests(
 function buildTwitterIntentPrompt(input: string): string {
   return `You are an intent classifier for a Twitter bot that builds AI assistants when users @mention it with requests like "Build me a math tutor bot".
 
-The input below has already passed a separate content-safety check; you are ONLY judging whether the user is genuinely asking the bot to BUILD AN AGENT.
+The input below has already passed a separate content-safety check; you are ONLY judging whether the author is genuinely asking the bot to BUILD AN AGENT for them.
+
+The deciding question is who the tweet is FOR: is the author asking the bot to make them an agent (agent_request), or are they talking about / showing off an agent (not_agent_request)?
 
 Classify into exactly one of two categories:
 
-- "agent_request": The user is requesting an AI agent / assistant / bot to be built. Examples: "Build me a math tutor", "Create a recipe assistant", "Make me a travel planner bot", "I need a bot that helps with coding".
+- "agent_request": The author is directly asking for an AI agent / assistant / bot to be built for them — an imperative or first-person request. Examples: "Build me a math tutor", "Create a recipe assistant", "Make me a travel planner bot", "I need a bot that helps with coding".
 
-- "not_agent_request": The content is something other than a build request. Examples: "follow me back", "retweet this", "hi", "good morning", "@bot what's up", "lol", generic greetings, requests for the bot to perform actions other than building agents.
+- "not_agent_request": Anything else. This includes:
+  • Greetings, chit-chat, and spam: "follow me back", "retweet this", "hi", "good morning", "@bot what's up", "lol".
+  • Requests for the bot to do something other than build an agent.
+  • Tweets that TALK ABOUT, DESCRIBE, ANNOUNCE, SHOWCASE, or PROMOTE an agent rather than ask for one — usually third-person ("Someone built…", "Check out this agent", "Here's the agent <link>") and often linking an agent that already exists. Describing in detail what an agent does — even listing its features — is NOT a request to build one; a showcase or announcement is not a build request.
 
 Respond with ONLY the classification label, nothing else. No quotes, no explanation, no extra text.
 

--- a/tests/evals/datasets/twitter-intent.jsonl
+++ b/tests/evals/datasets/twitter-intent.jsonl
@@ -1,0 +1,17 @@
+// Twitter-intent-classifier dataset. `expected` = the correct agent_request verdict.
+// true  = the author is asking the bot to build them an agent → agent_request.
+// false = spam/greeting, or a tweet that describes/showcases an agent → not_agent_request.
+// Drives tests/evals/twitter-intent.ts. See that file for usage.
+// The bot's own @handle is stripped by the worker before the classifier sees the
+// text, so the seeds below omit it (other @handles in the tweet are kept).
+{"id":"encore-showcase","expected":false,"input":"Someone built a live music agent on powered by @link\n\nAsk it to monitor your favorite local venues websites and send me weekly shows + grab tix. Uses @browserbase under the hood to go buy tickets for you using Link!\n\nHere's the agent convos.org/a/ledger.imfyi","notes":"The real prod miss: a third-person showcase of an existing agent (links it) that the gate wrongly built 'Encore' from. Describes agent features but asks for nothing → not_agent_request."}
+{"id":"friend-announcement","expected":false,"input":"Check out this agent my friend made — it plans weekly meal prep and spits out a grocery list every Sunday. Try it: convos.org/a/mealprep.tasty","notes":"Third-person announcement linking an existing agent."}
+{"id":"product-promo","expected":false,"input":"We just shipped an incredible travel-planner agent 🧳 It finds cheap flights, books hotels, and builds a day-by-day itinerary. Link below 👇 convos.org/a/wanderly.trips","notes":"Marketing/promo that lists features and links the agent — not a build request."}
+{"id":"describe-no-link","expected":false,"input":"This bot is wild — it watches crypto prices and DMs you the moment your coins move 5%. The future is here.","notes":"Describes an agent with no ask and no link — still not a build request."}
+{"id":"math-tutor","expected":true,"input":"Build me a math tutor bot that explains calculus step by step","notes":"Direct imperative build request."}
+{"id":"fridge-recipes","expected":true,"input":"make me a recipe assistant that suggests dinners from whatever's in my fridge","notes":"First-person build request."}
+{"id":"concert-tickets-request","expected":true,"input":"I want an agent that tracks concert tickets for my favorite bands and grabs them the second they drop","notes":"Same music/ticket domain as encore-showcase but framed as a first-person request — must NOT be over-rejected as a showcase."}
+{"id":"travel-planner-request","expected":true,"input":"create a travel planner that finds cheap flights and builds an itinerary","notes":"Same domain as product-promo but an actual request → agent_request."}
+{"id":"greeting","expected":false,"input":"gm ☀️","notes":"Greeting, no request."}
+{"id":"follow-spam","expected":false,"input":"follow me back and I'll follow you","notes":"Engagement spam."}
+{"id":"chitchat","expected":false,"input":"lol this is the funniest thing I've seen all day","notes":"Chit-chat."}

--- a/tests/evals/datasets/twitter-intent.jsonl
+++ b/tests/evals/datasets/twitter-intent.jsonl
@@ -12,6 +12,8 @@
 {"id":"fridge-recipes","expected":true,"input":"make me a recipe assistant that suggests dinners from whatever's in my fridge","notes":"First-person build request."}
 {"id":"concert-tickets-request","expected":true,"input":"I want an agent that tracks concert tickets for my favorite bands and grabs them the second they drop","notes":"Same music/ticket domain as encore-showcase but framed as a first-person request — must NOT be over-rejected as a showcase."}
 {"id":"travel-planner-request","expected":true,"input":"create a travel planner that finds cheap flights and builds an itinerary","notes":"Same domain as product-promo but an actual request → agent_request."}
+{"id":"third-party-dad","expected":true,"input":"build my dad a medication reminder bot that pings him when it's time to take each pill","notes":"A build request with a third-party beneficiary — still agent_request; the describe-vs-request axis is not about who benefits."}
+{"id":"third-party-students","expected":true,"input":"create a homework helper for my students that explains problems without giving away the answer","notes":"Third-party-beneficiary request → agent_request (guards against narrowing agent_request to first-person)."}
 {"id":"greeting","expected":false,"input":"gm ☀️","notes":"Greeting, no request."}
 {"id":"follow-spam","expected":false,"input":"follow me back and I'll follow you","notes":"Engagement spam."}
 {"id":"chitchat","expected":false,"input":"lol this is the funniest thing I've seen all day","notes":"Chit-chat."}

--- a/tests/evals/twitter-intent.ts
+++ b/tests/evals/twitter-intent.ts
@@ -1,0 +1,261 @@
+/**
+ * Twitter-intent-classifier eval (run under tsx).
+ *
+ * Answers: when a tweet @mentions the build bot, does the intent gate correctly
+ * tell a genuine build request from a tweet that merely TALKS ABOUT / SHOWS OFF
+ * an agent? A real prod build ("Encore") fired off @ShaneMac's third-person
+ * showcase of an existing agent — the gate read the described features as a
+ * request. This eval scores the gate on a labeled dataset (showcases /
+ * announcements / spam as expected=false; genuine build requests as
+ * expected=true) so the prompt is tuned empirically, not by guesswork.
+ *
+ * Variants:
+ *   baseline — the intent prompt BEFORE this change (frozen inline). No
+ *              describe-vs-request distinction; expected to build the showcases.
+ *   current  — the SHIPPED gate (checkTwitterIntent) with this PR's prompt.
+ *
+ * Usage:
+ *   BUILDER_OPENROUTER_API_KEY=...  \
+ *   pnpm tsx tests/evals/twitter-intent.ts --variants baseline,current --samples 3
+ *
+ * An OpenRouter key is required (BUILDER_OPENROUTER_API_KEY or
+ * EVAL_OPENROUTER_API_KEY); the eval calls the real classifier model. There is
+ * no Braintrust dependency — the console summary is the whole report.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-non-null-assertion */
+
+import { parseArgs } from "node:util";
+import { mapLimit } from "./lib/concurrency";
+import { loadCases } from "./lib/dataset";
+import type { EvalCase } from "./lib/types";
+
+// ---------------------------------------------------------------------------
+// Config (flags > env > default)
+// ---------------------------------------------------------------------------
+const { values } = parseArgs({
+  options: {
+    variants: { type: "string" },
+    model: { type: "string" },
+    samples: { type: "string" },
+    dataset: { type: "string" },
+    concurrency: { type: "string" },
+  },
+});
+
+const ALL_VARIANTS = ["baseline", "current"] as const;
+type Variant = (typeof ALL_VARIANTS)[number];
+
+const VARIANTS: Variant[] = (() => {
+  const raw = (values.variants ?? process.env.EVAL_VARIANTS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const picked = (raw.length ? raw : ALL_VARIANTS) as Variant[];
+  for (const v of picked) {
+    if (!ALL_VARIANTS.includes(v)) {
+      throw new Error(
+        `Unknown variant "${v}". Choose from ${ALL_VARIANTS.join(", ")}`,
+      );
+    }
+  }
+  return picked;
+})();
+const MODEL =
+  values.model ??
+  process.env.CONTENT_MODERATION_MODEL ??
+  "google/gemini-3.1-flash-lite";
+const SAMPLES = Math.max(
+  1,
+  Number(values.samples ?? process.env.EVAL_SAMPLES ?? 3),
+);
+const DATASET =
+  values.dataset ??
+  process.env.EVAL_DATASET ??
+  "tests/evals/datasets/twitter-intent.jsonl";
+const CONCURRENCY = Math.max(1, Number(values.concurrency ?? 6));
+
+interface IntentCase extends EvalCase {
+  /** true = the tweet is a genuine agent_request. */
+  expected: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Env bootstrap (mirror lib/generate.ts) — @/config validates at import time,
+// so set placeholders BEFORE the dynamic imports in loadDeps() below.
+// ---------------------------------------------------------------------------
+function setDefault(key: string, value: string): void {
+  if (!process.env[key]) process.env[key] = value;
+}
+setDefault("XMTP_NOTIFICATION_SECRET", "eval-placeholder-secret");
+setDefault("NOTIFICATION_SERVER_URL", "http://localhost:8080");
+setDefault("ASSISTANT_API_URL", "https://assistants.test.local");
+setDefault("SIWE_DOMAIN", "convos.app");
+setDefault("SIWE_URI", "https://convos.app");
+setDefault("NONCE_HMAC_SECRET", "0".repeat(64));
+setDefault("SIWE_ALLOWED_CHAIN_IDS", "1");
+setDefault("BUILDER_SITE_URL", "https://dev.convos.org");
+
+const OPENROUTER_KEY =
+  process.env.BUILDER_OPENROUTER_API_KEY?.trim() ||
+  process.env.EVAL_OPENROUTER_API_KEY?.trim() ||
+  "";
+
+// ---------------------------------------------------------------------------
+// Frozen pre-change prompt (baseline). Verbatim from before this PR so the
+// before/after is visible in one run.
+// ---------------------------------------------------------------------------
+function baselineIntentPrompt(input: string): string {
+  return `You are an intent classifier for a Twitter bot that builds AI assistants when users @mention it with requests like "Build me a math tutor bot".
+
+The input below has already passed a separate content-safety check; you are ONLY judging whether the user is genuinely asking the bot to BUILD AN AGENT.
+
+Classify into exactly one of two categories:
+
+- "agent_request": The user is requesting an AI agent / assistant / bot to be built. Examples: "Build me a math tutor", "Create a recipe assistant", "Make me a travel planner bot", "I need a bot that helps with coding".
+
+- "not_agent_request": The content is something other than a build request. Examples: "follow me back", "retweet this", "hi", "good morning", "@bot what's up", "lol", generic greetings, requests for the bot to perform actions other than building agents.
+
+Respond with ONLY the classification label, nothing else. No quotes, no explanation, no extra text.
+
+Tweet text to classify:
+${input}`;
+}
+
+// agent_request ⇒ true, not_agent_request ⇒ false, anything else ⇒ null (the
+// real gate fails open on an odd label; here we report it as an error rather
+// than scoring it as a miss).
+function parseLabel(raw: string | null | undefined): boolean | null {
+  const t = (raw ?? "").trim().toLowerCase();
+  if (t === "agent_request") return true;
+  if (t === "not_agent_request") return false;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Deps — dynamic-imported after the env bootstrap above (relative paths, since
+// the tsx path-alias resolver differs for dynamic import()).
+// ---------------------------------------------------------------------------
+let _mod: any = null;
+let _client: any = null;
+async function loadDeps(): Promise<{ mod: any; client: any }> {
+  if (!_mod || !_client) {
+    _mod = await import("../../src/api/v2/agent-templates/services/moderation");
+    _client =
+      await import("../../src/api/v2/agent-templates/services/openrouter-client");
+    _mod.__setBuilderApiKeyOverrideForTests(OPENROUTER_KEY);
+    _mod.__setContentModelOverrideForTests(MODEL);
+  }
+  return { mod: _mod, client: _client };
+}
+
+async function runBaseline(input: string): Promise<boolean | null> {
+  const { client } = await loadDeps();
+  const resp = await client.openRouterChatCompletion({
+    apiKey: OPENROUTER_KEY,
+    stage: "twitter-intent",
+    body: {
+      model: MODEL,
+      messages: [{ role: "user", content: baselineIntentPrompt(input) }],
+      temperature: 0.1,
+      max_tokens: 20,
+    },
+  });
+  return parseLabel(resp.choices[0]?.message?.content);
+}
+
+async function runCurrent(input: string): Promise<boolean | null> {
+  const { mod } = await loadDeps();
+  const res = await mod.checkTwitterIntent(input);
+  return Boolean(res.allowed);
+}
+
+async function runVariant(v: Variant, input: string): Promise<boolean | null> {
+  return v === "baseline" ? runBaseline(input) : runCurrent(input);
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+async function main(): Promise<void> {
+  const cases = loadCases(DATASET) as IntentCase[];
+  for (const c of cases) {
+    if (typeof c.expected !== "boolean") {
+      throw new Error(`Case "${c.id}" is missing a boolean \`expected\` field`);
+    }
+  }
+  if (!OPENROUTER_KEY) {
+    throw new Error(
+      "No OpenRouter key — set BUILDER_OPENROUTER_API_KEY or EVAL_OPENROUTER_API_KEY.",
+    );
+  }
+
+  const runs = cases.flatMap((c) =>
+    Array.from({ length: SAMPLES }, (_u, sample) => ({ c, sample })),
+  );
+
+  // variant → caseId → correct-sample-count / non-null-sample-count.
+  const tally = new Map<Variant, Map<string, number>>();
+  const seen = new Map<Variant, Map<string, number>>();
+
+  for (const variant of VARIANTS) {
+    tally.set(variant, new Map());
+    seen.set(variant, new Map());
+    console.log(`\n▶ ${variant} (${MODEL}, ${runs.length} runs)…`);
+    await mapLimit(runs, CONCURRENCY, async ({ c }) => {
+      let verdict: boolean | null = null;
+      try {
+        verdict = await runVariant(variant, c.input);
+      } catch (err) {
+        console.error(`  ✗ ${variant} · ${c.id}: ${String(err)}`);
+      }
+      if (verdict !== null) {
+        const correct = verdict === c.expected ? 1 : 0;
+        tally
+          .get(variant)!
+          .set(c.id, (tally.get(variant)!.get(c.id) ?? 0) + correct);
+        seen.get(variant)!.set(c.id, (seen.get(variant)!.get(c.id) ?? 0) + 1);
+      }
+    });
+  }
+
+  // A case is correct only when a MAJORITY of its non-null samples match; a case
+  // whose every sample errored is reported as "error", never as a miss.
+  const seenCount = (v: Variant, c: IntentCase) => seen.get(v)!.get(c.id) ?? 0;
+  const isCorrect = (v: Variant, c: IntentCase) => {
+    const n = seenCount(v, c);
+    return n > 0 && (tally.get(v)!.get(c.id) ?? 0) * 2 >= n;
+  };
+  const cell = (v: Variant, c: IntentCase): string => {
+    if (seenCount(v, c) === 0) return "error ⚠";
+    const ok = isCorrect(v, c);
+    const got = ok ? c.expected : !c.expected;
+    return `${got ? "agent_request" : "not_agent_request"}${ok ? " ✓" : " ✗"}`;
+  };
+
+  console.log(
+    `\n=== twitter-intent eval — model=${MODEL}, samples=${SAMPLES} ===`,
+  );
+  console.log(`case (expected)                 | ${VARIANTS.join(" | ")}`);
+  for (const c of cases) {
+    const exp = c.expected ? "agent_request" : "not_agent_request";
+    const cols = VARIANTS.map((v) => cell(v, c)).join(" | ");
+    console.log(`${(c.id + " (" + exp + ")").padEnd(31)} | ${cols}`);
+  }
+  for (const v of VARIANTS) {
+    const correctCases = cases.filter((c) => isCorrect(v, c)).length;
+    const errored = cases.filter((c) => seenCount(v, c) === 0).length;
+    const errNote = errored ? ` (${errored} errored)` : "";
+    console.log(`accuracy ${v}: ${correctCases}/${cases.length}${errNote}`);
+  }
+
+  if (_mod) {
+    _mod.__setContentModelOverrideForTests(null);
+    _mod.__setBuilderApiKeyOverrideForTests(undefined);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The Twitter build bot generated a stray agent ("Encore") off a third-person **showcase** tweet — [@ShaneMac's](https://x.com/ShaneMac) *"Someone built a live music agent on @convosmessenger… Ask it to monitor your favorite local venues… Here's the agent convos.org/a/ledger.imfyi"*. That tweet describes an agent and links an existing one; it asks for nothing.

The `checkTwitterIntent` gate that's supposed to catch exactly this let it through. Its `not_agent_request` examples were all trivially-short spam/greetings — nothing covered a tweet that *describes/announces/showcases* an agent. Since the tweet detailed agent functionality, the model matched it to `agent_request`.

This is a **precision miss in the existing gate**, fixed at the gate:

- `buildTwitterIntentPrompt` now leads with the deciding question — is the author *asking for an agent to be built for them*, or *talking about / showing off* one — and enumerates describe / announce / showcase / promote (usually third-person, often linking an existing agent) as `not_agent_request`. Listing an agent's features is not a request to build one.
- The fail-open posture is unchanged; this only sharpens the describe-vs-request boundary. Genuine requests — including first-person ones in the same domain ("I want an agent that tracks concert tickets…") — still classify as `agent_request`.

## Regression eval

The existing twitter unit tests **mock** `checkTwitterIntent`, so they can't exercise a prompt change. Added a runnable eval in the repo's tsx-eval idiom (mirrors `tests/evals/classifier.ts`):

- `tests/evals/datasets/twitter-intent.jsonl` — labeled cases: showcases/announcements/spam (`expected:false`) and genuine build requests (`expected:true`), including the real Encore tweet and a same-domain first-person request as a discrimination check.
- `tests/evals/twitter-intent.ts` — scores the **real** gate, with a frozen `baseline` variant (the pre-change prompt) so the before/after shows in one run.
- `pnpm eval:twitter-intent` (needs `BUILDER_OPENROUTER_API_KEY` / `EVAL_OPENROUTER_API_KEY`).

`pnpm check` (typecheck + prettier + eslint) passes. **I could not run the live eval here — no OpenRouter key in this environment — so the model-side before/after is unverified by me;** run `pnpm eval:twitter-intent` with a key to confirm `baseline` builds the showcases and `current` rejects them while keeping the requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786127031&installation_id=128169237&pr_number=344&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F344&signature=56aed5857680b25d4965ee9f5cce71c339e9e6c39c99fd080cf9b9762f022a35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify agent showcases as `not_agent_request` in Twitter intent moderation
> - Updates `buildTwitterIntentPrompt` in [moderation.ts](https://github.com/ephemeraHQ/convos-backend/pull/344/files#diff-ebf0afac89691310720a0ccd58b90c00f68696c2624edca642434965a4defe2a) to distinguish between requests to build a new agent and tweets that describe, announce, or showcase an existing one — the latter are now labeled `not_agent_request`
> - Expands the `agent_request` definition to include requests made on someone else's behalf, and adds clarifying examples for both categories
> - Adds a runnable eval script ([twitter-intent.ts](https://github.com/ephemeraHQ/convos-backend/pull/344/files#diff-0fbe09c52d7e45385cd40aedb245a119e0944e5d7d62e981ad7aab6b0085d876)) that benchmarks baseline vs. current prompt accuracy against a labeled dataset via OpenRouter
> - Behavioral Change: tweets that previously matched as `agent_request` (e.g. showcasing an existing agent) may now be classified as `not_agent_request`, changing downstream allow/deny outcomes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 242ea75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new evaluation command for Twitter intent checks, making it easier to run classification tests from the command line.
  * Introduced a dedicated Twitter-intent evaluation dataset with clearer examples and label guidance.

* **Bug Fixes**
  * Improved intent classification guidance so tweets that only discuss or showcase an agent are less likely to be treated as build requests.
  * Added broader coverage for greetings, spam, promos, and direct request examples to improve classification consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->