### PR TITLE
fix(agent-templates): retry transient OpenRouter connection drops in the builder

### DIFF
--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -45,6 +45,7 @@ import {
   OpenAI,
 } from "openai";
 import { getPostHogClient } from "@/api/v2/agent-templates/services/posthog";
+import logger from "@/utils/logger";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
@@ -286,9 +287,16 @@ export async function openRouterChatCompletion(
       // can't hold the resolved upstream: that's only on the response, after the
       // wrapper has captured `$ai_generation`. So we emit it ourselves to tell
       // whether the Bedrock preference took effect or fell back, and to segment
-      // latency by upstream. Fire-and-forget; only on success (errors are
-      // captured by the wrapper's own event).
-      captureProviderTelemetry(opts, response, performance.now() - startedMs);
+      // latency by upstream. `attempt` is the retry count that preceded this
+      // success (0 on the first try) so retry frequency is monitorable in
+      // PostHog. Fire-and-forget; only on success (errors are captured by the
+      // wrapper's own event).
+      captureProviderTelemetry(
+        opts,
+        response,
+        performance.now() - startedMs,
+        attempt,
+      );
       return response;
     } catch (err) {
       const delayMs = TRANSIENT_RETRY_BASE_DELAY_MS * 2 ** attempt;
@@ -303,9 +311,17 @@ export async function openRouterChatCompletion(
       ) {
         throw err;
       }
-      console.warn(
-        `[openrouter] transient connection error on stage=${opts.stage} attempt=${attempt + 1}/${TRANSIENT_RETRY_ATTEMPTS + 1}; retrying in ${delayMs}ms:`,
-        err instanceof Error ? err.message : String(err),
+      // Structured so retry frequency is queryable (by stage/attempt) in the log
+      // pipeline, not just eyeballed in raw console output.
+      logger.warn(
+        {
+          stage: opts.stage,
+          attempt: attempt + 1,
+          maxAttempts: TRANSIENT_RETRY_ATTEMPTS + 1,
+          delayMs,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "[openrouter] transient connection error, retrying",
       );
       await sleep(delayMs);
     }
@@ -319,6 +335,7 @@ function captureProviderTelemetry(
   opts: OpenRouterChatOptions,
   response: OpenAI.Chat.Completions.ChatCompletion,
   latencyMs: number,
+  retryCount: number,
 ): void {
   if (!opts.trace) return;
   const ph = getPostHogClient();
@@ -338,6 +355,9 @@ function captureProviderTelemetry(
         // providers/responses that don't report it.
         upstream_provider: r.provider,
         latency_ms: latencyMs,
+        // Transient-connection retries that preceded this success (0 = first
+        // try). Lets retry frequency be monitored alongside the call.
+        retry_count: retryCount,
       },
     });
   } catch {

--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -247,14 +247,25 @@ export async function openRouterChatCompletion(
         }
       : {};
 
-  // Only set request options that are defined — the OpenAI SDK validates
-  // `timeout` as a positive integer and rejects an explicit `undefined`.
   const requestOptions: Record<string, unknown> = {};
   if (opts.signal) requestOptions.signal = opts.signal;
-  if (typeof opts.timeoutMs === "number")
-    requestOptions.timeout = opts.timeoutMs;
+
+  // `timeoutMs` is the wallclock cap for the whole call, not per attempt — a
+  // single deadline shared across retries + backoff. Each attempt gets only the
+  // time still left in the budget, so retries can never multiply the cap. The
+  // OpenAI SDK validates `timeout` as a positive integer, so it's floored at 1.
+  const deadlineMs =
+    typeof opts.timeoutMs === "number"
+      ? performance.now() + opts.timeoutMs
+      : null;
 
   for (let attempt = 0; ; attempt++) {
+    if (deadlineMs !== null) {
+      requestOptions.timeout = Math.max(
+        1,
+        Math.ceil(deadlineMs - performance.now()),
+      );
+    }
     const startedMs = performance.now();
     try {
       const response = await client.chat.completions.create(
@@ -277,16 +288,18 @@ export async function openRouterChatCompletion(
       captureProviderTelemetry(opts, response, performance.now() - startedMs);
       return response;
     } catch (err) {
-      // Give up once the caller has cancelled, the budget is spent, or the error
-      // isn't a transient connection drop — the caller's error handling owns it.
+      const delayMs = TRANSIENT_RETRY_BASE_DELAY_MS * 2 ** attempt;
+      // Give up when the caller cancelled, the retry budget is spent, the error
+      // isn't a transient connection drop, or the wallclock deadline can't fit
+      // another attempt after backoff — the caller's error handling owns those.
       if (
         opts.signal?.aborted ||
         attempt >= TRANSIENT_RETRY_ATTEMPTS ||
-        !isTransientConnectionError(err)
+        !isTransientConnectionError(err) ||
+        (deadlineMs !== null && performance.now() + delayMs >= deadlineMs)
       ) {
         throw err;
       }
-      const delayMs = TRANSIENT_RETRY_BASE_DELAY_MS * 2 ** attempt;
       console.warn(
         `[openrouter] transient connection error on stage=${opts.stage} attempt=${attempt + 1}/${TRANSIENT_RETRY_ATTEMPTS + 1}; retrying in ${delayMs}ms:`,
         err instanceof Error ? err.message : String(err),

--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -17,8 +17,13 @@
  * When `POSTHOG_PROJECT_TOKEN` is unset, `getPostHogClient()` returns null and
  * we fall back to a plain OpenAI client — no tracing, no monitoring params, no
  * behavioural change. A custom `fetch` delegates to `globalThis.fetch` at call
- * time so existing fetch-mocking tests keep working, and `maxRetries: 0`
- * preserves the old single-attempt semantics of the raw-fetch code.
+ * time so existing fetch-mocking tests keep working. `maxRetries: 0` disables
+ * the SDK's own retry so retry policy lives here explicitly:
+ * `openRouterChatCompletion` retries a transient connection failure (a dropped
+ * socket — undici "terminated"/ECONNRESET, or the SDK's `APIConnectionError`)
+ * a couple of times with backoff, while an HTTP error status and a caller/
+ * timeout abort stay single-attempt (the call site's error handling and the
+ * wallclock cap own those).
  *
  * Model attribution note: the wrapper records the *requested* model as
  * `$ai_model` (`openAIParams.model ?? result.model`). The default model is a
@@ -32,7 +37,13 @@
 
 import { randomUUID } from "node:crypto";
 import { OpenAI as PostHogOpenAI } from "@posthog/ai/openai";
-import { OpenAI } from "openai";
+import {
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  APIError,
+  APIUserAbortError,
+  OpenAI,
+} from "openai";
 import { getPostHogClient } from "@/api/v2/agent-templates/services/posthog";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
@@ -86,8 +97,9 @@ function buildClient(apiKey: string): { client: OpenAI; wrapped: boolean } {
   const common = {
     apiKey,
     baseURL: OPENROUTER_BASE_URL,
-    // The raw-fetch code made a single attempt; keep that so error/timeout
-    // tests don't see silent retries.
+    // Disable the SDK's own retry — `openRouterChatCompletion` owns retry policy
+    // (transient connection errors only), so the SDK must not also retry and
+    // double up on 4xx/5xx/timeouts.
     maxRetries: 0,
     // Attribute every builder call to the "Convos Agents" app in OpenRouter.
     defaultHeaders: OPENROUTER_ATTRIBUTION_HEADERS,
@@ -159,12 +171,56 @@ export interface OpenRouterChatOptions {
   trace?: TraceContext;
 }
 
+// Retry budget for a transient connection failure. A dropped socket usually
+// fails fast (the incident that motivated this — an `ECONNRESET`/"terminated"
+// mid-generate — failed in ~0s), so a couple of quick attempts recover it well
+// inside the per-request wallclock cap.
+const TRANSIENT_RETRY_ATTEMPTS = 2;
+const TRANSIENT_RETRY_BASE_DELAY_MS = 250;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Whether an error is a transient connection failure worth retrying: the socket
+ * dropped before a response arrived. NOT a caller/timeout abort (its own error
+ * handling and the wallclock cap own that) and NOT an HTTP error status (a
+ * response arrived — a 4xx/5xx is the model/gateway's answer, not a broken
+ * connection). The SDK wraps a failed socket as `APIConnectionError` (an
+ * `APIError` subclass with no `status`); the raw undici error ("terminated" /
+ * ECONNRESET) can also surface directly, so its signature is matched as a
+ * fallback. `APIConnectionTimeoutError` extends `APIConnectionError`, so it is
+ * excluded first.
+ */
+function isTransientConnectionError(err: unknown): boolean {
+  if (err instanceof APIConnectionTimeoutError) return false;
+  if (err instanceof APIUserAbortError) return false;
+  if ((err as { name?: unknown }).name === "AbortError") return false;
+  if (err instanceof APIError && typeof err.status === "number") return false;
+  if (err instanceof APIConnectionError) return true;
+  const e = err as {
+    message?: unknown;
+    code?: unknown;
+    cause?: { code?: unknown; message?: unknown };
+  };
+  const signature = [e.message, e.code, e.cause?.code, e.cause?.message]
+    .filter((s): s is string => typeof s === "string")
+    .join(" ")
+    .toLowerCase();
+  return /terminated|econnreset|econnrefused|etimedout|epipe|socket hang up|other side closed|network error|fetch failed/.test(
+    signature,
+  );
+}
+
 /**
  * Make one OpenRouter chat completion. When PostHog is configured the call is
  * routed through `@posthog/ai`'s wrapper, which auto-emits a `$ai_generation`
  * (input, output, tokens, latency) tagged with the trace context. Otherwise it
- * is a plain OpenAI SDK call. Errors propagate to the caller unchanged so each
- * call site keeps its own error handling.
+ * is a plain OpenAI SDK call. A transient connection failure is retried a couple
+ * of times with backoff (each attempt emits its own `$ai_generation`); every
+ * other error — HTTP status, abort/timeout, malformed body — propagates to the
+ * caller unchanged so each call site keeps its own error handling.
  */
 export async function openRouterChatCompletion(
   opts: OpenRouterChatOptions,
@@ -198,27 +254,46 @@ export async function openRouterChatCompletion(
   if (typeof opts.timeoutMs === "number")
     requestOptions.timeout = opts.timeoutMs;
 
-  const startedMs = performance.now();
-  const response = await client.chat.completions.create(
-    // `provider` is an OpenRouter extension (passed through by the OpenAI SDK).
-    // Default first so a caller-supplied `body.provider` can still override.
-    {
-      provider: DEFAULT_PROVIDER_PREFERENCE,
-      ...opts.body,
-      ...monitoring,
-    } as any,
-    requestOptions,
-  );
-
-  // Record which upstream OpenRouter actually routed to. `$ai_provider` is the
-  // native API-provider field (now "openrouter" — the gateway), but it can't
-  // hold the resolved upstream: that's only on the response, after the wrapper
-  // has captured `$ai_generation`. So we emit it ourselves to tell whether the
-  // Bedrock preference took effect or fell back, and to segment latency by
-  // upstream. Fire-and-forget; only on success (errors are captured by the
-  // wrapper's own event).
-  captureProviderTelemetry(opts, response, performance.now() - startedMs);
-  return response;
+  for (let attempt = 0; ; attempt++) {
+    const startedMs = performance.now();
+    try {
+      const response = await client.chat.completions.create(
+        // `provider` is an OpenRouter extension (passed through by the OpenAI
+        // SDK). Default first so a caller-supplied `body.provider` can override.
+        {
+          provider: DEFAULT_PROVIDER_PREFERENCE,
+          ...opts.body,
+          ...monitoring,
+        } as any,
+        requestOptions,
+      );
+      // Record which upstream OpenRouter actually routed to. `$ai_provider` is
+      // the native API-provider field (now "openrouter" — the gateway), but it
+      // can't hold the resolved upstream: that's only on the response, after the
+      // wrapper has captured `$ai_generation`. So we emit it ourselves to tell
+      // whether the Bedrock preference took effect or fell back, and to segment
+      // latency by upstream. Fire-and-forget; only on success (errors are
+      // captured by the wrapper's own event).
+      captureProviderTelemetry(opts, response, performance.now() - startedMs);
+      return response;
+    } catch (err) {
+      // Give up once the caller has cancelled, the budget is spent, or the error
+      // isn't a transient connection drop — the caller's error handling owns it.
+      if (
+        opts.signal?.aborted ||
+        attempt >= TRANSIENT_RETRY_ATTEMPTS ||
+        !isTransientConnectionError(err)
+      ) {
+        throw err;
+      }
+      const delayMs = TRANSIENT_RETRY_BASE_DELAY_MS * 2 ** attempt;
+      console.warn(
+        `[openrouter] transient connection error on stage=${opts.stage} attempt=${attempt + 1}/${TRANSIENT_RETRY_ATTEMPTS + 1}; retrying in ${delayMs}ms:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      await sleep(delayMs);
+    }
+  }
 }
 
 /** Custom event recording the resolved upstream provider + served model for one

--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -208,7 +208,10 @@ function isTransientConnectionError(err: unknown): boolean {
     .filter((s): s is string => typeof s === "string")
     .join(" ")
     .toLowerCase();
-  return /terminated|econnreset|econnrefused|etimedout|epipe|socket hang up|other side closed|network error|fetch failed/.test(
+  // Note: no ETIMEDOUT here — a timeout stays single-attempt per the contract
+  // above (the SDK's own wallclock timeout raises APIConnectionTimeoutError,
+  // already excluded); only unambiguous connection drops are retried.
+  return /terminated|econnreset|econnrefused|epipe|socket hang up|other side closed|network error|fetch failed/.test(
     signature,
   );
 }

--- a/tests/template-gen.openrouter-retry.test.ts
+++ b/tests/template-gen.openrouter-retry.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Transient-connection retry tests for the template generation service.
+ *
+ * A dropped socket (undici "terminated" / ECONNRESET — the failure mode that
+ * silently killed a Twitter build with no reply) is retried a couple of times
+ * with backoff, while an HTTP error status and a caller/timeout abort stay
+ * single-attempt. These assert the retry recovers a transient blip, gives up
+ * after the budget, and never retries an abort.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const TEST_API_KEY = "test-or-key-retry-1234567890";
+
+const originalFetch = globalThis.fetch;
+
+function urlOf(input: any): string {
+  return typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+}
+
+/** A valid 200 completion the generate stage can parse into a template. */
+function okTemplateResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      model: "anthropic/claude-opus-4.8-fast",
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              prompt: "test",
+              agentName: "Bot",
+              emoji: "🤖",
+              description: "desc",
+              category: "Work",
+              tools: [],
+            }),
+          },
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+/** An undici-style dropped-socket rejection: `TypeError: terminated` with an
+ *  `ECONNRESET` cause — exactly the shape that reached the executor as
+ *  "Generate stage failed: terminated". */
+function connectionResetError(): Error {
+  const err = new TypeError("terminated");
+  (err as any).cause = { code: "ECONNRESET", message: "read ECONNRESET" };
+  return err;
+}
+
+describe("templateGen service — transient connection retry", () => {
+  let orCalls: number;
+
+  beforeEach(async () => {
+    orCalls = 0;
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    mod.__setBuilderApiKeyOverrideForTests(TEST_API_KEY);
+    mod.__setBuilderModelOverrideForTests(null);
+    mod.__setExaKeyOverrideForTests(null);
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    mod.__setBuilderApiKeyOverrideForTests(undefined);
+    mod.__setBuilderModelOverrideForTests(null);
+    mod.__setExaKeyOverrideForTests(undefined);
+  });
+
+  test("a transient connection reset is retried and then succeeds", async () => {
+    globalThis.fetch = ((input: any) => {
+      if (urlOf(input) === OPENROUTER_URL) {
+        orCalls++;
+        // Fail the first attempt, then serve a valid completion.
+        return orCalls === 1
+          ? Promise.reject(connectionResetError())
+          : Promise.resolve(okTemplateResponse());
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as any;
+
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    const result = await mod.generateTemplate({ text: "Build me a bot" });
+
+    expect(result.template.agentName).toBe("Bot");
+    expect(orCalls).toBe(2); // one failure + one successful retry
+  });
+
+  test("a persistent connection reset is retried up to the budget, then throws", async () => {
+    globalThis.fetch = ((input: any) => {
+      if (urlOf(input) === OPENROUTER_URL) {
+        orCalls++;
+        return Promise.reject(connectionResetError());
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as any;
+
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+
+    await expect(
+      mod.generateTemplate({ text: "Build me a bot" }),
+    ).rejects.toThrow();
+    expect(orCalls).toBe(3); // initial attempt + 2 retries
+  });
+
+  test("an abort/timeout is not retried", async () => {
+    globalThis.fetch = ((input: any) => {
+      if (urlOf(input) === OPENROUTER_URL) {
+        orCalls++;
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        return Promise.reject(err);
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as any;
+
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+
+    await expect(
+      mod.generateTemplate({ text: "Build me a bot" }),
+    ).rejects.toThrow(/timed out/i);
+    expect(orCalls).toBe(1); // never retried
+  });
+
+  test("an HTTP 500 is not treated as a transient connection error", async () => {
+    globalThis.fetch = ((input: any) => {
+      if (urlOf(input) === OPENROUTER_URL) {
+        orCalls++;
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: { message: "boom" } }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as any;
+
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+
+    await expect(
+      mod.generateTemplate({ text: "Build me a bot" }),
+    ).rejects.toThrow(/OpenRouter API error 500/);
+    expect(orCalls).toBe(1); // HTTP status is a response, not a broken socket
+  });
+});


### PR DESCRIPTION
## Summary

Closes CON-661. A transient connection drop to OpenRouter during a builder generation — undici `TypeError: terminated` with an `ECONNRESET` cause — surfaced to the executor as `Generate stage failed: terminated`, and the generation was marked `failed` with **no retry**. For the Twitter bot that means a valid @mention silently gets no reply (the worker drops a `failed` generation and never re-polls).

Repro: production generation `17998d92-acd3-4dad-b249-03f9151a164d` (2026-07-08, `twitter:petermdenton`) — moderation → `safe` ✓, twitter-intent → `agent_request` ✓, then generate (`anthropic/claude-opus-4.8-fast`) died on `read ECONNRESET` at connection time (HTTP 500, 0 output tokens, ~0s). It was the only generate-stage failure across ~a day of builds — a transient blip, exactly what a retry recovers.

## Change

`openRouterChatCompletion` now owns retry policy:

- A **transient connection failure** — the SDK's `APIConnectionError`, or the raw undici `terminated`/`ECONNRESET`/`ECONNREFUSED`/`socket hang up`/… signature — is retried up to 2 times with backoff (250ms, 500ms). Each attempt emits its own `$ai_generation`, so the transient error and the recovery are both visible in the trace.
- An **HTTP error status** (4xx/5xx) and a **caller/timeout abort** stay single-attempt: a response arrived, or the wallclock cap fired, and the call site's existing handling (`OpenRouter API error N` / `timed out`) owns those. `APIConnectionTimeoutError` extends `APIConnectionError`, so it's excluded first.
- `maxRetries: 0` still disables the SDK's own retry so it can't double up.

Because the retry lives in the shared client, every builder stage (moderation, twitter-intent, generate, compose-reply, …) gets the same protection — not just the Twitter path.

## Why not the worker

A worker-side retry can't cover this: the Twitter bot's idempotency key is a v5 UUID derived from the tweet ID, so a re-POST collapses onto the same already-`failed` row. The retry has to live in the generate path.

## Scope note

Deliberately scoped to connection drops (the observed failure), not 5xx/429. Retrying a 5xx often just re-hits a genuinely-erroring upstream, and 429 needs `Retry-After` handling; both are also locked to single-attempt by existing error tests. Easy to extend later if we want it.

## Verification

- `pnpm typecheck` + `eslint` clean.
- New `tests/template-gen.openrouter-retry.test.ts` (4 cases): a transient reset is retried and succeeds (2 calls); a persistent reset exhausts the budget then throws (3 calls); an abort is not retried (1 call, surfaces as timeout); an HTTP 500 is not retried (1 call). Existing `openrouter-errors` + `openrouter-timeout` suites still green (17 tests total).

## Related

Twitter-bot side (full long-tweet text + linked-page extraction so the builder gets the real request): xmtplabs/convos-assistants#2541

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786130059&installation_id=128169237&pr_number=345&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F345&signature=2ab11aff91492a50a606553b9dbeacf3529a4ac1da8b5239c81995e109b0bcf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transient OpenRouter connection drops in the agent template builder
> - Adds retry logic to `openRouterChatCompletion` in [openrouter-client.ts](https://github.com/ephemeraHQ/convos-backend/pull/345/files#diff-6350fa102ccf82d602fd5ecd832731a3c9feb5914c17a24758537d6e4e634626): up to 2 retries with exponential backoff (250ms base) for transient connection errors (e.g. ECONNRESET, EPIPE, dropped sockets).
> - Introduces `isTransientConnectionError` to classify retryable errors, explicitly excluding HTTP status errors, timeouts, and aborts from retries.
> - Enforces a single wallclock deadline across all retry attempts using `opts.timeoutMs`, passing remaining time to each OpenAI SDK call.
> - Adds `retry_count` to the PostHog `LLM_CALL_EVENT` payload via `captureProviderTelemetry`.
> - New Vitest suite in [template-gen.openrouter-retry.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/345/files#diff-900e879349ed47c56d3a3a307dd64c1fdd358383cabfb5db87a2cd4f629c3624) covers ECONNRESET recovery, exhausted retries, abort non-retry, and HTTP 500 non-retry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8fee3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating templates by automatically retrying certain temporary connection failures.
  * Reduced failed requests caused by brief network issues, while still respecting timeouts and cancellations.
  * Non-recoverable errors, such as server-side failures or user-aborted requests, still stop immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->