### PR TITLE
fix(subscriptions): make apple-ssn DID_RENEW fixture relative to now

### DIFF
--- a/tests/subscriptions/apple-ssn.test.ts
+++ b/tests/subscriptions/apple-ssn.test.ts
@@ -209,12 +209,18 @@ describe("POST /v2/webhooks/apple/ssn", () => {
     const otid = "1000000000000010";
     const { subscription } = await seedSubscription(otid);
 
+    // The renewal must extend into the future so the derived status is active
+    // regardless of the calendar date the suite runs on.
+    const purchaseDate = new Date();
+    const expiresDate = new Date(
+      purchaseDate.getTime() + 30 * 24 * 60 * 60 * 1000,
+    );
     const transactionJws = await signTransaction({
       originalTransactionId: otid,
       transactionId: "3000000000000010",
       productId: "app.convos.subs.monthly",
-      purchaseDate: new Date("2026-06-01T00:00:00.000Z").getTime(),
-      expiresDate: new Date("2026-07-01T00:00:00.000Z").getTime(),
+      purchaseDate: purchaseDate.getTime(),
+      expiresDate: expiresDate.getTime(),
     });
     const signedPayload = await signNotification({
       notificationType: "DID_RENEW",
@@ -231,7 +237,7 @@ describe("POST /v2/webhooks/apple/ssn", () => {
       where: { id: subscription.id },
     });
     expect(updated?.currentPeriodEnd.toISOString()).toBe(
-      "2026-07-01T00:00:00.000Z",
+      expiresDate.toISOString(),
     );
     expect(updated?.status).toBe(SubscriptionStatus.active);
 


### PR DESCRIPTION
The `DID_RENEW: extends currentPeriodEnd` test in `tests/subscriptions/apple-ssn.test.ts` hardcoded `expiresDate: 2026-07-01` and asserted the derived subscription status is `active`. Status is derived in `deriveSubscriptionStatusFromTransaction` from `expiresDate <= now`, so once the calendar crossed 2026-07-01 the renewal derived `expired` and the assertion failed on **every** branch's CI (`expected 'expired' to be 'active'`), unrelated to the branch's changes.

This anchors the renewal window to `now + 30d` and ties the `currentPeriodEnd` assertion to that same value, so the derived status stays `active` regardless of when the suite runs. The other fixtures in the file assert clock-independent outcomes (stored `currentPeriodEnd`, `grace`/`billingRetry`/`expired`/`revoked` statuses) and are left as absolute dates.

Verified locally against a migrated Postgres: full `apple-ssn` suite 15/15 green across repeated runs.

Fixes CON-637.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786134873&installation_id=128169237&pr_number=348&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F348&signature=0ad0a0289acae9f81871516f15283ede23e0e32a34c0753e20a162df4626b6b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `DID_RENEW` Apple SSN test fixture to use dates relative to current time
> The `DID_RENEW` test in [apple-ssn.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/348/files#diff-7bc8745da01533d0a874841806775b613c68642be0811e8c010751d5abd5cd91) used hardcoded `purchaseDate` and `expiresDate` values that would eventually fall in the past, causing the derived subscription status to become inactive. Both dates are now computed at test runtime, with `expiresDate` set to 30 days after `purchaseDate`, and the `currentPeriodEnd` assertion compares against the computed value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac7eb49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->