### PR TITLE
fix(agent-templates): make OpenRouter retry backoff abortable

### DIFF
--- a/src/api/v2/agent-templates/services/openrouter-client.ts
+++ b/src/api/v2/agent-templates/services/openrouter-client.ts
@@ -183,8 +183,24 @@ export interface OpenRouterChatOptions {
 const TRANSIENT_RETRY_ATTEMPTS = 2;
 const TRANSIENT_RETRY_BASE_DELAY_MS = 250;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+// Resolves early if `signal` aborts, so a caller's cancellation takes effect
+// during the retry backoff instead of only after the timer elapses. Resolving
+// (not rejecting) hands control back to the loop, whose catch guard sees the
+// aborted signal on the next attempt and throws the underlying error.
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onDone = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onDone);
+      resolve();
+    };
+    const timer = setTimeout(onDone, ms);
+    signal?.addEventListener("abort", onDone);
+  });
 }
 
 /**
@@ -327,7 +343,7 @@ export async function openRouterChatCompletion(
         },
         "[openrouter] transient connection error, retrying",
       );
-      await sleep(delayMs);
+      await sleep(delayMs, opts.signal);
     }
   }
 }

--- a/tests/template-gen.openrouter-retry.test.ts
+++ b/tests/template-gen.openrouter-retry.test.ts
@@ -155,3 +155,51 @@ describe("templateGen service — transient connection retry", () => {
     expect(orCalls).toBe(1); // HTTP status is a response, not a broken socket
   });
 });
+
+describe("openRouterChatCompletion — abort during retry backoff", () => {
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    const client =
+      await import("@/api/v2/agent-templates/services/openrouter-client");
+    client.__resetOpenRouterClientForTests();
+  });
+
+  test("aborting mid-backoff stops promptly instead of waiting out the delay", async () => {
+    // First backoff is 250ms. Fail transiently so a retry is scheduled, then
+    // abort ~5ms in — while the backoff timer is running. The abortable sleep
+    // must hand control back at once (loop re-checks the signal and throws),
+    // so total time stays far below the 250ms it would take if the sleep
+    // ignored the signal and ran to completion.
+    globalThis.fetch = ((input: any) => {
+      if (urlOf(input) === OPENROUTER_URL) {
+        return Promise.reject(connectionResetError());
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as any;
+
+    const client =
+      await import("@/api/v2/agent-templates/services/openrouter-client");
+    client.__resetOpenRouterClientForTests();
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, 5);
+    const startedMs = performance.now();
+    await expect(
+      client.openRouterChatCompletion({
+        apiKey: TEST_API_KEY,
+        stage: "generate",
+        body: {
+          model: "test/model",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+    const elapsedMs = performance.now() - startedMs;
+    clearTimeout(timer);
+
+    expect(elapsedMs).toBeLessThan(150);
+  });
+});


### PR DESCRIPTION
Follow-up to the Macroscope note on #349: the OpenRouter transient-connection retry backoff wasn't tied to the caller's abort signal.

## Problem
`openRouterChatCompletion`'s retry loop did `await sleep(delayMs)` — a plain timer. If the caller aborted `opts.signal` (or its deadline passed) *during* the backoff window, the function sat in the timer and only re-checked cancellation on the next loop iteration. Worst case the generation kept running ~one backoff window (up to 500ms) past the abort.

## Fix
`sleep` now takes the optional `AbortSignal` and resolves early when it aborts. Resolving (not rejecting) hands control straight back to the loop, whose existing catch guard (`opts.signal?.aborted`) throws the underlying error on the next attempt — so cancellation semantics and the thrown error are unchanged, it just happens promptly. Listener is cleaned up on both paths (timer fires / abort fires).

## Test
Adds a case driving `openRouterChatCompletion` directly: a transient failure schedules a 250ms backoff, the signal aborts ~5ms in, and the call is asserted to reject in well under the full backoff — which fails against the old unconditional `sleep`.

## Promotion note
Not for this promotion cycle — lands on `otr-dev` and rides the **next** `otr-dev → otr-prod` promotion. #349 ships as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786138204&installation_id=128169237&pr_number=350&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F350&signature=90fbac3d073f477220744af6ae1b54405589529ad0d969628f2e951b416793ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make OpenRouter retry backoff in `openRouterChatCompletion` abortable via `AbortSignal`
> - Extends the `sleep` utility in [openrouter-client.ts](https://github.com/ephemeraHQ/convos-backend/pull/350/files#diff-6350fa102ccf82d602fd5ecd832731a3c9feb5914c17a24758537d6e4e634626) to accept an optional `AbortSignal`, resolving early if the signal is already aborted or becomes aborted during the delay.
> - Passes `opts.signal` into `sleep` during retry backoff so cancellation takes effect immediately rather than waiting out the full delay.
> - Adds a test suite in [template-gen.openrouter-retry.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/350/files#diff-900e879349ed47c56d3a3a307dd64c1fdd358383cabfb5db87a2cd4f629c3624) verifying that aborting ~5ms into a backoff resolves in <150ms instead of the full backoff duration.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c8cc264. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->