### PR TITLE
docs(payments): money-domain AGENTS.md — the ledger-wallet law

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+Repo-wide guidance for agents and humans working in `convos-backend`. Start
+here, then read the domain-specific `AGENTS.md` nearest the code you are
+changing.
+
+## Domain guides
+
+- **Money / credits / balances / subscription billing → [`src/payments/AGENTS.md`](src/payments/AGENTS.md).**
+  MANDATORY before touching any credits, wallet, or subscription-billing code.
+  The one rule up front: all balance movement goes through the ledger wallet
+  (`@/payments` `consume` / `grant` / `adjust`); `getBalance` is the single
+  source of truth; never write `UserCredits` / `CreditLedger` directly outside
+  `src/payments/ledger/`. Everything else — entry points, idempotency, units —
+  is in that file.
+
+## Client-facing API request contracts
+
+Request schemas under `src/api/v2/**` are an append-only contract with shipped
+mobile clients we cannot force-update: new fields optional + server-defaulted,
+never tighten an existing shape, version the path if you must break it. Full
+rule and rationale in [`CLAUDE.md`](CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,23 @@ schema, pin every legacy shape with `assertLegacyShapeValidates` (see
 CI instead of breaking users. Example:
 `tests/subscriptions/verify-body-contract.test.ts`.
 
+## Money / credits: go through the ledger wallet
+
+Any change touching credits, balances, or subscription billing MUST go through
+the ledger wallet. `getBalance` is the single source of truth; all balance
+movement goes through `@/payments` `consume` / `grant` / `adjust` (subscriptions
+via `grantSubscriptionPeriod` / `forfeitSubscriptionPeriod`). Never write
+`UserCredits` or `CreditLedger` directly outside `src/payments/ledger/`.
+
+Read the full law before writing money code: **`src/payments/AGENTS.md`**.
+Repo-wide agent guidance: `AGENTS.md`.
+
 ## PR checklist
 
 - [ ] Any change touching `src/api/v2/**` request schemas: backwards-compatible
       for shipped clients? (old request shapes still validate — add/extend a
       contract test)
+- [ ] Any change touching credits/balances: routed through `@/payments`
+      (`consume` / `grant` / `adjust`), no direct `UserCredits` / `CreditLedger`
+      writes outside `src/payments/ledger/`, idempotency key present
+      (see `src/payments/AGENTS.md`)

--- a/src/payments/AGENTS.md
+++ b/src/payments/AGENTS.md
@@ -76,9 +76,16 @@ the `@/payments` names in new code.
 ## Idempotency keys
 
 Every ledger mutation carries an idempotency key, charset
-`^[A-Za-z0-9_-]{1,255}$` — underscore separators, **not** colon. Replays are
-validated field-by-field: the same key with a different payload throws
-`IdempotencyMismatchError` (surfaced as HTTP 409), it does not silently double-move.
+`^[A-Za-z0-9_-]{1,255}$` — underscore separators, **not** colon.
+
+The top-level entry points (`consume` / `grant` / `adjust`) validate replays
+field-by-field: the same key with a different payload throws
+`IdempotencyMismatchError` (HTTP 409), and a matching replay returns the prior
+result instead of double-moving. That guarantee lives in `applyDelta`, **not**
+in `applyDeltaWithTx`. If you call `applyDeltaWithTx` directly (as the
+subscription helpers do), you own the idempotency pre-check — look up the prior
+row first (see `grantSubscriptionPeriod`'s `findLedgerRow` short-circuit), or a
+duplicate key surfaces as a raw Prisma `P2002`, not a 409.
 
 Server-generated key shapes: `signup_bonus_<accountId>`,
 `daily_refill_<accountId>_<YYYY-MM-DD>`, and per-period `sub_grant` / `sub_forfeit`
@@ -98,8 +105,9 @@ keys. The `consume` key is client-supplied by the assistants harness
 
 ## Adding a new money flow — checklist
 
-1. Add, debit, or admin-adjust? Use `grant`, `consume`, or `adjust`. Do not
-   invent a new mutation path.
+1. Add, debit, or admin-adjust? Use `grant`, `consume`, or `adjust`.
+   Subscription billing? Use `grantSubscriptionPeriod` / `forfeitSubscriptionPeriod`.
+   Do not invent a new mutation path.
 2. New systematic source of granted credits? Define a `GrantKind` (migration +
    seed) and pass its id to `grant`. Don't overload `manual` for a systematic
    source.

--- a/src/payments/AGENTS.md
+++ b/src/payments/AGENTS.md
@@ -1,0 +1,117 @@
+# Money & Credits — how to work in this domain
+
+This is the law for any code that touches credits, balances, or subscription
+billing. Read it before writing or reviewing money code. Ledger changes move
+real user balances and are hard to reverse — treat this surface with care.
+
+## The one invariant
+
+`getBalance(accountId)` — which reads `UserCredits.balance` — is the single
+source of truth for an account's spendable credits. It is the **same wallet for
+everyone**: subscribers and non-subscribers read the same number.
+
+`UserCredits.balance` is a materialized running balance. `CreditLedger` is the
+append-only journal. They are kept in lockstep by exactly **one** code path:
+
+    applyDelta / applyDeltaWithTx   (src/payments/ledger/repository.ts)
+
+which, in a single transaction, writes the `CreditLedger` row **and** updates
+`UserCredits.balance`. Nothing else may move a balance. Move the balance any
+other way and the journal and the materialized balance diverge — the invariant
+is broken and every downstream number (spend gate, admin view, reconciliation)
+becomes a lie.
+
+## Sanctioned entry points — the ONLY way to touch money
+
+**Read** (`@/payments`):
+
+| Function                                           | Purpose                                                                                                              |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `getBalance(accountId)`                            | Spendable balance — the source of truth.                                                                             |
+| `isAllowed(accountId)`                             | Advisory UX gate (`balance >= reservedMaxTurnCredits`). NOT authorization — `consume` enforces the floor atomically. |
+| `getHistory(accountId, limit?, cursor?)`           | Ledger rows, descending, cursor-paginated.                                                                           |
+| `getBucketedConsumption(accountId, since, bucket)` | Consume sums per UTC day/week/month.                                                                                 |
+
+**Mutate** (`@/payments`):
+
+| Function        | Purpose                                                                                   |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| `consume(args)` | Debit for model/agent spend. Converts `usdCostMicros`→credits, floor-checked, idempotent. |
+| `grant(args)`   | Add credits. Validates the `GrantKind` is active in-tx, idempotent.                       |
+| `adjust(args)`  | Manual +/- adjustment (admin). Floor-checked when negative, idempotent.                   |
+
+**Subscriptions only** (`src/subscriptions/grants.ts`) — materialize entitlement
+into the wallet:
+
+| Function                           | Purpose                                                                          |
+| ---------------------------------- | -------------------------------------------------------------------------------- |
+| `grantSubscriptionPeriod(tx, …)`   | Writes a real `sub_grant` credit row on verify/renewal.                          |
+| `forfeitSubscriptionPeriod(tx, …)` | Bounded `sub_forfeit` clawback on expiry — never wipes non-subscription credits. |
+
+Both run `applyDeltaWithTx` inside the caller's transaction, so the subscription
+row update and the ledger row commit or roll back together.
+
+`getSpendableBalance` / `isSpendAllowed` / `recordConsume`
+(`src/payments/spendable.ts`) are thin aliases to `getBalance` / the floor check
+/ `consume`, kept so the agent gate and admin view keep stable imports. Prefer
+the `@/payments` names in new code.
+
+## Hard rules — do NOT
+
+- **Do NOT write `UserCredits` or `CreditLedger` directly** (`prisma.userCredits.update`,
+  `prisma.creditLedger.create`, raw SQL) anywhere outside `src/payments/ledger/`.
+  Read-only queries for reporting are fine; mutations are not.
+- **Do NOT derive a balance.** There is no `tierGrant − periodConsumes`, no
+  bimodal switch on `isEntitledSubscription`. One wallet, one number.
+- **Do NOT re-add `recordOnly`** or any subscriber-only no-mutation debit path.
+  It was removed on purpose (#324): subscriber period credits live in the wallet,
+  so there is one debit path for everyone.
+- **Do NOT re-add a materialize CLI** to paper over the Option-A `n=1` window (an
+  entitled subscriber whose current period was not yet materialized, having
+  already drained their raw wallet, can transiently hit `InsufficientBalanceError`;
+  the next verify/renewal materializes the period and fixes it). This is
+  documented and accepted — see the migration doc.
+- **Do NOT call a money mutation without an idempotency key.**
+
+## Idempotency keys
+
+Every ledger mutation carries an idempotency key, charset
+`^[A-Za-z0-9_-]{1,255}$` — underscore separators, **not** colon. Replays are
+validated field-by-field: the same key with a different payload throws
+`IdempotencyMismatchError` (surfaced as HTTP 409), it does not silently double-move.
+
+Server-generated key shapes: `signup_bonus_<accountId>`,
+`daily_refill_<accountId>_<YYYY-MM-DD>`, and per-period `sub_grant` / `sub_forfeit`
+keys. The `consume` key is client-supplied by the assistants harness
+(`consume_<instanceId>_<generationId>`).
+
+## Units
+
+- Credits are `BigInt` end to end (`UserCredits.balance`, `CreditLedger.delta`).
+- `usdCostMicros` on a consume row is the **raw provider cost** (what the model
+  call cost), pre-markup. Credits debited = `usdToCredits(usdCostMicros)` =
+  `usdCostMicros × markupRate × creditsPerDollar`, ceil-rounded per row
+  (`src/payments/credits/pricing.ts`). So summing `usdCostMicros` gives cost of
+  goods, not revenue and not what users were charged.
+- `consume` is USD-cost-denominated; `grant` / `adjust` are credit-denominated
+  (no pricing snapshot needed — the delta is the record).
+
+## Adding a new money flow — checklist
+
+1. Add, debit, or admin-adjust? Use `grant`, `consume`, or `adjust`. Do not
+   invent a new mutation path.
+2. New systematic source of granted credits? Define a `GrantKind` (migration +
+   seed) and pass its id to `grant`. Don't overload `manual` for a systematic
+   source.
+3. Needs atomicity with other DB writes (e.g. a subscription row)? Take a tx and
+   call `applyDeltaWithTx(tx, …)`. Otherwise the top-level `grant` / `consume` /
+   `adjust` already open their own transaction.
+4. Provide a deterministic idempotency key (charset above). One logical event =
+   one key.
+5. Test balance movement, idempotent replay (same key → no double move), and
+   floor behavior on debits.
+
+## Deeper reference
+
+`docs/plans/credits-single-ledger-migration.md` — the single-ledger model, the
+`sub_grant` / `sub_forfeit` design, and the Option-A migration tradeoff in full.

--- a/src/payments/AGENTS.md
+++ b/src/payments/AGENTS.md
@@ -56,6 +56,15 @@ row update and the ledger row commit or roll back together.
 / `consume`, kept so the agent gate and admin view keep stable imports. Prefer
 the `@/payments` names in new code.
 
+A few existing internal flows write through the low-level primitives directly
+rather than the `consume`/`grant`/`adjust` façade: the signup bonus
+(`grantSignupBonusWithTx`, `src/payments/signup-bonus.ts`) and daily refill
+(`src/payments/daily-refill/service.ts`) call `applyDeltaWithTx` / `applyDelta`
+with their own `GrantKind`, because they must commit inside a wider transaction
+or a batch loop. They are precedent, not violations — a new tx-scoped flow
+follows the same pattern (see the checklist below), and still lives inside
+`src/payments`.
+
 ## Hard rules — do NOT
 
 - **Do NOT write `UserCredits` or `CreditLedger` directly** (`prisma.userCredits.update`,
@@ -113,7 +122,10 @@ keys. The `consume` key is client-supplied by the assistants harness
    source.
 3. Needs atomicity with other DB writes (e.g. a subscription row)? Take a tx and
    call `applyDeltaWithTx(tx, …)`. Otherwise the top-level `grant` / `consume` /
-   `adjust` already open their own transaction.
+   `adjust` already open their own transaction. Caveat: `applyDeltaWithTx` /
+   `applyDelta` do NOT enforce the `GrantKind.active` gate that `grant()` does —
+   if your credit source uses a `GrantKind` that can be deactivated, either go
+   through `grant()` or replicate the active-check in your tx.
 4. Provide a deterministic idempotency key (charset above). One logical event =
    one key.
 5. Test balance movement, idempotent replay (same key → no double move), and


### PR DESCRIPTION
## What

Adds normative agent/human guidance for the money domain so nobody re-creates the two-bucket bug (subscription writing a parallel display balance that never grants into the ledger wallet → agent spend check reads raw \`getBalance\`→0→blocked).

Three docs, no code:

- **\`src/payments/AGENTS.md\`** — the full law. One invariant: \`getBalance\` = \`UserCredits.balance\` = single source of truth for everyone; balance moves ONLY through \`applyDelta\`/\`applyDeltaWithTx\` (journal row + materialized balance, one atomic tx). Sanctioned entry points (\`consume\`/\`grant\`/\`adjust\` + reads); subscriptions via \`grant\`/\`forfeitSubscriptionPeriod\`. Hard DO-NOTs: no direct \`UserCredits\`/\`CreditLedger\` writes outside \`src/payments/ledger/\`, no derived balance, idempotency charset + unit conventions.
- **\`AGENTS.md\`** (repo root) — thin entrypoint routing to the domain guide + the API-contract rule.
- **\`CLAUDE.md\`** — Money/credits section + PR-checklist line.

## Why

Cross-engineer comms failure during wallet/ledger vs subscription dev shipped the two-bucket bug to prod. This pins the invariant so it can't recur. Follows #324 (single-ledger unification, merged 2026-07-02).

## Scope

Docs only — zero runtime change. All claims verified against real \`otr-dev\` code pre-commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786189129&installation_id=128169237&pr_number=352&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F352&signature=f172c37f362d31d9e2d55dd76c744f0b01858d878fb5f703d72e9ba1d37bdb62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document the ledger-wallet law for money domain changes in payments
> - Adds [src/payments/AGENTS.md](https://github.com/ephemeraHQ/convos-backend/pull/352/files#diff-d297b5b8f22a6db9b40302fe8f087779791192d78c306782e59d77b267e53c77) as the authoritative domain guide for money and credits, defining `getBalance` as the single source of truth and requiring all balance movement to go through `consume`/`grant`/`adjust` (or `applyDeltaWithTx` for tx-scoped flows).
> - Updates [CLAUDE.md](https://github.com/ephemeraHQ/convos-backend/pull/352/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) to direct all credits/balances/subscription-billing changes through the ledger wallet, forbid direct writes to `UserCredits` or `CreditLedger` outside `src/payments/ledger/`, and add PR checklist items for idempotency keys.
> - Adds a repo-wide [AGENTS.md](https://github.com/ephemeraHQ/convos-backend/pull/352/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) that mandates consulting `src/payments/AGENTS.md` for any money-related change and documents append-only rules for `src/api/v2/**` client-facing contracts.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9b1ba07. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated guidance for working with credits, balances, and subscription billing.
  * Clarified the required request-shape rules for versioned API endpoints, including how future changes should be introduced safely.
  * Added more detailed instructions for handling money-related updates consistently and safely, including idempotency and balance handling expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->