### PR TITLE
add agent variant update endpoint

### DIFF
--- a/src/api/v2/agents/agents.router.ts
+++ b/src/api/v2/agents/agents.router.ts
@@ -6,6 +6,7 @@ import {
 } from "@/middleware/rateLimit";
 import { joinHandler } from "./handlers/join";
 import { joinStatusHandler } from "./handlers/join-status";
+import { updateAgentVariantHandler } from "./handlers/update-variant";
 
 export const agentsRouter = Router();
 
@@ -19,6 +20,11 @@ export const agentsRouter = Router();
 // budget re-minting the same account-less token, surfacing as a confusing
 // `notAuthenticated`. A 403 fails honestly and breaks that loop.
 agentsRouter.post("/join", agentJoinLimiter, requireAccount, joinHandler);
+agentsRouter.patch(
+  "/:instanceId/variant",
+  requireAccount,
+  updateAgentVariantHandler,
+);
 // Generous limit on status polling (60/5min) — clients on the fallback
 // async path may poll every ~5s; status reads have no upstream side-effects.
 agentsRouter.get(

--- a/src/api/v2/agents/handlers/update-variant.ts
+++ b/src/api/v2/agents/handlers/update-variant.ts
@@ -1,0 +1,178 @@
+import type { Response as ExpressResponse, Request } from "express";
+import { z } from "zod";
+import { liveVariantWhere } from "@/api/v2/agents/lib/variant-routing";
+import { XMTP_ENV } from "@/config";
+import { accountIdSchema } from "@/utils/account-id";
+import { prisma } from "@/utils/prisma";
+import { getAssistantApiKey, getAssistantApiUrl } from "./assistant-config";
+
+const paramsSchema = z.object({
+  instanceId: z.string().uuid(),
+});
+
+const bodySchema = z
+  .object({
+    variantId: z.string().trim().min(1).max(64).nullable(),
+  })
+  .strict();
+
+const assistantUpdateResponseSchema = z.object({
+  ok: z.literal(true),
+  variant: z.string().nullable(),
+});
+
+type VariantDescriptor = {
+  slug: string;
+  label: string;
+  whatToTest: string;
+  prUrl: string;
+};
+
+function serializeVariantDescriptor(variant: VariantDescriptor): string {
+  return JSON.stringify({
+    slug: variant.slug,
+    label: variant.label,
+    whatToTest: variant.whatToTest,
+    prUrl: variant.prUrl,
+  });
+}
+
+function statusFromAssistantError(status: number): number {
+  if ([400, 401, 403, 404, 409, 410].includes(status)) return status;
+  return 502;
+}
+
+export async function updateAgentVariantHandler(
+  req: Request,
+  res: ExpressResponse,
+) {
+  if (XMTP_ENV === "production") {
+    res.status(403).json({ error: "AGENT_VARIANTS_UNAVAILABLE" });
+    return;
+  }
+
+  const accountId = accountIdSchema.safeParse(res.locals.accountId);
+  if (!accountId.success) {
+    res.status(403).json({ error: "ACCOUNT_REQUIRED" });
+    return;
+  }
+
+  const params = paramsSchema.safeParse(req.params);
+  if (!params.success) {
+    res.status(400).json({ error: "INVALID_INSTANCE_ID" });
+    return;
+  }
+
+  const body = bodySchema.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: "INVALID_REQUEST_BODY" });
+    return;
+  }
+
+  const assistantApiUrl = getAssistantApiUrl();
+  const assistantApiKey = getAssistantApiKey();
+  if (!assistantApiUrl || !assistantApiKey) {
+    req.log.error("Assistant API is not configured for variant update");
+    res.status(503).json({ error: "NO_AGENTS_AVAILABLE" });
+    return;
+  }
+
+  let variant: VariantDescriptor | null = null;
+  if (body.data.variantId !== null) {
+    try {
+      variant = await prisma.agentVariant.findFirst({
+        where: liveVariantWhere(body.data.variantId),
+        select: {
+          slug: true,
+          label: true,
+          whatToTest: true,
+          prUrl: true,
+        },
+      });
+    } catch (error) {
+      req.log.error(
+        { error, variantId: body.data.variantId },
+        "Failed to look up agent variant",
+      );
+      res.status(500).json({ error: "VARIANT_LOOKUP_FAILED" });
+      return;
+    }
+
+    if (!variant) {
+      res.status(404).json({ error: "VARIANT_NOT_FOUND" });
+      return;
+    }
+  }
+
+  const metadataVariant =
+    variant === null ? null : serializeVariantDescriptor(variant);
+  const assistantUrl = new URL(
+    `/api/assistants/${encodeURIComponent(params.data.instanceId)}/variant`,
+    assistantApiUrl,
+  );
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(assistantUrl, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${assistantApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        ownerAccountId: accountId.data,
+        variant: metadataVariant,
+      }),
+    });
+  } catch (error) {
+    req.log.error(
+      { error, instanceId: params.data.instanceId },
+      "Assistant variant metadata update failed",
+    );
+    res.status(502).json({ error: "ASSISTANT_VARIANT_UPDATE_FAILED" });
+    return;
+  }
+
+  let upstreamBody: unknown = null;
+  try {
+    upstreamBody = await upstream.json();
+  } catch {
+    upstreamBody = null;
+  }
+
+  if (!upstream.ok) {
+    req.log.warn(
+      {
+        instanceId: params.data.instanceId,
+        status: upstream.status,
+        upstreamBody,
+      },
+      "Assistant variant metadata update returned an error",
+    );
+    res.status(statusFromAssistantError(upstream.status)).json({
+      error: "ASSISTANT_VARIANT_UPDATE_FAILED",
+    });
+    return;
+  }
+
+  const parsed = assistantUpdateResponseSchema.safeParse(upstreamBody);
+  if (!parsed.success) {
+    req.log.error(
+      {
+        instanceId: params.data.instanceId,
+        upstreamBody,
+        issues: parsed.error.issues,
+      },
+      "Assistant variant metadata update returned invalid JSON",
+    );
+    res.status(502).json({ error: "ASSISTANT_VARIANT_UPDATE_FAILED" });
+    return;
+  }
+
+  res.status(200).json({
+    success: true,
+    instanceId: params.data.instanceId,
+    variantId: variant?.slug ?? null,
+    applied: "profile_metadata",
+  });
+}

--- a/tests/agents-update-variant.test.ts
+++ b/tests/agents-update-variant.test.ts
@@ -1,0 +1,230 @@
+import type { Server } from "node:http";
+import express, {
+  type Response as ExpressResponse,
+  type NextFunction,
+  type Request,
+} from "express";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { __setAssistantConfigOverridesForTests } from "@/api/v2/agents/handlers/assistant-config";
+import { updateAgentVariantHandler } from "@/api/v2/agents/handlers/update-variant";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { prisma } from "@/utils/prisma";
+
+const ASSISTANT_URL = "https://assistants.test.local";
+const ASSISTANT_KEY = "assistant-key";
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+const VARIANT_SLUG = "pr-test-update-variant";
+const FAILED_SLUG = "pr-test-update-failed";
+const ALL_SLUGS = [VARIANT_SLUG, FAILED_SLUG];
+
+type RecordedCall = {
+  url: string;
+  method?: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown> | null;
+};
+
+const calls: RecordedCall[] = [];
+const originalFetch = globalThis.fetch;
+
+function testAccountMiddleware(
+  _req: Request,
+  res: ExpressResponse,
+  next: NextFunction,
+) {
+  res.locals.accountId = ACCOUNT_ID;
+  next();
+}
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use(testAccountMiddleware);
+app.patch("/api/v2/agents/:instanceId/variant", updateAgentVariantHandler);
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function record(url: string | URL, init?: RequestInit): void {
+  calls.push({
+    url: String(url),
+    method: init?.method,
+    headers: (init?.headers ?? {}) as Record<string, string>,
+    body:
+      typeof init?.body === "string"
+        ? (JSON.parse(init.body) as Record<string, unknown>)
+        : null,
+  });
+}
+
+let server: Server;
+let baseURL: string;
+
+function patchVariant(instanceId: string, body: unknown): Promise<Response> {
+  return originalFetch(
+    `${baseURL}/api/v2/agents/${encodeURIComponent(instanceId)}/variant`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+beforeAll(async () => {
+  await prisma.agentVariant.deleteMany({
+    where: { slug: { in: ALL_SLUGS } },
+  });
+  await prisma.agentVariant.createMany({
+    data: [
+      {
+        slug: VARIANT_SLUG,
+        label: "Variant Update",
+        whatToTest: "profile switch",
+        status: "ready",
+        assistantWorkerUrl: null,
+        builderPromptSlug: null,
+        prUrl: "https://github.com/x/y/pull/10",
+        branch: "b",
+        commit: "c",
+      },
+      {
+        slug: FAILED_SLUG,
+        label: "Failed",
+        whatToTest: "not selectable",
+        status: "failed",
+        assistantWorkerUrl: null,
+        builderPromptSlug: null,
+        prUrl: "https://github.com/x/y/pull/11",
+        branch: "b",
+        commit: "c",
+      },
+    ],
+  });
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("Failed to resolve test server address");
+      }
+      baseURL = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  globalThis.fetch = originalFetch;
+  __setAssistantConfigOverridesForTests({});
+  await prisma.agentVariant.deleteMany({
+    where: { slug: { in: ALL_SLUGS } },
+  });
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+});
+
+beforeEach(() => {
+  calls.length = 0;
+  vi.restoreAllMocks();
+  __setAssistantConfigOverridesForTests({
+    assistantApiUrl: ASSISTANT_URL,
+    assistantApiKey: ASSISTANT_KEY,
+  });
+  globalThis.fetch = vi.fn(async (url, init) => {
+    record(url, init);
+    return jsonResponse(200, { ok: true, variant: null });
+  }) as typeof fetch;
+});
+
+describe("PATCH /agents/:instanceId/variant", () => {
+  test("resolves a live variant and forwards its public descriptor", async () => {
+    const instanceId = "22222222-2222-4222-8222-222222222222";
+    const res = await patchVariant(instanceId, { variantId: VARIANT_SLUG });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      success: true,
+      instanceId,
+      variantId: VARIANT_SLUG,
+      applied: "profile_metadata",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      `${ASSISTANT_URL}/api/assistants/${instanceId}/variant`,
+    );
+    expect(calls[0]?.method).toBe("PATCH");
+    expect(calls[0]?.headers.Authorization).toBe(`Bearer ${ASSISTANT_KEY}`);
+    expect(calls[0]?.body?.ownerAccountId).toBe(ACCOUNT_ID);
+    expect(JSON.parse(String(calls[0]?.body?.variant))).toEqual({
+      slug: VARIANT_SLUG,
+      label: "Variant Update",
+      whatToTest: "profile switch",
+      prUrl: "https://github.com/x/y/pull/10",
+    });
+  });
+
+  test("sends null to clear the profile variant", async () => {
+    const instanceId = "33333333-3333-4333-8333-333333333333";
+    const res = await patchVariant(instanceId, { variantId: null });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      success: true,
+      instanceId,
+      variantId: null,
+      applied: "profile_metadata",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body).toEqual({
+      ownerAccountId: ACCOUNT_ID,
+      variant: null,
+    });
+  });
+
+  test("rejects unknown or non-live variants before calling the Worker", async () => {
+    const instanceId = "44444444-4444-4444-8444-444444444444";
+
+    const unknown = await patchVariant(instanceId, {
+      variantId: "pr-test-update-missing",
+    });
+    expect(unknown.status).toBe(404);
+
+    const failed = await patchVariant(instanceId, { variantId: FAILED_SLUG });
+    expect(failed.status).toBe(404);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("maps Worker ownership failures through as forbidden", async () => {
+    globalThis.fetch = vi.fn(async (url, init) => {
+      record(url, init);
+      return jsonResponse(403, { error: "forbidden" });
+    }) as typeof fetch;
+
+    const res = await patchVariant("55555555-5555-4555-8555-555555555555", {
+      variantId: null,
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: "ASSISTANT_VARIANT_UPDATE_FAILED",
+    });
+  });
+});


### PR DESCRIPTION
Summary
- add dev-only PATCH /v2/agents/:instanceId/variant
- resolve live variant records and forward the public profile descriptor to the assistant Worker
- add focused handler tests for apply, clear, missing variant, and Worker rejection paths

Why
- iOS needs a backend-owned way to switch an existing agent profile between registered dev variants.

Validation
- pnpm exec prettier --check src/api/v2/agents/handlers/update-variant.ts src/api/v2/agents/agents.router.ts tests/agents-update-variant.test.ts
- targeted Vitest/typecheck remain blocked locally by stale generated Prisma/protobuf artifacts; existing join-variant tests fail the same way because prisma.agentVariant is missing from the local generated client.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786193720&installation_id=128169237&pr_number=353&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F353&signature=cf13f8b86c83ea6889b22094a43f7c06e2b39279a4de91296b6932556379885c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PATCH `/api/v2/agents/:instanceId/variant` endpoint to update agent instance variants
> - Registers a new `PATCH /:instanceId/variant` route in [agents.router.ts](https://github.com/ephemeraHQ/convos-backend/pull/353/files#diff-84f305f10df11c4dd024b1bfff65513af285fc5aafa597520b5ddee9fa10eac6), protected by `requireAccount`.
> - The [updateAgentVariantHandler](https://github.com/ephemeraHQ/convos-backend/pull/353/files#diff-8751e0e1620a8912d56640a890b6bab318255c4479baf6030fe273572e3aaea4) validates the `variantId` (a slug or null), looks up a live `agentVariant` record, serializes its descriptor, and proxies a PATCH to the configured Assistant API.
> - Returns 200 with `applied: 'profile_metadata'` on success; maps upstream errors to 400/403/404/409/410/502 as appropriate.
> - The endpoint is disabled in production (returns 403).
> - Vitest suite in [tests/agents-update-variant.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/353/files#diff-7d4fc676b69d4395527fbaaaad59307b7e44203c144e2cd64ffb1769676de4ec) covers success, variant clearing, unknown/non-live variant rejection, and upstream 403 mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f482c8c. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating an agent’s variant through a new authenticated API endpoint.
  * Variant changes can now be applied or cleared from the app, with the result sent to the backend service.

* **Bug Fixes**
  * Added validation and clearer error handling for missing accounts, invalid instance IDs, unavailable services, and unknown variants.
  * Improved responses when the upstream service rejects or returns unexpected data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->