### PR TITLE
fix(agent-templates): find the link anywhere in a build submission

### DIFF
--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -484,14 +484,25 @@ export interface SubmittedUrl {
   residual: string;
 }
 
-// A link stops at whitespace and at the delimiters that wrap one in prose
-// rather than belong to it. Trailing sentence punctuation is stripped
-// separately: `.` and `?` are legal in a URL but usually end the sentence.
+// A link stops at whitespace, and at the delimiters that wrap one in prose rather
+// than belong to it: angle brackets (`<https://…>`), quotes, backticks, and the
+// bracket pairs a link gets parenthesised or markdown-linked with. All of these
+// are legal inside a URL but overwhelmingly appear around one, and a link that
+// genuinely needs them can percent-encode them.
+//
+// Trailing sentence punctuation is stripped separately rather than excluded from
+// the token, because `.` `?` and `!` are common *inside* a URL and only ambiguous
+// at the very end ("see https://x.com/a." — the period ends the sentence).
 const URL_TOKEN_RE = /https?:\/\/[^\s<>"'`()[\]{}]+/i;
 const URL_TRAILING_PUNCT_RE = /[.,;:!?]+$/;
 
-/** First usable link anywhere in the text, with the surrounding prose split
- *  out. Null when the text holds no parseable link. Exported for tests. */
+/** First usable link anywhere in the text, with the surrounding prose split out.
+ *  Null when the text holds no parseable link.
+ *
+ *  Only the FIRST link is returned. A build is generated from one source, so a
+ *  submission carrying several links is read as being about the first one; any
+ *  others stay in `residual` and reach the model as part of the user's intent
+ *  rather than being fetched. Exported for tests. */
 export function extractFirstUrl(text: string): SubmittedUrl | null {
   const match = URL_TOKEN_RE.exec(text);
   if (!match) return null;

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -51,6 +51,12 @@ import {
 
 const MAX_CONTENT_LENGTH = 10_000;
 
+/** Longest prose around a link that still reads as an instruction about it
+ *  ("build me an agent from this"). Past this the submission is a paste that
+ *  merely cites a link, and the paste is itself the source material — fetching
+ *  the citation would throw away what the user actually sent. */
+const URL_INTENT_MAX_RESIDUAL = 300;
+
 /** The only tool values a generated template may use. Mirrors the SUPERPOWERS
  *  table + field requirements in `data/template-generator-prompt.txt`; the
  *  json_schema enum on the generate call enforces it at decode time so a custom
@@ -469,6 +475,41 @@ export function appendBrevityRail(
  *  to be tolerant of pasted content. Exported for tests. */
 export function looksLikeUrl(text: string): boolean {
   return /^https?:\/\//i.test(text.trim());
+}
+
+/** A link found in a submission, plus whatever the user typed around it. */
+export interface SubmittedUrl {
+  url: string;
+  /** The submission with the link removed — the user's instruction, if any. */
+  residual: string;
+}
+
+// A link stops at whitespace and at the delimiters that wrap one in prose
+// rather than belong to it. Trailing sentence punctuation is stripped
+// separately: `.` and `?` are legal in a URL but usually end the sentence.
+const URL_TOKEN_RE = /https?:\/\/[^\s<>"'`()[\]{}]+/i;
+const URL_TRAILING_PUNCT_RE = /[.,;:!?]+$/;
+
+/** First usable link anywhere in the text, with the surrounding prose split
+ *  out. Null when the text holds no parseable link. Exported for tests. */
+export function extractFirstUrl(text: string): SubmittedUrl | null {
+  const match = URL_TOKEN_RE.exec(text);
+  if (!match) return null;
+
+  const url = match[0].replace(URL_TRAILING_PUNCT_RE, "");
+  try {
+    new URL(url);
+  } catch {
+    return null;
+  }
+
+  const residual = (
+    text.slice(0, match.index) + text.slice(match.index + match[0].length)
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return { url, residual };
 }
 
 // ---------------------------------------------------------------------------
@@ -1479,14 +1520,16 @@ export async function generateTemplate(
   } else {
     // Text path: idea, content, or URL
     let extracted = intentText;
+    // Fetched content replaces the submission, so an instruction the user wrapped
+    // around the link ("make this summarize every morning") is the only part of
+    // what they typed that survives. Carry it into the prompt. A bare link has none.
+    let urlIntent = "";
 
-    if (intentText && looksLikeUrl(intentText)) {
-      const url = intentText.trim();
-      try {
-        new URL(url);
-      } catch {
-        throw new AppError(400, "Invalid URL");
-      }
+    const submitted = intentText ? extractFirstUrl(intentText) : null;
+
+    if (submitted && submitted.residual.length <= URL_INTENT_MAX_RESIDUAL) {
+      const { url, residual } = submitted;
+      urlIntent = residual;
 
       // For GitHub URLs, try to short-circuit:
       //  - `passthrough`: the repo/file IS an agent prompt → return verbatim.
@@ -1516,6 +1559,11 @@ export async function generateTemplate(
         githubResult?.kind === "rawContent"
           ? githubResult.content
           : await extractUrl(url, trace);
+    } else if (!submitted && looksLikeUrl(intentText)) {
+      // URL-shaped submission with no parseable link in it. The user meant to
+      // send a link, so say the link is broken rather than quietly building an
+      // agent out of the malformed string.
+      throw new AppError(400, "Invalid URL");
     }
 
     if (!extracted.trim()) {
@@ -1545,7 +1593,8 @@ export async function generateTemplate(
       extracted = extracted.slice(0, MAX_CONTENT_LENGTH);
     }
 
-    userContent = `Create an assistant based on the following content:\n\n---\n${extracted}\n---`;
+    const urlIntentNote = urlIntent ? `\n\nUser's intent: ${urlIntent}` : "";
+    userContent = `Create an assistant based on the following content:\n\n---\n${extracted}\n---${urlIntentNote}`;
   }
 
   // Fold two user-message addenda into the directive text:

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -1914,6 +1914,102 @@ describe("templateGen service — OpenRouter integration", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Link extraction: the link is the material, the prose around it is the
+  // instruction. Both survive into the prompt.
+  // -----------------------------------------------------------------------
+
+  test("extractFirstUrl finds a link anywhere in the text and splits off the prose", async () => {
+    const { extractFirstUrl } =
+      await import("@/api/v2/agent-templates/services/templateGen");
+
+    expect(extractFirstUrl("https://example.com")).toEqual({
+      url: "https://example.com",
+      residual: "",
+    });
+    expect(
+      extractFirstUrl("Make me an agent about https://example.com"),
+    ).toEqual({
+      url: "https://example.com",
+      residual: "Make me an agent about",
+    });
+    expect(extractFirstUrl("https://example.com check this out")).toEqual({
+      url: "https://example.com",
+      residual: "check this out",
+    });
+    // The link ends at whitespace — a trailing word is prose, not query string.
+    expect(extractFirstUrl("https://example.com/a?b=1 and more")).toEqual({
+      url: "https://example.com/a?b=1",
+      residual: "and more",
+    });
+    // Sentence punctuation that trails a link is not part of it.
+    expect(extractFirstUrl("Read https://example.com, it's great")).toEqual({
+      url: "https://example.com",
+      residual: "Read it's great",
+    });
+    expect(extractFirstUrl("just some text")).toBeNull();
+    expect(extractFirstUrl("https://[invalid-url")).toBeNull();
+  });
+
+  test("a link wrapped in an instruction is fetched, and the instruction rides the prompt", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+    mod.__setExaKeyOverrideForTests("test-exa-key");
+
+    fetchMockResponses.set("api.exa.ai", {
+      status: 200,
+      body: { results: [{ text: "Widgets Inc sells widgets." }] },
+    });
+    setOpenRouterResponse(templateResponse());
+
+    await generateTemplate({
+      text: "Make me an agent about https://example.com that answers support questions",
+    });
+
+    // The bare link is what gets fetched — not the whole sentence.
+    const exaReq = capturedRequests.find((r) => r.url.includes("api.exa.ai"));
+    expect(exaReq?.body.urls).toEqual(["https://example.com"]);
+
+    const userMsg = getLastOpenRouterRequest().body.messages.at(-1).content;
+    expect(userMsg).toContain("Widgets Inc sells widgets.");
+    expect(userMsg).toContain(
+      "User's intent: Make me an agent about that answers support questions",
+    );
+  });
+
+  test("a long paste that merely cites a link is the material — the link is not fetched", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+    mod.__setExaKeyOverrideForTests("test-exa-key");
+
+    const paste = `${"Our support playbook says to greet the customer warmly. ".repeat(
+      8,
+    )} See https://example.com for details.`;
+    expect(paste.length).toBeGreaterThan(300); // long enough for the classifier
+
+    setOpenRouterResponseQueue([
+      // classifier: raw material, not an agent definition
+      {
+        model: BUILDER_CLASSIFIER_MODEL,
+        choices: [
+          {
+            message: { content: JSON.stringify({ isPassthrough: false }) },
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      },
+      templateResponse(),
+    ]);
+
+    await generateTemplate({ text: paste });
+
+    expect(capturedRequests.some((r) => r.url.includes("api.exa.ai"))).toBe(
+      false,
+    );
+    const userMsg = getLastOpenRouterRequest().body.messages.at(-1).content;
+    expect(userMsg).toContain("Our support playbook");
+  });
+
+  // -----------------------------------------------------------------------
   // parseTemplateResponse handles various input formats
   // -----------------------------------------------------------------------
   test("parseTemplateResponse handles clean JSON", async () => {

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -1946,6 +1946,21 @@ describe("templateGen service — OpenRouter integration", () => {
       url: "https://example.com",
       residual: "Read it's great",
     });
+    // Several links: the first is the source material. The rest stay in the
+    // residual and reach the model as intent rather than being fetched.
+    expect(extractFirstUrl("compare https://a.com and https://b.com")).toEqual({
+      url: "https://a.com",
+      residual: "compare and https://b.com",
+    });
+
+    // A link wrapped in prose delimiters keeps them out of the URL. They stay
+    // behind in the residual, which only ever becomes an intent note — so the
+    // leftover brackets cost nothing and aren't worth a cleanup rule.
+    expect(extractFirstUrl("see <https://example.com> for more")).toEqual({
+      url: "https://example.com",
+      residual: "see <> for more",
+    });
+
     expect(extractFirstUrl("just some text")).toBeNull();
     expect(extractFirstUrl("https://[invalid-url")).toBeNull();
   });


### PR DESCRIPTION
The builder fetched a URL only when the **entire** submission was that URL (`looksLikeUrl` was an anchored `/^https?:\/\//` test). Every other way a person pastes a link routed wrong:

| Submission | Before |
|---|---|
| `Make me an agent about https://foo.com` | link never fetched — generates from the bare sentence |
| `https://foo.com check this out` | `new URL` throws → **build fails, 400 Invalid URL** |
| `https://foo.com/a?b=1 and more` | trailing words swallowed into the query string → fetches the wrong URL |

All three are ordinary human pastes, and the first is the same failure mode as the bare-`t.co` twitter-bot case: the source content never reaches the model, so the builder invents a generic agent.

`extractFirstUrl` now pulls the first parseable link from anywhere in the text and splits off the prose around it. The link is fetched as source material; the prose rides into the prompt as `User's intent:`, reusing the directive the attachment path already uses — so "make it answer support questions" survives instead of being discarded along with the rest of the sentence.

Two behaviors deliberately preserved:

- A paste longer than 300 chars that merely *cites* a link is still treated as the source material. The paste is what the user sent; fetching the citation would throw it away.
- A URL-shaped submission with no parseable link in it (`https://[invalid-url`) still fails with `Invalid URL` rather than quietly generating an agent from a malformed string.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786502444&installation_id=128169237&pr_number=355&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F355&signature=3975e49a5f96a0569b9b3c0eb73f5d3cb0f1c1a3397f2abb55bb9145f07b37f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix URL detection in `generateTemplate` to find links anywhere in a build submission
> - Adds `extractFirstUrl` to scan free-form text for the first valid URL token, strip trailing punctuation, and return the URL plus the surrounding residual prose.
> - Updates `generateTemplate` to fetch the extracted URL only when the residual prose is ≤300 chars; longer text is treated as pasted source material with no fetch.
> - Appends the residual prose as a `User's intent:` note in the prompt when a URL is fetched.
> - Returns a 400 error for URL-shaped text that contains no parseable URL token.
> - Behavioral Change: previously, URLs had to appear in a specific position in the submission; now any submission containing a URL token anywhere is handled correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b3061a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved link detection in text-based template generation.
  * Preserves brief instructions surrounding a submitted link as user intent.
  * Fetches content from embedded links while retaining relevant instructions.
* **Bug Fixes**
  * Rejects malformed URL-like submissions with a clear “Invalid URL” error.
  * Correctly removes trailing punctuation from detected links.
  * Avoids fetching links when they are only incidental references in longer text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->