### PR TITLE
feat(agent-templates): accept text files as build attachments

### DIFF
--- a/src/api/v2/agent-templates/services/attachment-resolver.ts
+++ b/src/api/v2/agent-templates/services/attachment-resolver.ts
@@ -24,6 +24,7 @@ import { AppError } from "@/utils/errors";
 import {
   classifyMime,
   decodeTextAttachment,
+  defaultTextFilename,
   getBuildObjectBytes,
   maxBytesForKind,
   normalizeMime,
@@ -128,7 +129,7 @@ async function resolveOne(
   }
 
   if (kind === "text") {
-    const filename = ref.filename || "attachment.txt";
+    const filename = ref.filename || defaultTextFilename(ref.mimeType);
     const text = decodeTextAttachment(bytes, filename);
     // A text attachment is user-supplied prose heading straight for the prompt,
     // so it gets the same content check the typed directive and voice transcripts

--- a/src/api/v2/agent-templates/services/attachment-resolver.ts
+++ b/src/api/v2/agent-templates/services/attachment-resolver.ts
@@ -6,9 +6,10 @@
  * size/type (defense-in-depth over the submit-time caps), then:
  *   - image → moderate (Rekognition) + emit an `image` data-URI block,
  *   - pdf   → emit a `pdf` data-URI block,
+ *   - text  → decode UTF-8 + moderate + emit an inline `text` block,
  *   - audio → transcribe to text + moderate the transcript.
  *
- * Images/PDFs come back as `ResolvedAttachment`s; audio comes back as
+ * Images/PDFs/text files come back as `ResolvedAttachment`s; audio comes back as
  * `transcripts` the caller folds into the generation's text. Shared by the
  * async executor (moderate: true) and the admin ephemeral endpoint
  * (moderate: false — the caller is trusted and nothing is persisted).
@@ -22,6 +23,7 @@ import {
 import { AppError } from "@/utils/errors";
 import {
   classifyMime,
+  decodeTextAttachment,
   getBuildObjectBytes,
   maxBytesForKind,
   normalizeMime,
@@ -123,6 +125,29 @@ async function resolveOne(
       }
     }
     return { kind: "transcript", transcript, byteLength: bytes.length };
+  }
+
+  if (kind === "text") {
+    const filename = ref.filename || "attachment.txt";
+    const text = decodeTextAttachment(bytes, filename);
+    // A text attachment is user-supplied prose heading straight for the prompt,
+    // so it gets the same content check the typed directive and voice transcripts
+    // get. Images go to Rekognition; PDFs are the one kind whose contents still
+    // reach the model unchecked.
+    if (opts.moderate) {
+      const verdict = await checkContent(text, opts.trace);
+      if (!verdict.allowed) {
+        throw new AttachmentModerationError(
+          verdict.reason ?? "blocked",
+          ref.objectKey,
+        );
+      }
+    }
+    return {
+      kind: "attachment",
+      byteLength: bytes.length,
+      attachment: { kind: "text", filename, text },
+    };
   }
 
   if (kind === "image" && opts.moderate) {

--- a/src/api/v2/agent-templates/services/build-attachments.ts
+++ b/src/api/v2/agent-templates/services/build-attachments.ts
@@ -2,8 +2,8 @@
  * Build-attachment storage — private-bucket upload + backend byte-fetch for the
  * agent-template generator.
  *
- * The builder uploads each generation attachment (image / PDF / voice) to the
- * PRIVATE_ASSETS_BUCKET via a presigned PUT, then sends the generation request
+ * The builder uploads each generation attachment (image / PDF / text file / voice)
+ * to the PRIVATE_ASSETS_BUCKET via a presigned PUT, then sends the generation request
  * lightweight `{ objectKey, mimeType, filename? }` references instead of base64
  * bytes. The backend reads the bytes itself (`GetObject`) for generation +
  * moderation, so decrypted conversation content never gets a public CDN URL.
@@ -33,9 +33,9 @@ import { AppError } from "@/utils/errors";
 // Allowlist + per-class size caps
 // ---------------------------------------------------------------------------
 
-/** What the generator can do with an attachment. `image`/`pdf` become LLM
+/** What the generator can do with an attachment. `image`/`pdf`/`text` become LLM
  *  content blocks; `audio` is transcribed to text before generation. */
-export type AttachmentKind = "image" | "pdf" | "audio";
+export type AttachmentKind = "image" | "pdf" | "audio" | "text";
 
 // Per-file byte caps, set against real model ceilings rather than the bucket's
 // physical limit. Images go to a vision model as an inline data URI, so they're
@@ -46,14 +46,19 @@ const MAX_BYTES_BY_KIND: Record<AttachmentKind, number> = {
   image: 10 * 1024 * 1024,
   pdf: 25 * 1024 * 1024,
   audio: 25 * 1024 * 1024,
+  // A text file is inlined into the prompt, so what actually bounds it is the
+  // character cap in the resolver, not this. This is only an upload guard.
+  text: 1 * 1024 * 1024,
 };
 
 /** MIME → kind allowlist. Anything not here is rejected at submit time.
  *  Images are PNG/JPEG only — the formats AWS Rekognition can read — so every
- *  accepted image is moderatable (webp/gif would fail moderation open). Audio
- *  covers the common mobile-recording containers (m4a/aac on iOS, ogg/webm on
- *  Android) plus mp3/wav; actual transcription-model format support is a
- *  separate concern handled in services/transcribe.ts. */
+ *  accepted image is moderatable (webp/gif would fail moderation open); clients
+ *  transcode before upload. Audio covers the common mobile-recording containers
+ *  (m4a/aac on iOS, ogg/webm on Android) plus mp3/wav; actual transcription-model
+ *  format support is a separate concern handled in services/transcribe.ts. Text
+ *  is an explicit list rather than a `text/*` prefix match, so a novel text-ish
+ *  MIME fails closed instead of being decoded on faith. */
 const KIND_BY_MIME: Record<string, AttachmentKind> = {
   "image/png": "image",
   "image/jpeg": "image",
@@ -67,6 +72,18 @@ const KIND_BY_MIME: Record<string, AttachmentKind> = {
   "audio/x-wav": "audio",
   "audio/ogg": "audio",
   "audio/webm": "audio",
+  "text/plain": "text",
+  "text/markdown": "text",
+  "text/csv": "text",
+  "text/tab-separated-values": "text",
+  "text/xml": "text",
+  "text/yaml": "text",
+  "text/vcard": "text",
+  "text/calendar": "text",
+  "application/json": "text",
+  "application/xml": "text",
+  "application/yaml": "text",
+  "application/x-yaml": "text",
 };
 
 /** Normalize a wire MIME type: lowercase + strip parameters (`; codecs=…`).
@@ -83,6 +100,40 @@ export function classifyMime(mimeType: string): AttachmentKind | null {
 /** Per-file byte cap for a kind. */
 export function maxBytesForKind(kind: AttachmentKind): number {
   return MAX_BYTES_BY_KIND[kind];
+}
+
+/** Cap on how much of a text attachment reaches the prompt. Matches the runtime's
+ *  inline-attachment cap, so a file an agent can read in a conversation is a file
+ *  the builder can read while creating that agent. */
+export const TEXT_ATTACHMENT_MAX_CHARS = 20_000;
+
+/** Decode a text attachment to UTF-8, refusing bytes that aren't really text.
+ *
+ *  The MIME allowlist is the client's claim about a file; this is where the claim
+ *  is checked. Strict UTF-8 plus a NUL-byte probe rejects a binary mislabelled as
+ *  `text/plain` — otherwise it would decode to mojibake and be fed to the model as
+ *  though it were prose. Past the cap the head is kept and the omission is stated,
+ *  so the model is never handed a silently truncated document. */
+export function decodeTextAttachment(
+  bytes: Uint8Array,
+  filename: string,
+): string {
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new AppError(400, `Attachment ${filename} is not valid UTF-8 text`);
+  }
+  if (text.includes("\u0000")) {
+    throw new AppError(400, `Attachment ${filename} is not a text file`);
+  }
+  if (!text.trim()) {
+    throw new AppError(400, `Attachment ${filename} is empty`);
+  }
+  if (text.length <= TEXT_ATTACHMENT_MAX_CHARS) return text;
+
+  const omitted = text.length - TEXT_ATTACHMENT_MAX_CHARS;
+  return `${text.slice(0, TEXT_ATTACHMENT_MAX_CHARS)}\n\n[${omitted.toLocaleString()} more characters not shown]`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/v2/agent-templates/services/build-attachments.ts
+++ b/src/api/v2/agent-templates/services/build-attachments.ts
@@ -152,8 +152,18 @@ export function decodeTextAttachment(
   }
   if (text.length <= TEXT_ATTACHMENT_MAX_CHARS) return text;
 
-  const omitted = text.length - TEXT_ATTACHMENT_MAX_CHARS;
-  return `${text.slice(0, TEXT_ATTACHMENT_MAX_CHARS)}\n\n[${omitted.toLocaleString()} more characters not shown]`;
+  // The cap counts UTF-16 code units, so it can land between the halves of a
+  // surrogate pair — an emoji in a markdown file is enough. Back off one unit in
+  // that case: a lone surrogate isn't valid text and would reach the model as a
+  // replacement character.
+  let end = TEXT_ATTACHMENT_MAX_CHARS;
+  const lastUnit = text.charCodeAt(end - 1);
+  if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) end -= 1;
+
+  // Fixed locale: the host's would otherwise decide whether the model reads
+  // "5,000" or "5.000".
+  const omitted = (text.length - end).toLocaleString("en-US");
+  return `${text.slice(0, end)}\n\n[${omitted} more characters not shown]`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/v2/agent-templates/services/build-attachments.ts
+++ b/src/api/v2/agent-templates/services/build-attachments.ts
@@ -102,9 +102,17 @@ export function maxBytesForKind(kind: AttachmentKind): number {
   return MAX_BYTES_BY_KIND[kind];
 }
 
-/** Cap on how much of a text attachment reaches the prompt. Matches the runtime's
- *  inline-attachment cap, so a file an agent can read in a conversation is a file
- *  the builder can read while creating that agent. */
+/** Cap on how much of a text attachment reaches the prompt.
+ *
+ *  The cap exists to bound prompt budget: the decoded text rides into the model's
+ *  context, so an unbounded paste of a large CSV would soak it. 20k specifically is
+ *  the Hermes runtime's existing inline-attachment cap — matching it means a file an
+ *  agent can read in a conversation is a file the builder can read while creating
+ *  that agent, and it's one number across the two pipelines instead of two.
+ *
+ *  This is per file, and nothing below it bounds the total: the byte caps are far
+ *  looser than the character cap, so with BUILD_ATTACHMENTS_MAX_COUNT at 9 a single
+ *  generation's inlined text tops out near 180k characters. */
 export const TEXT_ATTACHMENT_MAX_CHARS = 20_000;
 
 /** Name to fence a text attachment with when the client didn't send a filename.

--- a/src/api/v2/agent-templates/services/build-attachments.ts
+++ b/src/api/v2/agent-templates/services/build-attachments.ts
@@ -107,6 +107,15 @@ export function maxBytesForKind(kind: AttachmentKind): number {
  *  the builder can read while creating that agent. */
 export const TEXT_ATTACHMENT_MAX_CHARS = 20_000;
 
+/** Name to fence a text attachment with when the client didn't send a filename.
+ *  Derived from the MIME rather than defaulted to `.txt`, because the extension is
+ *  part of what tells the model what it's reading — a CSV labelled `attachment.txt`
+ *  reads as prose instead of a table. */
+export function defaultTextFilename(mimeType: string): string {
+  const ext = mime.extension(normalizeMime(mimeType));
+  return ext ? `attachment.${ext}` : "attachment.txt";
+}
+
 /** Decode a text attachment to UTF-8, refusing bytes that aren't really text.
  *
  *  The MIME allowlist is the client's claim about a file; this is where the claim
@@ -125,7 +134,10 @@ export function decodeTextAttachment(
     throw new AppError(400, `Attachment ${filename} is not valid UTF-8 text`);
   }
   if (text.includes("\u0000")) {
-    throw new AppError(400, `Attachment ${filename} is not a text file`);
+    throw new AppError(
+      400,
+      `Attachment ${filename} contains binary data, not text`,
+    );
   }
   if (!text.trim()) {
     throw new AppError(400, `Attachment ${filename} is empty`);

--- a/src/api/v2/agent-templates/services/distill.ts
+++ b/src/api/v2/agent-templates/services/distill.ts
@@ -25,6 +25,7 @@ import {
 } from "./openrouter-client";
 import {
   decodeEmojiEscapes,
+  fenceTextAttachment,
   getModel,
   sanitizeEmojiField,
   type GenerationPrefill,
@@ -238,10 +239,7 @@ function buildDistillUserContent(
         return { type: "image_url", image_url: { url: attachment.dataUri } };
       }
       if (attachment.kind === "text") {
-        return {
-          type: "text",
-          text: `--- ${attachment.filename} ---\n${attachment.text}\n--- end ${attachment.filename} ---`,
-        };
+        return { type: "text", text: fenceTextAttachment(attachment) };
       }
       return {
         type: "file",

--- a/src/api/v2/agent-templates/services/distill.ts
+++ b/src/api/v2/agent-templates/services/distill.ts
@@ -232,31 +232,40 @@ function buildDistillUserContent(
 
   return [
     { type: "text", text: `${intro}${pinned}` },
-    // Preserve the caller's mixed image/PDF order in the content blocks.
-    ...attachments.map((attachment) =>
-      attachment.kind === "image"
-        ? { type: "image_url", image_url: { url: attachment.dataUri } }
-        : {
-            type: "file",
-            file: {
-              filename: attachment.filename,
-              file_data: attachment.dataUri,
-            },
-          },
-    ),
+    // Preserve the caller's mixed order in the content blocks.
+    ...attachments.map((attachment) => {
+      if (attachment.kind === "image") {
+        return { type: "image_url", image_url: { url: attachment.dataUri } };
+      }
+      if (attachment.kind === "text") {
+        return {
+          type: "text",
+          text: `--- ${attachment.filename} ---\n${attachment.text}\n--- end ${attachment.filename} ---`,
+        };
+      }
+      return {
+        type: "file",
+        file: {
+          filename: attachment.filename,
+          file_data: attachment.dataUri,
+        },
+      };
+    }),
   ];
 }
 
-/** Short noun phrase for the attached files, for the image/PDF-only directive. */
+/** Short noun phrase for the attached files, for the file-only directive. */
 function describeDistillFiles(attachments: ResolvedAttachment[]): string {
   const images = attachments.filter((a) => a.kind === "image").length;
-  const pdfs = attachments.filter((a) => a.kind === "pdf").length;
+  const docs = attachments.filter(
+    (a) => a.kind === "pdf" || a.kind === "text",
+  ).length;
   const noun = (n: number, singular: string) =>
     `${n} ${singular}${n === 1 ? "" : "s"}`;
-  if (images > 0 && pdfs > 0) {
-    return `files (${noun(images, "image")} and ${noun(pdfs, "document")})`;
+  if (images > 0 && docs > 0) {
+    return `files (${noun(images, "image")} and ${noun(docs, "document")})`;
   }
-  if (pdfs > 0) return noun(pdfs, "document");
+  if (docs > 0) return noun(docs, "document");
   return noun(images, "image");
 }
 

--- a/src/api/v2/agent-templates/services/generation-executor.ts
+++ b/src/api/v2/agent-templates/services/generation-executor.ts
@@ -247,7 +247,9 @@ function summarizeInputType(
   }
   if (kinds.size === 0) return "text";
   if (kinds.size === 1) {
-    return [...kinds][0] as "image" | "pdf" | "audio";
+    // An attached text file meters as "text", same as a typed directive — the
+    // metering axis is modality, and both are characters in the prompt.
+    return [...kinds][0] as "text" | "image" | "pdf" | "audio";
   }
   return "mixed";
 }

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -445,22 +445,22 @@ function fenceTextAttachment(
 
 /** Lead instruction for the multimodal path, phrased for the actual mix of
  *  attached files so the model knows whether it's looking at images, reading
- *  documents, or both. */
-function describeAttachments(
-  imageCount: number,
-  pdfCount: number,
-  textCount: number,
-): string {
+ *  documents, or both. A text file counts as a document: to the model it reads
+ *  the same as a PDF, only inlined rather than sent as bytes. */
+function describeAttachments(attachments: ResolvedAttachment[]): string {
+  const images = attachments.filter((a) => a.kind === "image").length;
+  const docs = attachments.filter(
+    (a) => a.kind === "pdf" || a.kind === "text",
+  ).length;
   const noun = (n: number, singular: string) =>
     `${n} ${singular}${n === 1 ? "" : "s"}`;
-  const docCount = pdfCount + textCount;
-  if (imageCount > 0 && docCount > 0) {
-    return `Create an assistant based on the attached files (${noun(imageCount, "image")} and ${noun(docCount, "document")}). Use all of them together to infer the topic, purpose, and audience.`;
+  if (images > 0 && docs > 0) {
+    return `Create an assistant based on the attached files (${noun(images, "image")} and ${noun(docs, "document")}). Use all of them together to infer the topic, purpose, and audience.`;
   }
-  if (docCount > 0) {
-    return `Create an assistant based on the content of the attached ${docCount === 1 ? "document" : `${docCount} documents`}.`;
+  if (docs > 0) {
+    return `Create an assistant based on the content of the attached ${docs === 1 ? "document" : `${docs} documents`}.`;
   }
-  return `Create an assistant based on what you see in the attached ${imageCount === 1 ? "image" : `${imageCount} images`}. Infer the topic, purpose, and audience from the visual content.`;
+  return `Create an assistant based on what you see in the attached ${images === 1 ? "image" : `${images} images`}. Infer the topic, purpose, and audience from the visual content.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -1457,27 +1457,15 @@ export async function generateTemplate(
   const attachments = opts.attachments ?? [];
 
   if (attachments.length > 0) {
-    // Multimodal path: text directive + N image/PDF blocks. Images go to the
-    // vision model as `image_url`; PDFs as native `file` blocks. The executor
-    // already fetched the bytes and built each data URI, so this just lays out
-    // the blocks. The URL/GitHub/passthrough logic below is text-only and
-    // doesn't apply when files are attached.
-    const images = attachments.filter(
-      (a): a is Extract<ResolvedAttachment, { kind: "image" }> =>
-        a.kind === "image",
-    );
-    const pdfs = attachments.filter(
-      (a): a is Extract<ResolvedAttachment, { kind: "pdf" }> =>
-        a.kind === "pdf",
-    );
-    const texts = attachments.filter(
-      (a): a is Extract<ResolvedAttachment, { kind: "text" }> =>
-        a.kind === "text",
-    );
+    // Multimodal path: a text directive + one block per file. Images go to the
+    // vision model as `image_url`, PDFs as native `file` blocks, text files as
+    // inline `text` blocks. The executor already fetched the bytes and built each
+    // data URI, so this just lays out the blocks. The URL/GitHub/passthrough logic
+    // below is text-only and doesn't apply when files are attached.
     userContent = [
       {
         type: "text",
-        text: `${describeAttachments(images.length, pdfs.length, texts.length)}${intentNote}`,
+        text: `${describeAttachments(attachments)}${intentNote}`,
       },
       // Map the original `attachments` array (not the filtered ones) so a mixed
       // order from the caller is preserved in the content blocks.

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -346,7 +346,8 @@ export const DEFAULT_TEST_METRICS: GenerationMetrics = {
  *  transcribed to text upstream and folded into `text`. */
 export type ResolvedAttachment =
   | { kind: "image"; mimeType: string; dataUri: string }
-  | { kind: "pdf"; filename: string; dataUri: string };
+  | { kind: "pdf"; filename: string; dataUri: string }
+  | { kind: "text"; filename: string; text: string };
 
 export interface GenerateTemplateInput {
   /** What the user typed in the composer, plus any transcribed voice notes the
@@ -357,8 +358,9 @@ export interface GenerateTemplateInput {
    *  legacy `idea` / `content` / `url` fields into this single field at the API
    *  boundary. */
   text?: string;
-  /** Image / PDF attachments, resolved to data URIs. Images become `image_url`
-   *  vision blocks; PDFs become native `file` blocks. */
+  /** Resolved attachments. Images become `image_url` vision blocks, PDFs native
+   *  `file` blocks, and text files inlined `text` blocks labelled with their
+   *  filename — so the model can tell a CSV of FAQs from the user's directive. */
   attachments?: ResolvedAttachment[];
 }
 
@@ -432,17 +434,31 @@ function buildCapabilitiesDirective(connections?: string[] | null): string {
   );
 }
 
+/** Wrap a text attachment in a labelled fence. The filename is the point: it tells
+ *  the model this is an attached file rather than more of the user's directive, and
+ *  the name itself is signal ("support-faq.csv" says more than its rows do). */
+function fenceTextAttachment(
+  attachment: Extract<ResolvedAttachment, { kind: "text" }>,
+): string {
+  return `--- ${attachment.filename} ---\n${attachment.text}\n--- end ${attachment.filename} ---`;
+}
+
 /** Lead instruction for the multimodal path, phrased for the actual mix of
  *  attached files so the model knows whether it's looking at images, reading
  *  documents, or both. */
-function describeAttachments(imageCount: number, pdfCount: number): string {
+function describeAttachments(
+  imageCount: number,
+  pdfCount: number,
+  textCount: number,
+): string {
   const noun = (n: number, singular: string) =>
     `${n} ${singular}${n === 1 ? "" : "s"}`;
-  if (imageCount > 0 && pdfCount > 0) {
-    return `Create an assistant based on the attached files (${noun(imageCount, "image")} and ${noun(pdfCount, "document")}). Use all of them together to infer the topic, purpose, and audience.`;
+  const docCount = pdfCount + textCount;
+  if (imageCount > 0 && docCount > 0) {
+    return `Create an assistant based on the attached files (${noun(imageCount, "image")} and ${noun(docCount, "document")}). Use all of them together to infer the topic, purpose, and audience.`;
   }
-  if (pdfCount > 0) {
-    return `Create an assistant based on the content of the attached ${pdfCount === 1 ? "document" : `${pdfCount} documents`}.`;
+  if (docCount > 0) {
+    return `Create an assistant based on the content of the attached ${docCount === 1 ? "document" : `${docCount} documents`}.`;
   }
   return `Create an assistant based on what you see in the attached ${imageCount === 1 ? "image" : `${imageCount} images`}. Infer the topic, purpose, and audience from the visual content.`;
 }
@@ -1454,27 +1470,32 @@ export async function generateTemplate(
       (a): a is Extract<ResolvedAttachment, { kind: "pdf" }> =>
         a.kind === "pdf",
     );
+    const texts = attachments.filter(
+      (a): a is Extract<ResolvedAttachment, { kind: "text" }> =>
+        a.kind === "text",
+    );
     userContent = [
       {
         type: "text",
-        text: `${describeAttachments(images.length, pdfs.length)}${intentNote}`,
+        text: `${describeAttachments(images.length, pdfs.length, texts.length)}${intentNote}`,
       },
       // Map the original `attachments` array (not the filtered ones) so a mixed
-      // image/PDF order from the caller is preserved in the content blocks.
-      ...attachments.map((attachment) =>
-        attachment.kind === "image"
-          ? {
-              type: "image_url",
-              image_url: { url: attachment.dataUri },
-            }
-          : {
-              type: "file",
-              file: {
-                filename: attachment.filename,
-                file_data: attachment.dataUri,
-              },
-            },
-      ),
+      // order from the caller is preserved in the content blocks.
+      ...attachments.map((attachment) => {
+        if (attachment.kind === "image") {
+          return { type: "image_url", image_url: { url: attachment.dataUri } };
+        }
+        if (attachment.kind === "text") {
+          return { type: "text", text: fenceTextAttachment(attachment) };
+        }
+        return {
+          type: "file",
+          file: {
+            filename: attachment.filename,
+            file_data: attachment.dataUri,
+          },
+        };
+      }),
     ];
   } else {
     // Text path: idea, content, or URL

--- a/src/api/v2/agent-templates/services/templateGen.ts
+++ b/src/api/v2/agent-templates/services/templateGen.ts
@@ -436,8 +436,11 @@ function buildCapabilitiesDirective(connections?: string[] | null): string {
 
 /** Wrap a text attachment in a labelled fence. The filename is the point: it tells
  *  the model this is an attached file rather than more of the user's directive, and
- *  the name itself is signal ("support-faq.csv" says more than its rows do). */
-function fenceTextAttachment(
+ *  the name itself is signal ("support-faq.csv" says more than its rows do).
+ *
+ *  Shared with the distill stage: the two stages describe the same file to the same
+ *  model, so the fence is a contract between them, not a local formatting choice. */
+export function fenceTextAttachment(
   attachment: Extract<ResolvedAttachment, { kind: "text" }>,
 ): string {
   return `--- ${attachment.filename} ---\n${attachment.text}\n--- end ${attachment.filename} ---`;

--- a/tests/agent-templates.distill.service.test.ts
+++ b/tests/agent-templates.distill.service.test.ts
@@ -16,6 +16,7 @@ import {
   parseDistillResponse,
 } from "@/api/v2/agent-templates/services/distill";
 import { __resetOpenRouterClientForTests } from "@/api/v2/agent-templates/services/openrouter-client";
+import { fenceTextAttachment } from "@/api/v2/agent-templates/services/templateGen";
 
 const VALID = {
   agentName: "Wave Boss",
@@ -205,6 +206,57 @@ describe("distill()", () => {
     expect(types).toContain("image_url");
     const imageBlock = blocks.find((b) => b.type === "image_url");
     expect(imageBlock?.image_url?.url).toBe("data:image/png;base64,AAAA");
+  });
+
+  test("a text attachment reaches distill fenced exactly as the generate stage fences it", async () => {
+    let capturedBody: { messages?: unknown } | undefined;
+    globalThis.fetch = ((_url: unknown, init?: { body?: string }) => {
+      capturedBody = init?.body
+        ? (JSON.parse(init.body) as { messages?: unknown })
+        : undefined;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "cmpl-3",
+            model: "anthropic/claude-opus-4.8-fast",
+            choices: [
+              {
+                message: { role: "assistant", content: JSON.stringify(VALID) },
+              },
+            ],
+            usage: { prompt_tokens: 10, completion_tokens: 20 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as typeof fetch;
+
+    const attachment = {
+      kind: "text",
+      filename: "support-faq.csv",
+      text: "question,answer\nrefunds?,30 days",
+    } as const;
+
+    await distill({ attachments: [attachment] });
+
+    const messages = (capturedBody?.messages ?? []) as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const blocks = (messages.find((m) => m.role === "user")?.content ??
+      []) as Array<{ type: string; text?: string }>;
+
+    // Never a base64 file block — a text file is inlined.
+    expect(blocks.map((b) => b.type)).toEqual(["text", "text"]);
+    expect(JSON.stringify(blocks)).not.toContain("base64");
+
+    // The two stages describe the same file to the same model, so distill must
+    // emit byte-for-byte what the generate stage emits. Comparing against the
+    // shared helper is what fails if either side ever hand-rolls the fence again.
+    expect(blocks[1].text).toBe(fenceTextAttachment(attachment));
+    expect(blocks[1].text).toBe(
+      "--- support-faq.csv ---\nquestion,answer\nrefunds?,30 days\n--- end support-faq.csv ---",
+    );
   });
 
   test("throws when there is neither text nor an attachment", async () => {

--- a/tests/attachment-resolver.service.test.ts
+++ b/tests/attachment-resolver.service.test.ts
@@ -76,8 +76,8 @@ test("image → data-uri block; moderation runs when moderate:true", async () =>
   expect(out.attachments[0]).toMatchObject({
     kind: "image",
     mimeType: "image/png",
+    dataUri: expect.stringMatching(/^data:image\/png;base64,/),
   });
-  expect(out.attachments[0].dataUri).toMatch(/^data:image\/png;base64,/);
   expect(checked).toEqual(["build/a.png"]);
 });
 
@@ -122,8 +122,8 @@ test("pdf → file data-uri block carrying the filename", async () => {
   expect(out.attachments[0]).toMatchObject({
     kind: "pdf",
     filename: "report.pdf",
+    dataUri: expect.stringMatching(/^data:application\/pdf;base64,/),
   });
-  expect(out.attachments[0].dataUri).toMatch(/^data:application\/pdf;base64,/);
 });
 
 test("audio → transcript folded into transcripts, never an attachment block", async () => {
@@ -148,6 +148,80 @@ test("audio transcript blocked by content moderation → error", async () => {
       moderate: true,
     }),
   ).rejects.toBeInstanceOf(AttachmentModerationError);
+});
+
+// ---------------------------------------------------------------------------
+// Text attachments — decoded and inlined, not uploaded as opaque bytes
+// ---------------------------------------------------------------------------
+
+test("text file → decoded inline block carrying its filename", async () => {
+  stubBytes(new TextEncoder().encode("question,answer\nrefunds?,30 days\n"));
+  const out = await resolveAttachments(
+    [
+      {
+        objectKey: "build/faq.csv",
+        mimeType: "text/csv",
+        filename: "support-faq.csv",
+      },
+    ],
+    { moderate: false },
+  );
+
+  expect(out.transcripts).toEqual([]);
+  expect(out.attachments).toEqual([
+    {
+      kind: "text",
+      filename: "support-faq.csv",
+      text: "question,answer\nrefunds?,30 days\n",
+    },
+  ]);
+});
+
+test("text file contents go through content moderation", async () => {
+  stubBytes(new TextEncoder().encode("bad stuff"));
+  __resetModerationForTests(() =>
+    Promise.resolve({ allowed: false, reason: "blocked" }),
+  );
+  await expect(
+    resolveAttachments(
+      [{ objectKey: "build/n.txt", mimeType: "text/plain", filename: "n.txt" }],
+      { moderate: true },
+    ),
+  ).rejects.toBeInstanceOf(AttachmentModerationError);
+});
+
+test("a binary mislabelled as text/plain is rejected, not decoded to mojibake", async () => {
+  // Valid UTF-8 but with an embedded NUL — the shape of a binary claiming text.
+  stubBytes(new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00, 0x41]));
+  await expect(
+    resolveAttachments(
+      [{ objectKey: "build/x.txt", mimeType: "text/plain", filename: "x.txt" }],
+      { moderate: false },
+    ),
+  ).rejects.toThrow(/not a text file/i);
+});
+
+test("invalid UTF-8 claiming to be text is rejected", async () => {
+  stubBytes(new Uint8Array([0xff, 0xfe, 0xfd]));
+  await expect(
+    resolveAttachments(
+      [{ objectKey: "build/x.md", mimeType: "text/markdown" }],
+      { moderate: false },
+    ),
+  ).rejects.toThrow(/not valid UTF-8/i);
+});
+
+test("an over-long text file keeps its head and states the omission", async () => {
+  const body = "x".repeat(25_000);
+  stubBytes(new TextEncoder().encode(body));
+  const out = await resolveAttachments(
+    [{ objectKey: "build/big.md", mimeType: "text/markdown" }],
+    { moderate: false },
+  );
+
+  const text = (out.attachments[0] as { text: string }).text;
+  expect(text).toContain("5,000 more characters not shown");
+  expect(text.startsWith("x".repeat(20_000))).toBe(true);
 });
 
 test("over-cap image → throws before any moderation", async () => {

--- a/tests/attachment-resolver.service.test.ts
+++ b/tests/attachment-resolver.service.test.ts
@@ -198,7 +198,7 @@ test("a binary mislabelled as text/plain is rejected, not decoded to mojibake", 
       [{ objectKey: "build/x.txt", mimeType: "text/plain", filename: "x.txt" }],
       { moderate: false },
     ),
-  ).rejects.toThrow(/not a text file/i);
+  ).rejects.toThrow(/contains binary data/i);
 });
 
 test("invalid UTF-8 claiming to be text is rejected", async () => {

--- a/tests/attachment-resolver.service.test.ts
+++ b/tests/attachment-resolver.service.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/api/v2/agent-templates/services/attachment-resolver";
 import { __resetImageModerationForTests } from "@/api/v2/agent-templates/services/image-moderation";
 import { __resetModerationForTests } from "@/api/v2/agent-templates/services/moderation";
+import type { ResolvedAttachment } from "@/api/v2/agent-templates/services/templateGen";
 import { __resetTranscribeForTests } from "@/api/v2/agent-templates/services/transcribe";
 
 const mockSend = vi.fn(
@@ -51,6 +52,16 @@ function stubBytes(bytes: Uint8Array): void {
   });
 }
 
+/** Assert an attachment's kind and narrow to that variant, so a test can read the
+ *  fields that only exist on it (`dataUri` on image/pdf, `text` on text). */
+function expectKind<K extends ResolvedAttachment["kind"]>(
+  attachment: ResolvedAttachment,
+  kind: K,
+): Extract<ResolvedAttachment, { kind: K }> {
+  expect(attachment.kind).toBe(kind);
+  return attachment as Extract<ResolvedAttachment, { kind: K }>;
+}
+
 afterEach(() => {
   mockSend.mockReset();
   __resetImageModerationForTests(null);
@@ -73,11 +84,9 @@ test("image → data-uri block; moderation runs when moderate:true", async () =>
 
   expect(out.transcripts).toEqual([]);
   expect(out.attachments).toHaveLength(1);
-  expect(out.attachments[0]).toMatchObject({
-    kind: "image",
-    mimeType: "image/png",
-    dataUri: expect.stringMatching(/^data:image\/png;base64,/),
-  });
+  const image = expectKind(out.attachments[0], "image");
+  expect(image.mimeType).toBe("image/png");
+  expect(image.dataUri).toMatch(/^data:image\/png;base64,/);
   expect(checked).toEqual(["build/a.png"]);
 });
 
@@ -119,11 +128,9 @@ test("pdf → file data-uri block carrying the filename", async () => {
     ],
     { moderate: true },
   );
-  expect(out.attachments[0]).toMatchObject({
-    kind: "pdf",
-    filename: "report.pdf",
-    dataUri: expect.stringMatching(/^data:application\/pdf;base64,/),
-  });
+  const pdf = expectKind(out.attachments[0], "pdf");
+  expect(pdf.filename).toBe("report.pdf");
+  expect(pdf.dataUri).toMatch(/^data:application\/pdf;base64,/);
 });
 
 test("audio → transcript folded into transcripts, never an attachment block", async () => {
@@ -219,7 +226,7 @@ test("an over-long text file keeps its head and states the omission", async () =
     { moderate: false },
   );
 
-  const text = (out.attachments[0] as { text: string }).text;
+  const { text } = expectKind(out.attachments[0], "text");
   expect(text).toContain("5,000 more characters not shown");
   expect(text.startsWith("x".repeat(20_000))).toBe(true);
 });

--- a/tests/build-attachments.service.test.ts
+++ b/tests/build-attachments.service.test.ts
@@ -146,6 +146,22 @@ describe("decodeTextAttachment", () => {
     );
     expect(out).toBe("x".repeat(TEXT_ATTACHMENT_MAX_CHARS));
   });
+
+  test("truncation never splits a surrogate pair", () => {
+    // "😀" is two UTF-16 code units. Place it so the cap falls exactly between
+    // them — the naive slice would leave a lone high surrogate at the cut.
+    const head = "x".repeat(TEXT_ATTACHMENT_MAX_CHARS - 1);
+    const out = decodeTextAttachment(
+      utf8(`${head}😀${"y".repeat(100)}`),
+      "emoji.md",
+    );
+
+    const body = out.split("\n\n[")[0];
+    expect(body).toBe(head);
+    // No high surrogate left without its partner.
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+    expect(out).toContain("102 more characters not shown");
+  });
 });
 
 describe("defaultTextFilename", () => {

--- a/tests/build-attachments.service.test.ts
+++ b/tests/build-attachments.service.test.ts
@@ -7,10 +7,12 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   classifyMime,
+  decodeTextAttachment,
   getBuildObjectBytes,
   headBuildObject,
   maxBytesForKind,
   presignBuildUpload,
+  TEXT_ATTACHMENT_MAX_CHARS,
 } from "@/api/v2/agent-templates/services/build-attachments";
 
 const mockSend = vi.fn(
@@ -70,13 +72,79 @@ describe("classifyMime", () => {
   test("rejects webp/gif (Rekognition can't read them) and unknown types", () => {
     expect(classifyMime("image/webp")).toBeNull();
     expect(classifyMime("image/gif")).toBeNull();
-    expect(classifyMime("text/plain")).toBeNull();
+    expect(classifyMime("application/zip")).toBeNull();
+  });
+
+  test("classifies the text family, and fails closed outside it", () => {
+    expect(classifyMime("text/plain")).toBe("text");
+    expect(classifyMime("text/markdown")).toBe("text");
+    expect(classifyMime("text/csv")).toBe("text");
+    expect(classifyMime("application/json")).toBe("text");
+
+    // The allowlist is explicit, not a `text/*` prefix match: an unlisted
+    // text-ish type is rejected rather than decoded on the client's say-so.
+    expect(classifyMime("text/html")).toBeNull();
+
+    // Office formats have no path in the generator yet.
+    expect(
+      classifyMime(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ),
+    ).toBeNull();
   });
 });
 
 test("maxBytesForKind caps images tighter than pdf/audio", () => {
   expect(maxBytesForKind("image")).toBeLessThan(maxBytesForKind("pdf"));
   expect(maxBytesForKind("audio")).toBe(maxBytesForKind("pdf"));
+  // The byte cap on a text file is only an upload guard — the character cap in
+  // decodeTextAttachment is what actually bounds what reaches the prompt.
+  expect(maxBytesForKind("text")).toBeLessThan(maxBytesForKind("pdf"));
+});
+
+describe("decodeTextAttachment", () => {
+  const utf8 = (s: string) => new TextEncoder().encode(s);
+
+  test("decodes UTF-8, including multi-byte characters", () => {
+    expect(decodeTextAttachment(utf8("héllo — 世界"), "a.txt")).toBe(
+      "héllo — 世界",
+    );
+  });
+
+  test("rejects invalid UTF-8 rather than producing mojibake", () => {
+    expect(() =>
+      decodeTextAttachment(new Uint8Array([0xff, 0xfe, 0xfd]), "a.txt"),
+    ).toThrow(/not valid UTF-8/i);
+  });
+
+  test("rejects a binary carrying an embedded NUL", () => {
+    expect(() =>
+      decodeTextAttachment(new Uint8Array([0x41, 0x00, 0x42]), "a.txt"),
+    ).toThrow(/not a text file/i);
+  });
+
+  test("rejects an empty file", () => {
+    expect(() => decodeTextAttachment(utf8("   \n"), "a.txt")).toThrow(
+      /empty/i,
+    );
+  });
+
+  test("truncation keeps the head and states how much was dropped", () => {
+    const out = decodeTextAttachment(
+      utf8("x".repeat(TEXT_ATTACHMENT_MAX_CHARS + 500)),
+      "big.md",
+    );
+    expect(out).toContain("500 more characters not shown");
+    expect(out.startsWith("x".repeat(TEXT_ATTACHMENT_MAX_CHARS))).toBe(true);
+  });
+
+  test("a file exactly at the cap is not truncated", () => {
+    const out = decodeTextAttachment(
+      utf8("x".repeat(TEXT_ATTACHMENT_MAX_CHARS)),
+      "exact.md",
+    );
+    expect(out).toBe("x".repeat(TEXT_ATTACHMENT_MAX_CHARS));
+  });
 });
 
 describe("presignBuildUpload", () => {

--- a/tests/build-attachments.service.test.ts
+++ b/tests/build-attachments.service.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   classifyMime,
   decodeTextAttachment,
+  defaultTextFilename,
   getBuildObjectBytes,
   headBuildObject,
   maxBytesForKind,
@@ -120,7 +121,7 @@ describe("decodeTextAttachment", () => {
   test("rejects a binary carrying an embedded NUL", () => {
     expect(() =>
       decodeTextAttachment(new Uint8Array([0x41, 0x00, 0x42]), "a.txt"),
-    ).toThrow(/not a text file/i);
+    ).toThrow(/contains binary data/i);
   });
 
   test("rejects an empty file", () => {
@@ -144,6 +145,22 @@ describe("decodeTextAttachment", () => {
       "exact.md",
     );
     expect(out).toBe("x".repeat(TEXT_ATTACHMENT_MAX_CHARS));
+  });
+});
+
+describe("defaultTextFilename", () => {
+  test("derives the extension from the MIME so structured data stays labelled", () => {
+    expect(defaultTextFilename("text/csv")).toBe("attachment.csv");
+    expect(defaultTextFilename("application/json")).toBe("attachment.json");
+    expect(defaultTextFilename("text/plain")).toBe("attachment.txt");
+    expect(defaultTextFilename("text/csv; charset=utf-8")).toBe(
+      "attachment.csv",
+    );
+  });
+
+  test("falls back to .txt for a MIME with no known extension", () => {
+    // mime-types has no extension for application/x-yaml.
+    expect(defaultTextFilename("application/x-yaml")).toBe("attachment.txt");
   });
 });
 

--- a/tests/template-gen.service.test.ts
+++ b/tests/template-gen.service.test.ts
@@ -919,6 +919,69 @@ describe("templateGen service — OpenRouter integration", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Text attachments: an inline block fenced with its filename, so the model
+  // can tell an attached file from the user's directive
+  // -----------------------------------------------------------------------
+  test("text attachment becomes a fenced text block, not a file block", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+    setOpenRouterResponse(templateResponse());
+
+    await generateTemplate({
+      attachments: [
+        {
+          kind: "text",
+          filename: "support-faq.csv",
+          text: "question,answer\nrefunds?,30 days",
+        },
+      ],
+      text: "Answer support questions from this",
+    });
+
+    const userContent = getLastOpenRouterRequest().body.messages[1].content;
+    expect(Array.isArray(userContent)).toBe(true);
+    expect(userContent).toHaveLength(2);
+
+    // The lead directive counts a text file as a document, same as a PDF.
+    expect(userContent[0].type).toBe("text");
+    expect(userContent[0].text).toContain("document");
+    expect(userContent[0].text).toContain(
+      "User's intent: Answer support questions from this",
+    );
+
+    // The file rides as text, fenced by name — never a base64 file block.
+    expect(userContent[1].type).toBe("text");
+    expect(userContent[1].text).toBe(
+      "--- support-faq.csv ---\nquestion,answer\nrefunds?,30 days\n--- end support-faq.csv ---",
+    );
+    expect(JSON.stringify(userContent)).not.toContain("base64");
+  });
+
+  test("a text file mixed with an image keeps caller order and both block types", async () => {
+    const mod = await import("@/api/v2/agent-templates/services/templateGen");
+    generateTemplate = mod.generateTemplate;
+    setOpenRouterResponse(templateResponse());
+
+    await generateTemplate({
+      attachments: [
+        { kind: "text", filename: "notes.md", text: "# Notes" },
+        {
+          kind: "image",
+          mimeType: "image/png",
+          dataUri: "data:image/png;base64,iVBORw0KGgo=",
+        },
+      ],
+    });
+
+    const userContent = getLastOpenRouterRequest().body.messages[1].content;
+    expect(userContent[0].text).toContain("1 image");
+    expect(userContent[0].text).toContain("1 document");
+    expect(userContent[1].type).toBe("text");
+    expect(userContent[1].text).toContain("--- notes.md ---");
+    expect(userContent[2].type).toBe("image_url");
+  });
+
+  // -----------------------------------------------------------------------
   // Brevity rail asymmetry: appended on production-LLM path only
   // -----------------------------------------------------------------------
   test("brevity rail appended on production-LLM path", async () => {


### PR DESCRIPTION
Prep for iOS document uploads: put text-file handling in the backend so every client just uploads bytes.

## Why

The generator's allowlist is png/jpeg/pdf/audio. So the web builder handles `.md/.txt/.json/.csv` **client-side** — it reads them in the browser and concatenates the contents onto the typed prompt (`create-client.tsx:560`, `[text, ...fileTexts].join("\n\n")` → `body.text`). They're never uploaded.

That has three costs:

- **Provenance is destroyed.** A CSV of FAQs arrives welded to the user's sentence with no filename and no boundary. The model can't tell the instruction from the file.
- **File contents land in `body.text`** — the same field the URL extractor reads, so a link plus a short attached file lets file contents be read as an instruction about the link.
- **It can't be reused.** iOS only ever constructs `image/jpeg` + `audio/m4a`; Android mirrors the *backend* allowlist and so has no text-file support at all. Three clients, three answers, and iOS copying the web trick would make a fourth.

## What

A `text` attachment kind:

- **Allowlist** — an explicit text MIME list, not a `text/*` prefix match, so an unlisted text-ish type fails closed rather than being decoded on the client's say-so.
- **Decode** — strict UTF-8 with a NUL probe. The MIME is the client's *claim* about a file; this is where it's checked. A binary mislabelled `text/plain` is rejected instead of decoding to mojibake and being fed to the model as prose.
- **Cap** — `TEXT_ATTACHMENT_MAX_CHARS = 20_000`, matching the number the Hermes runtime already uses for the identical concept (`channel.py`), so a file an agent can read in a conversation is a file the builder can read while creating that agent. Past the cap the head is kept and the omission is stated, so the model is never handed a silently truncated document.
- **Block** — inlined and fenced with the filename, so the model can tell `support-faq.csv` from the directive. The name is itself signal.
- **Moderation** — text contents now run through the same content check the typed directive and voice transcripts get. On the inline path they were never moderated at all.

## Follow-ons (not here)

- iOS: widen the picker and send the real MIME instead of the two hardcoded values.
- Web: delete the inline hack and just upload.
- Android: mirror the new allowlist.
- Office formats (docx/xlsx/pptx) still have no path in either pipeline — that's a separate build-vs-buy call on a parse step, and it isn't blocking iOS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786503589&installation_id=128169237&pr_number=356&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F356&signature=98d7f1402f0a1726e79f5577990da748cb05d363241c993cb05e65f0c098c4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add text file support as build attachments in agent templates
> - Extends the attachment pipeline to accept text MIME types (plain, markdown, CSV, JSON, YAML, etc.) alongside existing image and PDF support.
> - Decodes text attachments as strict UTF-8, rejects binary content or NUL characters, and caps decoded content at 20,000 characters per file with a localized omission notice on truncation.
> - Inlines text attachments as labeled fenced blocks in both distill and generation prompt content, counting them as 'documents' in lead directive text.
> - Applies a 1 MB per-file byte cap before decoding, and supports optional content moderation for text attachments.
> - Risk: Any attachment MIME type not in the explicit allowlist (e.g. `text/html`) continues to be rejected; callers switching on `ResolvedAttachment` kind must now handle the new `'text'` variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53725ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for text attachments (plain text, Markdown, CSV, XML, YAML, JSON), including automatic filenames, strict UTF-8 decoding, and per-type upload limits.
  * Text is now moderated (when enabled) and inlined into prompts as labeled fenced text blocks, preserving original attachment order alongside images.
  * Updated template generation and distillation wording to treat text as “documents”.
* **Bug Fixes**
  * Rejects invalid UTF-8, NUL/binary payloads, and empty content misidentified as text; enforces character truncation with an omission indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->