### PR TITLE
fix(subscriptions): materialize grants on verify replay + AAT 409 + explicit refill kill-switch

### DIFF
--- a/docs/plans/subscription-ownership-reconciliation.md
+++ b/docs/plans/subscription-ownership-reconciliation.md
@@ -1,0 +1,79 @@
+# SSN/verify ownership reconciliation — options note (decision deferred)
+
+Status: **open question**, no decision. Written alongside the July 2026 fix
+bundle (verify-replay grant materializer, AAT-conflict 409, daily-refill
+kill-switch). This note only frames the problem and two candidate directions.
+
+## The gap
+
+A `Subscription` row belongs to the account that **first** verified it, and the
+two write paths treat ownership asymmetrically:
+
+- **Server notifications (Apple SSN / Play RTDN → `applyNotification`)** look
+  the row up by provider identity (OTX / purchaseToken) and keep _enriching_ it
+  no matter who owns it: status transitions, period advances, and — since the
+  single-ledger migration — `grantSubscriptionPeriod` credits for every renewal,
+  all landing on the row's (possibly dead) `accountId`.
+- **Client verify (`upsertFromVerify`)** _refuses_ when the authenticated caller
+  differs from the row's owner: `SubscriptionAccountMismatchError` → 409.
+
+So after an account deletion + recreation (common: iOS reuses the per-install
+`appAccountToken`, and Apple keeps renewing the same subscription), the person
+keeps paying, Apple keeps notifying, renewals keep granting credits into the
+orphaned old wallet — while the account the human actually uses gets a
+truthful-but-dead-end 409 ("contact support"). The 409 is correct as a
+_safety_ posture (fixed in this bundle to replace a 500); it is not a
+_resolution_.
+
+## Option A — provider-proven ownership transfer at verify time
+
+When verify presents a **fresh, provider-verified** transaction (Apple-signed
+JWS / Play API-confirmed purchase) whose provider identity matches a row owned
+by another account, re-home the row — `accountId`, and therefore all future
+SSN-driven grants — to the authenticated caller. Plausible gates: only when the
+old account is deleted/inactive, or when the caller proves the same install
+identity (same `appAccountToken` in the signed payload, not just the request).
+
+- **Pros:** self-serve healing, zero support latency; renewals immediately
+  enrich the right wallet; matches what the paying user meant.
+- **Cons / open problems:**
+  - Ownership transfer is an attack surface. A replayed receipt or leaked JWS
+    must not steal a subscription; mitigations (freshness window, matching
+    AAT inside the signed transaction, old-account-deleted gate, rate limits)
+    each add real complexity and each have edge cases.
+  - Money questions: the old wallet may hold already-granted period credits.
+    Forfeit-from-old + grant-to-new is the clean ledger story but claws back a
+    commingled wallet; leaving them double-counts the period.
+  - Auditability: transfers need their own journal (who, when, on what proof)
+    and probably an undo path.
+
+## Option B — keep the 409; support-mediated relink + detection
+
+Verify keeps refusing cross-account matches. Add: (1) an admin endpoint that
+re-homes a subscription after human verification (writing an audit row), and
+(2) telemetry/alerting on `subscription.verify.account_mismatch` so support
+reaches out instead of waiting for a ticket. Optional stopgap: suppress
+renewal grants when the owning account is deleted, so credits stop pouring
+into orphaned wallets in the interim.
+
+- **Pros:** no automated hijack surface; explicit human judgment + audit trail
+  on every transfer; small, boring blast radius; buildable in a day.
+- **Cons:** paying users stay broken for hours/days until a human acts; support
+  load scales with account-recreation volume; the asymmetry itself (SSN
+  enriches, verify refuses) remains — only its cost is managed.
+
+## Adjacent notes
+
+- An iOS-side change (generate `appAccountToken` per _account_ instead of per
+  install) shrinks the future collision class but heals nothing already in the
+  wild, and OTX-based collisions (resubscribe from a new account on the same
+  Apple ID) remain either way.
+- Play has the same latent shape via `obfuscatedAccountId`
+  (`subscription_play_oid_unique`); any decision here should cover both
+  providers.
+
+## Decision
+
+Deferred. Revisit when mismatch-409 telemetry shows real volume, or at the next
+subscriptions design review — whichever comes first. Option B's detection half
+is cheap and useful under either outcome; it is the natural first step.

--- a/src/api/v2/accounts/handlers/credits-get.ts
+++ b/src/api/v2/accounts/handlers/credits-get.ts
@@ -36,11 +36,46 @@ const MONTH_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", {
  *     `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS`; `monthlyGrantUsed` =
  *     `max(0, cap − balance)`; `nextRefreshAt` = start of next UTC day;
  *     `periodLabel` = "Daily".
+ *   - When the daily refill is DISABLED (cap = 0, the config kill-switch): do
+ *     not promise a refresh that will not come. The response mirrors the iOS
+ *     app's own design-approved free-state fixture —
+ *     `CreditsStatePreset.noSubNoTrial` (ConvosCore/Services/Credits/
+ *     CreditsStatePreset.swift): `monthlyGrant`/`Used` = 0, `nextRefreshAt` =
+ *     now, `periodLabel` = REFILL_DISABLED_PERIOD_LABEL ("—"). See the
+ *     constant below for why every key must stay present.
  *
  * Note for v1: field names reuse `monthlyGrant`/`monthlyGrantUsed` for the
  * daily cap so iOS doesn't need a client-side change. Proper `dailyCap` /
  * `dailyUsed` fields are a follow-up requiring iOS coordination.
  */
+
+/**
+ * `periodLabel` when the daily refill is disabled — the exact label the iOS
+ * design fixture uses for the "no sub / no trial" state.
+ *
+ * Shipped-client constraints (all verified against convos-ios origin/dev):
+ * - `CreditBalance.nextRefreshAt` is a NON-OPTIONAL `Date`
+ *   (ConvosCore/Storage/Models/CreditBalance.swift:7): omitting the key or
+ *   sending null makes Codable throw and breaks the whole credits fetch for
+ *   every installed build, so the key must stay present and parseable.
+ * - The only user-facing renders of these fields are on
+ *   SubscriptionSettingsView: "\(balance) / \(monthlyGrant)" and
+ *   "Refreshes \(mediumDate(nextRefreshAt))", shown whenever a balance
+ *   exists — there is no data-driven hide condition, so we cannot suppress
+ *   the footer; we can only choose the least-wrong date.
+ * - `periodLabel` and `monthlyGrantUsed` render in the debug menu only;
+ *   `fractionRemaining`/`isLow` have no shipped consumers, and grant = 0 is
+ *   guarded in the model (`guard monthlyGrant > 0 else nil`) — no NaN risk.
+ *
+ * Emitting `{ monthlyGrant: 0, monthlyGrantUsed: 0, nextRefreshAt: now,
+ * periodLabel: "—" }` therefore reproduces `CreditsStatePreset.noSubNoTrial`
+ * exactly — the canned state designers/QA already dogfooded and signed off —
+ * rather than inventing a new one. The footer reads "Refreshes <today>",
+ * which is the least-wrong string the shipped format can produce: unlike
+ * tomorrow's date it makes no forward promise, and unlike a far-future
+ * sentinel it doesn't render an absurd year. No iOS update is required.
+ */
+export const REFILL_DISABLED_PERIOD_LABEL = "—";
 export async function creditsGetHandler(req: Request, res: Response) {
   const accountId = res.locals.accountId as string;
 
@@ -52,14 +87,21 @@ export async function creditsGetHandler(req: Request, res: Response) {
 
     if (!subscription || !isEntitledSubscription(subscription)) {
       const cap = config.freeTierDailyCapCredits;
+      // cap = 0 → the refill kill-switch is on; there is no daily grant and no
+      // refresh coming, so advertise neither (used clamps to 0 with cap 0) and
+      // emit the iOS design fixture's free-state combo instead — see
+      // REFILL_DISABLED_PERIOD_LABEL for the shipped-client rendering analysis.
+      const refillEnabled = cap > 0;
       const used = Math.max(0, cap - balanceCredits);
       const now = new Date();
       res.status(200).json({
         balance: balanceCredits,
         monthlyGrant: cap,
         monthlyGrantUsed: used,
-        nextRefreshAt: startOfNextUtcDay(now).toISOString(),
-        periodLabel: "Daily",
+        nextRefreshAt: refillEnabled
+          ? startOfNextUtcDay(now).toISOString()
+          : now.toISOString(),
+        periodLabel: refillEnabled ? "Daily" : REFILL_DISABLED_PERIOD_LABEL,
       });
       return;
     }

--- a/src/payments/credits/config.ts
+++ b/src/payments/credits/config.ts
@@ -115,18 +115,32 @@ const loadMinBalanceCredits = (): bigint => {
 
 // PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS
 //   Daily top-up-to-cap amount applied by the /credits/daily cron to
-//   SIWE-verified non-subscriber accounts. Must be a positive integer.
+//   SIWE-verified non-subscriber accounts.
+//   OPTIONAL by design: unset/empty/"0" => 0 => daily refill DISABLED
+//   (kill-switch, mirrors PAYMENTS_SIGNUP_BONUS_CREDITS). The refill was
+//   deactivated as a business decision (~Jun 11 2026) by simply not running
+//   the cron, but the loader still REQUIRED a positive cap — so the OFF state
+//   was inexpressible in config and GET /v2/accounts/me/credits kept
+//   advertising a `nextRefreshAt` that never came. With 0/unset, the credits
+//   endpoint stops promising a refresh and `runDailyRefill` naturally no-ops
+//   (headroom = 0 − balance ≤ 0). Any positive value keeps the previous
+//   behavior identical. Do NOT convert back to a require* loader; "unset =
+//   off" is the intended contract.
 export const loadFreeTierDailyCapCredits = (): number => {
-  const big = requireBigInt(
-    "PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS",
-    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS,
-  );
-  if (big <= 0n || big > BigInt(Number.MAX_SAFE_INTEGER)) {
+  const raw = process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS;
+  if (raw === undefined || raw.trim() === "") {
+    return 0;
+  }
+  const trimmed = raw.trim();
+  if (
+    !/^\d+$/.test(trimmed) ||
+    BigInt(trimmed) > BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
     throw new ValidationError(
-      `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS must be a positive safe integer, got: ${big}`,
+      `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS must be a non-negative safe integer, got: ${raw}`,
     );
   }
-  return Number(big);
+  return Number(trimmed);
 };
 
 // PAYMENTS_SIGNUP_BONUS_CREDITS

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -15,6 +15,7 @@ import {
 import {
   effectiveSubscriptionStatus,
   ENTITLED_SUBSCRIPTION_STATUSES,
+  isEntitledSubscription,
   isEntitledSubscriptionStatus,
 } from "@/subscriptions/status";
 import {
@@ -391,10 +392,19 @@ export const upsertFromVerify = async (
         // concurrent renewal/verify cannot double-grant; the pre-check below
         // only avoids taking the wallet lock on the common already-granted
         // replay. Replay semantics stay intact: receiptCreated stays false.
+        //
+        // The gate MUST be the TIME-AWARE `isEntitledSubscription` (the same
+        // helper credits-get uses), not the stored-status check: a replay can
+        // arrive long after the stored state went stale. Prod holds rows whose
+        // stored status is still `active`/`grace` because the terminal EXPIRED
+        // webhook was lost or delayed — their entitlement window has already
+        // elapsed, and effectiveSubscriptionStatus resolves them to `expired`.
+        // Backfilling a full period grant for such a LAPSED period would mint
+        // credits that credits-get simultaneously frames as free-tier state.
         const replayed = existingReceipt.subscription;
         const isStaleReplay =
           input.currentPeriodEnd < replayed.currentPeriodEnd;
-        if (!isStaleReplay && isEntitledSubscriptionStatus(replayed.status)) {
+        if (!isStaleReplay && isEntitledSubscription(replayed)) {
           const currentPeriodGrant = await tx.creditLedger.findUnique({
             where: {
               accountId_idempotencyKey: {
@@ -452,6 +462,16 @@ export const upsertFromVerify = async (
       // re-verify of the same period, or an S2S DID_RENEW racing this verify
       // all resolve to one row. Only grant when the verified state is
       // entitled and the verify is not a stale (out-of-order) replay.
+      //
+      // DELIBERATELY the stored-status gate here (unlike the time-aware gate
+      // on the replay backfill above): this status was just derived from the
+      // provider-verified input — deriveSubscriptionStatusFromTransaction
+      // already maps a past expiresDate to `expired`, so stored ≈ effective at
+      // this instant. The single-ledger contract is grant-then-forfeit: a
+      // fresh verify grants the period and an expiry webhook claws back the
+      // unused portion (pinned by account-credits.test.ts "past-ended active
+      // subscription … wallet credits persist until forfeit"). Switching this
+      // to the effective check would break that pinned semantic for nothing.
       if (!isStaleVerify && isEntitledSubscriptionStatus(subscription.status)) {
         const grantResult = await grantSubscriptionPeriod(tx, {
           subscription,

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -10,6 +10,7 @@ import {
 import {
   forfeitSubscriptionPeriod,
   grantSubscriptionPeriod,
+  subGrantKey,
 } from "@/subscriptions/grants";
 import {
   effectiveSubscriptionStatus,
@@ -376,8 +377,44 @@ export const upsertFromVerify = async (
       });
 
       if (existingReceipt) {
+        // Exact VERIFY replay — but do NOT return before the grant check.
+        // Subscribers who bought BEFORE the single-ledger deploy (#324) have a
+        // Subscription + BillingReceipt but no `sub_grant` ledger row for the
+        // period they are living in: their original verify predates the grant
+        // write. This short-circuit used to return here unconditionally, so a
+        // re-verify could never heal them — their wallet stayed unfunded (and
+        // could sit negative) until the next renewal. Instead, make re-verify a
+        // universal materializer: when the replayed subscription is entitled
+        // and this verify is not stale, backfill the CURRENT period's grant if
+        // its canonical `sub_grant` row is missing. `grantSubscriptionPeriod`
+        // is idempotent per (sub, periodStart) and lock-serialized, so a
+        // concurrent renewal/verify cannot double-grant; the pre-check below
+        // only avoids taking the wallet lock on the common already-granted
+        // replay. Replay semantics stay intact: receiptCreated stays false.
+        const replayed = existingReceipt.subscription;
+        const isStaleReplay =
+          input.currentPeriodEnd < replayed.currentPeriodEnd;
+        if (!isStaleReplay && isEntitledSubscriptionStatus(replayed.status)) {
+          const currentPeriodGrant = await tx.creditLedger.findUnique({
+            where: {
+              accountId_idempotencyKey: {
+                accountId: replayed.accountId,
+                idempotencyKey: subGrantKey(
+                  replayed.id,
+                  replayed.currentPeriodStart,
+                ),
+              },
+            },
+          });
+          if (!currentPeriodGrant) {
+            await grantSubscriptionPeriod(tx, {
+              subscription: replayed,
+              periodStart: replayed.currentPeriodStart,
+            });
+          }
+        }
         return {
-          subscription: existingReceipt.subscription,
+          subscription: replayed,
           receiptCreated: false,
         };
       }

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -474,6 +474,10 @@ export const upsertFromVerify = async (
     //   - Subscription provider-unique → the documented cold-start race (two
     //     concurrent creates of the same provider sub). Benign idempotent
     //     replay: re-read the committed row.
+    //     - EXCEPT the Apple appAccountToken unique: the colliding row holds a
+    //       DIFFERENT originalTransactionId, so the OTX re-read below finds
+    //       nothing. That case gets its own (provider, appAccountToken)
+    //       re-read further down instead of falling through to the rethrow.
     //   - BillingReceipt idempotencyKey → two concurrent /verify calls for the
     //     same transaction raced past the `existingReceipt` pre-check above and
     //     both reached `billingReceipt.create`. The loser must ALSO resolve
@@ -501,6 +505,43 @@ export const upsertFromVerify = async (
           );
         }
         return { subscription: current, receiptCreated: false };
+      }
+
+      // reReadAfterRace resolves by OTX/purchaseToken only, so an
+      // appAccountToken-unique conflict re-read null here and used to fall
+      // through to the rethrow — a raw 500 to the user. That is the
+      // account-recreation path: iOS generates the appAccountToken per
+      // INSTALL, so it survives account deletion + recreation, and the
+      // recreated account's fresh purchase (NEW originalTransactionId)
+      // collides on the AAT unique with the OLD account's row. Resolve the
+      // conflict by the index that actually fired: re-read by
+      // (provider, appAccountToken) and surface the truthful outcome — the
+      // standard account-mismatch 409 when the holder is another account, or
+      // an idempotent replay when the caller already holds the row (mirrors
+      // the same-account branch above). Mismatch semantics are unchanged;
+      // only the crash becomes an honest 409.
+      if (
+        input.provider === BillingProvider.apple &&
+        isAppleAppAccountTokenConflict(err)
+      ) {
+        const holder = await prisma.subscription.findUnique({
+          where: {
+            subscription_apple_aat_unique: {
+              provider: BillingProvider.apple,
+              appAccountToken: input.appAccountToken,
+            },
+          },
+        });
+        if (holder) {
+          if (holder.accountId !== input.accountId) {
+            throw new SubscriptionAccountMismatchError(
+              holder.accountId,
+              input.accountId,
+              externalId,
+            );
+          }
+          return { subscription: holder, receiptCreated: false };
+        }
       }
     }
     throw err;
@@ -543,6 +584,31 @@ const isSubscriptionProviderUniqueConflict = (
     (t) =>
       SUBSCRIPTION_PROVIDER_UNIQUE_FIELDS.has(t) ||
       SUBSCRIPTION_PROVIDER_UNIQUE_INDEX_NAMES.has(t),
+  );
+};
+
+// The Apple (provider, appAccountToken) unique specifically — a SUBSET of the
+// provider-unique set above, needed because reReadAfterRace cannot resolve this
+// conflict: it re-reads by originalTransactionId, and the colliding row holds a
+// DIFFERENT one (account recreation reuses the per-install AAT with a fresh
+// purchase). Same target-shape tolerance as its siblings: the Postgres driver
+// surfaces the conflicting FIELD names in `err.meta.target`; some adapters
+// surface the index NAME instead.
+const isAppleAppAccountTokenConflict = (
+  err: Prisma.PrismaClientKnownRequestError,
+): boolean => {
+  if (err.meta?.modelName && err.meta.modelName !== "Subscription") {
+    return false;
+  }
+  const target = err.meta?.target;
+  const tokens =
+    typeof target === "string"
+      ? [target]
+      : Array.isArray(target)
+        ? target.map(String)
+        : [];
+  return tokens.some(
+    (t) => t === "appAccountToken" || t === "subscription_apple_aat_unique",
   );
 };
 

--- a/tests/payments/daily-refill-config.unit.test.ts
+++ b/tests/payments/daily-refill-config.unit.test.ts
@@ -11,27 +11,36 @@ describe("PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS", () => {
     }
   });
 
-  test("loads positive int", async () => {
+  test("loads positive int (refill enabled, behavior unchanged)", async () => {
     process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "100";
     const { loadFreeTierDailyCapCredits } =
       await import("@/payments/credits/config");
     expect(loadFreeTierDailyCapCredits()).toBe(100);
   });
 
-  test("rejects missing", async () => {
+  // Kill-switch contract (mirrors PAYMENTS_SIGNUP_BONUS_CREDITS): unset,
+  // empty, or "0" all mean "daily refill disabled" — the OFF state must be
+  // expressible in config so credits-get stops advertising a refresh that
+  // will not come. Do NOT re-tighten these to throw.
+  test("missing → 0 (refill disabled)", async () => {
     delete process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS;
     const { loadFreeTierDailyCapCredits } =
       await import("@/payments/credits/config");
-    expect(() => loadFreeTierDailyCapCredits()).toThrow(/not configured/);
+    expect(loadFreeTierDailyCapCredits()).toBe(0);
   });
 
-  test("rejects zero", async () => {
+  test("empty string → 0 (refill disabled)", async () => {
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "";
+    const { loadFreeTierDailyCapCredits } =
+      await import("@/payments/credits/config");
+    expect(loadFreeTierDailyCapCredits()).toBe(0);
+  });
+
+  test("zero → 0 (refill disabled)", async () => {
     process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "0";
     const { loadFreeTierDailyCapCredits } =
       await import("@/payments/credits/config");
-    expect(() => loadFreeTierDailyCapCredits()).toThrow(
-      /must be a positive safe integer/,
-    );
+    expect(loadFreeTierDailyCapCredits()).toBe(0);
   });
 
   test("rejects negative", async () => {
@@ -39,7 +48,7 @@ describe("PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS", () => {
     const { loadFreeTierDailyCapCredits } =
       await import("@/payments/credits/config");
     expect(() => loadFreeTierDailyCapCredits()).toThrow(
-      /must be a positive safe integer/,
+      /must be a non-negative safe integer/,
     );
   });
 
@@ -47,13 +56,26 @@ describe("PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS", () => {
     process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "1.5";
     const { loadFreeTierDailyCapCredits } =
       await import("@/payments/credits/config");
-    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be an integer/);
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(
+      /must be a non-negative safe integer/,
+    );
   });
 
   test("rejects alpha string", async () => {
     process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "abc";
     const { loadFreeTierDailyCapCredits } =
       await import("@/payments/credits/config");
-    expect(() => loadFreeTierDailyCapCredits()).toThrow(/must be an integer/);
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(
+      /must be a non-negative safe integer/,
+    );
+  });
+
+  test("rejects unsafe magnitude", async () => {
+    process.env.PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS = "9007199254740993";
+    const { loadFreeTierDailyCapCredits } =
+      await import("@/payments/credits/config");
+    expect(() => loadFreeTierDailyCapCredits()).toThrow(
+      /must be a non-negative safe integer/,
+    );
   });
 });

--- a/tests/payments/daily-refill/service.integration.test.ts
+++ b/tests/payments/daily-refill/service.integration.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { LedgerReason } from "@prisma/client";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { getBalance } from "@/payments";
+import { config } from "@/payments/credits/config";
 import { runDailyRefill } from "@/payments/daily-refill/service";
 import { ymdUtc } from "@/payments/daily-refill/utc";
 import { idempotencyKeySchema } from "@/payments/ledger/idempotency-key";
@@ -364,6 +365,32 @@ describe("runDailyRefill — idempotency", () => {
     );
     // Balance must remain at 40n — no double-credit.
     expect(await balanceOf(accountId)).toBe(40n);
+  });
+});
+
+describe("runDailyRefill — kill-switch (cap = 0)", () => {
+  // The refill can be disabled via PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS=0
+  // (or unset). The route/service stay in place so the business can turn it
+  // back on; with cap 0 every eligible account has headroom = 0 − balance ≤ 0
+  // and the run is a clean no-op — no grants, no errors, no ledger rows.
+  test("cap 0 → eligible accounts get nothing, no ledger rows written", async () => {
+    const originalCap = config.freeTierDailyCapCredits;
+    config.freeTierDailyCapCredits = 0;
+    try {
+      const accountId = await seedAccount();
+      const summary = await runDailyRefill({ now: NOW });
+      expect(summary.skipped).toBe(false);
+      expect(summary.refilled).toEqual([]);
+      expect(summary.errors).toEqual([]);
+      expect(summary.noOp).toBeGreaterThanOrEqual(1);
+      expect(await balanceOf(accountId)).toBe(0n);
+      const rows = await prisma.creditLedger.count({
+        where: { accountId, grantKindId: "daily_refill" },
+      });
+      expect(rows).toBe(0);
+    } finally {
+      config.freeTierDailyCapCredits = originalCap;
+    }
   });
 });
 

--- a/tests/subscriptions/account-credits.test.ts
+++ b/tests/subscriptions/account-credits.test.ts
@@ -3,8 +3,10 @@ import express from "express";
 import request from "supertest";
 import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { accountsMeRouter } from "@/api/v2/accounts/accountsMeRouter";
+import { REFILL_DISABLED_PERIOD_LABEL } from "@/api/v2/accounts/handlers/credits-get";
 import { authMiddleware } from "@/middleware/auth";
 import { pinoMiddleware } from "@/middleware/pino";
+import { config } from "@/payments/credits/config";
 import { getSpendableBalance } from "@/payments/spendable";
 import {
   AppleEnv,
@@ -433,6 +435,65 @@ describe("GET /v2/accounts/me/credits — free-tier (no subscription)", () => {
     expect(body.balance).toBe(0);
     expect(body.monthlyGrant).toBe(100);
     expect(body.monthlyGrantUsed).toBe(100);
+  });
+
+  // Daily-refill kill-switch (cap = 0): the refill is intentionally
+  // deactivated, so the endpoint must stop promising a FUTURE refresh. iOS's
+  // shipped `CreditBalance` model requires `nextRefreshAt` as a non-optional
+  // Date, so the key stays present — the response mirrors the iOS design
+  // fixture `CreditsStatePreset.noSubNoTrial` exactly (grant/used 0,
+  // nextRefreshAt = now, periodLabel "—") so shipped binaries render a state
+  // design already signed off. See REFILL_DISABLED_PERIOD_LABEL in the
+  // handler for the full shipped-client analysis.
+  describe("daily refill disabled (cap = 0)", () => {
+    const originalCap = config.freeTierDailyCapCredits;
+
+    afterEach(() => {
+      config.freeTierDailyCapCredits = originalCap;
+    });
+
+    test("no future refresh advertised; combo mirrors the iOS free-state fixture", async () => {
+      config.freeTierDailyCapCredits = 0;
+      const accountId = await newAccount();
+      const token = await tokenFor(accountId);
+      await prisma.userCredits.create({ data: { accountId, balance: 60n } });
+      const before = Date.now();
+      const res = await request(makeApp())
+        .get("/v2/accounts/me/credits")
+        .set("X-Convos-AuthToken", token);
+      const after = Date.now();
+      expect(res.status).toBe(200);
+      const body = res.body as BalanceBody;
+      expect(body.balance).toBe(60);
+      expect(body.monthlyGrant).toBe(0);
+      // No cap → nothing to have "used" against it.
+      expect(body.monthlyGrantUsed).toBe(0);
+      // The assertion that matters: nextRefreshAt is NOW (request time), not
+      // tomorrow — no forward promise, matching the fixture's `now`.
+      const next = new Date(body.nextRefreshAt).getTime();
+      expect(Number.isNaN(next)).toBe(false);
+      expect(next).toBeGreaterThanOrEqual(before);
+      expect(next).toBeLessThanOrEqual(after);
+      // Fixture's period label for the no-grant state.
+      expect(body.periodLabel).toBe(REFILL_DISABLED_PERIOD_LABEL);
+      expect(body.periodLabel).toBe("—");
+    });
+
+    test("re-enabling the cap restores the daily-refresh advertisement unchanged", async () => {
+      config.freeTierDailyCapCredits = originalCap;
+      const accountId = await newAccount();
+      const token = await tokenFor(accountId);
+      const res = await request(makeApp())
+        .get("/v2/accounts/me/credits")
+        .set("X-Convos-AuthToken", token);
+      const body = res.body as BalanceBody;
+      expect(body.monthlyGrant).toBe(originalCap);
+      expect(body.periodLabel).toBe("Daily");
+      const next = new Date(body.nextRefreshAt).getTime();
+      expect(next).toBeGreaterThan(Date.now());
+      // Within the next 24h — i.e. start of next UTC day, not "now".
+      expect(next).toBeLessThanOrEqual(Date.now() + 24 * 60 * 60 * 1000);
+    });
   });
 
   test("expired subscription → takes free-tier branch (NOT stale tierGrant)", async () => {

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -407,8 +407,17 @@ describe("upsertFromVerify", () => {
   // before the grant, so re-verify could never heal them. These tests pin the
   // new behavior: a replayed verify backfills a MISSING current-period grant,
   // and only that — no double-grant, no grant on stale replays, no grant for
-  // non-entitled rows.
+  // rows whose EFFECTIVE (time-aware) status is not entitled, including
+  // stored-`active` rows whose entitlement window already elapsed (lost
+  // EXPIRED webhook).
   describe("replay materializes missing current-period grant", () => {
+    // The backfill gate is time-aware (`isEntitledSubscription`), so entitled
+    // fixtures need a period window that actually spans "now" — fixed calendar
+    // dates would silently lapse as the wall clock passes them.
+    const DAY = 24 * 60 * 60 * 1000;
+    const CURRENT_START = new Date(Date.now() - 5 * DAY);
+    const CURRENT_END = new Date(Date.now() + 25 * DAY);
+
     // Simulate the pre-deploy state: subscription + receipt exist, but the
     // period's sub_grant ledger row was never written (grants only started
     // being written at deploy time). Deleting the row and unwinding its delta
@@ -443,6 +452,8 @@ describe("upsertFromVerify", () => {
         accountId,
         originalTransactionId: "otid-materialize",
         transactionId: "tx-materialize",
+        currentPeriodStart: CURRENT_START,
+        currentPeriodEnd: CURRENT_END,
       });
       const first = await upsertFromVerify(input);
       expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
@@ -473,6 +484,8 @@ describe("upsertFromVerify", () => {
         accountId,
         originalTransactionId: "otid-no-double",
         transactionId: "tx-no-double",
+        currentPeriodStart: CURRENT_START,
+        currentPeriodEnd: CURRENT_END,
       });
       await upsertFromVerify(input);
       const replay = await upsertFromVerify(input);
@@ -488,18 +501,18 @@ describe("upsertFromVerify", () => {
         accountId,
         originalTransactionId: otid,
         transactionId: "tx-stale-old",
-        currentPeriodStart: new Date("2026-05-01T00:00:00.000Z"),
-        currentPeriodEnd: new Date("2026-06-01T00:00:00.000Z"),
+        currentPeriodStart: new Date(CURRENT_START.getTime() - 30 * DAY),
+        currentPeriodEnd: CURRENT_START,
       });
       await upsertFromVerify(oldInput);
-      // Renewal advances the row to period 2 and grants it.
+      // Renewal advances the row to period 2 (spanning now) and grants it.
       const renewed = await upsertFromVerify(
         verifyInput({
           accountId,
           originalTransactionId: otid,
           transactionId: "tx-stale-new",
-          currentPeriodStart: new Date("2026-06-01T00:00:00.000Z"),
-          currentPeriodEnd: new Date("2026-07-01T00:00:00.000Z"),
+          currentPeriodStart: CURRENT_START,
+          currentPeriodEnd: CURRENT_END,
         }),
       );
       expect(await getBalance(accountId)).toBe(BigInt(perPeriod() * 2));
@@ -527,6 +540,44 @@ describe("upsertFromVerify", () => {
       });
       await upsertFromVerify(input);
       expect(await getBalance(accountId)).toBe(0n);
+      const replay = await upsertFromVerify(input);
+      expect(replay.receiptCreated).toBe(false);
+      expect(await getBalance(accountId)).toBe(0n);
+      expect(await countSubGrants(accountId)).toBe(0);
+    });
+
+    // Time-aware gate regression: a row whose STORED status is still `active`
+    // but whose currentPeriodEnd already passed (lost/delayed EXPIRED webhook
+    // — prod holds such rows) must NOT get a backfill for the lapsed period.
+    // effectiveSubscriptionStatus resolves it to `expired`; the stored-status
+    // check alone would have minted a full sub_grant that credits-get
+    // simultaneously frames as free-tier state.
+    test("stored-active row with an elapsed period: replay does NOT backfill the lapsed grant", async () => {
+      const accountId = await newAccount();
+      const input = verifyInput({
+        accountId,
+        originalTransactionId: "otid-lapsed-active",
+        transactionId: "tx-lapsed-active",
+        status: SubscriptionStatus.active,
+        currentPeriodStart: new Date(Date.now() - 35 * DAY),
+        currentPeriodEnd: new Date(Date.now() - 5 * DAY),
+      });
+      // The FRESH verify still grants (stored-status gate, provider-fresh
+      // input; forfeit-on-expiry is the reconciliation path) — pinned
+      // elsewhere by account-credits "past-ended active subscription".
+      const first = await upsertFromVerify(input);
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+
+      // Simulate the pre-deploy shape: the grant row is missing.
+      await stripPeriodGrant(
+        first.subscription.id,
+        accountId,
+        first.subscription.currentPeriodStart,
+      );
+      expect(await getBalance(accountId)).toBe(0n);
+
+      // Replay: NOT stale (same period), stored status entitled — but the
+      // effective status is expired, so the healer must refuse.
       const replay = await upsertFromVerify(input);
       expect(replay.receiptCreated).toBe(false);
       expect(await getBalance(accountId)).toBe(0n);

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { getBalance } from "@/payments";
+import { subGrantKey } from "@/subscriptions/grants";
 import {
   applyNotification,
   BillingProvider,
@@ -316,6 +317,139 @@ describe("upsertFromVerify", () => {
       });
       expect(receipts).toHaveLength(1);
     }
+  });
+
+  // Verify-replay materializer: subscribers who bought BEFORE the single-ledger
+  // deploy (#324) have a Subscription + BillingReceipt but no `sub_grant` row
+  // for the period they are living in — the replay short-circuit used to return
+  // before the grant, so re-verify could never heal them. These tests pin the
+  // new behavior: a replayed verify backfills a MISSING current-period grant,
+  // and only that — no double-grant, no grant on stale replays, no grant for
+  // non-entitled rows.
+  describe("replay materializes missing current-period grant", () => {
+    // Simulate the pre-deploy state: subscription + receipt exist, but the
+    // period's sub_grant ledger row was never written (grants only started
+    // being written at deploy time). Deleting the row and unwinding its delta
+    // reproduces exactly that shape.
+    const stripPeriodGrant = async (
+      subscriptionId: string,
+      accountId: string,
+      periodStart: Date,
+    ) => {
+      const key = subGrantKey(subscriptionId, periodStart);
+      const row = await prisma.creditLedger.findUnique({
+        where: {
+          accountId_idempotencyKey: { accountId, idempotencyKey: key },
+        },
+      });
+      if (!row) return;
+      await prisma.creditLedger.delete({ where: { id: row.id } });
+      await prisma.userCredits.update({
+        where: { accountId },
+        data: { balance: { decrement: row.delta } },
+      });
+    };
+
+    const countSubGrants = (accountId: string) =>
+      prisma.creditLedger.count({
+        where: { accountId, grantKindId: "sub_grant" },
+      });
+
+    test("replayed verify backfills the missing grant (pre-deploy subscriber heals)", async () => {
+      const accountId = await newAccount();
+      const input = verifyInput({
+        accountId,
+        originalTransactionId: "otid-materialize",
+        transactionId: "tx-materialize",
+      });
+      const first = await upsertFromVerify(input);
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+
+      await stripPeriodGrant(
+        first.subscription.id,
+        accountId,
+        first.subscription.currentPeriodStart,
+      );
+      expect(await getBalance(accountId)).toBe(0n);
+
+      const replay = await upsertFromVerify(input);
+      expect(replay.receiptCreated).toBe(false);
+      expect(replay.subscription.id).toBe(first.subscription.id);
+      // The missing period grant was materialized by the replay.
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+      expect(await countSubGrants(accountId)).toBe(1);
+      // Still exactly one receipt — replay semantics intact.
+      const receipts = await prisma.billingReceipt.findMany({
+        where: { transactionId: "tx-materialize" },
+      });
+      expect(receipts).toHaveLength(1);
+    });
+
+    test("replayed verify with the grant present does not double-grant", async () => {
+      const accountId = await newAccount();
+      const input = verifyInput({
+        accountId,
+        originalTransactionId: "otid-no-double",
+        transactionId: "tx-no-double",
+      });
+      await upsertFromVerify(input);
+      const replay = await upsertFromVerify(input);
+      expect(replay.receiptCreated).toBe(false);
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+      expect(await countSubGrants(accountId)).toBe(1);
+    });
+
+    test("stale replay does not materialize the advanced period's grant", async () => {
+      const accountId = await newAccount();
+      const otid = "otid-stale-no-materialize";
+      const oldInput = verifyInput({
+        accountId,
+        originalTransactionId: otid,
+        transactionId: "tx-stale-old",
+        currentPeriodStart: new Date("2026-05-01T00:00:00.000Z"),
+        currentPeriodEnd: new Date("2026-06-01T00:00:00.000Z"),
+      });
+      await upsertFromVerify(oldInput);
+      // Renewal advances the row to period 2 and grants it.
+      const renewed = await upsertFromVerify(
+        verifyInput({
+          accountId,
+          originalTransactionId: otid,
+          transactionId: "tx-stale-new",
+          currentPeriodStart: new Date("2026-06-01T00:00:00.000Z"),
+          currentPeriodEnd: new Date("2026-07-01T00:00:00.000Z"),
+        }),
+      );
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod() * 2));
+
+      // Remove period 2's grant, then replay the OLD transaction. Its period
+      // end predates the stored one → stale → must NOT backfill period 2.
+      await stripPeriodGrant(
+        renewed.subscription.id,
+        accountId,
+        renewed.subscription.currentPeriodStart,
+      );
+      const replay = await upsertFromVerify(oldInput);
+      expect(replay.receiptCreated).toBe(false);
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+      expect(await countSubGrants(accountId)).toBe(1);
+    });
+
+    test("replay of a non-entitled (expired) subscription does not grant", async () => {
+      const accountId = await newAccount();
+      const input = verifyInput({
+        accountId,
+        originalTransactionId: "otid-expired-replay",
+        transactionId: "tx-expired-replay",
+        status: SubscriptionStatus.expired,
+      });
+      await upsertFromVerify(input);
+      expect(await getBalance(accountId)).toBe(0n);
+      const replay = await upsertFromVerify(input);
+      expect(replay.receiptCreated).toBe(false);
+      expect(await getBalance(accountId)).toBe(0n);
+      expect(await countSubGrants(accountId)).toBe(0);
+    });
   });
 
   test("concurrent verifies, different accountId: exactly one wins, the other rejects with account-mismatch", async () => {

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -257,6 +257,88 @@ describe("upsertFromVerify", () => {
     expect(receiptB).toBeNull();
   });
 
+  // AAT-collision (account recreation): iOS generates the appAccountToken per
+  // INSTALL, so it survives account deletion + recreation. The recreated
+  // account's fresh purchase carries a NEW originalTransactionId, so
+  // findExistingForVerify sees no row, Subscription.create fires, and Postgres
+  // rejects it on the (provider, appAccountToken) unique held by the OLD
+  // account's row. This used to fall through reReadAfterRace (OTX-only re-read
+  // → null) to a raw rethrow — a 500 to the user. It must surface the standard
+  // account-mismatch (→ 409) instead.
+  test("same appAccountToken, different account + different OTX: account-mismatch, not a 500", async () => {
+    const accountA = await newAccount();
+    const accountB = await newAccount();
+    const aat = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+    const first = await upsertFromVerify(
+      verifyInput({
+        accountId: accountA,
+        appAccountToken: aat,
+        originalTransactionId: "otid-aat-a",
+        transactionId: "tx-aat-a",
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await upsertFromVerify(
+        verifyInput({
+          accountId: accountB,
+          appAccountToken: aat,
+          originalTransactionId: "otid-aat-b",
+          transactionId: "tx-aat-b",
+        }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(SubscriptionAccountMismatchError);
+    const mismatch = caught as SubscriptionAccountMismatchError;
+    expect(mismatch.existingAccountId).toBe(accountA);
+    expect(mismatch.attemptedAccountId).toBe(accountB);
+    expect(mismatch.providerSubscriptionId).toBe("otid-aat-b");
+
+    // Account A keeps ownership; account B persisted nothing.
+    expect((await findCurrentByAccountId(accountA))?.id).toBe(
+      first.subscription.id,
+    );
+    expect(await findCurrentByAccountId(accountB)).toBeNull();
+    expect(await findAppleByOriginalTransactionId("otid-aat-b")).toBeNull();
+    expect(
+      await findReceiptByTransactionId(BillingProvider.apple, "tx-aat-b"),
+    ).toBeNull();
+  });
+
+  test("same appAccountToken, SAME account, different OTX: resolves idempotently to the existing row", async () => {
+    const accountId = await newAccount();
+    const aat = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+    const first = await upsertFromVerify(
+      verifyInput({
+        accountId,
+        appAccountToken: aat,
+        originalTransactionId: "otid-aat-same-1",
+        transactionId: "tx-aat-same-1",
+      }),
+    );
+    // Same account re-purchasing under the same install token: the create
+    // loses on the AAT unique, and the caller already holds the row → replay
+    // semantics (mirrors the cold-start race resolution), not a crash.
+    const second = await upsertFromVerify(
+      verifyInput({
+        accountId,
+        appAccountToken: aat,
+        originalTransactionId: "otid-aat-same-2",
+        transactionId: "tx-aat-same-2",
+      }),
+    );
+    expect(second.receiptCreated).toBe(false);
+    expect(second.subscription.id).toBe(first.subscription.id);
+    // No double period grant either.
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+  });
+
   test("concurrent verifies, same accountId: exactly one creates the receipt, both return the same subscription", async () => {
     const accountId = await newAccount();
     const input = verifyInput({


### PR DESCRIPTION
## Context: live credits incident (Jul 12-13)

Three user-facing failures traced during the "out of power" incident:

1. **Pre-deploy subscribers never materialize.** The single-ledger deploy (Jul 6, prod) grants credits only on new-transaction verify or renewal. Everyone mid-period at deploy got neither: their verify replays short-circuit before the grant. One prod paying account went dark at balance -19; an annual subscriber's next organic grant was a year away.
2. **Account-recreation purchases crash.** iOS `appAccountToken` is a per-install UUID reused across account recreations. A Subscription create hitting the AAT unique routed to a re-read by OTX only, found nothing, and rethrew as a 500.
3. **Clients shown a refresh promise that never comes.** The free-tier daily refill was intentionally deactivated (~Jun 11, business decision), but `credits-get` still advertised `nextRefreshAt` = tomorrow.

## Commits

- **`fix(subscriptions): materialize missing period grant on verify replay`** - the `existingReceipt` short-circuit now backfills the current period's `sub_grant` (canonical key, idempotent, same tx) when the replayed subscription is entitled and the verify is not stale. A simple app-open re-verify heals every un-materialized subscriber.
- **`fix(subscriptions): AAT conflict -> 409 not 500`** - when the P2002 target is `subscription_apple_aat_unique`, re-read by `(provider, appAccountToken)`: different holder -> `SubscriptionAccountMismatchError` (existing 409 mapping); same account -> idempotent replay.
- **`fix(credits): explicit refill kill-switch + honest client rendering`** - `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS=0`/unset now means disabled (mirrors the signup-bonus kill-switch). When disabled, `credits-get` emits the design-approved free-state combo (`monthlyGrant: 0, monthlyGrantUsed: 0, nextRefreshAt: now, periodLabel: "-"`, matching iOS `CreditsStatePreset.noSubNoTrial`), so shipped clients render sanely with **no iOS update**: no forward refresh promise, no NaN (grant=0 is guarded in the model), "No power" surfaces unchanged.
- **`docs(subscriptions): ownership reconciliation options`** - SSN renewals enrich a row that verify 409s for the requester (account-recreation case). Two options sketched (provider-proven transfer vs support relink + telemetry); decision deferred.

## Verification

- `pnpm check` (typecheck + format + lint) green.
- Subscriptions + payments suites: 306/306 (new tests: replay-materialize heal / no-double / stale-gate / non-entitled-gate; AAT 409 + same-account replay; kill-switch rendering).
- No `src/api/v2/**` request schema touched (append-only contract safe). Response keys unchanged and decodable by shipped clients.

## Post-merge ops

Deploy, then: the un-materialized annual subscriber just opens the app (re-verify materializes 6M canonically). Monthly cohort heals on app-open or renewal, whichever first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786529222&installation_id=128169237&pr_number=357&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F357&signature=1e04d8d52f1111f2cd8482bf509a71b1e5da0d9f1ca1d2224d9857e5e163be1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix subscription grant materialization on verify replay, Apple AAT 409 handling, and add daily refill kill-switch
> - `upsertFromVerify` in [`repository.ts`](https://github.com/ephemeraHQ/convos-backend/pull/357/files#diff-16668c0e0aabb5ea30e88f32f8983171d113e2f6f072e791d726724e97461ee9) now backfills a missing current-period `sub_grant` ledger row during a non-stale verify replay when the subscription is time-entitled, preserving idempotent receipt semantics.
> - Apple `appAccountToken` unique conflicts during verify now return a `SubscriptionAccountMismatchError` (409) for cross-account conflicts and an idempotent success for same-account conflicts, instead of a generic 500.
> - `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS` can now be unset, empty, or `"0"` to disable the daily credit refill; `GET /v2/accounts/me/credits` returns `monthlyGrant=0`, `nextRefreshAt=now`, and `periodLabel="—"` when the cap is 0.
> - Behavioral Change: previously, missing or zero `PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS` caused a validation error; it now maps to a disabled-refill state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5edba3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for disabling free-tier daily credit refills through configuration.
  - Credit balances now clearly indicate when daily refills are disabled instead of showing a future refresh date.

- **Bug Fixes**
  - Replaying a subscription verification can restore a missing credit grant without creating duplicates.
  - Improved handling of Apple subscription ownership conflicts, returning a clear account mismatch result instead of a generic server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->