### PR TITLE
fix: forward optional join idempotencyKey to the assistants dispatch

### DIFF
--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -101,6 +101,18 @@ export const bodySchema = z
       .transform((v) => v.toLowerCase())
       .optional(),
     templateId: z.string().uuid().optional(),
+    // Client-minted join idempotency key. Forwarded verbatim to the
+    // assistants service, where it becomes the Workflow instance id — a
+    // retried join whose response was lost (timeout, app suspension)
+    // adopts the already-provisioned instance instead of creating a
+    // duplicate. Optional for backwards compatibility with shipped
+    // clients. Lowercased here as an early gate; the assistants boundary
+    // is the authoritative normalizer (instance ids are lowercase-only).
+    idempotencyKey: z
+      .string()
+      .uuid()
+      .transform((v) => v.toLowerCase())
+      .optional(),
     name: z.string().min(1).max(256).optional(),
     profileImage: z.string().min(1).max(2048).optional(),
     options: optionsSchema.optional(),
@@ -174,6 +186,10 @@ const dispatchBodySchema = z
     ownerAccountId: accountIdSchema,
     options: optionsSchema.optional(),
     timezone: timezoneSchema.optional(),
+    // Join idempotency key, already lowercased by the inbound schema's
+    // transform. The worker uses it as the Workflow instance id to dedup
+    // retried creates.
+    idempotencyKey: z.string().uuid().optional(),
     // Free-form XMTP-profile metadata seed forwarded to the worker. Used to
     // carry the per-PR variant descriptor ({ variant: <json> }), which the
     // worker stamps onto the agent's profile at Herald-join.
@@ -429,6 +445,7 @@ export async function joinHandler(req: Request, res: Response) {
     slug,
     conversationId,
     templateId,
+    idempotencyKey,
     name,
     profileImage,
     options,
@@ -687,6 +704,9 @@ export async function joinHandler(req: Request, res: Response) {
     }
     if (timezone !== undefined) {
       dispatchBody.timezone = timezone;
+    }
+    if (idempotencyKey !== undefined) {
+      dispatchBody.idempotencyKey = idempotencyKey;
     }
     // Stamp the variant onto the agent: the worker reads metadata.variant at
     // Herald-join and emits it into the XMTP profile so every participant sees

--- a/tests/agents-join-contract.test.ts
+++ b/tests/agents-join-contract.test.ts
@@ -41,4 +41,45 @@ describe("agents/join body schema — legacy client contract", () => {
     });
     expect(parsed.success).toBe(false);
   });
+
+  test("legacy join body without idempotencyKey still validates", () => {
+    assertLegacyShapeValidates(
+      bodySchema,
+      {
+        slug: "join-token-abc123",
+        templateId: "33333333-3333-4333-8333-333333333333",
+      },
+      "legacy join body (no idempotencyKey)",
+    );
+  });
+});
+
+describe("agents/join body schema — idempotencyKey", () => {
+  const KEY = "6f0f7a8e-1b2c-4d3e-8f4a-5b6c7d8e9f0a";
+
+  test("idempotencyKey is optional and accepted", () => {
+    const parsed = bodySchema.safeParse({
+      slug: "join-token-abc123",
+      idempotencyKey: KEY,
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.idempotencyKey).toBe(KEY);
+  });
+
+  test("uppercase idempotencyKey is lowercased (early gate)", () => {
+    const parsed = bodySchema.safeParse({
+      slug: "join-token-abc123",
+      idempotencyKey: KEY.toUpperCase(),
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.idempotencyKey).toBe(KEY);
+  });
+
+  test("non-uuid idempotencyKey is rejected", () => {
+    const parsed = bodySchema.safeParse({
+      slug: "join-token-abc123",
+      idempotencyKey: "not-a-uuid",
+    });
+    expect(parsed.success).toBe(false);
+  });
 });

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -1012,6 +1012,77 @@ describe("agents join (assistant API)", () => {
       expect(capturedBody!.ownerAccountId).toBe(DEFAULT_TEST_ACCOUNT_ID);
     });
 
+    test("idempotencyKey is forwarded to the dispatch body, lowercased", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+      mockFetchImpl = (url, init) => {
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-idem" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, { instanceId: "inst-idem", joinStatus: "joined" }),
+        );
+      };
+
+      const res = await post({
+        conversationId: "abcdef1234567890",
+        idempotencyKey: "6F0F7A8E-1B2C-4D3E-8F4A-5B6C7D8E9F0A",
+      });
+      expect(res.status).toBe(200);
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody!.idempotencyKey).toBe(
+        "6f0f7a8e-1b2c-4d3e-8f4a-5b6c7d8e9f0a",
+      );
+    });
+
+    test("dispatch body omits idempotencyKey when the caller sends none", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+      mockFetchImpl = (url, init) => {
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-no-idem" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-no-idem",
+            joinStatus: "joined",
+          }),
+        );
+      };
+
+      const res = await post({ conversationId: "abcdef1234567890" });
+      expect(res.status).toBe(200);
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody).not.toHaveProperty("idempotencyKey");
+    });
+
+    test("non-uuid idempotencyKey → 400 INVALID_REQUEST, no dispatch", async () => {
+      let fetchCalled = false;
+      mockFetchImpl = () => {
+        fetchCalled = true;
+        return Promise.reject(new Error("should not dispatch"));
+      };
+
+      const res = await post({
+        conversationId: "abcdef1234567890",
+        idempotencyKey: "not-a-uuid",
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toBe("INVALID_REQUEST");
+      expect(fetchCalled).toBe(false);
+    });
+
     test("refuses to dispatch when accountId is not a uuid", async () => {
       let fetchCalled = false;
       mockFetchImpl = () => {


### PR DESCRIPTION
Related PRs:
- https://github.com/xmtplabs/convos-assistants/pull/2668
- https://github.com/xmtplabs/convos-ios/pull/1171

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786566769&installation_id=128169237&pr_number=359&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F359&signature=54ce95da05e1b8b1be8fc5ce243fb7138d5436a242bda7e97a0632d899b323ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward optional `idempotencyKey` from join request to assistants dispatch
> - Adds an optional `idempotencyKey` field (UUID) to the `POST /api/v2/agents/join` request body in [join.ts](https://github.com/ephemeraHQ/convos-backend/pull/359/files#diff-56b3806a78b9509421cf23cd82891715d11c219bad27f45a5a9ff9665a18cd7c); non-UUID values are rejected with a 400 `INVALID_REQUEST`.
> - Normalizes the key to lowercase on ingestion and forwards it in the dispatch payload to the assistants service when present, omitting it when absent.
> - Extends `dispatchBodySchema` to accept the already-lowercased `idempotencyKey` without failing strict validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a7018b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional idempotency keys to agent join requests.
  * Idempotency keys are validated as UUIDs and normalized to lowercase.
  * Valid keys are forwarded for reliable request processing.

* **Bug Fixes**
  * Invalid idempotency keys now return a clear request error without triggering dispatch.
  * Existing join requests without an idempotency key remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->