### PR TITLE
fix(telemetry): release the batch claim before answering, not after

### DIFF
--- a/src/api/v2/telemetry/handlers/metrics.ts
+++ b/src/api/v2/telemetry/handlers/metrics.ts
@@ -77,10 +77,14 @@ export async function postMetrics(req: Request, res: Response) {
   // an unexpected throw without double-deleting.
   let accepted = false;
   let released = false;
+  // Only a delete that actually landed marks the claim released. Latching the
+  // flag before the await would let a failed explicit release swallow the
+  // `finally`'s retry, stranding the claim until the TTL sweep — the same
+  // dropped-retry outcome this is here to avoid.
   const releaseClaim = async () => {
     if (released) return;
-    released = true;
     await releaseBatch(batchId);
+    released = true;
   };
 
   try {

--- a/src/api/v2/telemetry/handlers/metrics.ts
+++ b/src/api/v2/telemetry/handlers/metrics.ts
@@ -69,7 +69,20 @@ export async function postMetrics(req: Request, res: Response) {
 
   // Only an accepted batch keeps the claim; any other outcome releases it so
   // the client's retry with the same Idempotency-Key isn't dropped as a dup.
+  //
+  // The release has to land BEFORE the response goes out. A client that retries
+  // the instant it sees the error would otherwise race the delete and have its
+  // retry dropped as a duplicate — the precise outcome this claim/release pair
+  // exists to prevent. Releasing is idempotent, so the `finally` can still cover
+  // an unexpected throw without double-deleting.
   let accepted = false;
+  let released = false;
+  const releaseClaim = async () => {
+    if (released) return;
+    released = true;
+    await releaseBatch(batchId);
+  };
+
   try {
     const receivedAtMs = Date.now();
     let prepared;
@@ -83,6 +96,7 @@ export async function postMetrics(req: Request, res: Response) {
     } catch (error) {
       if (error instanceof ValidationError) {
         countTelemetryBatch(client, "rejected");
+        await releaseClaim();
         res.status(400).json({ error: error.message });
         return;
       }
@@ -118,6 +132,7 @@ export async function postMetrics(req: Request, res: Response) {
       const ok = await forwardMetrics(prepared.body);
       if (!ok) {
         countTelemetryBatch(client, "forward_failed");
+        await releaseClaim();
         res.status(502).json({ error: "Telemetry forwarding failed" });
         return;
       }
@@ -127,8 +142,9 @@ export async function postMetrics(req: Request, res: Response) {
     countTelemetryBatch(client, "accepted");
     res.status(202).json({ status: "accepted" });
   } finally {
+    // Covers an unexpected throw, where the error middleware answers after this.
     if (!accepted) {
-      await releaseBatch(batchId);
+      await releaseClaim();
     }
   }
 }

--- a/tests/telemetry-metrics.test.ts
+++ b/tests/telemetry-metrics.test.ts
@@ -1,6 +1,8 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import type * as DedupModule from "@/api/v2/telemetry/services/dedup";
+import { releaseBatch } from "@/api/v2/telemetry/services/dedup";
 import { forwardMetrics } from "@/api/v2/telemetry/services/forwarder";
 import { telemetryRouter } from "@/api/v2/telemetry/telemetry.router";
 import { appCheckOnlyMiddleware } from "@/middleware/auth";
@@ -21,6 +23,12 @@ vi.mock("@/api/v2/telemetry/services/forwarder", () => ({
 vi.mock("@/utils/metrics", () => ({
   countTelemetryBatch: vi.fn(),
 }));
+// Real claim/release against the DB; releaseBatch is wrapped so a test can make
+// one call fail and assert the handler retries it.
+vi.mock("@/api/v2/telemetry/services/dedup", async (importOriginal) => {
+  const actual = await importOriginal<typeof DedupModule>();
+  return { ...actual, releaseBatch: vi.fn(actual.releaseBatch) };
+});
 
 function makeApp() {
   const app = express();
@@ -79,6 +87,7 @@ describe("POST /telemetry/metrics", () => {
     vi.mocked(forwardMetrics).mockClear();
     vi.mocked(forwardMetrics).mockResolvedValue(true);
     vi.mocked(countTelemetryBatch).mockClear();
+    vi.mocked(releaseBatch).mockClear();
   });
 
   test("happy path → 202, forwarded, batch recorded", async () => {
@@ -219,6 +228,25 @@ describe("POST /telemetry/metrics", () => {
     const retry = await post(app).send(makeBody());
     expect(retry.status).toBe(202);
     expect(retry.body).toEqual({ status: "accepted" });
+  });
+
+  test("a failed release is retried, so a claim never strands until the TTL sweep", async () => {
+    vi.mocked(forwardMetrics).mockResolvedValue(false);
+
+    // The explicit release throws once, then the real delete runs. The finally
+    // must retry it: if the handler counted the claim as released the moment it
+    // *attempted* the delete, the row would survive and every retry of this
+    // Idempotency-Key would be dropped as a duplicate until the 48h TTL sweep.
+    vi.mocked(releaseBatch).mockRejectedValueOnce(
+      new Error("transient db failure"),
+    );
+
+    await post(makeApp()).send(makeBody());
+
+    expect(releaseBatch).toHaveBeenCalledTimes(2);
+    expect(
+      await prisma.telemetryBatch.findUnique({ where: { batchId: BATCH_ID } }),
+    ).toBeNull();
   });
 
   test("forward failure → 502 and batch NOT recorded (retry stays possible)", async () => {


### PR DESCRIPTION
Found while investigating a CI failure on #356 that turned out to have nothing to do with that PR.

## The bug

`POST /telemetry/metrics` claims the batch id up front (the INSERT is the duplicate gate), then releases the claim on any non-accepted outcome. The comment says why:

> Only an accepted batch keeps the claim; any other outcome releases it so the client's retry with the same Idempotency-Key isn't dropped as a dup.

But the failure paths respond **inside the `try`** and release in the **`finally`**, so the DELETE lands *after* the response is already on the wire:

```ts
if (!ok) {
  res.status(502).json({ error: "Telemetry forwarding failed" });
  return;              // ← client already has the 502
}
} finally {
  if (!accepted) await releaseBatch(batchId);   // ← delete happens now
}
```

A client that retries the instant it sees the 400/502 can arrive while the claim is still held, and its retry is dropped as a duplicate — precisely the outcome the claim/release pair exists to prevent. The window is small, but retry-on-error is exactly when clients are fastest.

## The fix

Release before responding, idempotently, so the `finally` still covers an unexpected throw without double-deleting. Both non-accepted paths (400 validation, 502 forward failure) are covered.

## Why this surfaced now

`tests/telemetry-metrics.test.ts:230` asserts no row survives a 502. Supertest resolves the moment the response lands, so the assertion was racing the not-yet-awaited delete. It passed by luck. Unrelated test additions on #356 shifted timing enough to lose the race, and CI went red there — twice, deterministically, on a diff that cannot reach telemetry code.

After this change the ordering is deterministic by construction: the response cannot be sent until the delete has resolved, so the test cannot observe the row.

Verified against a local Postgres: `telemetry-metrics` 8/8 green, and the full suite green twice with #356 merged in (it was red twice without this).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786566802&installation_id=128169237&pr_number=360&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F360&signature=b41568c06e69c1b42d429c920e79330e42a68f7958887705df0f27af930b15b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release telemetry batch claim before sending error responses in `postMetrics`
> - Previously, the batch claim was released after the response was sent, meaning failed requests left a stranded claim that caused retries with the same `Idempotency-Key` to be dropped as duplicates.
> - Introduces an idempotent `releaseClaim` helper in [metrics.ts](https://github.com/ephemeraHQ/convos-backend/pull/360/files#diff-a83323badd1dc37c84717e42602973f30e408676bb22464b16b4e0da622c1a66) that deletes the claimed batch row and sets a `released` flag to prevent double-deletes.
> - The handler now calls `releaseClaim` before emitting 400/502 responses; the `finally` block retries the release if the earlier delete failed.
> - A new test in [telemetry-metrics.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/360/files#diff-570fd2649012f48a3100d391157b00c419794e30b3dac9082ffddc935ad150ee) asserts that a failed release is retried (i.e. `releaseBatch` is called twice).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6187905.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->