### PR TITLE
feat(agent-templates): curate the featured gallery order with featuredRank

### DIFF
--- a/prisma/migrations/20260713120000_add_agent_template_featured_rank/migration.sql
+++ b/prisma/migrations/20260713120000_add_agent_template_featured_rank/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable
+-- Curation weight for the featured gallery, sorted descending (heaviest leads).
+-- 0 = unranked, which sorts below every curated row.
+ALTER TABLE "AgentTemplate" ADD COLUMN "featuredRank" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "AgentTemplate_status_featured_featuredRank_id_idx" ON "AgentTemplate"("status", "featured", "featuredRank", "id");
+
+-- Seed the weights from the order the gallery already renders — `createdAt`
+-- desc, id desc — so switching the site to sort by `featuredRank` is a no-op
+-- until someone curates. Reversing that comparator (createdAt asc, id asc)
+-- makes the oldest row weight 1 and the newest row weight N, which reads back
+-- newest-first under a descending sort. Non-featured rows keep 0.
+WITH ranked AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (ORDER BY "createdAt" ASC, "id" ASC) AS rank
+  FROM "AgentTemplate"
+  WHERE "featured" = true
+)
+UPDATE "AgentTemplate" AS t
+SET "featuredRank" = ranked.rank
+FROM ranked
+WHERE t."id" = ranked."id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -189,6 +189,10 @@ model AgentTemplate {
   firstPublishedAt DateTime?
   status           PublishStatus @default(draft)
   featured         Boolean       @default(false)
+  // Curation weight for the featured gallery, sorted descending: the heaviest
+  // template leads. 0 means unranked, so anything featured without an explicit
+  // weight sits below every curated row instead of displacing the lead slot.
+  featuredRank     Int           @default(0)
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt
 
@@ -201,6 +205,7 @@ model AgentTemplate {
   @@index([status, createdAt, id])
   @@index([status, category, createdAt, id])
   @@index([status, featured, createdAt, id])
+  @@index([status, featured, featuredRank, id])
   @@index([forkedFromId])
 }
 

--- a/src/api/v2/agent-templates/handlers/list.ts
+++ b/src/api/v2/agent-templates/handlers/list.ts
@@ -21,9 +21,17 @@ const VALID_STATUS_FILTERS = [
 
 // Columns the list can be sorted by. `createdAt` desc is the default and
 // preserves prior behavior. Each is keyset-paginatable: the cursor encodes
-// the active column's value plus `id` as the tiebreaker.
-const SORT_FIELDS = ["createdAt", "updatedAt", "agentName"] as const;
+// the active column's value plus `id` as the tiebreaker. `featuredRank` is
+// the gallery's curation weight — pair it with `featured=true&order=desc`.
+const SORT_FIELDS = [
+  "createdAt",
+  "updatedAt",
+  "agentName",
+  "featuredRank",
+] as const;
 type SortField = (typeof SORT_FIELDS)[number];
+
+const INTEGER_RE = /^-?\d+$/;
 
 const querySchema = z
   .object({
@@ -89,8 +97,11 @@ const parseLimit = (value: string | undefined) => {
   return Math.min(parsed, MAX_LIMIT);
 };
 
-const cursorValue = (template: AgentTemplate, sort: SortField): string =>
-  sort === "agentName" ? template.agentName : template[sort].toISOString();
+const cursorValue = (template: AgentTemplate, sort: SortField): string => {
+  if (sort === "agentName") return template.agentName;
+  if (sort === "featuredRank") return String(template.featuredRank);
+  return template[sort].toISOString();
+};
 
 const encodeCursor = (
   template: AgentTemplate,
@@ -134,8 +145,12 @@ const decodeCursor = (
       return undefined;
     }
 
-    // Date columns must round-trip to a valid Date.
-    if (
+    // Non-string columns must round-trip to their own type.
+    if (sort === "featuredRank") {
+      if (!INTEGER_RE.test(parsed.data.v)) {
+        return undefined;
+      }
+    } else if (
       sort !== "agentName" &&
       Number.isNaN(new Date(parsed.data.v).getTime())
     ) {
@@ -277,8 +292,12 @@ export async function listHandler(req: Request, res: Response) {
   // Keyset cursor pagination, generalized over the active sort column.
   if (cursor) {
     const dir = order === "asc" ? "gt" : "lt";
-    const value: string | Date =
-      sort === "agentName" ? cursor.value : new Date(cursor.value);
+    const value: string | number | Date =
+      sort === "agentName"
+        ? cursor.value
+        : sort === "featuredRank"
+          ? Number(cursor.value)
+          : new Date(cursor.value);
     const cursorFilter: Prisma.AgentTemplateWhereInput = {
       OR: [
         { [sort]: { [dir]: value } },

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -27,7 +27,9 @@ const bodySchema = z
     description: z.string().nullable().optional(),
     emoji: z.string().nullable().optional(),
     featured: z.boolean().optional(),
-    featuredRank: z.number().int().min(0).optional(),
+    // Capped to the column's `Int` range — a larger value would clear Zod and
+    // then blow up at persistence as a 500 rather than a 400.
+    featuredRank: z.number().int().min(0).max(2_147_483_647).optional(),
     prompt: z
       .string()
       .max(50_000, {
@@ -180,6 +182,25 @@ export async function patchHandler(req: Request, res: Response) {
         "Unauthorized agent-template access attempt",
       );
       res.status(403).json({ error: "Not authorized to modify this template" });
+      return;
+    }
+
+    // Gallery curation is not an ownership right. `featuredRank` decides what
+    // leads the convos.org homepage, and the guard above admits the template's
+    // owner — so without this an owner could weight their own template above
+    // the whole curated set. Only the dashboard (API-key) caller may write it.
+    if (parsedBody.data.featuredRank !== undefined && !isApiKeyListener) {
+      req.log.warn(
+        {
+          callerAccountId,
+          templateId: template.id,
+          action: "patch.featuredRank",
+        },
+        "Unauthorized agent-template curation attempt",
+      );
+      res
+        .status(403)
+        .json({ error: "Not authorized to set the featured gallery order" });
       return;
     }
 

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -27,6 +27,7 @@ const bodySchema = z
     description: z.string().nullable().optional(),
     emoji: z.string().nullable().optional(),
     featured: z.boolean().optional(),
+    featuredRank: z.number().int().min(0).optional(),
     prompt: z
       .string()
       .max(50_000, {
@@ -101,6 +102,11 @@ const applyContentFields = (
   // published template un-featured without a status change).
   if (body.featured !== undefined) {
     data.featured = body.featured;
+  }
+  // Position within the featured gallery. The dashboard reorders by writing a
+  // new weight per moved row; the gallery reads them descending.
+  if (body.featuredRank !== undefined) {
+    data.featuredRank = body.featuredRank;
   }
   if (body.prompt !== undefined) {
     data.prompt = body.prompt;

--- a/src/api/v2/agent-templates/lib/serialize-agent-template.ts
+++ b/src/api/v2/agent-templates/lib/serialize-agent-template.ts
@@ -53,6 +53,7 @@ export const serializeAgentTemplate = (
   publishedUrl: publishedUrlFor(template),
   status: template.status,
   featured: template.featured,
+  featuredRank: template.featuredRank,
   createdAt: template.createdAt.toISOString(),
   ...(options.includeSkills === true ? { skills: [] } : {}),
 });

--- a/src/api/v2/agents/lib/build-join-payload.ts
+++ b/src/api/v2/agents/lib/build-join-payload.ts
@@ -2,13 +2,14 @@ import type { AgentTemplate } from "@prisma/client";
 import { serializeAgentTemplate } from "@/api/v2/agent-templates/lib/serialize-agent-template";
 
 // Wire shape for the `template` field on `/api/assistants` — the full
-// AgentTemplate JSON minus `ownerAccountId`. The runtime persists this
-// verbatim as its on-disk `TEMPLATE.json` and doesn't need to know who
-// owns its template; the catalog row keeps `ownerAccountId` server-side
-// for authorization checks.
+// AgentTemplate JSON minus `ownerAccountId` and `featuredRank`. The runtime
+// persists this verbatim as its on-disk `TEMPLATE.json` and needs neither:
+// not who owns its template (the catalog row keeps `ownerAccountId`
+// server-side for authorization checks), nor where the template sits in the
+// website's featured gallery (a control-plane curation weight).
 export type TemplateForWire = Omit<
   ReturnType<typeof serializeAgentTemplate>,
-  "ownerAccountId" | "owner"
+  "ownerAccountId" | "owner" | "featuredRank"
 >;
 
 export type JoinPayload = {
@@ -20,9 +21,11 @@ export type JoinPayload = {
  * Build the template-bearing portion of the `/api/assistants` request
  * body from a resolved AgentTemplate.
  *
- * Two transforms — that's the whole job:
+ * Three transforms — that's the whole job:
  *  - Strip the template's own `ownerAccountId` (runtime never needs to
  *    know who owns its template).
+ *  - Strip `featuredRank` (gallery curation weight; the runtime has no
+ *    use for it and `TEMPLATE.json` stays free of control-plane state).
  *  - Pair the stripped template with the **joining user's** accountId,
  *    which the runtime later asserts back to the backend when creating
  *    templates the user owns mid-conversation.
@@ -52,6 +55,7 @@ export function buildJoinPayload(args: {
   const {
     ownerAccountId: _templateOwnerAccountId,
     owner: _templateOwner,
+    featuredRank: _templateFeaturedRank,
     ...template
   } = serialized;
 

--- a/tests/agent-templates.list-search-sort.test.ts
+++ b/tests/agent-templates.list-search-sort.test.ts
@@ -13,12 +13,14 @@ import {
   agentKeyHeaders,
   createTemplate,
   listTemplates,
+  patchTemplate,
   startAgentTemplatesServer,
   validAgentAssetsApiKey,
 } from "./agent-templates.cross.helpers";
 
 // Covers the list-API additions: free-text `q`, `sort`/`order` (incl. keyset
-// cursor under a non-default sort), and the `/counts` aggregate endpoint.
+// cursor under a non-default sort), the `featuredRank` gallery ordering, and
+// the `/counts` aggregate endpoint.
 // Tokens are globally unique so search/sort assertions are unaffected by any
 // other rows in the test DB; counts assertions are delta-based for the same
 // reason.
@@ -35,6 +37,7 @@ const cleanup = () =>
         { agentName: { startsWith: "Zxq" } },
         { agentName: { startsWith: "Zsort" } },
         { agentName: { startsWith: "Zcount" } },
+        { agentName: { startsWith: "Zrank" } },
       ],
     },
   });
@@ -182,6 +185,99 @@ describe("Agent templates list — search / sort / counts", () => {
     expect(page2.body.data.map((t) => t.agentName as string)).toEqual([
       "Zsort Bravo",
     ]);
+  });
+
+  // ── Featured gallery curation ──
+  test("?sort=featuredRank&order=desc leads with the heaviest row and sinks unranked ones", async () => {
+    const seed = async (name: string, rank: number | undefined) => {
+      const created = await createTemplate({
+        baseURL,
+        headers: agentKeyHeaders(),
+        body: {
+          agentName: name,
+          prompt: "p",
+          slug: `lss-${name.toLowerCase().replace(/\s+/g, "-")}`,
+          description: "zrankmarker",
+        },
+      });
+      await patchTemplate({
+        baseURL,
+        headers: agentKeyHeaders(),
+        id: created.body.id as string,
+        body:
+          rank === undefined
+            ? { featured: true }
+            : { featured: true, featuredRank: rank },
+      });
+      return created.body.id as string;
+    };
+
+    await seed("Zrank Light", 10);
+    await seed("Zrank Heavy", 30);
+    await seed("Zrank Middle", 20);
+    // Featured with no explicit weight — the default 0 must not seize the lead.
+    await seed("Zrank Unranked", undefined);
+
+    const gallery = await listTemplates({
+      baseURL,
+      query:
+        "?q=zrankmarker&featured=true&sort=featuredRank&order=desc&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(gallery.response.status).toBe(200);
+    expect(gallery.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zrank Heavy",
+      "Zrank Middle",
+      "Zrank Light",
+      "Zrank Unranked",
+    ]);
+    // The weight is serialized, so the dashboard can compute the next move.
+    expect(gallery.body.data.map((t) => t.featuredRank as number)).toEqual([
+      30, 20, 10, 0,
+    ]);
+
+    // keyset cursor walks the same order one page at a time
+    const page1 = await listTemplates({
+      baseURL,
+      query:
+        "?q=zrankmarker&featured=true&sort=featuredRank&order=desc&limit=1",
+      headers: agentKeyHeaders(),
+    });
+    expect(page1.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zrank Heavy",
+    ]);
+    expect(page1.body.hasMore).toBe(true);
+
+    const page2 = await listTemplates({
+      baseURL,
+      query: `?q=zrankmarker&featured=true&sort=featuredRank&order=desc&limit=1&cursor=${encodeURIComponent(
+        page1.body.nextCursor as string,
+      )}`,
+      headers: agentKeyHeaders(),
+    });
+    expect(page2.body.data.map((t) => t.agentName as string)).toEqual([
+      "Zrank Middle",
+    ]);
+  });
+
+  test("a negative featuredRank is rejected", async () => {
+    const created = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zrank Negative",
+        prompt: "p",
+        slug: "lss-rank-negative",
+        description: "zrankmarker",
+      },
+    });
+    const patched = await patchTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      id: created.body.id as string,
+      body: { featuredRank: -1 },
+    });
+    expect(patched.response.status).toBe(400);
   });
 
   test("a cursor built for a different sort is rejected with 400", async () => {

--- a/tests/agent-templates.list-search-sort.test.ts
+++ b/tests/agent-templates.list-search-sort.test.ts
@@ -12,6 +12,8 @@ import { prisma } from "@/utils/prisma";
 import {
   agentKeyHeaders,
   createTemplate,
+  getTemplate,
+  jwtHeaders,
   listTemplates,
   patchTemplate,
   startAgentTemplatesServer,
@@ -260,24 +262,89 @@ describe("Agent templates list — search / sort / counts", () => {
     ]);
   });
 
-  test("a negative featuredRank is rejected", async () => {
+  test("a featuredRank outside the column's Int range is rejected", async () => {
     const created = await createTemplate({
       baseURL,
       headers: agentKeyHeaders(),
       body: {
-        agentName: "Zrank Negative",
+        agentName: "Zrank Bounds",
         prompt: "p",
-        slug: "lss-rank-negative",
+        slug: "lss-rank-bounds",
         description: "zrankmarker",
       },
     });
-    const patched = await patchTemplate({
+    const id = created.body.id as string;
+
+    const negative = await patchTemplate({
       baseURL,
       headers: agentKeyHeaders(),
-      id: created.body.id as string,
+      id,
       body: { featuredRank: -1 },
     });
-    expect(patched.response.status).toBe(400);
+    expect(negative.response.status).toBe(400);
+
+    // Above Postgres' Int ceiling. Without the cap this clears Zod and dies at
+    // persistence, surfacing as a 500 rather than a validation error.
+    const tooLarge = await patchTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      id,
+      body: { featuredRank: 2_147_483_648 },
+    });
+    expect(tooLarge.response.status).toBe(400);
+  });
+
+  // Curation is not an ownership right: the PATCH guard admits the template's
+  // owner, so without a separate gate an owner could weight their own template
+  // to the top of the convos.org homepage, above the whole curated gallery.
+  test("only the dashboard's API key may write featuredRank", async () => {
+    const created = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Zrank Owner",
+        prompt: "p",
+        slug: "lss-rank-owner",
+        description: "zrankmarker",
+      },
+    });
+    const id = created.body.id as string;
+
+    // The owner, authenticated as a user rather than as the dashboard.
+    const selfPromote = await patchTemplate({
+      baseURL,
+      headers: await jwtHeaders(),
+      id,
+      body: { featuredRank: 2_000_000_000 },
+    });
+    expect(selfPromote.response.status).toBe(403);
+
+    // …and the weight did not move.
+    const after = await getTemplate({
+      baseURL,
+      path: id,
+      headers: agentKeyHeaders(),
+    });
+    expect(after.body.featuredRank).toBe(0);
+
+    // The same owner still edits their own content — only curation is gated.
+    const contentEdit = await patchTemplate({
+      baseURL,
+      headers: await jwtHeaders(),
+      id,
+      body: { emoji: "🛶" },
+    });
+    expect(contentEdit.response.status).toBe(200);
+
+    // The dashboard writes the weight.
+    const curated = await patchTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      id,
+      body: { featuredRank: 42 },
+    });
+    expect(curated.response.status).toBe(200);
+    expect(curated.body.featuredRank).toBe(42);
   });
 
   test("a cursor built for a different sort is rejected with 400", async () => {

--- a/tests/agent-templates.patch.test.ts
+++ b/tests/agent-templates.patch.test.ts
@@ -105,6 +105,7 @@ const expectTemplateShape = (body: TemplateBody) => {
     "description",
     "emoji",
     "featured",
+    "featuredRank",
     "firstPublishedAt",
     "forkedFromId",
     "id",

--- a/tests/agent-templates.publish.test.ts
+++ b/tests/agent-templates.publish.test.ts
@@ -101,6 +101,7 @@ const expectTemplateShape = (body: TemplateBody) => {
     "description",
     "emoji",
     "featured",
+    "featuredRank",
     "firstPublishedAt",
     "forkedFromId",
     "id",

--- a/tests/agent-templates.schema.test.ts
+++ b/tests/agent-templates.schema.test.ts
@@ -86,6 +86,7 @@ describe("AgentTemplate schema", () => {
       "@@index([status, createdAt, id])",
       "@@index([status, category, createdAt, id])",
       "@@index([status, featured, createdAt, id])",
+      "@@index([status, featured, featuredRank, id])",
       "@@index([forkedFromId])",
     ];
 
@@ -94,7 +95,7 @@ describe("AgentTemplate schema", () => {
     }
 
     expect(agentTemplateBlock).not.toMatch(/@@unique\(/);
-    expect(agentTemplateBlock.match(/@@(?:unique|index)\(/g)).toHaveLength(5);
+    expect(agentTemplateBlock.match(/@@(?:unique|index)\(/g)).toHaveLength(6);
   });
 
   test("applies PublishStatus enum, foreign keys, and required indexes in Postgres", async () => {
@@ -177,6 +178,7 @@ describe("AgentTemplate schema", () => {
       "AgentTemplate_status_category_createdAt_id_idx",
       "AgentTemplate_status_createdAt_id_idx",
       "AgentTemplate_status_featured_createdAt_id_idx",
+      "AgentTemplate_status_featured_featuredRank_id_idx",
     ]);
 
     const indexDefinitions = indexes.map((index) =>

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -75,6 +75,7 @@ const baseTemplate = (
   firstPublishedAt: new Date("2026-01-01T00:00:00.000Z"),
   status: "published",
   featured: false,
+  featuredRank: 0,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
   ...overrides,

--- a/tests/build-join-payload.test.ts
+++ b/tests/build-join-payload.test.ts
@@ -50,6 +50,7 @@ const rowFromSnapshot = (
       : new Date(snapshot.firstPublishedAt as string),
   status: snapshot.status as PublishStatus,
   featured: snapshot.featured as boolean,
+  featuredRank: 0,
   createdAt: new Date(snapshot.createdAt as string),
   updatedAt: new Date(snapshot.createdAt as string),
   ...overrides,


### PR DESCRIPTION
The convos.org featured gallery renders whatever order the list API returns, which has always been `createdAt` desc. So the only lever anyone had on the homepage was *when a template happened to be created* — there was nowhere to say "this one leads."

Adds `featuredRank`, a curation weight the admin Templates console writes, and lets the list sort by it. The console side is [convos-assistants#2673](https://github.com/xmtplabs/convos-assistants/pull/2673).

### Why a descending weight, not an ascending position

Sorted descending — heaviest leads — so the `@default(0)` reads as *unranked* and sinks to the bottom.

That's load-bearing rather than cosmetic: `featured` gets flipped true from paths that know nothing about ranking (the admin MCP bridge reflects `PATCH /:id` as an agent-callable tool). Under an ascending-position scheme those flips default to 0 and silently seize the lead slot of the homepage. Descending weights make the same mistake land harmlessly at the end.

### The migration is a no-op until someone curates

The backfill seeds weights from the order the gallery already renders (`createdAt` desc), by reversing that comparator so the oldest row gets weight 1 and the newest gets N. Verified against a real Postgres: the before and after orderings are identical, and non-featured rows keep 0.

### Notes

- `sort=featuredRank` is keyset-paginatable like the other sort fields — the cursor carries an integer instead of a date, and a cursor minted for a different sort/order is still rejected.
- `featuredRank` is stripped at the join-payload boundary alongside `ownerAccountId`. The runtime persists that payload verbatim as its on-disk `TEMPLATE.json` and has no use for a gallery curation weight, so the cross-repo shape is unchanged.

### Deploy order

**This has to deploy before the convos-assistants side.** The website's featured fetch swallows errors into an empty array, so a website that asks for `sort=featuredRank` against a backend without the column 400s and renders an *empty* gallery rather than degrading. This PR is additive and backward-compatible on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxFzZNgXaSnFWAYR8XPpCR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786569689&installation_id=128169237&pr_number=361&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F361&signature=c31d9c1b85e8aa59ad42ceeabb4a12623ede7b83488999f1d25022a530021319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `featuredRank` to agent templates to support curated gallery ordering
> - Adds a `featuredRank` integer column (default 0) to `AgentTemplate` with a composite index on `(status, featured, featuredRank, id)` for efficient sorted queries.
> - Extends the list API to accept `sort=featuredRank`, with keyset pagination that compares numeric rank values correctly across pages.
> - Adds `featuredRank` to the PATCH API body schema (range 0–2,147,483,647); only API-key authenticated callers may set it — user-authenticated owners receive 403.
> - Excludes `featuredRank` from the runtime join payload in [`build-join-payload.ts`](https://github.com/ephemeraHQ/convos-backend/pull/361/files#diff-5c0759731228a27bfd93e91f5928986b8621345bdd6ef27c71248eba04bef5a5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ac8574.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added featured-gallery ranking for agent templates via a new featured rank value.
  * Featured templates can now be sorted by featured rank (including cursor-based pagination).
  * Exposed featured rank in agent template API responses where applicable.
  * Enabled updating featured rank through the API for featured curation.

* **Bug Fixes**
  * Prevented invalid featured rank values (e.g., negative or out of range) from being accepted.
  * Ensured featured rank is not sent in assistant join payloads.

* **Security/Permissions**
  * Restricted featured-rank updates to the appropriate API key; non-authorized callers receive a 403.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->