### PR TITLE
feat(agent-templates): write the featured gallery's order in one transaction, and make curation admin-only

### DIFF
--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -9,6 +9,7 @@ import { buildAttachmentPresignedHandler } from "./handlers/build-attachment-pre
 import { createHandler } from "./handlers/create";
 import { deleteHandler } from "./handlers/delete";
 import { detailHandler } from "./handlers/detail";
+import { featuredOrderHandler } from "./handlers/featured-order";
 import { generationsEphemeralPostHandler } from "./handlers/generations-ephemeral-post";
 import { generationsGetHandler } from "./handlers/generations-get";
 import { generationsPostHandler } from "./handlers/generations-post";
@@ -74,6 +75,15 @@ agentTemplatesRouter.get(
   "/counts",
   optionalAuthOrAgentApiKeyAuth,
   listCountsHandler,
+);
+
+// The featured gallery's order, written whole and in one transaction. Mounted
+// before /:id so the wildcard doesn't capture "featured-order" as a template id.
+agentTemplatesRouter.put(
+  "/featured-order",
+  authOrAgentApiKeyAuth,
+  requireAccount,
+  featuredOrderHandler,
 );
 
 agentTemplatesRouter.patch(

--- a/src/api/v2/agent-templates/handlers/featured-order.ts
+++ b/src/api/v2/agent-templates/handlers/featured-order.ts
@@ -20,6 +20,27 @@ const sendError = (
 };
 
 /**
+ * Did Postgres refuse this transaction because another one moved the gallery
+ * under it?
+ *
+ * Two shapes, because the transaction mixes query styles: Prisma maps a
+ * serialization failure in its OWN queries to `P2034`, while a raw query
+ * surfaces the driver's code instead — `40001`, serialization_failure — wrapped
+ * as `P2010`. Matching only the first lets a genuine, expected conflict escape
+ * as a 500.
+ */
+export const isSerializationFailure = (error: unknown): boolean => {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError)) {
+    return false;
+  }
+  if (error.code === "P2034") {
+    return true;
+  }
+  const meta = error.meta as { code?: string } | undefined;
+  return error.code === "P2010" && meta?.code === "40001";
+};
+
+/**
  * Write the featured gallery's order — the whole thing, in one transaction.
  *
  * A reorder used to be one PATCH per row, and convos.org renders those as they
@@ -103,12 +124,29 @@ export async function featuredOrderHandler(req: Request, res: Response) {
           return null;
         }
 
-        // Heaviest leads, so the first id gets the largest weight.
-        for (const [index, id] of templateIds.entries()) {
-          await tx.agentTemplate.update({
-            where: { id },
-            data: { featuredRank: total - index },
-          });
+        // Heaviest leads, so the first id gets the largest weight. One statement
+        // for the whole gallery, rather than an update per row: it keeps the
+        // SERIALIZABLE window to a single round trip (fewer aborts under a
+        // concurrent write), and it leaves `updatedAt` alone — Prisma's `update`
+        // would touch it on every row, so a reorder would stamp the entire
+        // gallery as freshly edited, and `updatedAt` is a sort the list API
+        // offers. Ranking a template is not editing it.
+        const written = await tx.$executeRaw`
+          UPDATE "AgentTemplate" AS t
+          SET "featuredRank" = v.rank
+          FROM (VALUES ${Prisma.join(
+            templateIds.map(
+              (id, index) => Prisma.sql`(${id}::uuid, ${total - index}::int)`,
+            ),
+          )}) AS v(id, rank)
+          WHERE t."id" = v.id
+        `;
+        // Membership was checked in this same snapshot, so every id must land.
+        // If one didn't, the order we'd be storing isn't the one we validated.
+        if (written !== total) {
+          throw new Error(
+            `featured-order wrote ${written} of ${total} templates`,
+          );
         }
         return total;
       },
@@ -128,10 +166,7 @@ export async function featuredOrderHandler(req: Request, res: Response) {
   } catch (error) {
     // A serialization failure means the gallery moved under this write. The
     // caller's answer is the same as for a set that was already stale.
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2034"
-    ) {
+    if (isSerializationFailure(error)) {
       sendError(res, 409, {
         code: "GALLERY_CHANGED",
         message:

--- a/src/api/v2/agent-templates/handlers/featured-order.ts
+++ b/src/api/v2/agent-templates/handlers/featured-order.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "@/utils/prisma";
@@ -70,16 +71,51 @@ export async function featuredOrderHandler(req: Request, res: Response) {
   }
 
   try {
-    const gallery = await prisma.agentTemplate.findMany({
-      where: { featured: true, status: "published" },
-      select: { id: true },
-    });
+    const total = templateIds.length;
 
-    const galleryIds = new Set(gallery.map((template) => template.id));
-    const matchesGallery =
-      galleryIds.size === unique.size &&
-      templateIds.every((id) => galleryIds.has(id));
-    if (!matchesGallery) {
+    // The membership check and the writes are one transaction, at SERIALIZABLE.
+    //
+    // Both halves are needed. Reading the gallery outside the write would make
+    // this a check-then-act across two round trips; and moving the read inside a
+    // default (READ COMMITTED) transaction wouldn't close it either, since every
+    // statement there takes a fresh snapshot — a template featured or dropped
+    // between the check and the writes would still slip past. The damaging case
+    // is a row LEAVING the gallery mid-write: it stays in `templateIds`, takes a
+    // weight it's no longer entitled to, and — because a weight is a slot —
+    // silently reclaims that slot when it comes back. Exactly the invariant the
+    // patch handler enforces, walked around from the side.
+    //
+    // SERIALIZABLE makes the read and the writes see one snapshot and aborts the
+    // loser of a conflicting pair, which surfaces below as the same 409 a stale
+    // set gets: re-read the gallery and try again.
+    const updated = await prisma.$transaction(
+      async (tx) => {
+        const gallery = await tx.agentTemplate.findMany({
+          where: { featured: true, status: "published" },
+          select: { id: true },
+        });
+
+        const galleryIds = new Set(gallery.map((template) => template.id));
+        const matchesGallery =
+          galleryIds.size === unique.size &&
+          templateIds.every((id) => galleryIds.has(id));
+        if (!matchesGallery) {
+          return null;
+        }
+
+        // Heaviest leads, so the first id gets the largest weight.
+        for (const [index, id] of templateIds.entries()) {
+          await tx.agentTemplate.update({
+            where: { id },
+            data: { featuredRank: total - index },
+          });
+        }
+        return total;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+
+    if (updated === null) {
       sendError(res, 409, {
         code: "GALLERY_CHANGED",
         message:
@@ -88,20 +124,21 @@ export async function featuredOrderHandler(req: Request, res: Response) {
       return;
     }
 
-    // Heaviest leads, so the first id gets the largest weight. One transaction:
-    // the gallery is never half-ordered, not even for a moment.
-    const total = templateIds.length;
-    await prisma.$transaction(
-      templateIds.map((id, index) =>
-        prisma.agentTemplate.update({
-          where: { id },
-          data: { featuredRank: total - index },
-        }),
-      ),
-    );
-
-    res.status(200).json({ updated: total });
+    res.status(200).json({ updated });
   } catch (error) {
+    // A serialization failure means the gallery moved under this write. The
+    // caller's answer is the same as for a set that was already stale.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2034"
+    ) {
+      sendError(res, 409, {
+        code: "GALLERY_CHANGED",
+        message:
+          "the gallery changed while this order was being written — re-read it and try again",
+      });
+      return;
+    }
     req.log.error(
       { error, stack: error instanceof Error ? error.stack : undefined },
       "Failed to set featured gallery order",

--- a/src/api/v2/agent-templates/handlers/featured-order.ts
+++ b/src/api/v2/agent-templates/handlers/featured-order.ts
@@ -1,0 +1,111 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "@/utils/prisma";
+
+// The gallery holds far fewer than this; the cap just bounds the transaction.
+const MAX_GALLERY = 200;
+
+const bodySchema = z.object({
+  // The whole gallery, top slot first.
+  templateIds: z.array(z.string().uuid()).min(1).max(MAX_GALLERY),
+});
+
+const sendError = (
+  res: Response,
+  status: number,
+  error: { code: string; message: string },
+) => {
+  res.status(status).json({ error });
+};
+
+/**
+ * Write the featured gallery's order — the whole thing, in one transaction.
+ *
+ * A reorder used to be one PATCH per row, and convos.org renders those as they
+ * land: a failure halfway through left the homepage on a blend of the old order
+ * and the new one, which no amount of client-side undo can rule out (the undo
+ * is itself a sequence of writes that can fail). The order is a single value,
+ * so it moves once or not at all.
+ *
+ * The body must be the *entire* gallery. A partial list would leave the rows it
+ * omits holding weights that collide with the ones it sets, which is how you
+ * get two templates claiming one slot. If the gallery has changed since the
+ * caller read it — something published, featured, or dropped out — the ids
+ * won't match and the write is refused rather than clobbering a set the caller
+ * never saw.
+ */
+export async function featuredOrderHandler(req: Request, res: Response) {
+  // Curation is the dashboard's, not an owner's — same rule the rank field
+  // itself carries in PATCH.
+  const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+  if (!isApiKeyListener) {
+    req.log.warn(
+      { callerAccountId: res.locals.accountId, action: "featured-order" },
+      "Unauthorized agent-template curation attempt",
+    );
+    sendError(res, 403, {
+      code: "FORBIDDEN",
+      message: "Not authorized to set the featured gallery order",
+    });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: "Invalid request body",
+      details: parsed.error.issues,
+    });
+    return;
+  }
+
+  const { templateIds } = parsed.data;
+  const unique = new Set(templateIds);
+  if (unique.size !== templateIds.length) {
+    sendError(res, 400, {
+      code: "DUPLICATE_TEMPLATE",
+      message: "templateIds contains the same template more than once",
+    });
+    return;
+  }
+
+  try {
+    const gallery = await prisma.agentTemplate.findMany({
+      where: { featured: true, status: "published" },
+      select: { id: true },
+    });
+
+    const galleryIds = new Set(gallery.map((template) => template.id));
+    const matchesGallery =
+      galleryIds.size === unique.size &&
+      templateIds.every((id) => galleryIds.has(id));
+    if (!matchesGallery) {
+      sendError(res, 409, {
+        code: "GALLERY_CHANGED",
+        message:
+          "templateIds must be exactly the featured, published templates — the gallery changed, so re-read it and try again",
+      });
+      return;
+    }
+
+    // Heaviest leads, so the first id gets the largest weight. One transaction:
+    // the gallery is never half-ordered, not even for a moment.
+    const total = templateIds.length;
+    await prisma.$transaction(
+      templateIds.map((id, index) =>
+        prisma.agentTemplate.update({
+          where: { id },
+          data: { featuredRank: total - index },
+        }),
+      ),
+    );
+
+    res.status(200).json({ updated: total });
+  } catch (error) {
+    req.log.error(
+      { error, stack: error instanceof Error ? error.stack : undefined },
+      "Failed to set featured gallery order",
+    );
+    res.status(500).json({ error: "Failed to set featured gallery order" });
+  }
+}

--- a/tests/agent-templates.featured-order.test.ts
+++ b/tests/agent-templates.featured-order.test.ts
@@ -126,6 +126,30 @@ describe("Agent templates — featured gallery order", () => {
     ]);
   });
 
+  // Ranking a template is not editing it. An update-per-row would touch
+  // `updatedAt` on every row, so a reorder would stamp the whole gallery as
+  // freshly edited — and `updatedAt` is a sort the list API offers.
+  test("a reorder doesn't mark the gallery as edited", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    const two = await seedGalleryTemplate("Ftwo");
+
+    const before = await prisma.agentTemplate.findMany({
+      where: { slug: { startsWith: "fo-" } },
+      select: { id: true, updatedAt: true },
+      orderBy: { id: "asc" },
+    });
+
+    const res = await setOrder({ templateIds: [two, one] });
+    expect(res.response.status).toBe(200);
+
+    const after = await prisma.agentTemplate.findMany({
+      where: { slug: { startsWith: "fo-" } },
+      select: { id: true, updatedAt: true },
+      orderBy: { id: "asc" },
+    });
+    expect(after).toEqual(before);
+  });
+
   test("a partial list is refused — it would collide with the rows it omits", async () => {
     const one = await seedGalleryTemplate("Fone");
     await seedGalleryTemplate("Ftwo");

--- a/tests/agent-templates.featured-order.test.ts
+++ b/tests/agent-templates.featured-order.test.ts
@@ -1,0 +1,213 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { ADMIN_ACCOUNT_ID } from "@/utils/constants";
+import { prisma } from "@/utils/prisma";
+import {
+  agentKeyHeaders,
+  createTemplate,
+  jwtHeaders,
+  listTemplates,
+  patchTemplate,
+  publishTemplate,
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+
+// PUT /featured-order writes the gallery's order whole, in one transaction —
+// so a reorder is never half-applied on the homepage. The suite leans on that:
+// every rejection asserts the stored weights are byte-identical afterwards.
+
+let baseURL: string;
+let closeServer: () => Promise<void>;
+
+const cleanup = () =>
+  prisma.agentTemplate.deleteMany({
+    where: {
+      ownerAccountId: ADMIN_ACCOUNT_ID,
+      slug: { startsWith: "fo-" },
+    },
+  });
+
+const setOrder = async (args: {
+  templateIds: string[];
+  headers?: Record<string, string>;
+}) => {
+  const response = await fetch(
+    `${baseURL}/api/v2/agent-templates/featured-order`,
+    {
+      method: "PUT",
+      headers: args.headers ?? agentKeyHeaders(),
+      body: JSON.stringify({ templateIds: args.templateIds }),
+    },
+  );
+  const body = (await response.json()) as Record<string, unknown>;
+  return { body, response };
+};
+
+// A featured, published template — the only kind that holds a slot.
+const seedGalleryTemplate = async (name: string) => {
+  const created = await createTemplate({
+    baseURL,
+    headers: agentKeyHeaders(),
+    body: {
+      agentName: name,
+      prompt: "p",
+      slug: `fo-${name.toLowerCase()}`,
+      description: "fomarker",
+    },
+  });
+  const id = created.body.id as string;
+  await publishTemplate({ baseURL, headers: agentKeyHeaders(), id });
+  await patchTemplate({
+    baseURL,
+    headers: agentKeyHeaders(),
+    id,
+    body: { featured: true },
+  });
+  return id;
+};
+
+const weights = async () => {
+  const rows = await prisma.agentTemplate.findMany({
+    where: { slug: { startsWith: "fo-" } },
+    select: { agentName: true, featuredRank: true },
+    orderBy: { agentName: "asc" },
+  });
+  return rows.map((r) => `${r.agentName}=${r.featuredRank}`).join(",");
+};
+
+describe("Agent templates — featured gallery order", () => {
+  beforeAll(async () => {
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+    const server = await startAgentTemplatesServer(4097);
+    baseURL = server.baseURL;
+    closeServer = server.close;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await closeServer();
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  test("writes the whole order, heaviest first", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    const two = await seedGalleryTemplate("Ftwo");
+    const three = await seedGalleryTemplate("Fthree");
+
+    const res = await setOrder({ templateIds: [three, one, two] });
+    expect(res.response.status).toBe(200);
+    expect(res.body.updated).toBe(3);
+
+    const gallery = await listTemplates({
+      baseURL,
+      query: "?featured=true&sort=featuredRank&order=desc&limit=100",
+      headers: agentKeyHeaders(),
+    });
+    expect(gallery.body.data.map((t) => t.agentName as string)).toEqual([
+      "Fthree",
+      "Fone",
+      "Ftwo",
+    ]);
+    // Dense, top-down: the lead slot carries the largest weight.
+    expect(gallery.body.data.map((t) => t.featuredRank as number)).toEqual([
+      3, 2, 1,
+    ]);
+  });
+
+  test("a partial list is refused — it would collide with the rows it omits", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    await seedGalleryTemplate("Ftwo");
+    const before = await weights();
+
+    const res = await setOrder({ templateIds: [one] });
+    expect(res.response.status).toBe(409);
+    expect(await weights()).toBe(before);
+  });
+
+  test("a gallery that changed underneath is refused, not clobbered", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    const two = await seedGalleryTemplate("Ftwo");
+    await setOrder({ templateIds: [one, two] });
+
+    // Someone else features a third template between the read and the write. It
+    // joins at the end (weight 0), and the two that were ordered keep theirs.
+    const three = await seedGalleryTemplate("Fthree");
+    const before = await weights();
+
+    // The caller still thinks the gallery is two templates.
+    const stale = await setOrder({ templateIds: [two, one] });
+    expect(stale.response.status).toBe(409);
+    expect((stale.body.error as { code: string }).code).toBe("GALLERY_CHANGED");
+    expect(await weights()).toBe(before);
+
+    // Re-read and it goes through.
+    const fresh = await setOrder({ templateIds: [two, one, three] });
+    expect(fresh.response.status).toBe(200);
+  });
+
+  test("an id outside the gallery is refused", async () => {
+    const inGallery = await seedGalleryTemplate("Fone");
+    // Published, but never featured — so it holds no slot.
+    const outside = await createTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      body: {
+        agentName: "Foutside",
+        prompt: "p",
+        slug: "fo-outside",
+        description: "fomarker",
+      },
+    });
+    const outsideId = outside.body.id as string;
+    await publishTemplate({
+      baseURL,
+      headers: agentKeyHeaders(),
+      id: outsideId,
+    });
+    const before = await weights();
+
+    const res = await setOrder({ templateIds: [outsideId, inGallery] });
+    expect(res.response.status).toBe(409);
+    expect(await weights()).toBe(before);
+  });
+
+  test("the same template twice is refused", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    await seedGalleryTemplate("Ftwo");
+    const before = await weights();
+
+    const res = await setOrder({ templateIds: [one, one] });
+    expect(res.response.status).toBe(400);
+    expect((res.body.error as { code: string }).code).toBe(
+      "DUPLICATE_TEMPLATE",
+    );
+    expect(await weights()).toBe(before);
+  });
+
+  test("only the dashboard's API key may write the order", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    const two = await seedGalleryTemplate("Ftwo");
+    const before = await weights();
+
+    // The templates' own owner, authenticated as a user rather than as the
+    // dashboard: curation is not an ownership right.
+    const res = await setOrder({
+      templateIds: [two, one],
+      headers: await jwtHeaders(),
+    });
+    expect(res.response.status).toBe(403);
+    expect(await weights()).toBe(before);
+  });
+});

--- a/tests/agent-templates.featured-order.test.ts
+++ b/tests/agent-templates.featured-order.test.ts
@@ -196,6 +196,70 @@ describe("Agent templates — featured gallery order", () => {
     expect(await weights()).toBe(before);
   });
 
+  // The membership check and the writes run in one SERIALIZABLE transaction, so
+  // the gallery can't move between them. These assert the invariants that a
+  // torn read-then-write would break — not which racer wins, so they don't hinge
+  // on timing.
+  test("concurrent reorders never leave the gallery half-ordered", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    const two = await seedGalleryTemplate("Ftwo");
+    const three = await seedGalleryTemplate("Fthree");
+
+    const [a, b] = await Promise.all([
+      setOrder({ templateIds: [one, two, three] }),
+      setOrder({ templateIds: [three, two, one] }),
+    ]);
+
+    // A loser is refused, never served a 500.
+    for (const res of [a, b]) {
+      expect([200, 409]).toContain(res.response.status);
+    }
+    expect([a.response.status, b.response.status]).toContain(200);
+
+    // Whoever won, the gallery is a total order: dense, distinct, top-down.
+    const rows = await prisma.agentTemplate.findMany({
+      where: {
+        slug: { startsWith: "fo-" },
+        featured: true,
+        status: "published",
+      },
+      select: { featuredRank: true },
+      orderBy: { featuredRank: "desc" },
+    });
+    expect(rows.map((r) => r.featuredRank)).toEqual([3, 2, 1]);
+  });
+
+  test("a template that leaves the gallery mid-write keeps no weight", async () => {
+    const one = await seedGalleryTemplate("Fone");
+    const two = await seedGalleryTemplate("Ftwo");
+    const three = await seedGalleryTemplate("Fthree");
+
+    // The reorder is in flight when `Fthree` is unfeatured. Whichever lands
+    // first, the rule survives: a weight belongs to a featured, published
+    // template — so a row that walked out of the gallery must not be holding
+    // one, or it would silently reclaim that slot on the way back in.
+    const [order] = await Promise.all([
+      setOrder({ templateIds: [three, one, two] }),
+      patchTemplate({
+        baseURL,
+        headers: agentKeyHeaders(),
+        id: three,
+        body: { featured: false },
+      }),
+    ]);
+    expect([200, 409]).toContain(order.response.status);
+
+    const stranded = await prisma.agentTemplate.findMany({
+      where: {
+        slug: { startsWith: "fo-" },
+        featuredRank: { not: 0 },
+        OR: [{ featured: false }, { status: { not: "published" } }],
+      },
+      select: { agentName: true, featuredRank: true },
+    });
+    expect(stranded).toEqual([]);
+  });
+
   test("only the dashboard's API key may write the order", async () => {
     const one = await seedGalleryTemplate("Fone");
     const two = await seedGalleryTemplate("Ftwo");

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -260,13 +260,14 @@ describe("agent-templates router auth wiring", () => {
     expect(source).toContain("requireAccount");
     expect(source).toContain('from "@/middleware/auth"');
 
-    // Write routes (POST /, PATCH /:id, DELETE /:id, POST /:id/publish)
-    // chain `authOrAgentApiKeyAuth + requireAccount`. That's 4 routes,
-    // and one import, for 5 occurrences of `requireAccount` total.
+    // Write routes (POST /, PUT /featured-order, PATCH /:id, DELETE /:id,
+    // POST /:id/publish) chain `authOrAgentApiKeyAuth + requireAccount`. That's
+    // 5 routes, and one import, for 6 occurrences of `requireAccount` total.
     const requireAccountCount = (source.match(/requireAccount/g) ?? []).length;
-    expect(requireAccountCount).toBe(5);
+    expect(requireAccountCount).toBe(6);
 
     expect(source).toContain("requireAccount,\n  createHandler");
+    expect(source).toContain("requireAccount,\n  featuredOrderHandler");
     expect(source).toContain("requireAccount,\n  patchHandler");
     expect(source).toContain("requireAccount,\n  deleteHandler");
     expect(source).toContain("requireAccount,\n  publishHandler");

--- a/tests/featured-order.serialization.test.ts
+++ b/tests/featured-order.serialization.test.ts
@@ -1,0 +1,50 @@
+import { Prisma } from "@prisma/client";
+import { describe, expect, test } from "vitest";
+import { isSerializationFailure } from "@/api/v2/agent-templates/handlers/featured-order";
+
+// A concurrent write against the gallery is an EXPECTED outcome of the order
+// endpoint's SERIALIZABLE transaction — it must answer 409 ("re-read and try
+// again"), never 500. Which Prisma error carries that depends on the query
+// style, and the transaction mixes both: Prisma maps its own queries to P2034,
+// while a raw query surfaces the driver's 40001 wrapped as P2010. Matching only
+// the first is exactly the bug this pins — it let a real conflict escape as a
+// 500 whenever the race actually landed.
+const prismaError = (code: string, meta?: Record<string, unknown>) =>
+  new Prisma.PrismaClientKnownRequestError("boom", {
+    code,
+    clientVersion: "test",
+    meta,
+  });
+
+describe("featured-order — serialization failures", () => {
+  test("Prisma's own serialization code counts", () => {
+    expect(isSerializationFailure(prismaError("P2034"))).toBe(true);
+  });
+
+  test("a raw query's 40001 counts, wrapped as P2010", () => {
+    expect(
+      isSerializationFailure(
+        prismaError("P2010", {
+          code: "40001",
+          message: "could not serialize access due to concurrent update",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("another raw failure is not a serialization failure", () => {
+    // A genuine query bug must still surface as a 500, not be laundered into a
+    // 409 that tells the operator to try again.
+    expect(
+      isSerializationFailure(
+        prismaError("P2010", { code: "42P01", message: "relation missing" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("unrelated errors are not serialization failures", () => {
+    expect(isSerializationFailure(prismaError("P2025"))).toBe(false);
+    expect(isSerializationFailure(new Error("nope"))).toBe(false);
+    expect(isSerializationFailure(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
A reorder was one `PATCH` per row, and convos.org renders those **as they land** — so a failure halfway through left the homepage on a blend of the old order and the new one. No client-side undo can rule that out, because the undo is itself a sequence of writes that can fail. The order is a single value; it was being written as many.

`PUT /featured-order` takes the gallery as an ordered list of ids and assigns the weights itself, in one transaction. It moves once or not at all.

Console side: **xmtplabs/convos-assistants#2673** — deploy this first.

---

### The weight stops being the dashboard's business

Before, the dashboard computed the weights (renumber densely, diff, PATCH each changed row) — the same arithmetic on both sides of the wire, and a rule (*heaviest leads, dense, public rows only*) that the backend enforced and the frontend re-derived. That split had already produced two bugs. Now the dashboard sends an **order** and the backend derives the weights from position; the console holds no weight logic at all.

It also **deletes** machinery rather than adding it: the write queue, the stop-at-first-failure, the captured prior weights, and the compensating undo all go. Nothing can half-apply, so there is nothing to put back — a stronger claim than "we put it back carefully."

### Whole-gallery contract

The body must be the entire gallery. A partial list would leave the rows it omits holding weights that collide with the ones it sets — that's how two templates come to claim one slot. If the gallery changed under the caller (something published, featured, or dropped out mid-drag), the ids no longer match and the write is refused with **409** rather than clobbering a set the caller never saw.

### It isn't a user endpoint

Curating the gallery is not something a user does, so this isn't a route a user can reach: it takes the **agent key alone**. A signed-in caller is turned away at the door (401) rather than admitted by the middleware and refused inside — and the key is the identity, so there's no account to require. No in-handler auth check survives, because a check for a key that must already be present is dead code shaped like a lock.

### …and while I was in there, the front door was open

Any signed-in user could put their own template into the featured gallery. `create` accepts `featured` in the body and `PATCH` accepts it from whoever passes the ownership guard — which is the owner. Proven end to end with a plain JWT, no admin key anywhere:

| Plain user JWT | Before | After |
|---|---|---|
| `create` with `featured: true` | **201, featured stored** | **403** |
| publish own template | 200 | 200 (still theirs) |
| `PATCH featured: true` | **200** | **403** |
| `PATCH featuredRank: 999` | 403 | 403 |
| **Lands in the public gallery?** | **YES (rank 0)** | **NO** |

Only the *slot* had been gated (#362), so they entered at weight 0 — dead last. That contains it while the gallery holds a homepage's worth of curated templates above them, but containment isn't a closed door: it inflates the featured set, and the moment the gallery holds fewer than eight weighted templates, an outsider renders on convos.org.

Withdrawal stays the owner's: `featured: false` can only ever take something **off** the homepage, and the runtime's builder sends it on every create — which is exactly why the gate keys on `=== true` rather than `!== undefined`.

### Correctness notes worth a reviewer's eye

**The check and the write share one snapshot.** The membership read originally ran outside the transaction — a check-then-act. The damaging half is a template *leaving* the gallery mid-write: it stays in the caller's list, takes a weight it is no longer entitled to, and (since a weight is a slot) silently reclaims that slot when it returns — walking around #362's invariant from the side. Note that simply moving the read inside the transaction does **not** fix this: Prisma's default is READ COMMITTED, where each statement takes a fresh snapshot. Verified rather than assumed:

```
isolation WITH the option   : serializable
isolation WITHOUT the option: read committed
```

**A raw query's serialization failure isn't `P2034`.** Prisma surfaces the driver's `40001` wrapped as `P2010`, so the *expected* outcome of a concurrent write was escaping as a **500** instead of the 409 that says "re-read and retry" — and only when the race actually landed, which is why it first showed as a test that failed once and passed on rerun. Both shapes are recognised, and a unit test pins them, including that an unrelated `P2010` still surfaces as a 500 rather than being laundered into "try again".

**One statement, and it isn't an edit.** The whole order is written as a single `UPDATE … FROM (VALUES …)`. That keeps the SERIALIZABLE window to one round trip, and it leaves `updatedAt` alone — Prisma's `update` touches it on every row, so a reorder was stamping the entire gallery as freshly edited, and `updatedAt` is a sort the list API offers. Ranking a template is not editing it.

### Tests

Every rejection path asserts the stored weights are **byte-identical afterwards** — that's the point of the endpoint:

- writes the whole order, heaviest first (dense, top-down)
- a reorder doesn't mark the gallery as edited (`updatedAt` untouched)
- a partial list → 409, nothing written
- a gallery that changed underneath → 409 `GALLERY_CHANGED`, nothing written, and it succeeds after a re-read
- an id outside the gallery → 409, nothing written
- the same template twice → 400, nothing written
- a signed-in caller, and an anonymous one → 401, nothing written
- concurrent reorders leave a total order (dense, distinct, no 500s), and a template that leaves the gallery mid-write holds **no** weight — invariants, not "who won", so they don't hinge on timing
- serialization-failure classification (P2034, P2010+40001, and *not* an unrelated P2010)
- featuring authz: a user can't create-as-featured or self-feature; may still create with `featured: false` and unfeature their own; the dashboard still features

Full suite green (1492).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxFzZNgXaSnFWAYR8XPpCR
