### PR TITLE
fix(agent-templates): featuring is the dashboard's, not the owner's

### DIFF
--- a/src/api/v2/agent-templates/agent-templates.router.ts
+++ b/src/api/v2/agent-templates/agent-templates.router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import {
+  agentApiKeyAuth,
   authOrAgentApiKeyAuth,
   optionalAuthOrAgentApiKeyAuth,
 } from "@/middleware/agentAuth";
@@ -77,12 +78,18 @@ agentTemplatesRouter.get(
   listCountsHandler,
 );
 
-// The featured gallery's order, written whole and in one transaction. Mounted
-// before /:id so the wildcard doesn't capture "featured-order" as a template id.
+// The featured gallery's order, written whole and in one transaction.
+//
+// Curation is not something a user does, so this isn't an endpoint a user
+// reaches: the agent key is required outright, and a signed-in caller is turned
+// away at the door rather than admitted and refused inside. The key IS the
+// identity here — there is no account to require.
+//
+// Mounted before /:id so the wildcard doesn't capture "featured-order" as a
+// template id.
 agentTemplatesRouter.put(
   "/featured-order",
-  authOrAgentApiKeyAuth,
-  requireAccount,
+  agentApiKeyAuth,
   featuredOrderHandler,
 );
 

--- a/src/api/v2/agent-templates/handlers/create.ts
+++ b/src/api/v2/agent-templates/handlers/create.ts
@@ -114,6 +114,25 @@ export async function createHandler(req: Request, res: Response) {
   //     (users can't create rows owned by someone else).
   //   - Anonymous: no account → 403 below.
   const isApiKeyListener = res.locals.isApiKeyListener ?? false;
+
+  // Featuring is curation, and the gallery is the homepage's — not the template
+  // owner's. Anyone may create a template; only the dashboard may put one in
+  // front of everybody. Without this an ordinary signed-in user could mint a
+  // self-featured template in a single request and publish it into the gallery
+  // convos.org renders.
+  //
+  // Asking for `featured: false` is a no-op and passes: the runtime's builder
+  // sends it on every create, and a template that isn't featured is exactly what
+  // a create would produce anyway.
+  if (parsed.data.featured === true && !isApiKeyListener) {
+    req.log.warn(
+      { callerAccountId: res.locals.accountId, action: "create.featured" },
+      "Unauthorized agent-template curation attempt",
+    );
+    res.status(403).json({ error: "Not authorized to feature a template" });
+    return;
+  }
+
   let ownerAccountId: string | undefined;
   if (isApiKeyListener && parsed.data.ownerAccountId !== undefined) {
     const assertedAccountId = parsed.data.ownerAccountId;

--- a/src/api/v2/agent-templates/handlers/featured-order.ts
+++ b/src/api/v2/agent-templates/handlers/featured-order.ts
@@ -56,22 +56,10 @@ export const isSerializationFailure = (error: unknown): boolean => {
  * won't match and the write is refused rather than clobbering a set the caller
  * never saw.
  */
+// Reachable only behind `agentApiKeyAuth` (see the router): curation is not a
+// thing a user does, so there is no caller here to authorize — a request without
+// the agent key never arrives.
 export async function featuredOrderHandler(req: Request, res: Response) {
-  // Curation is the dashboard's, not an owner's — same rule the rank field
-  // itself carries in PATCH.
-  const isApiKeyListener = res.locals.isApiKeyListener ?? false;
-  if (!isApiKeyListener) {
-    req.log.warn(
-      { callerAccountId: res.locals.accountId, action: "featured-order" },
-      "Unauthorized agent-template curation attempt",
-    );
-    sendError(res, 403, {
-      code: "FORBIDDEN",
-      message: "Not authorized to set the featured gallery order",
-    });
-    return;
-  }
-
   const parsed = bodySchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({

--- a/src/api/v2/agent-templates/handlers/patch.ts
+++ b/src/api/v2/agent-templates/handlers/patch.ts
@@ -185,6 +185,29 @@ export async function patchHandler(req: Request, res: Response) {
       return;
     }
 
+    // Getting INTO the gallery is curation too, not just where you sit in it.
+    // The guard above admits the template's owner, so without this an owner
+    // could feature their own template onto convos.org — they couldn't pick a
+    // slot (that's gated below, and they'd enter at weight 0, last), but they
+    // would be in the gallery, and in front of everyone the moment it holds
+    // fewer than a homepage's worth of curated templates.
+    //
+    // Taking a template back OUT stays theirs: `featured: false` is a
+    // withdrawal, like unpublishing, and it can only ever remove something from
+    // the homepage.
+    if (parsedBody.data.featured === true && !isApiKeyListener) {
+      req.log.warn(
+        {
+          callerAccountId,
+          templateId: template.id,
+          action: "patch.featured",
+        },
+        "Unauthorized agent-template curation attempt",
+      );
+      res.status(403).json({ error: "Not authorized to feature a template" });
+      return;
+    }
+
     // Gallery curation is not an ownership right. `featuredRank` decides what
     // leads the convos.org homepage, and the guard above admits the template's
     // owner — so without this an owner could weight their own template above

--- a/tests/agent-templates.featured-order.test.ts
+++ b/tests/agent-templates.featured-order.test.ts
@@ -284,18 +284,29 @@ describe("Agent templates — featured gallery order", () => {
     expect(stranded).toEqual([]);
   });
 
-  test("only the dashboard's API key may write the order", async () => {
+  // Curation isn't something a user does, so this isn't an endpoint a user
+  // reaches: a signed-in caller is turned away at the door (401, no agent key)
+  // rather than admitted and refused inside.
+  test("a signed-in caller can't reach the endpoint at all", async () => {
     const one = await seedGalleryTemplate("Fone");
     const two = await seedGalleryTemplate("Ftwo");
     const before = await weights();
 
     // The templates' own owner, authenticated as a user rather than as the
-    // dashboard: curation is not an ownership right.
-    const res = await setOrder({
+    // dashboard.
+    const asUser = await setOrder({
       templateIds: [two, one],
       headers: await jwtHeaders(),
     });
-    expect(res.response.status).toBe(403);
+    expect(asUser.response.status).toBe(401);
+    expect(await weights()).toBe(before);
+
+    // And with no credentials at all.
+    const anonymous = await setOrder({
+      templateIds: [two, one],
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(anonymous.response.status).toBe(401);
     expect(await weights()).toBe(before);
   });
 });

--- a/tests/agent-templates.featuring-authz.test.ts
+++ b/tests/agent-templates.featuring-authz.test.ts
@@ -1,0 +1,161 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { __setAgentAssetsApiKeyOverrideForTests } from "@/middleware/agentAuth";
+import { createJwtToken } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+import {
+  agentKeyHeaders,
+  startAgentTemplatesServer,
+  validAgentAssetsApiKey,
+} from "./agent-templates.cross.helpers";
+
+// The featured gallery is the homepage's, not the template owner's. These pin
+// the whole path shut: an ordinary signed-in user could otherwise mint a
+// self-featured template, publish it (owners may publish their own), and appear
+// in the gallery convos.org renders. They couldn't pick a slot — that was
+// already gated — but being in the gallery at all is the front door.
+
+// A plain punter: not the admin account, no API key.
+const USER = "00000000-0000-4000-8000-eeeeeeee0001";
+
+let baseURL: string;
+let close: () => Promise<void>;
+
+const userHeaders = async () => ({
+  "Content-Type": "application/json",
+  "X-Convos-AuthToken": await createJwtToken({
+    deviceId: "featuring-authz-device",
+    accountId: USER,
+  }),
+});
+
+const create = async (
+  headers: Record<string, string>,
+  body: Record<string, unknown>,
+) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-templates`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return { response, body: (await response.json()) as Record<string, unknown> };
+};
+
+const patch = async (
+  headers: Record<string, string>,
+  id: string,
+  body: Record<string, unknown>,
+) => {
+  const response = await fetch(`${baseURL}/api/v2/agent-templates/${id}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return { response, body: (await response.json()) as Record<string, unknown> };
+};
+
+const featuredOf = async (id: string) =>
+  (
+    await prisma.agentTemplate.findUniqueOrThrow({
+      where: { id },
+      select: { featured: true },
+    })
+  ).featured;
+
+describe("Featuring is the dashboard's, not the owner's", () => {
+  beforeAll(async () => {
+    __setAgentAssetsApiKeyOverrideForTests(validAgentAssetsApiKey);
+    await prisma.account.upsert({
+      where: { id: USER },
+      create: { id: USER },
+      update: {},
+    });
+    const server = await startAgentTemplatesServer(4098);
+    baseURL = server.baseURL;
+    close = server.close;
+  });
+
+  afterAll(async () => {
+    await prisma.agentTemplate.deleteMany({ where: { ownerAccountId: USER } });
+    await close();
+    __setAgentAssetsApiKeyOverrideForTests(undefined);
+  });
+
+  beforeEach(async () => {
+    await prisma.agentTemplate.deleteMany({ where: { ownerAccountId: USER } });
+  });
+
+  test("a user can't create a template that is already featured", async () => {
+    const headers = await userHeaders();
+    const res = await create(headers, {
+      agentName: "Self Featured",
+      prompt: "p",
+      slug: "authz-self-featured",
+      featured: true,
+    });
+    expect(res.response.status).toBe(403);
+
+    // And nothing was written.
+    const rows = await prisma.agentTemplate.findMany({
+      where: { ownerAccountId: USER },
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("a user can't feature their own template afterwards", async () => {
+    const headers = await userHeaders();
+    const created = await create(headers, {
+      agentName: "Ordinary",
+      prompt: "p",
+      slug: "authz-ordinary",
+    });
+    const id = created.body.id as string;
+    expect(await featuredOf(id)).toBe(false);
+
+    const res = await patch(headers, id, { featured: true });
+    expect(res.response.status).toBe(403);
+    expect(await featuredOf(id)).toBe(false);
+  });
+
+  // The builder sends `featured: false` on every create, and withdrawing a
+  // template from the homepage can only ever remove something from it.
+  test("a user may still create with featured:false, and unfeature their own", async () => {
+    const headers = await userHeaders();
+    const created = await create(headers, {
+      agentName: "Opts Out",
+      prompt: "p",
+      slug: "authz-opts-out",
+      featured: false,
+    });
+    expect(created.response.status).toBe(201);
+    const id = created.body.id as string;
+
+    // The dashboard features it...
+    const featured = await patch(agentKeyHeaders(), id, { featured: true });
+    expect(featured.response.status).toBe(200);
+    expect(await featuredOf(id)).toBe(true);
+
+    // ...and the owner can take it back out.
+    const withdrawn = await patch(headers, id, { featured: false });
+    expect(withdrawn.response.status).toBe(200);
+    expect(await featuredOf(id)).toBe(false);
+  });
+
+  test("the dashboard still features templates", async () => {
+    const created = await create(agentKeyHeaders(), {
+      agentName: "Curated",
+      prompt: "p",
+      slug: "authz-curated",
+      featured: true,
+      ownerAccountId: USER,
+    });
+    expect(created.response.status).toBe(201);
+    expect(await featuredOf(created.body.id as string)).toBe(true);
+  });
+});

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -260,17 +260,23 @@ describe("agent-templates router auth wiring", () => {
     expect(source).toContain("requireAccount");
     expect(source).toContain('from "@/middleware/auth"');
 
-    // Write routes (POST /, PUT /featured-order, PATCH /:id, DELETE /:id,
-    // POST /:id/publish) chain `authOrAgentApiKeyAuth + requireAccount`. That's
-    // 5 routes, and one import, for 6 occurrences of `requireAccount` total.
+    // Write routes (POST /, PATCH /:id, DELETE /:id, POST /:id/publish)
+    // chain `authOrAgentApiKeyAuth + requireAccount`. That's 4 routes,
+    // and one import, for 5 occurrences of `requireAccount` total.
     const requireAccountCount = (source.match(/requireAccount/g) ?? []).length;
-    expect(requireAccountCount).toBe(6);
+    expect(requireAccountCount).toBe(5);
 
     expect(source).toContain("requireAccount,\n  createHandler");
-    expect(source).toContain("requireAccount,\n  featuredOrderHandler");
     expect(source).toContain("requireAccount,\n  patchHandler");
     expect(source).toContain("requireAccount,\n  deleteHandler");
     expect(source).toContain("requireAccount,\n  publishHandler");
+
+    // Curating the featured gallery is not a user action, so the order endpoint
+    // takes the agent key ALONE — no JWT path reaches it, and there is no
+    // account to require. Chaining `authOrAgentApiKeyAuth` here would admit a
+    // signed-in caller and leave the refusal to the handler.
+    expect(source).toContain("agentApiKeyAuth,\n  featuredOrderHandler");
+    expect(source).not.toContain("requireAccount,\n  featuredOrderHandler");
 
     // Public routes use the optional middleware: GET /, GET /:idOrUrlSlug,
     // POST /generations, GET /generations/:generationId. The optional

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -266,28 +266,47 @@ describe("agent-templates router auth wiring", () => {
     const requireAccountCount = (source.match(/requireAccount/g) ?? []).length;
     expect(requireAccountCount).toBe(5);
 
-    expect(source).toContain("requireAccount,\n  createHandler");
-    expect(source).toContain("requireAccount,\n  patchHandler");
-    expect(source).toContain("requireAccount,\n  deleteHandler");
-    expect(source).toContain("requireAccount,\n  publishHandler");
+    // These pin each route's middleware CHAIN by reading the router's source, so
+    // they're matched whitespace-agnostically: a formatter reflowing the file
+    // must not be able to turn a real auth regression into a green test, nor a
+    // harmless reflow into a red one. The leading lookbehind is what stops
+    // `agentApiKeyAuth` from matching inside `authOrAgentApiKeyAuth` — the two
+    // differ by exactly the thing these assertions exist to tell apart.
+    const chain = (middleware: string, handler: string) =>
+      new RegExp(`(?<![A-Za-z])${middleware},\\s+${handler}\\b`);
+
+    expect(source).toMatch(chain("requireAccount", "createHandler"));
+    expect(source).toMatch(chain("requireAccount", "patchHandler"));
+    expect(source).toMatch(chain("requireAccount", "deleteHandler"));
+    expect(source).toMatch(chain("requireAccount", "publishHandler"));
 
     // Curating the featured gallery is not a user action, so the order endpoint
     // takes the agent key ALONE — no JWT path reaches it, and there is no
-    // account to require. Chaining `authOrAgentApiKeyAuth` here would admit a
+    // account to require. Either permissive middleware here would admit a
     // signed-in caller and leave the refusal to the handler.
-    expect(source).toContain("agentApiKeyAuth,\n  featuredOrderHandler");
-    expect(source).not.toContain("requireAccount,\n  featuredOrderHandler");
+    expect(source).toMatch(chain("agentApiKeyAuth", "featuredOrderHandler"));
+    expect(source).not.toMatch(
+      chain("authOrAgentApiKeyAuth", "featuredOrderHandler"),
+    );
+    expect(source).not.toMatch(
+      chain("optionalAuthOrAgentApiKeyAuth", "featuredOrderHandler"),
+    );
+    expect(source).not.toMatch(chain("requireAccount", "featuredOrderHandler"));
 
     // Public routes use the optional middleware: GET /, GET /:idOrUrlSlug,
     // POST /generations, GET /generations/:generationId. The optional
     // middleware MUST NOT be followed by requireAccount.
-    expect(source).toContain("optionalAuthOrAgentApiKeyAuth, listHandler");
-    expect(source).toContain("optionalAuthOrAgentApiKeyAuth,\n  detailHandler");
-    expect(source).toContain(
-      "optionalAuthOrAgentApiKeyAuth,\n  generationsPostHandler",
+    expect(source).toMatch(
+      chain("optionalAuthOrAgentApiKeyAuth", "listHandler"),
     );
-    expect(source).toContain(
-      "optionalAuthOrAgentApiKeyAuth,\n  generationsGetHandler",
+    expect(source).toMatch(
+      chain("optionalAuthOrAgentApiKeyAuth", "detailHandler"),
+    );
+    expect(source).toMatch(
+      chain("optionalAuthOrAgentApiKeyAuth", "generationsPostHandler"),
+    );
+    expect(source).toMatch(
+      chain("optionalAuthOrAgentApiKeyAuth", "generationsGetHandler"),
     );
     expect(source).not.toMatch(
       /optionalAuthOrAgentApiKeyAuth,\s*requireAccount/,


### PR DESCRIPTION
Follow-up to #363 — these two commits were pushed to that branch after it was squash-merged, so they didn't land with it. Nothing new since; this is the same work, cherry-picked onto the merged `otr-dev` and re-verified there.

Curation is the dashboard's. Two holes closed.

### The front door was open

Any signed-in user could put their own template into the convos.org featured gallery. `create` accepts `featured` in the body, and `PATCH` accepts it from whoever passes the ownership guard — which is the owner. Proven end to end with a plain JWT, no admin key anywhere:

| Plain user JWT | Before | After |
|---|---|---|
| `create` with `featured: true` | **201, featured stored** | **403** |
| publish own template | 200 | 200 (still theirs) |
| `PATCH featured: true` | **200** | **403** |
| `PATCH featuredRank: 999` | 403 | 403 |
| **Lands in the public gallery?** | **YES (rank 0)** | **NO** |

Only the *slot* was gated (#362), so a self-featured template entered at weight 0 — dead last. That contains it while the gallery holds a homepage's worth of curated templates above it, but containment is not a closed door: it inflates the featured set, and the moment the gallery holds fewer than eight weighted templates, an outsider renders on the homepage.

**Withdrawal stays the owner's.** `featured: false` can only ever take something *off* the homepage, and the runtime's builder sends it on every create — which is why the gate keys on `=== true`, not `!== undefined`. Gating that too would 403 every template the builder makes.

I checked that nothing legitimate features templates: across the runtime, website and workers, the only non-admin writer of `featured` is `build.mjs`, writing `false`. The admin console reaches the backend as an API-key caller and is unaffected — and the full suite passing with no test needing an update is itself evidence no existing flow relied on a user featuring anything.

### `PUT /featured-order` was mounted as a user endpoint

It admitted any signed-in caller at the middleware and then refused them inside with an `isApiKeyListener` check. That makes a pure curation tool part of the user-facing API surface and leaves its safety resting on a guard in the handler body.

It now takes the **agent key alone**: a signed-in caller is turned away at the door (401) rather than let in and told no, and the key is the identity, so there's no account to require. The in-handler check goes with it — once the route can't be reached without the key, a check for one is dead code shaped like a lock, and the next reader would reasonably infer the route was reachable without it.

The auth-wiring guard test pins the shape both ways, so it can't be quietly re-mounted behind the permissive middleware later:

```ts
expect(source).toContain("agentApiKeyAuth,\n  featuredOrderHandler");
expect(source).not.toContain("requireAccount,\n  featuredOrderHandler");
```

The dashboard is unaffected: the worker already injects the same `X-Agent-API-Key` (`AGENT_ASSETS_API_KEY`) that this stricter guard validates.

### Tests

- a user can't create a template that is already featured (403, and nothing is written)
- a user can't feature their own template afterwards (403, `featured` unchanged)
- a user may still create with `featured: false`, and unfeature their own
- the dashboard still features templates
- the order endpoint: a signed-in caller **and** an anonymous one both get 401, with the stored weights byte-identical afterwards

Full suite green (1492) on top of the merged `otr-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxFzZNgXaSnFWAYR8XPpCR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786597085&installation_id=128169237&pr_number=364&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F364&signature=3520f403a85c5bcbef73ae0a2c386c982b10a9e4a5a17bb30a61096d64c2925c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict agent template featuring to dashboard (agent API key) callers only
> - `PUT /featured-order` now uses `agentApiKeyAuth` exclusively; JWT-authenticated and anonymous callers receive 401.
> - `POST` and `PATCH` handlers for agent templates now return 403 if a non-agent-key caller attempts to set `featured: true`; setting `featured: false` remains permitted for owners.
> - The in-handler auth check is removed from [featured-order.ts](https://github.com/ephemeraHQ/convos-backend/pull/364/files#diff-11ed8f07178f6c010f5caf897115db3a4c2d79030baab96d32251cfd758b2b00) since the middleware now enforces it at the router level.
> - New test suite in [agent-templates.featuring-authz.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/364/files#diff-864a56eb5f52eedf3274079cfb9e0f92f2445a14107964281dab1ff54a11d792) covers create/patch featuring authorization for both user and agent-key callers.
> - Behavioral Change: template owners can no longer feature their own templates via the public API; only the dashboard agent key can set `featured: true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 699779c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted featured gallery ordering to authorized API-key access.
  * Added authorization controls for featuring agent templates during creation and updates.
  * Allowed authorized dashboard actions to feature or unfeature templates.

* **Bug Fixes**
  * Unauthorized attempts to feature templates now receive clear access-denied responses.
  * Unauthorized featured-order requests are rejected without changing gallery ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->