### PR TITLE
docs(subscriptions): fix stale tier-config ledger comment

### DIFF
--- a/src/subscriptions/tier-config.ts
+++ b/src/subscriptions/tier-config.ts
@@ -14,11 +14,12 @@ const parsePositiveInt = (key: string, raw: string | undefined): number => {
 };
 
 /**
- * Per-tier monthly credit allotment, env-driven.
+ * Per-tier per-period credit allotment, env-driven.
  *
- * These values are the source of truth for `monthlyGrant` in the iOS
- * `CreditBalance` model. They do NOT write to the ledger — subscription
- * allotments are derived (Subscription row + this config) at read time.
+ * Single-ledger model: `grantSubscriptionPeriod` writes this amount into the
+ * wallet as a real `sub_grant` credit row on subscribe/renewal — balances are
+ * materialized, never derived at read time. The same value also frames
+ * `monthlyGrant` in the iOS `CreditBalance` model.
  *
  * Annual subscriptions inherit the monthly amount per period; the renewal
  * cycle is just 12× longer. iOS displays `monthlyGrant` either way; the


### PR DESCRIPTION
## Summary
- The `tierGrant` docstring still claimed subscription allotments "do NOT write to the ledger" and are "derived at read time" — true under the old Option-B model, false since the single-ledger migration (#324).
- `grantSubscriptionPeriod` now materializes this amount into the wallet as a real `sub_grant` credit row. Correct the comment; the value still also frames iOS `monthlyGrant`.
- Comment-only change; no runtime behavior.

Found during a post-single-ledger audit of the credits domain (1 of 5 small PRs).

## Test Plan
- [x] `pnpm typecheck` / `eslint` / `prettier --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786616590&installation_id=128169237&pr_number=365&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F365&signature=726599855d78117f0fbf9b25eb905011ca1ea9f73596fcc60d49806b585938ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale comment in `tier-config` subscription ledger documentation
> Updates the module-level comment in [tier-config.ts](https://github.com/ephemeraHQ/convos-backend/pull/365/files#diff-ae2142f94bf5def9e2feb828f9e010655ecf8625d968f2adf75a07e1cf13bd71) to reflect the current single-ledger model. Corrects "per-tier monthly" to "per-tier per-period", clarifies that `grantSubscriptionPeriod` writes a `sub_grant` credit row on subscribe/renewal, and notes that balances are materialized rather than derived. Also documents that annual subscriptions use the same per-period amount with a longer renewal cycle, and that the `tier` parameter is preserved for future branching despite currently having a single tier.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4980e18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how subscription credit allotments are configured and recorded.
  * Documented that subscription grants are added to the wallet ledger as subscription grant entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->