### PR TITLE
docs(payments): require admin-page sync on money-model changes

### DIFF
--- a/src/payments/AGENTS.md
+++ b/src/payments/AGENTS.md
@@ -130,6 +130,31 @@ keys. The `consume` key is client-supplied by the assistants harness
    one key.
 5. Test balance movement, idempotent replay (same key → no double move), and
    floor behavior on debits.
+6. Did the change alter the balance model, add a `GrantKind` / `LedgerReason`,
+   or touch entitlement math (not just add a flow)? Update the credits admin
+   page too — see the next section.
+
+## The credits admin page mirrors this domain — keep it in sync
+
+`src/api/v2/credits-admin/` is a live read/write mirror of the ledger: it shows
+`getBalance`, the `CreditLedger` history, per-period consume sums, and the
+subscription entitlement view, and it mutates through `grant` / `adjust`. It is
+**not** generated — it hard-codes the current balance model, so it drifts
+silently when the model changes underneath it.
+
+Any change to how credits are stored, computed, or displayed MUST carry a
+matching update to the admin page, or its numbers become a lie:
+
+- New `GrantKind` / `LedgerReason` → surface it in the ledger view.
+- Changed meaning of `getBalance` / spendable, or a removed derived path →
+  update the balance cards and their labels. (The Option-B → single-ledger
+  migration left "Spendable (derived)" and "Raw parked balance" cards rendering
+  identical numbers precisely because this step was skipped.)
+- Changed subscription entitlement math (tier grant, period, forfeit) → update
+  the subscription view and per-period figures.
+
+Treat the admin page as part of the blast radius of any money-model change, the
+same as any downstream consumer.
 
 ## Deeper reference
 


### PR DESCRIPTION
## Summary
- Adds a rule to the money law (`src/payments/AGENTS.md`): any change to how credits are stored, computed, or displayed (new `GrantKind`/`LedgerReason`, changed `getBalance`/spendable meaning, changed entitlement math) MUST carry a matching update to the credits admin page.
- The admin page hard-codes the balance model and is not generated — the Option-B → single-ledger migration changed what balance means but skipped it, leaving two balance cards rendering identical numbers under stale labels. This rule is the meta-fix for that drift.
- Wired into both the add-a-money-flow checklist and a dedicated section.

## Test Plan
- [x] `prettier --check` clean (docs-only)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786616591&installation_id=128169237&pr_number=366&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F366&signature=8205cf9ffcf68dc9f2c2af04bce2cc1a7f28cfc48c44b9ed79b28b06fea9b2c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document requirement to sync credits admin page on money-model changes
> Adds a checklist item and dedicated section to [AGENTS.md](https://github.com/ephemeraHQ/convos-backend/pull/366/files#diff-d297b5b8f22a6db9b40302fe8f087779791192d78c306782e59d77b267e53c77) instructing engineers to update `src/api/v2/credits-admin/` whenever the balance model, `GrantKind`/`LedgerReason` set, or entitlement math changes. The admin page is hard-coded (not generated) and must be kept in sync manually, covering the ledger view, balance cards, and subscription entitlement figures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 412b8ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->