### PR TITLE
refactor(credits-admin): collapse duplicate balance cards into one

### DIFF
--- a/src/api/v2/credits-admin/handlers/account-view-get.ts
+++ b/src/api/v2/credits-admin/handlers/account-view-get.ts
@@ -1,7 +1,7 @@
 import type { CreditLedger } from "@prisma/client";
 import type { Request, Response } from "express";
 import { getBalance, getBucketedConsumption } from "@/payments";
-import { getSpendableBalance, sumPeriodConsumes } from "@/payments/spendable";
+import { sumPeriodConsumes } from "@/payments/spendable";
 import { findCurrentByAccountId } from "@/subscriptions/repository";
 import {
   effectiveSubscriptionStatus,
@@ -79,8 +79,7 @@ export const accountViewGetHandler = async (
     };
   }
 
-  const [spendable, raw, ledgerRows, refillRows, usage] = await Promise.all([
-    getSpendableBalance(accountId),
+  const [balance, ledgerRows, refillRows, usage] = await Promise.all([
     getBalance(accountId),
     prisma.creditLedger.findMany({
       where: { accountId },
@@ -104,8 +103,7 @@ export const accountViewGetHandler = async (
     accountCreatedAt: account.createdAt.toISOString(),
     subscription: subView,
     isEntitled: subView?.isEntitled ?? false,
-    spendableCredits: spendable.toString(),
-    rawBalanceCredits: raw.toString(),
+    balanceCredits: balance.toString(),
     periodConsumesCredits,
     ledger: ledgerRows.map(serializeLedger),
     dailyRefills: refillRows.map(serializeLedger),

--- a/src/api/v2/credits-admin/handlers/admin-page.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page.ts
@@ -51,8 +51,7 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
   .balance { padding: 12px 16px; border-radius: 8px; background: #f5f5f7; min-width: 160px; }
   .balance .k { font-size: 12px; color: #6e6e73; }
   .balance .v { font-size: 20px; font-weight: 700; }
-  .balance.spendable { background: #e3f2e8; }
-  .balance.raw { background: #eef0ff; }
+  .balance.primary { background: #e3f2e8; }
   .badge { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
   .badge-yes { background: #d1f0d6; color: #14752a; }
   .badge-no { background: #f7d6d6; color: #a3151f; }
@@ -98,8 +97,7 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
   <div class="card">
     <h2>Account <span id="detail-id" style="font-weight:400;font-size:13px"></span></h2>
     <div class="balances">
-      <div class="balance spendable"><div class="k">Spendable (derived)</div><div class="v" id="b-spendable"></div></div>
-      <div class="balance raw"><div class="k">Raw parked balance</div><div class="v" id="b-raw"></div></div>
+      <div class="balance primary"><div class="k">Balance</div><div class="v" id="b-balance"></div></div>
       <div class="balance"><div class="k">Entitled</div><div class="v"><span id="b-entitled"></span></div></div>
     </div>
     <div id="sub-block" style="margin-top:16px"></div>
@@ -228,8 +226,7 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
   function renderDetail(j) {
     document.getElementById("detail").classList.remove("hidden");
     document.getElementById("detail-id").textContent = j.accountId;
-    document.getElementById("b-spendable").textContent = fmtCredits(j.spendableCredits);
-    document.getElementById("b-raw").textContent = fmtCredits(j.rawBalanceCredits);
+    document.getElementById("b-balance").textContent = fmtCredits(j.balanceCredits);
     document.getElementById("b-entitled").innerHTML = j.isEntitled
       ? '<span class="badge badge-yes">entitled</span>'
       : '<span class="badge badge-no">not entitled</span>';

--- a/tests/credits-admin/account-view.integration.test.ts
+++ b/tests/credits-admin/account-view.integration.test.ts
@@ -25,8 +25,7 @@ type AccountViewBody = {
     isInTrial: boolean;
   } | null;
   isEntitled: boolean;
-  spendableCredits: string;
-  rawBalanceCredits: string;
+  balanceCredits: string;
   periodConsumesCredits: number;
   ledger: {
     id: string;
@@ -53,11 +52,11 @@ describe("GET /api/v2/credits-admin/accounts/:accountId", () => {
     tracker.length = 0;
   });
 
-  it("entitled subscriber → spendable == raw wallet (single-ledger), isEntitled true", async () => {
+  it("entitled subscriber → balance is the materialized wallet (single-ledger), isEntitled true", async () => {
     const accountId = await seedAccount();
     tracker.push(accountId);
     // Single-ledger: subscribing materializes a sub_grant into the one wallet,
-    // so spendable and raw are the SAME positive value (no derived path).
+    // so the balance is a single positive value (no derived/parked split).
     await seedPlusMonthlySubscription(accountId);
     const res = await adminRequest(app).get(
       `/api/v2/credits-admin/accounts/${accountId}`,
@@ -66,11 +65,10 @@ describe("GET /api/v2/credits-admin/accounts/:accountId", () => {
     const body = res.body as AccountViewBody;
     expect(body.isEntitled).toBe(true);
     expect(body.subscription?.effectiveStatus).toBe("active");
-    expect(BigInt(body.rawBalanceCredits)).toBeGreaterThan(0n);
-    expect(body.spendableCredits).toBe(body.rawBalanceCredits);
+    expect(BigInt(body.balanceCredits)).toBeGreaterThan(0n);
   });
 
-  it("non-subscriber → no subscription, spendable equals raw", async () => {
+  it("non-subscriber → no subscription, single wallet balance", async () => {
     const accountId = await seedAccount();
     tracker.push(accountId);
     await seedBalance(accountId, 1_000n);
@@ -81,8 +79,7 @@ describe("GET /api/v2/credits-admin/accounts/:accountId", () => {
     const body = res.body as AccountViewBody;
     expect(body.subscription).toBeNull();
     expect(body.isEntitled).toBe(false);
-    expect(body.rawBalanceCredits).toBe("1000");
-    expect(body.spendableCredits).toBe("1000");
+    expect(body.balanceCredits).toBe("1000");
     expect(body.ledger.length).toBeGreaterThanOrEqual(1);
     expect(body.ledger[0].delta).toBe("1000");
   });


### PR DESCRIPTION
## Summary
Post single-ledger, `getSpendableBalance` is a pure alias of `getBalance`, so the account view fetched the same number twice and rendered it in two cards — "Spendable (derived)" and "Raw parked balance" — both showing identical values under labels that no longer describe anything.

- Drop the redundant `getSpendableBalance` read.
- Collapse the JSON to a single `balanceCredits` field (internal admin response, no shipped-client contract).
- Render one "Balance" card; retire dead `.spendable`/`.raw` CSS naming.
- Update the account-view contract test.

Part of a 5-PR credits-admin audit sweep. Touches `admin-page.ts` — **merge before the render-panels and allotment PRs** (or rebase them).

## Test Plan
- [x] `pnpm vitest run tests/credits-admin/` → 51/51 (TDD red→green on the reshape)
- [x] `typecheck` / `eslint` / `prettier --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786616594&installation_id=128169237&pr_number=367&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F367&signature=1559a93424e94d783e3d14d5cfbb541d406f36836af926310a138c27c803d918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse duplicate balance cards into a single `balanceCredits` field in credits admin
> Replaces the separate `spendableCredits` and `rawBalanceCredits` fields with a single `balanceCredits` field backed by `getBalance`. The admin page UI is updated to show one "Balance" card, and the GET handler response shape changes accordingly.
>
> - Risk: any clients consuming `spendableCredits` or `rawBalanceCredits` from the account view API will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16a57f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->