### PR TITLE
feat(credits-admin): render daily-refills and 30-day usage panels

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page.ts
@@ -59,6 +59,8 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
   table { width: 100%; border-collapse: collapse; font-size: 13px; }
   th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid #ececec; }
   th { color: #6e6e73; font-weight: 600; }
+  .spark { display: flex; align-items: flex-end; gap: 2px; height: 56px; }
+  .spark .bar { flex: 1 1 0; min-width: 3px; min-height: 2px; background: #0071e3; border-radius: 2px 2px 0 0; }
   .hidden { display: none; }
   .toast { position: fixed; bottom: 24px; right: 24px; padding: 12px 18px; border-radius: 8px; color: #fff; opacity: 0; transition: opacity .2s; pointer-events: none; }
   .toast.show { opacity: 1; }
@@ -126,6 +128,16 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
   <div class="card">
     <h2>Recent ledger</h2>
     <div style="overflow-x:auto"><table id="ledger-table"><thead><tr><th>When</th><th>Δ</th><th>Reason</th><th>Kind</th><th>Note</th></tr></thead><tbody></tbody></table></div>
+  </div>
+
+  <div class="card">
+    <h2>Usage (last 30 days)</h2>
+    <div id="usage-spark" class="spark"></div>
+  </div>
+
+  <div class="card">
+    <h2>Daily refills</h2>
+    <div style="overflow-x:auto"><table id="refills-table"><thead><tr><th>When</th><th>Δ</th><th>Note</th></tr></thead><tbody></tbody></table></div>
   </div>
 
   <div class="card">
@@ -251,6 +263,31 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
     lt.innerHTML = (j.ledger || []).map(function (r) {
       return "<tr><td>" + fmtDate(r.createdAt) + "</td><td>" + esc(r.delta) + "</td><td>" + esc(r.reason) + "</td><td>" + esc(r.grantKindId || "—") + "</td><td>" + esc(r.note || "") + "</td></tr>";
     }).join("");
+
+    var refills = j.dailyRefills || [];
+    var ft = document.querySelector("#refills-table tbody");
+    ft.innerHTML = refills.length
+      ? refills.map(function (r) {
+          return "<tr><td>" + fmtDate(r.createdAt) + "</td><td>" + esc(r.delta) + "</td><td>" + esc(r.note || "") + "</td></tr>";
+        }).join("")
+      : '<tr><td colspan="3" class="hint">No daily refills.</td></tr>';
+
+    var usage = j.usageDaily || [];
+    var spark = document.getElementById("usage-spark");
+    if (!usage.length) {
+      spark.innerHTML = '<span class="hint">No usage in the last 30 days.</span>';
+    } else {
+      var maxUsage = usage.reduce(function (m, u) {
+        var c = Number(u.consumed);
+        return c > m ? c : m;
+      }, 0);
+      spark.innerHTML = usage.map(function (u) {
+        var c = Number(u.consumed);
+        var h = maxUsage > 0 ? Math.max(2, Math.round((c / maxUsage) * 100)) : 2;
+        var title = esc(u.bucketStart + " · " + fmtCredits(u.consumed) + " credits");
+        return '<div class="bar" style="height:' + h + '%" title="' + title + '"></div>';
+      }).join("");
+    }
   }
 
   function loadAudit(accountId) {

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -28,4 +28,16 @@ describe("credits-admin page", () => {
     expect(res.text).not.toContain('credentials: "include"');
     expect(res.text).toContain('id="clear-token"');
   });
+
+  it("renders the daily-refills panel and consumes j.dailyRefills", async () => {
+    const res = await adminRequest(app, false).get("/api/v2/credits-admin/");
+    expect(res.text).toContain('id="refills-table"');
+    expect(res.text).toContain("dailyRefills");
+  });
+
+  it("renders the usage sparkline and consumes j.usageDaily", async () => {
+    const res = await adminRequest(app, false).get("/api/v2/credits-admin/");
+    expect(res.text).toContain('id="usage-spark"');
+    expect(res.text).toContain("usageDaily");
+  });
 });


### PR DESCRIPTION
## Summary
The account view already fetched `dailyRefills` (daily_refill ledger rows) and `usageDaily` (30-day bucketed consumption) and shipped them in the JSON, but the client rendered neither — two dead queries per page load.

- Wire up a **Daily refills** table and an inline **bar sparkline** for usage (CSP-safe, CSS-only, no external lib), each with an empty state.
- Pin both with page tests.

Part of a 5-PR credits-admin audit sweep. Touches `admin-page.ts` — merge after the collapse-balance PR (or rebase).

## Test Plan
- [x] `pnpm vitest run tests/credits-admin/` → 53/53 (TDD red→green)
- [x] Rendered browser JS syntax-checked via `node --check`
- [x] `typecheck` / `eslint` / `prettier --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786616595&installation_id=128169237&pr_number=368&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F368&signature=b258e5bc135c9d01bea36148d17138e60442876204f5b3d0122317ab2ef3282d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add daily refills table and 30-day usage sparkline to credits admin page
> - Adds a 'Daily refills' card rendering `j.dailyRefills` into a `#refills-table` in [admin-page.ts](https://github.com/ephemeraHQ/convos-backend/pull/368/files#diff-54a9546633951cddf4f5141f75c1f4ad4ea4f1429c887629685df65cefcb2d0a), with an empty-state hint row when no data is present.
> - Adds a 'Usage (last 30 days)' card rendering `j.usageDaily` as a bar sparkline in `#usage-spark`, scaling bar heights relative to max usage (minimum 2%) with tooltips showing bucket start and credit amounts.
> - Adds tests in [admin-page.test.ts](https://github.com/ephemeraHQ/convos-backend/pull/368/files#diff-7d0875eac326a1bbd93638e071f0313a904a716e1008e235cc587934935dca84) asserting the HTML contains both new panel elements and their associated script references.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 272e60c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->