### PR TITLE
feat(credits-admin): show per-period allotment in subscription block

### DIFF
--- a/src/api/v2/credits-admin/handlers/account-view-get.ts
+++ b/src/api/v2/credits-admin/handlers/account-view-get.ts
@@ -7,6 +7,8 @@ import {
   effectiveSubscriptionStatus,
   ENTITLED_SUBSCRIPTION_STATUSES,
 } from "@/subscriptions/status";
+import { tierGrant } from "@/subscriptions/tier-config";
+import { requireSubscriptionTier } from "@/subscriptions/tiers";
 import { prisma } from "@/utils/prisma";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -54,6 +56,7 @@ export const accountViewGetHandler = async (
     environment: string | null;
     willRenew: boolean;
     isInTrial: boolean;
+    perPeriodCredits: number;
   } | null = null;
   let periodConsumesCredits = 0;
 
@@ -76,6 +79,10 @@ export const accountViewGetHandler = async (
       environment: subscription.environment ?? null,
       willRenew: subscription.willRenew,
       isInTrial: subscription.isInTrial,
+      perPeriodCredits: tierGrant(
+        requireSubscriptionTier(subscription.tier),
+        subscription.period,
+      ).perPeriod,
     };
   }
 

--- a/src/api/v2/credits-admin/handlers/admin-page.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page.ts
@@ -251,6 +251,7 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
         "<tr><th>Effective status</th><td>" + esc(s.effectiveStatus) + "</td></tr>" +
         "<tr><th>Period</th><td>" + fmtDate(s.currentPeriodStart) + " → " + fmtDate(s.currentPeriodEnd) + "</td></tr>" +
         "<tr><th>Environment</th><td>" + esc(s.environment) + "</td></tr>" +
+        "<tr><th>Allotment (per period)</th><td>" + fmtCredits(s.perPeriodCredits) + " credits</td></tr>" +
         "<tr><th>Period consumes</th><td>" + fmtCredits(j.periodConsumesCredits) + " credits</td></tr>" +
         "</tbody></table>";
     } else {

--- a/tests/credits-admin/account-view.integration.test.ts
+++ b/tests/credits-admin/account-view.integration.test.ts
@@ -23,6 +23,7 @@ type AccountViewBody = {
     environment: string | null;
     willRenew: boolean;
     isInTrial: boolean;
+    perPeriodCredits: number;
   } | null;
   isEntitled: boolean;
   balanceCredits: string;
@@ -66,6 +67,7 @@ describe("GET /api/v2/credits-admin/accounts/:accountId", () => {
     expect(body.isEntitled).toBe(true);
     expect(body.subscription?.effectiveStatus).toBe("active");
     expect(BigInt(body.balanceCredits)).toBeGreaterThan(0n);
+    expect(body.subscription?.perPeriodCredits).toBeGreaterThan(0);
   });
 
   it("non-subscriber → no subscription, single wallet balance", async () => {

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -40,4 +40,10 @@ describe("credits-admin page", () => {
     expect(res.text).toContain('id="usage-spark"');
     expect(res.text).toContain("usageDaily");
   });
+
+  it("renders the per-period allotment in the subscription block", async () => {
+    const res = await adminRequest(app, false).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("Allotment");
+    expect(res.text).toContain("perPeriodCredits");
+  });
 });


### PR DESCRIPTION
## Summary
The subscription block showed "Period consumes" with nothing to compare it against — an admin couldn't see used-of-allotment without eyeballing the `sub_grant` row in the ledger table.

- Add the tier's per-period allotment (`tierGrant.perPeriod`) as its own row, directly above "Period consumes".

Part of a 5-PR credits-admin audit sweep. Touches `admin-page.ts` + `account-view-get.ts` — merge after the earlier admin-page PRs (or rebase).

## Test Plan
- [x] `pnpm vitest run tests/credits-admin/` → 52/52 (TDD red→green)
- [x] Rendered browser JS syntax-checked via `node --check`
- [x] `typecheck` / `eslint` / `prettier --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786616598&installation_id=128169237&pr_number=369&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F369&signature=d1d5564ba6483795535be59d69419fa4726796006246f5a07d9e7b8591c8d699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show per-period credit allotment in credits-admin subscription block
> Adds a `perPeriodCredits` field to the account view API response, computed via `tierGrant` and `requireSubscriptionTier` from the subscription's tier and period. The admin HTML page renders this as a new 'Allotment (per period)' table row in the subscription block.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 823add8. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->