### PR TITLE
feat(credits-admin): show explicit subscription state chip

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page.ts
@@ -55,6 +55,7 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
   .badge { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
   .badge-yes { background: #d1f0d6; color: #14752a; }
   .badge-no { background: #f7d6d6; color: #a3151f; }
+  .badge-none { background: #e8e8ed; color: #6e6e73; }
   table { width: 100%; border-collapse: collapse; font-size: 13px; }
   th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid #ececec; }
   th { color: #6e6e73; font-weight: 600; }
@@ -100,7 +101,7 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
     <h2>Account <span id="detail-id" style="font-weight:400;font-size:13px"></span></h2>
     <div class="balances">
       <div class="balance primary"><div class="k">Balance</div><div class="v" id="b-balance"></div></div>
-      <div class="balance"><div class="k">Entitled</div><div class="v"><span id="b-entitled"></span></div></div>
+      <div class="balance"><div class="k">Subscription</div><div class="v"><span id="b-substate"></span></div></div>
     </div>
     <div id="sub-block" style="margin-top:16px"></div>
   </div>
@@ -239,9 +240,14 @@ function buildHTML(nonce: string, creditsPerUsd: number): string {
     document.getElementById("detail").classList.remove("hidden");
     document.getElementById("detail-id").textContent = j.accountId;
     document.getElementById("b-balance").textContent = fmtCredits(j.balanceCredits);
-    document.getElementById("b-entitled").innerHTML = j.isEntitled
-      ? '<span class="badge badge-yes">entitled</span>'
-      : '<span class="badge badge-no">not entitled</span>';
+    var subState = j.subscription ? j.subscription.effectiveStatus : "none";
+    var subClass = !j.subscription
+      ? "badge-none"
+      : j.isEntitled
+        ? "badge-yes"
+        : "badge-no";
+    document.getElementById("b-substate").innerHTML =
+      '<span class="badge ' + subClass + '">' + esc(subState) + "</span>";
     var sb = document.getElementById("sub-block");
     if (j.subscription) {
       var s = j.subscription;

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -46,4 +46,11 @@ describe("credits-admin page", () => {
     expect(res.text).toContain("Allotment");
     expect(res.text).toContain("perPeriodCredits");
   });
+
+  it("renders subscription state as a colored status chip (none/entitled/lapsed)", async () => {
+    const res = await adminRequest(app, false).get("/api/v2/credits-admin/");
+    expect(res.text).toContain('id="b-substate"');
+    expect(res.text).toContain("badge-none");
+    expect(res.text).toContain("effectiveStatus");
+  });
 });


### PR DESCRIPTION
## Summary
The "Entitled" badge collapsed two distinct states into "not entitled": an account that **never subscribed** (no `Subscription` row) and one whose subscription **lapsed** (expired/revoked). Admins couldn't tell them apart from the top card.

Replace the yes/no badge with a status chip driven by data already sent (`j.subscription`, `effectiveStatus`, `isEntitled`):

| Case | Chip | Color |
|------|------|-------|
| No `Subscription` row | `none` | grey |
| Entitled (trial/active/grace/billingRetry) | raw effective status | green |
| Lapsed (expired/revoked) | raw effective status | red |

Client-only (`admin-page.ts`). The sub-block below still shows stored-vs-effective status + periods for the row case.

Follows the credits-admin audit sweep. Touches `admin-page.ts` + `admin-page.test.ts` — same files as open #369; whichever merges second rebases the test (trivial, keep both new tests).

## Test Plan
- [x] TDD red→green; `pnpm vitest run tests/credits-admin/` → 54/54
- [x] Rendered browser JS syntax-checked via `node --check`
- [x] `typecheck` / `eslint` / `prettier --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786641441&installation_id=128169237&pr_number=370&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F370&signature=6b2d5124ce5d9cf5a1bf467c35044e2d10fdc2cb9b78649b5f8084a6bd4b2992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show subscription state chip in credits admin page
> Replaces the 'Entitled'/'Not Entitled' chip in the balances section with a 'Subscription' chip that displays the `effectiveStatus` from `j.subscription`. When no subscription exists, the chip shows 'none' with a neutral `badge-none` style; otherwise it uses `badge-yes` or `badge-no` based on `isEntitled`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48810e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->