### PR TITLE
feat(credits-admin): accounts-filter views + premium restyle

### DIFF
--- a/prisma/migrations/20260715140320_accounts_filter_indexes/migration.sql
+++ b/prisma/migrations/20260715140320_accounts_filter_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "CreditLedger_grantKindId_idx";
+
+-- CreateIndex
+CREATE INDEX "CreditLedger_grantKindId_createdAt_idx" ON "CreditLedger"("grantKindId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CreditLedger_reason_accountId_createdAt_idx" ON "CreditLedger"("reason", "accountId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "UserCredits_balance_idx" ON "UserCredits"("balance");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -328,6 +328,8 @@ model UserCredits {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   account   Account  @relation(fields: [accountId], references: [id])
+
+  @@index([balance])
 }
 
 model GrantKind {
@@ -362,7 +364,8 @@ model CreditLedger {
   @@unique([accountId, idempotencyKey])
   @@index([accountId, createdAt])
   @@index([requestId])
-  @@index([grantKindId])
+  @@index([grantKindId, createdAt])
+  @@index([reason, accountId, createdAt])
 }
 
 enum SubscriptionPeriod {

--- a/src/api/v2/credits-admin/accounts-repository.ts
+++ b/src/api/v2/credits-admin/accounts-repository.ts
@@ -3,19 +3,35 @@ import { prisma } from "@/utils/prisma";
 
 export const ACCOUNTS_LIST_LIMIT = 50;
 
-export type AccountRow = {
+export type BalanceRow = {
   accountId: string;
   balance: bigint;
-  tier?: string;
-  effectiveStatus?: string;
-  currentPeriodEnd?: Date | null;
-  latestGrantAt?: Date | null;
-  lastConsumeAt?: Date | null;
 };
 
-type Page = { rows: AccountRow[]; hasMore: boolean };
+export type BrokenRow = {
+  accountId: string;
+  balance: bigint;
+  tier: string;
+  effectiveStatus: string;
+  currentPeriodEnd: Date;
+};
 
-const page = (rows: AccountRow[], limit: number): Page => ({
+export type GrantKindRow = {
+  accountId: string;
+  balance: bigint;
+  latestGrantAt: Date;
+};
+
+/** `lastConsumeAt` is null for accounts that have never consumed. */
+export type ActivityRow = {
+  accountId: string;
+  balance: bigint;
+  lastConsumeAt: Date | null;
+};
+
+export type Page<T> = { rows: T[]; hasMore: boolean };
+
+const page = <T>(rows: T[], limit: number): Page<T> => ({
   rows: rows.slice(0, limit),
   hasMore: rows.length > limit,
 });
@@ -26,7 +42,7 @@ export const listByBalance = async (args: {
   sort?: "asc" | "desc";
   page?: number;
   limit?: number;
-}): Promise<Page> => {
+}): Promise<Page<BalanceRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
   const balance: Prisma.BigIntFilter = {};
@@ -49,19 +65,11 @@ export const listBrokenSubscribers = async (args: {
   maxBalance?: number;
   page?: number;
   limit?: number;
-}): Promise<Page> => {
+}): Promise<Page<BrokenRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
   const maxBalance = BigInt(args.maxBalance ?? 0);
-  const rows = await prisma.$queryRaw<
-    {
-      accountId: string;
-      balance: bigint;
-      tier: string;
-      effectiveStatus: string;
-      currentPeriodEnd: Date;
-    }[]
-  >`
+  const rows = await prisma.$queryRaw<BrokenRow[]>`
     SELECT uc."accountId", uc.balance,
            sub.tier, sub.status AS "effectiveStatus", sub."currentPeriodEnd"
     FROM "UserCredits" uc
@@ -97,12 +105,10 @@ export const listByGrantKind = async (args: {
   kind: string;
   page?: number;
   limit?: number;
-}): Promise<Page> => {
+}): Promise<Page<GrantKindRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
-  const rows = await prisma.$queryRaw<
-    { accountId: string; balance: bigint; latestGrantAt: Date }[]
-  >`
+  const rows = await prisma.$queryRaw<GrantKindRow[]>`
     SELECT cl."accountId", uc.balance, MAX(cl."createdAt") AS "latestGrantAt"
     FROM "CreditLedger" cl
     JOIN "UserCredits" uc ON uc."accountId" = cl."accountId"
@@ -126,7 +132,7 @@ export const listByActivity = async (args: {
   days?: number;
   page?: number;
   limit?: number;
-}): Promise<Page> => {
+}): Promise<Page<ActivityRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
   const days = args.days ?? 30;
@@ -144,9 +150,7 @@ export const listByActivity = async (args: {
           ORDER BY "lastConsumeAt" DESC, cl."accountId"
           LIMIT ${limit + 1} OFFSET ${skip}
         `
-      : await prisma.$queryRaw<
-          { accountId: string; balance: bigint; lastConsumeAt: Date | null }[]
-        >`
+      : await prisma.$queryRaw<ActivityRow[]>`
           SELECT uc."accountId", uc.balance,
             (SELECT MAX(cl2."createdAt") FROM "CreditLedger" cl2
              WHERE cl2."accountId" = uc."accountId" AND cl2.reason = 'consume') AS "lastConsumeAt"

--- a/src/api/v2/credits-admin/accounts-repository.ts
+++ b/src/api/v2/credits-admin/accounts-repository.ts
@@ -1,0 +1,170 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "@/utils/prisma";
+
+export const ACCOUNTS_LIST_LIMIT = 50;
+
+export type AccountRow = {
+  accountId: string;
+  balance: bigint;
+  tier?: string;
+  effectiveStatus?: string;
+  currentPeriodEnd?: Date | null;
+  latestGrantAt?: Date | null;
+  lastConsumeAt?: Date | null;
+};
+
+type Page = { rows: AccountRow[]; hasMore: boolean };
+
+const page = (rows: AccountRow[], limit: number): Page => ({
+  rows: rows.slice(0, limit),
+  hasMore: rows.length > limit,
+});
+
+export const listByBalance = async (args: {
+  min?: number | null;
+  max?: number | null;
+  sort?: "asc" | "desc";
+  page?: number;
+  limit?: number;
+}): Promise<Page> => {
+  const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
+  const skip = (args.page ?? 0) * limit;
+  const balance: Prisma.BigIntFilter = {};
+  if (args.min != null) balance.gte = BigInt(args.min);
+  if (args.max != null) balance.lte = BigInt(args.max);
+  const rows = await prisma.userCredits.findMany({
+    where: Object.keys(balance).length ? { balance } : {},
+    orderBy: [{ balance: args.sort ?? "desc" }, { accountId: "asc" }],
+    take: limit + 1,
+    skip,
+    select: { accountId: true, balance: true },
+  });
+  return page(
+    rows.map((r) => ({ accountId: r.accountId, balance: r.balance })),
+    limit,
+  );
+};
+
+export const listBrokenSubscribers = async (args: {
+  maxBalance?: number;
+  page?: number;
+  limit?: number;
+}): Promise<Page> => {
+  const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
+  const skip = (args.page ?? 0) * limit;
+  const maxBalance = BigInt(args.maxBalance ?? 0);
+  const rows = await prisma.$queryRaw<
+    {
+      accountId: string;
+      balance: bigint;
+      tier: string;
+      effectiveStatus: string;
+      currentPeriodEnd: Date;
+    }[]
+  >`
+    SELECT uc."accountId", uc.balance,
+           sub.tier, sub.status AS "effectiveStatus", sub."currentPeriodEnd"
+    FROM "UserCredits" uc
+    JOIN LATERAL (
+      SELECT s.tier, s.status, s."currentPeriodEnd"
+      FROM "Subscription" s
+      WHERE s."accountId" = uc."accountId"
+        AND (
+          s.status = 'billingRetry'
+          OR (s.status IN ('active','trial') AND s."currentPeriodEnd" > now())
+          OR (s.status = 'grace' AND COALESCE(s."gracePeriodEnd", s."currentPeriodEnd") > now())
+        )
+      ORDER BY s."currentPeriodEnd" DESC
+      LIMIT 1
+    ) sub ON true
+    WHERE uc.balance <= ${maxBalance}
+    ORDER BY uc.balance ASC, uc."accountId"
+    LIMIT ${limit + 1} OFFSET ${skip}
+  `;
+  return page(
+    rows.map((r) => ({
+      accountId: r.accountId,
+      balance: r.balance,
+      tier: r.tier,
+      effectiveStatus: r.effectiveStatus,
+      currentPeriodEnd: r.currentPeriodEnd,
+    })),
+    limit,
+  );
+};
+
+export const listByGrantKind = async (args: {
+  kind: string;
+  page?: number;
+  limit?: number;
+}): Promise<Page> => {
+  const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
+  const skip = (args.page ?? 0) * limit;
+  const rows = await prisma.$queryRaw<
+    { accountId: string; balance: bigint; latestGrantAt: Date }[]
+  >`
+    SELECT cl."accountId", uc.balance, MAX(cl."createdAt") AS "latestGrantAt"
+    FROM "CreditLedger" cl
+    JOIN "UserCredits" uc ON uc."accountId" = cl."accountId"
+    WHERE cl."grantKindId" = ${args.kind}
+    GROUP BY cl."accountId", uc.balance
+    ORDER BY "latestGrantAt" DESC, cl."accountId"
+    LIMIT ${limit + 1} OFFSET ${skip}
+  `;
+  return page(
+    rows.map((r) => ({
+      accountId: r.accountId,
+      balance: r.balance,
+      latestGrantAt: r.latestGrantAt,
+    })),
+    limit,
+  );
+};
+
+export const listByActivity = async (args: {
+  state: "active" | "dormant";
+  days?: number;
+  page?: number;
+  limit?: number;
+}): Promise<Page> => {
+  const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
+  const skip = (args.page ?? 0) * limit;
+  const days = args.days ?? 30;
+  const rows =
+    args.state === "active"
+      ? await prisma.$queryRaw<
+          { accountId: string; balance: bigint; lastConsumeAt: Date }[]
+        >`
+          SELECT cl."accountId", uc.balance, MAX(cl."createdAt") AS "lastConsumeAt"
+          FROM "CreditLedger" cl
+          JOIN "UserCredits" uc ON uc."accountId" = cl."accountId"
+          WHERE cl.reason = 'consume'
+            AND cl."createdAt" >= now() - (${days} * interval '1 day')
+          GROUP BY cl."accountId", uc.balance
+          ORDER BY "lastConsumeAt" DESC, cl."accountId"
+          LIMIT ${limit + 1} OFFSET ${skip}
+        `
+      : await prisma.$queryRaw<
+          { accountId: string; balance: bigint; lastConsumeAt: Date | null }[]
+        >`
+          SELECT uc."accountId", uc.balance,
+            (SELECT MAX(cl2."createdAt") FROM "CreditLedger" cl2
+             WHERE cl2."accountId" = uc."accountId" AND cl2.reason = 'consume') AS "lastConsumeAt"
+          FROM "UserCredits" uc
+          WHERE NOT EXISTS (
+            SELECT 1 FROM "CreditLedger" cl
+            WHERE cl."accountId" = uc."accountId" AND cl.reason = 'consume'
+              AND cl."createdAt" >= now() - (${days} * interval '1 day')
+          )
+          ORDER BY "lastConsumeAt" DESC NULLS LAST, uc."accountId"
+          LIMIT ${limit + 1} OFFSET ${skip}
+        `;
+  return page(
+    rows.map((r) => ({
+      accountId: r.accountId,
+      balance: r.balance,
+      lastConsumeAt: r.lastConsumeAt,
+    })),
+    limit,
+  );
+};

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
 import { accountViewGetHandler } from "./handlers/account-view-get";
+import { accountsListGetHandler } from "./handlers/accounts-list-get";
 import { adjustPostHandler } from "./handlers/adjust-post";
 import { adminPageHandler } from "./handlers/admin-page";
 import { auditGetHandler } from "./handlers/audit-get";
@@ -29,6 +30,11 @@ creditsAdminRouter.get(
   "/audit/recent",
   creditsAdminTokenAuth,
   auditRecentGetHandler,
+);
+creditsAdminRouter.get(
+  "/accounts",
+  creditsAdminTokenAuth,
+  accountsListGetHandler,
 );
 creditsAdminRouter.get(
   "/accounts/:accountId",

--- a/src/api/v2/credits-admin/handlers/accounts-list-get.ts
+++ b/src/api/v2/credits-admin/handlers/accounts-list-get.ts
@@ -62,6 +62,14 @@ export const accountsListGetHandler = async (
           })),
         };
       }
+      default: {
+        // Forcing function: a new mode in accountsListQuerySchema that isn't
+        // handled above narrows to that mode here instead of `never`, so this
+        // assignment fails to compile. Load-bearing — do not delete.
+        const _exhaustive: never = q;
+        void _exhaustive;
+        throw new Error("unhandled accounts-list mode");
+      }
     }
   })();
   res.status(200).json({

--- a/src/api/v2/credits-admin/handlers/accounts-list-get.ts
+++ b/src/api/v2/credits-admin/handlers/accounts-list-get.ts
@@ -1,0 +1,73 @@
+import type { Request, Response } from "express";
+import {
+  listBrokenSubscribers,
+  listByActivity,
+  listByBalance,
+  listByGrantKind,
+} from "../accounts-repository";
+import { accountsListQuerySchema } from "../schemas/requests";
+
+const base = (r: { accountId: string; balance: bigint }) => ({
+  accountId: r.accountId,
+  balanceCredits: r.balance.toString(),
+});
+
+export const accountsListGetHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const parsed = accountsListQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", details: parsed.error.errors });
+    return;
+  }
+  const q = parsed.data;
+  const listed = await (async () => {
+    switch (q.mode) {
+      case "balance": {
+        const p = await listByBalance(q);
+        return { hasMore: p.hasMore, rows: p.rows.map(base) };
+      }
+      case "broken": {
+        const p = await listBrokenSubscribers(q);
+        return {
+          hasMore: p.hasMore,
+          rows: p.rows.map((r) => ({
+            ...base(r),
+            tier: r.tier,
+            effectiveStatus: r.effectiveStatus,
+            currentPeriodEnd: r.currentPeriodEnd.toISOString(),
+          })),
+        };
+      }
+      case "grantKind": {
+        const p = await listByGrantKind(q);
+        return {
+          hasMore: p.hasMore,
+          rows: p.rows.map((r) => ({
+            ...base(r),
+            latestGrantAt: r.latestGrantAt.toISOString(),
+          })),
+        };
+      }
+      case "activity": {
+        const p = await listByActivity(q);
+        return {
+          hasMore: p.hasMore,
+          rows: p.rows.map((r) => ({
+            ...base(r),
+            lastConsumeAt: r.lastConsumeAt?.toISOString() ?? null,
+          })),
+        };
+      }
+    }
+  })();
+  res.status(200).json({
+    mode: q.mode,
+    page: q.page,
+    hasMore: listed.hasMore,
+    rows: listed.rows,
+  });
+};

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -54,7 +54,7 @@ export const consoleView = (): string => `
       </div>
     </aside>
     <section class="center">
-      <h2 style="font-size:16px;margin:0 0 12px">Recent admin activity</h2>
+      <h2 id="center-title" style="font-size:16px;margin:0 0 12px">Recent admin activity</h2>
       <div class="tablewrap">
         <table id="activity-table">
           <thead><tr><th>When</th><th>Actor</th><th>Account</th><th>Action</th><th>Δ</th><th>Reason</th></tr></thead>

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -55,7 +55,7 @@ export const consoleView = (): string => `
     </aside>
     <section class="center">
       <h2 id="center-title" style="font-size:16px;margin:0 0 12px">Recent admin activity</h2>
-      <div class="tablewrap">
+      <div id="activity-wrap" class="tablewrap">
         <table id="activity-table">
           <thead><tr><th>When</th><th>Actor</th><th>Account</th><th>Action</th><th>Δ</th><th>Reason</th></tr></thead>
           <tbody></tbody>

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -16,10 +16,41 @@ export const consoleView = (): string => `
         <button id="search-btn" class="btn btn-primary" style="width:100%;margin-top:8px">Search</button>
       </div>
       <div>
+        <label for="view-mode">View</label>
+        <select id="view-mode">
+          <option value="activity">Activity feed</option>
+          <option value="balance">Balance</option>
+          <option value="broken">Broken subs</option>
+          <option value="grantKind">Grant kind</option>
+          <option value="active">Active users</option>
+          <option value="dormant">Dormant users</option>
+        </select>
+      </div>
+      <div id="facet-group">
         <div style="font-size:12px;color:var(--muted);margin-bottom:6px">Filter activity</div>
         <span class="facet active" data-action="all">All</span>
         <span class="facet" data-action="grant">Grants</span>
         <span class="facet" data-action="adjust">Adjusts</span>
+      </div>
+      <div id="ctl-balance" class="mode-ctl hidden">
+        <input id="bal-min" type="number" placeholder="min credits">
+        <input id="bal-max" type="number" placeholder="max credits">
+        <select id="bal-sort"><option value="desc">High → low</option><option value="asc">Low → high</option></select>
+      </div>
+      <div id="ctl-broken" class="mode-ctl hidden">
+        <input id="broken-max" type="number" value="0" placeholder="max balance (≤)">
+      </div>
+      <div id="ctl-grantKind" class="mode-ctl hidden">
+        <select id="gk-kind">
+          <option value="signup_bonus">signup_bonus</option>
+          <option value="daily_refill">daily_refill</option>
+          <option value="manual">manual</option>
+          <option value="sub_grant">sub_grant</option>
+          <option value="sub_forfeit">sub_forfeit</option>
+        </select>
+      </div>
+      <div id="ctl-activity" class="mode-ctl hidden">
+        <input id="act-days" type="number" value="30" placeholder="days">
       </div>
     </aside>
     <section class="center">
@@ -29,6 +60,9 @@ export const consoleView = (): string => `
           <thead><tr><th>When</th><th>Actor</th><th>Account</th><th>Action</th><th>Δ</th><th>Reason</th></tr></thead>
           <tbody></tbody>
         </table>
+      </div>
+      <div id="accounts-wrap" class="tablewrap hidden">
+        <table id="accounts-table"><thead><tr id="accounts-head"></tr></thead><tbody></tbody></table>
       </div>
       <div id="activity-empty" class="hidden" style="color:var(--muted);padding:12px">No matching activity.</div>
       <button id="load-more" class="btn btn-secondary hidden" style="margin-top:12px">Load more</button>

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -4,18 +4,18 @@ export const consoleView = (): string => `
     <span class="brand" id="brand">💳 Credits Admin</span>
     <div class="header-right">
       <span id="identity"></span>
-      <button id="lock" class="btn btn-secondary" style="padding:6px 12px">Lock</button>
+      <button id="lock" class="btn btn-secondary btn-sm">Lock</button>
     </div>
   </header>
   <div class="console-grid">
     <aside class="rail">
-      <div>
+      <div class="rail-sec">
         <label for="search-value">Find account</label>
         <select id="search-key"><option value="accountId">accountId</option><option value="wallet">wallet</option></select>
         <input id="search-value" placeholder="accountId or wallet">
-        <button id="search-btn" class="btn btn-primary" style="width:100%;margin-top:8px">Search</button>
+        <button id="search-btn" class="btn btn-primary btn-block">Search</button>
       </div>
-      <div>
+      <div class="rail-sec">
         <label for="view-mode">View</label>
         <select id="view-mode">
           <option value="activity">Activity feed</option>
@@ -27,7 +27,7 @@ export const consoleView = (): string => `
         </select>
       </div>
       <div id="facet-group">
-        <div style="font-size:12px;color:var(--muted);margin-bottom:6px">Filter activity</div>
+        <div class="rail-label">Filter activity</div>
         <span class="facet active" data-action="all">All</span>
         <span class="facet" data-action="grant">Grants</span>
         <span class="facet" data-action="adjust">Adjusts</span>
@@ -54,18 +54,18 @@ export const consoleView = (): string => `
       </div>
     </aside>
     <section class="center">
-      <h2 id="center-title" style="font-size:16px;margin:0 0 12px">Recent admin activity</h2>
+      <h2 id="center-title" class="center-title">Recent admin activity</h2>
       <div id="activity-wrap" class="tablewrap">
         <table id="activity-table">
-          <thead><tr><th>When</th><th>Actor</th><th>Account</th><th>Action</th><th>Δ</th><th>Reason</th></tr></thead>
+          <thead><tr><th>When</th><th>Actor</th><th>Account</th><th>Action</th><th class="num">Δ</th><th>Reason</th></tr></thead>
           <tbody></tbody>
         </table>
       </div>
       <div id="accounts-wrap" class="tablewrap hidden">
         <table id="accounts-table"><thead><tr id="accounts-head"></tr></thead><tbody></tbody></table>
       </div>
-      <div id="activity-empty" class="hidden" style="color:var(--muted);padding:12px">No matching activity.</div>
-      <button id="load-more" class="btn btn-secondary hidden" style="margin-top:12px">Load more</button>
+      <div id="activity-empty" class="empty hidden">No matching activity.</div>
+      <button id="load-more" class="btn btn-secondary hidden">Load more</button>
     </section>
   </div>
   <div id="detail-scrim" class="detail-scrim hidden"></div>

--- a/src/api/v2/credits-admin/handlers/admin-page/login-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/login-view.ts
@@ -6,6 +6,6 @@ export const loginView = (): string => `
     <label for="token-input">Admin token</label>
     <input id="token-input" type="password" placeholder="paste CREDITS_ADMIN_API_TOKEN" autocomplete="off">
     <div id="login-error"></div>
-    <button id="unlock" class="btn btn-primary btn-block" style="margin-top:14px">Unlock</button>
+    <button id="unlock" class="btn btn-primary btn-block">Unlock</button>
   </div>
 </div>`;

--- a/src/api/v2/credits-admin/handlers/admin-page/login-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/login-view.ts
@@ -2,9 +2,10 @@ export const loginView = (): string => `
 <div id="login">
   <div class="login-card">
     <h1>💳 Credits Admin</h1>
+    <div class="login-sub">Restricted — internal operations</div>
     <label for="token-input">Admin token</label>
     <input id="token-input" type="password" placeholder="paste CREDITS_ADMIN_API_TOKEN" autocomplete="off">
     <div id="login-error"></div>
-    <button id="unlock" class="btn btn-primary" style="width:100%;margin-top:14px">Unlock</button>
+    <button id="unlock" class="btn btn-primary btn-block" style="margin-top:14px">Unlock</button>
   </div>
 </div>`;

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -75,10 +75,11 @@ export const clientScript = (): string => `
       activityCursor=j.nextCursor;
       el("load-more").classList.toggle("hidden", !j.nextCursor);
       var empty = reset && (!j.rows || j.rows.length===0);
+      el("activity-empty").textContent = "No matching activity.";
       el("activity-empty").classList.toggle("hidden", !empty);
     }).catch(function(e){ if(e.message!=="reauth") toast("Failed to load activity","error"); });
   }
-  el("load-more").addEventListener("click", function(){ loadActivity(false); });
+  el("load-more").addEventListener("click", function(){ if(currentView==="activity"){ loadActivity(false); } else { loadAccounts(false); } });
   Array.prototype.forEach.call(document.querySelectorAll(".facet"), function(f){
     f.addEventListener("click", function(){
       Array.prototype.forEach.call(document.querySelectorAll(".facet"), function(x){ x.classList.remove("active"); });
@@ -97,6 +98,75 @@ export const clientScript = (): string => `
   }
   el("search-btn").addEventListener("click", doSearch);
   el("search-value").addEventListener("keydown", function(e){ if(e.key==="Enter") doSearch(); });
+  var currentView="activity";
+  var accountsGen=0;
+  var accountsMode={balance:"balance",broken:"broken",grantKind:"grantKind",active:"activity",dormant:"activity"};
+  function accountsPage(){ return el("accounts-wrap"); }
+  function showModeControls(view){
+    Array.prototype.forEach.call(document.querySelectorAll(".mode-ctl"), function(c){ c.classList.add("hidden"); });
+    el("facet-group").classList.toggle("hidden", view!=="activity");
+    if(view==="balance") el("ctl-balance").classList.remove("hidden");
+    else if(view==="broken") el("ctl-broken").classList.remove("hidden");
+    else if(view==="grantKind") el("ctl-grantKind").classList.remove("hidden");
+    else if(view==="active"||view==="dormant") el("ctl-activity").classList.remove("hidden");
+  }
+  function accountsQuery(view, pageNo){
+    var qs="?mode="+encodeURIComponent(accountsMode[view])+"&page="+pageNo;
+    if(view==="balance"){ var mn=el("bal-min").value, mx=el("bal-max").value;
+      if(mn!=="") qs+="&min="+encodeURIComponent(mn); if(mx!=="") qs+="&max="+encodeURIComponent(mx);
+      qs+="&sort="+encodeURIComponent(el("bal-sort").value); }
+    else if(view==="broken"){ qs+="&maxBalance="+encodeURIComponent(el("broken-max").value||"0"); }
+    else if(view==="grantKind"){ qs+="&kind="+encodeURIComponent(el("gk-kind").value); }
+    else if(view==="active"||view==="dormant"){ qs+="&state="+(view==="active"?"active":"dormant")+"&days="+encodeURIComponent(el("act-days").value||"30"); }
+    return qs;
+  }
+  var accountsPageNo=0;
+  var accountCols={
+    balance:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}]],
+    broken:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Tier",function(r){return r.tier||"—";}],["Status",function(r){return r.effectiveStatus||"—";}]],
+    grantKind:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Latest grant",function(r){return fmtDate(r.latestGrantAt);}]],
+    active:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Last consume",function(r){return fmtDate(r.lastConsumeAt);}]],
+    dormant:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Last consume",function(r){return fmtDate(r.lastConsumeAt);}]]
+  };
+  function renderAccountRows(rows, view, append){
+    var cols=accountCols[view];
+    el("accounts-head").innerHTML=cols.map(function(c){ return "<th>"+esc(c[0])+"</th>"; }).join("");
+    var tb=document.querySelector("#accounts-table tbody");
+    var html=(rows||[]).map(function(r){
+      return '<tr class="row-clickable" data-account="'+esc(r.accountId)+'">'
+        +cols.map(function(c){ return "<td>"+esc(c[1](r))+"</td>"; }).join("")+"</tr>";
+    }).join("");
+    if(append){ tb.insertAdjacentHTML("beforeend", html); } else { tb.innerHTML=html; }
+    Array.prototype.forEach.call(document.querySelectorAll("#accounts-table tbody tr.row-clickable"), function(tr){
+      tr.onclick=function(){ openDetail(tr.getAttribute("data-account")); };
+    });
+  }
+  function loadAccounts(reset){
+    if(reset){ accountsPageNo=0; } else { accountsPageNo++; }
+    var view=currentView, gen=++accountsGen;
+    guardFetch("/accounts"+accountsQuery(view, accountsPageNo)).then(function(r){ if(!r.ok){ throw new Error("load_failed"); } return r.json(); }).then(function(j){
+      if(gen!==accountsGen) return;
+      renderAccountRows(j.rows||[], view, !reset);
+      el("load-more").classList.toggle("hidden", !j.hasMore);
+      var empty = reset && (!j.rows || j.rows.length===0);
+      el("activity-empty").textContent = empty ? "No matching accounts." : "No matching activity.";
+      el("activity-empty").classList.toggle("hidden", !empty);
+    }).catch(function(e){ if(e.message!=="reauth") toast("Failed to load accounts","error"); });
+  }
+  function setView(view){
+    currentView=view;
+    showModeControls(view);
+    var isActivity = view==="activity";
+    el("activity-table").parentNode.classList.toggle("hidden", !isActivity);
+    accountsPage().classList.toggle("hidden", isActivity);
+    el("activity-empty").classList.add("hidden");
+    el("load-more").classList.add("hidden");
+    if(isActivity){ loadActivity(true); } else { loadAccounts(true); }
+  }
+  el("view-mode").addEventListener("change", function(){ setView(el("view-mode").value); });
+  Array.prototype.forEach.call(document.querySelectorAll(".mode-ctl input, .mode-ctl select"), function(c){
+    c.addEventListener("change", function(){ if(currentView!=="activity") loadAccounts(true); });
+  });
   var currentAccountId=null;
   function subChip(j){
     var state=j.subscription?j.subscription.effectiveStatus:"none";

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -169,7 +169,7 @@ export const clientScript = (): string => `
     showModeControls(view);
     el("center-title").textContent=viewTitles[view];
     var isActivity = view==="activity";
-    el("activity-table").parentNode.classList.toggle("hidden", !isActivity);
+    el("activity-wrap").classList.toggle("hidden", !isActivity);
     accountsPage().classList.toggle("hidden", isActivity);
     el("activity-empty").classList.add("hidden");
     el("load-more").classList.add("hidden");

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -155,11 +155,12 @@ export const clientScript = (): string => `
     });
   }
   function loadAccounts(reset){
-    if(reset){ accountsPageNo=0; } else { accountsPageNo++; }
-    var view=currentView, gen=++accountsGen;
-    guardFetch("/accounts"+accountsQuery(view, accountsPageNo)).then(function(r){ if(!r.ok){ throw new Error("load_failed"); } return r.json(); }).then(function(j){
+    if(reset){ accountsPageNo=0; }
+    var view=currentView, gen=++accountsGen, pageNo=reset?0:accountsPageNo+1;
+    guardFetch("/accounts"+accountsQuery(view, pageNo)).then(function(r){ if(!r.ok){ throw new Error("load_failed"); } return r.json(); }).then(function(j){
       if(gen!==accountsGen) return;
       if(view!==currentView) return;
+      accountsPageNo=pageNo;
       renderAccountRows(j.rows||[], view, !reset);
       el("load-more").classList.toggle("hidden", !j.hasMore);
       var empty = reset && (!j.rows || j.rows.length===0);

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -122,12 +122,21 @@ export const clientScript = (): string => `
     return qs;
   }
   var accountsPageNo=0;
+  var userListCols=[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Last consume",function(r){return fmtDate(r.lastConsumeAt);}]];
   var accountCols={
     balance:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}]],
     broken:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Tier",function(r){return r.tier||"—";}],["Status",function(r){return r.effectiveStatus||"—";}]],
     grantKind:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Latest grant",function(r){return fmtDate(r.latestGrantAt);}]],
-    active:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Last consume",function(r){return fmtDate(r.lastConsumeAt);}]],
-    dormant:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Last consume",function(r){return fmtDate(r.lastConsumeAt);}]]
+    active:userListCols,
+    dormant:userListCols
+  };
+  var viewTitles={
+    activity:"Recent admin activity",
+    balance:"Accounts by balance",
+    broken:"Broken subscribers",
+    grantKind:"Accounts by grant kind",
+    active:"Active users",
+    dormant:"Dormant users"
   };
   function renderAccountRows(rows, view, append){
     var cols=accountCols[view];
@@ -158,6 +167,7 @@ export const clientScript = (): string => `
   function setView(view){
     currentView=view;
     showModeControls(view);
+    el("center-title").textContent=viewTitles[view];
     var isActivity = view==="activity";
     el("activity-table").parentNode.classList.toggle("hidden", !isActivity);
     accountsPage().classList.toggle("hidden", isActivity);

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -71,6 +71,7 @@ export const clientScript = (): string => `
     var qs="?action="+encodeURIComponent(activityAction)+(activityCursor?("&cursor="+encodeURIComponent(activityCursor)):"");
     guardFetch("/audit/recent"+qs).then(function(r){ if(!r.ok){ throw new Error("load_failed"); } return r.json(); }).then(function(j){
       if(gen!==activityGen) return;
+      if(currentView!=="activity") return;
       renderActivityRows(j.rows||[], !reset);
       activityCursor=j.nextCursor;
       el("load-more").classList.toggle("hidden", !j.nextCursor);
@@ -146,10 +147,11 @@ export const clientScript = (): string => `
     var view=currentView, gen=++accountsGen;
     guardFetch("/accounts"+accountsQuery(view, accountsPageNo)).then(function(r){ if(!r.ok){ throw new Error("load_failed"); } return r.json(); }).then(function(j){
       if(gen!==accountsGen) return;
+      if(view!==currentView) return;
       renderAccountRows(j.rows||[], view, !reset);
       el("load-more").classList.toggle("hidden", !j.hasMore);
       var empty = reset && (!j.rows || j.rows.length===0);
-      el("activity-empty").textContent = empty ? "No matching accounts." : "No matching activity.";
+      el("activity-empty").textContent = "No matching accounts.";
       el("activity-empty").classList.toggle("hidden", !empty);
     }).catch(function(e){ if(e.message!=="reauth") toast("Failed to load accounts","error"); });
   }

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -57,8 +57,8 @@ export const clientScript = (): string => `
     var tb=document.querySelector("#activity-table tbody");
     var html=rows.map(function(r){
       return '<tr class="row-clickable" data-account="'+esc(r.accountId)+'">'
-        +"<td>"+fmtDate(r.createdAt)+"</td><td>"+esc(r.actorEmail)+"</td><td>"+esc(shortId(r.accountId))
-        +"</td><td>"+esc(r.action)+"</td><td>"+esc(r.deltaCredits)+"</td><td>"+esc(r.reason)+"</td></tr>";
+        +'<td class="nowrap">'+fmtDate(r.createdAt)+"</td><td>"+esc(r.actorEmail)+'</td><td class="mono">'+esc(shortId(r.accountId))
+        +"</td><td>"+esc(r.action)+'</td><td class="num">'+esc(r.deltaCredits)+"</td><td>"+esc(r.reason)+"</td></tr>";
     }).join("");
     if(append){ tb.insertAdjacentHTML("beforeend", html); } else { tb.innerHTML=html; }
     Array.prototype.forEach.call(document.querySelectorAll("#activity-table tbody tr.row-clickable"), function(tr){
@@ -122,11 +122,13 @@ export const clientScript = (): string => `
     return qs;
   }
   var accountsPageNo=0;
-  var userListCols=[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Last consume",function(r){return fmtDate(r.lastConsumeAt);}]];
+  var colAccount=["Account",function(r){return shortId(r.accountId);},"mono"];
+  var colBalance=["Balance",function(r){return fmtCredits(r.balanceCredits);},"num"];
+  var userListCols=[colAccount,colBalance,["Last consume",function(r){return fmtDate(r.lastConsumeAt);},"nowrap"]];
   var accountCols={
-    balance:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}]],
-    broken:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Tier",function(r){return r.tier||"—";}],["Status",function(r){return r.effectiveStatus||"—";}]],
-    grantKind:[["Account",function(r){return shortId(r.accountId);}],["Balance",function(r){return fmtCredits(r.balanceCredits);}],["Latest grant",function(r){return fmtDate(r.latestGrantAt);}]],
+    balance:[colAccount,colBalance],
+    broken:[colAccount,colBalance,["Tier",function(r){return r.tier||"—";}],["Status",function(r){return r.effectiveStatus||"—";}]],
+    grantKind:[colAccount,colBalance,["Latest grant",function(r){return fmtDate(r.latestGrantAt);},"nowrap"]],
     active:userListCols,
     dormant:userListCols
   };
@@ -140,11 +142,12 @@ export const clientScript = (): string => `
   };
   function renderAccountRows(rows, view, append){
     var cols=accountCols[view];
-    el("accounts-head").innerHTML=cols.map(function(c){ return "<th>"+esc(c[0])+"</th>"; }).join("");
+    function colCls(c){ return c[2]?' class="'+c[2]+'"':""; }
+    el("accounts-head").innerHTML=cols.map(function(c){ return "<th"+colCls(c)+">"+esc(c[0])+"</th>"; }).join("");
     var tb=document.querySelector("#accounts-table tbody");
     var html=(rows||[]).map(function(r){
       return '<tr class="row-clickable" data-account="'+esc(r.accountId)+'">'
-        +cols.map(function(c){ return "<td>"+esc(c[1](r))+"</td>"; }).join("")+"</tr>";
+        +cols.map(function(c){ return "<td"+colCls(c)+">"+esc(c[1](r))+"</td>"; }).join("")+"</tr>";
     }).join("");
     if(append){ tb.insertAdjacentHTML("beforeend", html); } else { tb.innerHTML=html; }
     Array.prototype.forEach.call(document.querySelectorAll("#accounts-table tbody tr.row-clickable"), function(tr){
@@ -186,13 +189,16 @@ export const clientScript = (): string => `
     return '<span class="badge '+cls+'">'+esc(state)+"</span>";
   }
   function renderSpark(usage){
-    if(!usage||!usage.length) return '<span style="color:var(--muted)">No usage in the last 30 days.</span>';
+    if(!usage||!usage.length) return '<span class="muted-note">No usage in the last 30 days.</span>';
     var max=usage.reduce(function(m,u){ var c=Number(u.consumed); return c>m?c:m; },0);
     return usage.map(function(u){ var c=Number(u.consumed); var h=max>0?Math.max(2,Math.round(c/max*100)):2;
       return '<div class="bar" style="height:'+h+'%" title="'+esc(u.bucketStart+" · "+fmtCredits(u.consumed)+" credits")+'"></div>'; }).join("");
   }
   function rowsHtml(rows, cols){
-    return (rows||[]).map(function(r){ return "<tr>"+cols.map(function(c){ return "<td>"+c(r)+"</td>"; }).join("")+"</tr>"; }).join("");
+    return (rows||[]).map(function(r){ return "<tr>"+cols.map(function(c){
+      var fn = typeof c==="function" ? c : c[0], cls = typeof c==="function" ? "" : c[1];
+      return "<td"+(cls?' class="'+cls+'"':"")+">"+fn(r)+"</td>";
+    }).join("")+"</tr>"; }).join("");
   }
   function renderDetail(j){
     var sub=j.subscription;
@@ -206,12 +212,12 @@ export const clientScript = (): string => `
         +"<tr><th>Allotment (per period)</th><td>"+fmtCredits(sub.perPeriodCredits)+" credits</td></tr>"
         +"<tr><th>Period consumes</th><td>"+fmtCredits(j.periodConsumesCredits)+" credits</td></tr>"
         +"</tbody></table>"
-      : '<div style="color:var(--muted)">No subscription on record.</div>';
+      : '<div class="muted-note">No subscription on record.</div>';
     el("detail-body").innerHTML =
-      '<h2 style="font-size:16px">Account '+esc(shortId(j.accountId))+'</h2>'
-      +'<div class="card"><div class="k">Balance</div><div style="font-size:22px;font-weight:700">'+fmtCredits(j.balanceCredits)+'</div>'
+      '<h2 class="detail-title">Account <span class="mono">'+esc(shortId(j.accountId))+'</span></h2>'
+      +'<div class="card"><div class="k">Balance</div><div class="balance-value">'+fmtCredits(j.balanceCredits)+'</div>'
       +'<div class="k">'+usdHint(j.balanceCredits)+'</div>'
-      +'<div style="margin-top:6px">Subscription: '+subChip(j)+'</div></div>'
+      +'<div class="sub-line">Subscription: '+subChip(j)+'</div></div>'
       +'<div class="card">'+subBlock+'</div>'
       +'<div class="card"><h3>Grant</h3><input id="d-grant-credits" type="number" min="1" placeholder="credits"><input id="d-grant-reason" placeholder="reason"><button id="d-grant-btn" class="btn btn-primary">Grant</button></div>'
       +'<div class="card"><h3>Adjust</h3><input id="d-adjust-delta" type="number" placeholder="±credits"><input id="d-adjust-reason" placeholder="reason"><button id="d-adjust-btn" class="btn btn-danger">Adjust</button></div>'
@@ -221,20 +227,20 @@ export const clientScript = (): string => `
       +'<div class="card"><h3>Admin audit</h3><div class="tablewrap"><table><tbody id="d-audit"></tbody></table></div></div>';
     el("usage-spark").innerHTML = renderSpark(j.usageDaily);
     el("d-refills").innerHTML = (j.dailyRefills&&j.dailyRefills.length)
-      ? rowsHtml(j.dailyRefills,[function(r){return fmtDate(r.createdAt);},function(r){return esc(r.delta);},function(r){return esc(r.note||"");}])
-      : '<tr><td style="color:var(--muted)">No daily refills.</td></tr>';
-    el("d-ledger").innerHTML = rowsHtml(j.ledger,[function(r){return fmtDate(r.createdAt);},function(r){return esc(r.delta);},function(r){return esc(r.reason);},function(r){return esc(r.grantKindId||"—");},function(r){return esc(r.note||"");}]);
+      ? rowsHtml(j.dailyRefills,[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.note||"");}])
+      : '<tr><td class="muted-note">No daily refills.</td></tr>';
+    el("d-ledger").innerHTML = rowsHtml(j.ledger,[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.reason);},[function(r){return esc(r.grantKindId||"—");},"mono"],function(r){return esc(r.note||"");}]);
     el("d-grant-btn").addEventListener("click", function(){ mutate("grant"); });
     el("d-adjust-btn").addEventListener("click", function(){ mutate("adjust"); });
   }
   function loadAudit(accountId){
     guardFetch("/audit?accountId="+encodeURIComponent(accountId)).then(function(r){ return r.json(); }).then(function(j){
-      el("d-audit").innerHTML = rowsHtml(j.audit,[function(r){return fmtDate(r.createdAt);},function(r){return esc(r.actorEmail);},function(r){return esc(r.action);},function(r){return esc(r.deltaCredits);},function(r){return esc(r.reason);}]);
+      el("d-audit").innerHTML = rowsHtml(j.audit,[[function(r){return fmtDate(r.createdAt);},"nowrap"],function(r){return esc(r.actorEmail);},function(r){return esc(r.action);},[function(r){return esc(r.deltaCredits);},"num"],function(r){return esc(r.reason);}]);
     }).catch(function(){});
   }
   function openDetail(accountId){
     currentAccountId=accountId;
-    el("detail-body").innerHTML='<div style="color:var(--muted)">Loading…</div>';
+    el("detail-body").innerHTML='<div class="muted-note">Loading…</div>';
     el("detail").classList.add("open"); el("detail").setAttribute("aria-hidden","false"); el("detail-scrim").classList.remove("hidden");
     guardFetch("/accounts/"+encodeURIComponent(accountId)).then(function(r){ if(r.status===404){ throw new Error("not_found"); } return r.json(); })
       .then(function(j){ renderDetail(j); loadAudit(accountId); })

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -215,10 +215,10 @@ export const clientScript = (): string => `
       : '<div class="muted-note">No subscription on record.</div>';
     el("detail-body").innerHTML =
       '<h2 class="detail-title">Account <span class="mono">'+esc(shortId(j.accountId))+'</span></h2>'
-      +'<div class="card"><div class="k">Balance</div><div class="balance-value">'+fmtCredits(j.balanceCredits)+'</div>'
-      +'<div class="k">'+usdHint(j.balanceCredits)+'</div>'
+      +'<div class="card"><h3 class="tight">Balance</h3><div class="balance-value">'+fmtCredits(j.balanceCredits)+'</div>'
+      +'<div class="balance-hint">'+usdHint(j.balanceCredits)+'</div>'
       +'<div class="sub-line">Subscription: '+subChip(j)+'</div></div>'
-      +'<div class="card">'+subBlock+'</div>'
+      +'<div class="card"><h3>Subscription</h3>'+subBlock+'</div>'
       +'<div class="card"><h3>Grant</h3><input id="d-grant-credits" type="number" min="1" placeholder="credits"><input id="d-grant-reason" placeholder="reason"><button id="d-grant-btn" class="btn btn-primary">Grant</button></div>'
       +'<div class="card"><h3>Adjust</h3><input id="d-adjust-delta" type="number" placeholder="±credits"><input id="d-adjust-reason" placeholder="reason"><button id="d-adjust-btn" class="btn btn-danger">Adjust</button></div>'
       +'<div class="card"><h3>Usage (30d)</h3><div id="usage-spark" class="spark"></div></div>'

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -28,6 +28,8 @@ export const STYLES = `
   .center { overflow:auto; padding:16px; }
   .facet { display:inline-block; padding:6px 12px; border-radius:999px; border:1px solid var(--edge); cursor:pointer; font-size:13px; background:var(--surface); }
   .facet.active { background:var(--brand); color:#fff; border-color:var(--brand); }
+  .mode-ctl { display:flex; flex-direction:column; gap:8px; }
+  .mode-ctl input, .mode-ctl select, #view-mode, #search-key { width:100%; padding:8px; border:1px solid #d2d2d7; border-radius:8px; font-size:14px; }
 
   /* Buttons / badges / tables / toast / spark — reuse from prior page */
   .btn { padding:10px 16px; border:none; border-radius:8px; font-size:14px; font-weight:600; cursor:pointer; }

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -1,67 +1,222 @@
 export const STYLES = `
   :root {
-    --brand: #0071e3; --fg: #1d1d1f; --muted: #6e6e73; --surface: #fff;
-    --bg: #f5f5f7; --edge: #ececec; --ok: #14752a; --bad: #a3151f;
-    --rail-w: 260px; --header-h: 56px; --radius: 12px;
+    --brand: #0b5cff; --brand-strong: #0847cc; --brand-weak: #eef3ff;
+    --brand-ring: rgba(11,92,255,.28);
+    --fg: #0c111d; --fg-2: #344054; --muted: #667085;
+    --surface: #fff; --surface-2: #f9fafb; --bg: #f2f4f7;
+    --edge: #e4e7ec; --edge-2: #d0d5dd;
+    --ok: #067647; --ok-bg: #e7f6ee; --ok-solid: #079455;
+    --bad: #b42318; --bad-bg: #fee4e2; --bad-solid: #d92d20; --bad-strong: #912018;
+    --rail-w: 260px; --header-h: 60px; --center-max: 1160px;
+    --radius-sm: 8px; --radius: 12px; --radius-lg: 16px;
+    --shadow-1: 0 1px 2px rgba(16,24,40,.04), 0 1px 3px rgba(16,24,40,.06);
+    --shadow-2: 0 2px 4px -1px rgba(16,24,40,.05), 0 8px 16px -4px rgba(16,24,40,.08);
+    --shadow-pop: 0 12px 24px -8px rgba(16,24,40,.18), 0 32px 64px -16px rgba(16,24,40,.22);
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
     --ease: cubic-bezier(0.22, 1, 0.36, 1);
   }
   * { box-sizing: border-box; }
-  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; color:var(--fg); background:var(--bg); }
+  body {
+    margin:0; font-family:var(--sans); color:var(--fg); background:var(--bg);
+    -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+  }
   .hidden { display:none !important; }
+  :focus-visible { outline:2px solid var(--brand); outline-offset:2px; }
 
   /* Login */
-  #login { min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px; }
-  .login-card { background:var(--surface); border-radius:var(--radius); padding:28px; width:min(380px,92vw); box-shadow:0 1px 3px rgba(0,0,0,.1); }
-  .login-card h1 { font-size:20px; margin:0 0 16px; }
-  .login-card input { width:100%; padding:12px; border:1px solid #d2d2d7; border-radius:8px; font-size:15px; }
-  #login-error { color:var(--bad); font-size:13px; margin-top:10px; min-height:16px; }
+  #login {
+    min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px;
+    background:
+      radial-gradient(120% 90% at 50% -10%, #fff 0%, rgba(255,255,255,0) 60%),
+      radial-gradient(80% 60% at 85% 110%, var(--brand-weak) 0%, rgba(238,243,255,0) 70%),
+      var(--bg);
+  }
+  .login-card {
+    background:var(--surface); border:1px solid var(--edge); border-radius:var(--radius-lg);
+    padding:32px; width:min(400px,92vw); box-shadow:var(--shadow-2);
+  }
+  .login-card h1 { font-size:20px; font-weight:650; letter-spacing:-0.02em; margin:0 0 4px; }
+  .login-sub { font-size:12px; color:var(--muted); margin:0 0 24px; }
+  .login-card label {
+    display:block; font-size:11px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.06em; color:var(--muted); margin-bottom:6px;
+  }
+  #token-input { font-family:var(--mono); font-size:14px; }
+  #login-error { color:var(--bad); font-size:12px; margin-top:10px; min-height:16px; }
 
   /* Header */
-  .header { position:sticky; top:0; height:var(--header-h); display:flex; align-items:center; gap:12px; padding:0 16px; background:var(--surface); border-bottom:1px solid var(--edge); z-index:20; }
-  .brand { font-weight:700; cursor:pointer; }
-  .header-right { margin-left:auto; display:flex; align-items:center; gap:12px; }
-  #identity { font-size:13px; color:var(--muted); }
+  .header {
+    position:sticky; top:0; height:var(--header-h); display:flex; align-items:center; gap:12px;
+    padding:0 20px; background:rgba(255,255,255,.82); backdrop-filter:saturate(1.6) blur(10px);
+    -webkit-backdrop-filter:saturate(1.6) blur(10px);
+    border-bottom:1px solid var(--edge); z-index:20;
+  }
+  .brand { font-weight:650; font-size:14px; letter-spacing:-0.01em; cursor:pointer; user-select:none; }
+  .header-right { margin-left:auto; display:flex; align-items:center; gap:14px; }
+  #identity { font-size:12px; font-family:var(--mono); color:var(--muted); }
 
   /* Console grid */
   .console-grid { display:grid; grid-template-columns:var(--rail-w) 1fr; height:calc(100vh - var(--header-h)); }
-  .rail { border-right:1px solid var(--edge); padding:16px; overflow:auto; display:flex; flex-direction:column; gap:14px; }
-  .center { overflow:auto; padding:16px; }
-  .facet { display:inline-block; padding:6px 12px; border-radius:999px; border:1px solid var(--edge); cursor:pointer; font-size:13px; background:var(--surface); }
-  .facet.active { background:var(--brand); color:#fff; border-color:var(--brand); }
+  .rail {
+    background:var(--surface); border-right:1px solid var(--edge); padding:20px 16px;
+    overflow:auto; display:flex; flex-direction:column; gap:22px;
+  }
+  .rail-sec { display:flex; flex-direction:column; gap:8px; }
+  .rail label, .rail-label {
+    display:block; font-size:11px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.06em; color:var(--muted);
+  }
+  .rail input, .rail select, .login-card input {
+    width:100%; padding:9px 10px; border:1px solid var(--edge-2); border-radius:var(--radius-sm);
+    font-family:var(--sans); font-size:13px; color:var(--fg); background:var(--surface);
+    transition:border-color .15s, box-shadow .15s;
+  }
+  .rail input:focus, .rail select:focus, .login-card input:focus, .card input:focus {
+    outline:none; border-color:var(--brand); box-shadow:0 0 0 3px var(--brand-ring);
+  }
+  input[type=number] { font-variant-numeric:tabular-nums; }
+  #facet-group { display:flex; flex-wrap:wrap; gap:6px; }
+  #facet-group .rail-label { flex:1 0 100%; }
+  .facet {
+    display:inline-flex; align-items:center; padding:6px 12px; border-radius:999px;
+    border:1px solid var(--edge-2); background:var(--surface); color:var(--fg-2);
+    cursor:pointer; font-size:12px; font-weight:600; user-select:none;
+    transition:background .15s, color .15s, border-color .15s;
+  }
+  .facet:hover { background:var(--surface-2); }
+  .facet.active { background:var(--brand); color:#fff; border-color:var(--brand); box-shadow:var(--shadow-1); }
   .mode-ctl { display:flex; flex-direction:column; gap:8px; }
-  .mode-ctl input, .mode-ctl select, #view-mode, #search-key { width:100%; padding:8px; border:1px solid #d2d2d7; border-radius:8px; font-size:14px; }
 
-  /* Buttons / badges / tables / toast / spark — reuse from prior page */
-  .btn { padding:10px 16px; border:none; border-radius:8px; font-size:14px; font-weight:600; cursor:pointer; }
-  .btn-primary { background:var(--brand); color:#fff; } .btn-danger { background:#d70015; color:#fff; }
-  .btn-secondary { background:#e8e8ed; color:var(--fg); }
-  .badge { display:inline-block; padding:2px 10px; border-radius:999px; font-size:12px; font-weight:600; }
-  .badge-yes { background:#d1f0d6; color:var(--ok); } .badge-no { background:#f7d6d6; color:var(--bad); }
-  .badge-none { background:#e8e8ed; color:var(--muted); }
+  /* Center pane */
+  .center { overflow:auto; padding:24px; display:flex; flex-direction:column; gap:16px; }
+  .center > * { width:100%; max-width:var(--center-max); align-self:center; }
+  .center-title { font-size:17px; font-weight:650; letter-spacing:-0.01em; margin:0; }
+  .empty {
+    color:var(--muted); font-size:13px; padding:28px; text-align:center;
+    background:var(--surface); border:1px dashed var(--edge-2); border-radius:var(--radius);
+  }
+  #load-more { align-self:center; width:auto; max-width:none; min-width:180px; }
+
+  /* Buttons */
+  .btn {
+    display:inline-flex; align-items:center; justify-content:center; gap:6px;
+    padding:9px 16px; border:1px solid transparent; border-radius:var(--radius-sm);
+    font-family:var(--sans); font-size:13px; font-weight:600; letter-spacing:.01em;
+    cursor:pointer; box-shadow:var(--shadow-1);
+    transition:background .15s, border-color .15s, box-shadow .15s, transform .06s, opacity .15s;
+  }
+  .btn:active:not(:disabled) { transform:translateY(1px); box-shadow:none; }
+  .btn:disabled { cursor:not-allowed; opacity:.45; filter:saturate(.15); box-shadow:none; transform:none; }
+  .btn-primary { background:var(--brand); color:#fff; }
+  .btn-primary:hover:not(:disabled) { background:var(--brand-strong); }
+  .btn-secondary { background:var(--surface); color:var(--fg-2); border-color:var(--edge-2); }
+  .btn-secondary:hover:not(:disabled) { background:var(--surface-2); }
+  .btn-danger { background:var(--bad-solid); color:#fff; }
+  .btn-danger:hover:not(:disabled) { background:var(--bad-strong); }
+  .btn-block { width:100%; }
+  .btn-sm { padding:6px 12px; font-size:12px; }
+
+  /* Badges */
+  .badge {
+    display:inline-flex; align-items:center; padding:3px 10px; border-radius:999px;
+    border:1px solid transparent; font-size:11px; font-weight:600; letter-spacing:.02em;
+  }
+  .badge-yes { background:var(--ok-bg); color:var(--ok); border-color:rgba(6,118,71,.18); }
+  .badge-no { background:var(--bad-bg); color:var(--bad); border-color:rgba(180,35,24,.18); }
+  .badge-none { background:var(--surface-2); color:var(--muted); border-color:var(--edge-2); }
+
+  /* Tables */
   table { width:100%; border-collapse:collapse; font-size:13px; }
-  th,td { text-align:left; padding:8px; border-bottom:1px solid var(--edge); }
-  .tablewrap { overflow-x:auto; }
-  .row-clickable { cursor:pointer; } .row-clickable:hover { background:var(--bg); }
-  .spark { display:flex; align-items:flex-end; gap:2px; height:56px; }
-  .spark .bar { flex:1 1 0; min-width:3px; min-height:2px; background:var(--brand); border-radius:2px 2px 0 0; }
-  .card { background:var(--surface); border-radius:var(--radius); padding:16px; margin-bottom:14px; }
-  .k { font-size:12px; color:var(--muted); margin-bottom:4px; }
-  .toast { position:fixed; bottom:24px; right:24px; padding:12px 18px; border-radius:8px; color:#fff; opacity:0; transition:opacity .2s; pointer-events:none; z-index:50; }
-  .toast.show { opacity:1; } .toast-success { background:var(--ok); } .toast-error { background:var(--bad); }
+  thead th {
+    text-align:left; padding:10px 14px; font-size:11px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.06em; color:var(--muted); background:var(--surface-2);
+    border-bottom:1px solid var(--edge); white-space:nowrap;
+  }
+  tbody td { padding:11px 14px; border-bottom:1px solid var(--edge); color:var(--fg-2); vertical-align:top; }
+  tbody tr:last-child td, tbody tr:last-child th { border-bottom:none; }
+  tbody th {
+    text-align:left; padding:11px 14px; border-bottom:1px solid var(--edge);
+    font-weight:600; color:var(--muted); white-space:nowrap; width:40%;
+  }
+  .num { text-align:right; font-family:var(--mono); font-variant-numeric:tabular-nums; white-space:nowrap; }
+  .mono { font-family:var(--mono); color:var(--fg); }
+  .nowrap { white-space:nowrap; }
+  .center .tablewrap {
+    overflow-x:auto; background:var(--surface); border:1px solid var(--edge);
+    border-radius:var(--radius); box-shadow:var(--shadow-1);
+  }
+  .card .tablewrap { overflow-x:auto; }
+  .row-clickable { cursor:pointer; transition:background .12s; }
+  .row-clickable:hover td { background:var(--surface-2); }
+
+  /* Sparkline */
+  .spark { display:flex; align-items:flex-end; gap:3px; height:64px; }
+  .spark .bar {
+    flex:1 1 0; min-width:3px; min-height:2px; border-radius:3px 3px 1px 1px;
+    background:linear-gradient(180deg, #4d8bff 0%, var(--brand) 100%);
+    transition:opacity .15s;
+  }
+  .spark .bar:hover { opacity:.65; }
+
+  /* Cards */
+  .card {
+    background:var(--surface); border:1px solid var(--edge); border-radius:var(--radius);
+    padding:18px; margin-bottom:14px; box-shadow:var(--shadow-1);
+  }
+  .card h3 {
+    font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--muted); margin:0 0 12px;
+  }
+  .card input {
+    display:block; width:100%; padding:9px 10px; margin-bottom:8px;
+    border:1px solid var(--edge-2); border-radius:var(--radius-sm);
+    font-family:var(--sans); font-size:13px; color:var(--fg); background:var(--surface);
+    transition:border-color .15s, box-shadow .15s;
+  }
+  .card .btn { min-width:160px; }
+  .k { font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:4px; }
+  .balance-value { font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:30px; font-weight:650; letter-spacing:-0.02em; line-height:1.1; margin-bottom:6px; }
+  .sub-line { display:flex; align-items:center; gap:8px; margin-top:14px; font-size:13px; color:var(--fg-2); }
+  .muted-note { color:var(--muted); font-size:13px; }
+
+  /* Toast */
+  .toast {
+    position:fixed; bottom:24px; right:24px; padding:12px 18px; border-radius:var(--radius-sm);
+    color:#fff; font-size:13px; font-weight:600; box-shadow:var(--shadow-2);
+    opacity:0; transform:translateY(6px); transition:opacity .2s, transform .2s var(--ease);
+    pointer-events:none; z-index:50;
+  }
+  .toast.show { opacity:1; transform:none; }
+  .toast-success { background:var(--ok-solid); } .toast-error { background:var(--bad-solid); }
 
   /* Detail slide-over */
-  .detail-scrim { position:fixed; inset:0; background:rgba(0,0,0,.4); z-index:30; }
-  .detail { position:fixed; top:0; right:0; bottom:0; width:min(720px,64vw); background:var(--surface); box-shadow:-2px 0 12px rgba(0,0,0,.15); transform:translateX(102%); transition:transform .24s var(--ease); z-index:40; overflow:auto; padding:20px; }
+  .detail-scrim {
+    position:fixed; inset:0; background:rgba(12,17,29,.38);
+    backdrop-filter:blur(2px); -webkit-backdrop-filter:blur(2px); z-index:30;
+  }
+  .detail {
+    position:fixed; top:0; right:0; bottom:0; width:min(720px,64vw); background:var(--bg);
+    border-left:1px solid var(--edge); box-shadow:var(--shadow-pop);
+    transform:translateX(102%); transition:transform .28s var(--ease);
+    z-index:40; overflow:auto; padding:24px;
+  }
   .detail.open { transform:none; }
   .detail-close { float:right; }
+  .detail-title { font-size:17px; font-weight:650; letter-spacing:-0.01em; margin:0 0 16px; }
 
   /* Responsive */
   @media (max-width:768px) {
-    .console-grid { grid-template-columns:1fr; }
+    .console-grid { grid-template-columns:1fr; height:auto; }
     .rail { border-right:none; border-bottom:1px solid var(--edge); }
-    .detail { width:100vw; }
-    th,td { padding:6px; font-size:12px; }
+    .center { padding:16px; }
+    .detail { width:100vw; padding:16px; }
+    thead th { padding:8px 10px; }
+    tbody td, tbody th { padding:9px 10px; font-size:12px; }
   }
   @media (pointer:coarse) { .btn,.facet,.row-clickable { min-height:44px; } }
-  @media (prefers-reduced-motion:reduce) { .detail { transition:none; } }
+  @media (prefers-reduced-motion:reduce) {
+    * { transition:none !important; }
+    .detail { transition:none; }
+  }
 `;

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -5,9 +5,9 @@ export const STYLES = `
     --fg: #0c111d; --fg-2: #344054; --muted: #667085;
     --surface: #fff; --surface-2: #f9fafb; --bg: #f2f4f7;
     --edge: #e4e7ec; --edge-2: #d0d5dd;
-    --ok: #067647; --ok-bg: #e7f6ee; --ok-solid: #079455;
+    --ok: #067647; --ok-bg: #e7f6ee;
     --bad: #b42318; --bad-bg: #fee4e2; --bad-solid: #d92d20; --bad-strong: #912018;
-    --rail-w: 260px; --header-h: 60px; --center-max: 1160px;
+    --rail-w: 260px; --header-h: 60px; --center-max: 1160px; --control-h: 36px;
     --radius-sm: 8px; --radius: 12px; --radius-lg: 16px;
     --shadow-1: 0 1px 2px rgba(16,24,40,.04), 0 1px 3px rgba(16,24,40,.06);
     --shadow-2: 0 2px 4px -1px rgba(16,24,40,.05), 0 8px 16px -4px rgba(16,24,40,.08);
@@ -43,7 +43,8 @@ export const STYLES = `
     letter-spacing:.06em; color:var(--muted); margin-bottom:6px;
   }
   #token-input { font-family:var(--mono); font-size:14px; }
-  #login-error { color:var(--bad); font-size:12px; margin-top:10px; min-height:16px; }
+  #login-error { color:var(--bad); font-size:12px; margin-top:6px; min-height:16px; }
+  #unlock { margin-top:8px; }
 
   /* Header */
   .header {
@@ -68,9 +69,19 @@ export const STYLES = `
     letter-spacing:.06em; color:var(--muted);
   }
   .rail input, .rail select, .login-card input {
-    width:100%; padding:9px 10px; border:1px solid var(--edge-2); border-radius:var(--radius-sm);
+    width:100%; min-height:var(--control-h); padding:9px 10px;
+    border:1px solid var(--edge-2); border-radius:var(--radius-sm);
     font-family:var(--sans); font-size:13px; color:var(--fg); background:var(--surface);
     transition:border-color .15s, box-shadow .15s;
+  }
+  .rail select {
+    appearance:none; -webkit-appearance:none; padding-right:30px;
+    background-image:
+      linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+      linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+    background-position: calc(100% - 15px) 50%, calc(100% - 11px) 50%;
+    background-size: 5px 5px, 5px 5px;
+    background-repeat: no-repeat;
   }
   .rail input:focus, .rail select:focus, .login-card input:focus, .card input:focus {
     outline:none; border-color:var(--brand); box-shadow:0 0 0 3px var(--brand-ring);
@@ -107,7 +118,10 @@ export const STYLES = `
     transition:background .15s, border-color .15s, box-shadow .15s, transform .06s, opacity .15s;
   }
   .btn:active:not(:disabled) { transform:translateY(1px); box-shadow:none; }
-  .btn:disabled { cursor:not-allowed; opacity:.45; filter:saturate(.15); box-shadow:none; transform:none; }
+  .btn:disabled {
+    background:var(--surface-2); color:var(--muted); border-color:var(--edge-2);
+    cursor:not-allowed; box-shadow:none; transform:none; filter:none; opacity:1;
+  }
   .btn-primary { background:var(--brand); color:#fff; }
   .btn-primary:hover:not(:disabled) { background:var(--brand-strong); }
   .btn-secondary { background:var(--surface); color:var(--fg-2); border-color:var(--edge-2); }
@@ -139,9 +153,12 @@ export const STYLES = `
     text-align:left; padding:11px 14px; border-bottom:1px solid var(--edge);
     font-weight:600; color:var(--muted); white-space:nowrap; width:40%;
   }
-  .num { text-align:right; font-family:var(--mono); font-variant-numeric:tabular-nums; white-space:nowrap; }
-  .mono { font-family:var(--mono); color:var(--fg); }
+  .num { text-align:right; white-space:nowrap; }
+  .mono { font-family:var(--mono); }
   .nowrap { white-space:nowrap; }
+  thead th.mono, thead th.num { font-family:var(--sans); font-variant-numeric:normal; }
+  tbody td.num { font-family:var(--mono); font-variant-numeric:tabular-nums; }
+  tbody td.mono { color:var(--fg); }
   .center .tablewrap {
     overflow-x:auto; background:var(--surface); border:1px solid var(--edge);
     border-radius:var(--radius); box-shadow:var(--shadow-1);
@@ -168,6 +185,7 @@ export const STYLES = `
     font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.06em;
     color:var(--muted); margin:0 0 12px;
   }
+  .card h3.tight { margin-bottom:4px; }
   .card input {
     display:block; width:100%; padding:9px 10px; margin-bottom:8px;
     border:1px solid var(--edge-2); border-radius:var(--radius-sm);
@@ -175,8 +193,8 @@ export const STYLES = `
     transition:border-color .15s, box-shadow .15s;
   }
   .card .btn { min-width:160px; }
-  .k { font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:4px; }
-  .balance-value { font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:30px; font-weight:650; letter-spacing:-0.02em; line-height:1.1; margin-bottom:6px; }
+  .balance-value { font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:30px; font-weight:650; letter-spacing:-0.02em; line-height:1.1; margin-bottom:4px; }
+  .balance-hint { font-size:12px; color:var(--muted); }
   .sub-line { display:flex; align-items:center; gap:8px; margin-top:14px; font-size:13px; color:var(--fg-2); }
   .muted-note { color:var(--muted); font-size:13px; }
 
@@ -188,7 +206,7 @@ export const STYLES = `
     pointer-events:none; z-index:50;
   }
   .toast.show { opacity:1; transform:none; }
-  .toast-success { background:var(--ok-solid); } .toast-error { background:var(--bad-solid); }
+  .toast-success { background:var(--ok); } .toast-error { background:var(--bad-solid); }
 
   /* Detail slide-over */
   .detail-scrim {
@@ -214,7 +232,11 @@ export const STYLES = `
     thead th { padding:8px 10px; }
     tbody td, tbody th { padding:9px 10px; font-size:12px; }
   }
-  @media (pointer:coarse) { .btn,.facet,.row-clickable { min-height:44px; } }
+  @media (pointer:coarse) {
+    .btn,.facet { min-height:44px; }
+    tbody td, tbody th { padding-top:14px; padding-bottom:14px; line-height:16px; }
+    .rail input, .rail select, .card input { min-height:44px; font-size:16px; }
+  }
   @media (prefers-reduced-motion:reduce) {
     * { transition:none !important; }
     .detail { transition:none; }

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -1,17 +1,17 @@
 export const STYLES = `
   :root {
-    --brand: #0b5cff; --brand-strong: #0847cc; --brand-weak: #eef3ff;
-    --brand-ring: rgba(11,92,255,.28);
-    --fg: #0c111d; --fg-2: #344054; --muted: #667085;
-    --surface: #fff; --surface-2: #f9fafb; --bg: #f2f4f7;
-    --edge: #e4e7ec; --edge-2: #d0d5dd;
-    --ok: #067647; --ok-bg: #e7f6ee;
-    --bad: #b42318; --bad-bg: #fee4e2; --bad-solid: #d92d20; --bad-strong: #912018;
+    --brand: #283a75; --brand-strong: #1d2b58; --brand-weak: #e8e9f2;
+    --brand-ring: rgba(40,58,117,.30);
+    --fg: #211f1a; --fg-2: #3f3a32; --muted: #6b6455;
+    --surface: #fbfaf6; --surface-2: #f2efe6; --bg: #e9e5da;
+    --edge: #dcd7c9; --edge-2: #c3bca8;
+    --ok: #17603d; --ok-bg: #e4eddf;
+    --bad: #97231a; --bad-bg: #f7e2dc; --bad-solid: #bf2d1e; --bad-strong: #8f1f14;
     --rail-w: 260px; --header-h: 60px; --center-max: 1160px; --control-h: 36px;
     --radius-sm: 8px; --radius: 12px; --radius-lg: 16px;
-    --shadow-1: 0 1px 2px rgba(16,24,40,.04), 0 1px 3px rgba(16,24,40,.06);
-    --shadow-2: 0 2px 4px -1px rgba(16,24,40,.05), 0 8px 16px -4px rgba(16,24,40,.08);
-    --shadow-pop: 0 12px 24px -8px rgba(16,24,40,.18), 0 32px 64px -16px rgba(16,24,40,.22);
+    --shadow-1: 0 1px 2px rgba(33,31,26,.05), 0 1px 3px rgba(33,31,26,.07);
+    --shadow-2: 0 2px 4px -1px rgba(33,31,26,.06), 0 8px 16px -4px rgba(33,31,26,.10);
+    --shadow-pop: 0 12px 24px -8px rgba(33,31,26,.20), 0 32px 64px -16px rgba(33,31,26,.24);
     --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
     --ease: cubic-bezier(0.22, 1, 0.36, 1);
@@ -28,8 +28,8 @@ export const STYLES = `
   #login {
     min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px;
     background:
-      radial-gradient(120% 90% at 50% -10%, #fff 0%, rgba(255,255,255,0) 60%),
-      radial-gradient(80% 60% at 85% 110%, var(--brand-weak) 0%, rgba(238,243,255,0) 70%),
+      radial-gradient(120% 90% at 50% -10%, var(--surface) 0%, rgba(251,250,246,0) 60%),
+      radial-gradient(80% 60% at 85% 110%, var(--brand-weak) 0%, rgba(232,233,242,0) 70%),
       var(--bg);
   }
   .login-card {
@@ -49,7 +49,7 @@ export const STYLES = `
   /* Header */
   .header {
     position:sticky; top:0; height:var(--header-h); display:flex; align-items:center; gap:12px;
-    padding:0 20px; background:rgba(255,255,255,.82); backdrop-filter:saturate(1.6) blur(10px);
+    padding:0 20px; background:rgba(251,250,246,.82); backdrop-filter:saturate(1.6) blur(10px);
     -webkit-backdrop-filter:saturate(1.6) blur(10px);
     border-bottom:1px solid var(--edge); z-index:20;
   }
@@ -136,8 +136,8 @@ export const STYLES = `
     display:inline-flex; align-items:center; padding:3px 10px; border-radius:999px;
     border:1px solid transparent; font-size:11px; font-weight:600; letter-spacing:.02em;
   }
-  .badge-yes { background:var(--ok-bg); color:var(--ok); border-color:rgba(6,118,71,.18); }
-  .badge-no { background:var(--bad-bg); color:var(--bad); border-color:rgba(180,35,24,.18); }
+  .badge-yes { background:var(--ok-bg); color:var(--ok); border-color:rgba(23,96,61,.22); }
+  .badge-no { background:var(--bad-bg); color:var(--bad); border-color:rgba(151,35,26,.22); }
   .badge-none { background:var(--surface-2); color:var(--muted); border-color:var(--edge-2); }
 
   /* Tables */
@@ -171,7 +171,7 @@ export const STYLES = `
   .spark { display:flex; align-items:flex-end; gap:3px; height:64px; }
   .spark .bar {
     flex:1 1 0; min-width:3px; min-height:2px; border-radius:3px 3px 1px 1px;
-    background:linear-gradient(180deg, #4d8bff 0%, var(--brand) 100%);
+    background:linear-gradient(180deg, #46589c 0%, var(--brand) 100%);
     transition:opacity .15s;
   }
   .spark .bar:hover { opacity:.65; }
@@ -210,7 +210,7 @@ export const STYLES = `
 
   /* Detail slide-over */
   .detail-scrim {
-    position:fixed; inset:0; background:rgba(12,17,29,.38);
+    position:fixed; inset:0; background:rgba(33,31,26,.42);
     backdrop-filter:blur(2px); -webkit-backdrop-filter:blur(2px); z-index:30;
   }
   .detail {

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -36,22 +36,30 @@ export const adjustBodySchema = z.object({
   idempotencyKey: idempotencyKeySchema,
 });
 
+export const MAX_ACCOUNTS_PAGE = 10_000;
+
+const balanceFilterCredits = z.coerce
+  .number()
+  .int()
+  .min(-MAX_ADMIN_GRANT_CREDITS)
+  .max(MAX_ADMIN_GRANT_CREDITS);
+
 const accountsPageLimit = {
-  page: z.coerce.number().int().min(0).default(0),
+  page: z.coerce.number().int().min(0).max(MAX_ACCOUNTS_PAGE).default(0),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 };
 
 export const accountsListQuerySchema = z.discriminatedUnion("mode", [
   z.object({
     mode: z.literal("balance"),
-    min: z.coerce.number().int().optional(),
-    max: z.coerce.number().int().optional(),
+    min: balanceFilterCredits.optional(),
+    max: balanceFilterCredits.optional(),
     sort: z.enum(["asc", "desc"]).default("desc"),
     ...accountsPageLimit,
   }),
   z.object({
     mode: z.literal("broken"),
-    maxBalance: z.coerce.number().int().default(0),
+    maxBalance: balanceFilterCredits.default(0),
     ...accountsPageLimit,
   }),
   z.object({

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -35,3 +35,37 @@ export const adjustBodySchema = z.object({
   reason: z.string().trim().min(1).max(256),
   idempotencyKey: idempotencyKeySchema,
 });
+
+const accountsPageLimit = {
+  page: z.coerce.number().int().min(0).default(0),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+};
+
+export const accountsListQuerySchema = z.discriminatedUnion("mode", [
+  z.object({
+    mode: z.literal("balance"),
+    min: z.coerce.number().int().optional(),
+    max: z.coerce.number().int().optional(),
+    sort: z.enum(["asc", "desc"]).default("desc"),
+    ...accountsPageLimit,
+  }),
+  z.object({
+    mode: z.literal("broken"),
+    maxBalance: z.coerce.number().int().default(0),
+    ...accountsPageLimit,
+  }),
+  z.object({
+    mode: z.literal("grantKind"),
+    kind: z
+      .string()
+      .trim()
+      .regex(/^[A-Za-z0-9_-]{1,64}$/),
+    ...accountsPageLimit,
+  }),
+  z.object({
+    mode: z.literal("activity"),
+    state: z.enum(["active", "dormant"]),
+    days: z.coerce.number().int().min(1).max(365).default(30),
+    ...accountsPageLimit,
+  }),
+]);

--- a/tests/credits-admin/accounts-list.integration.test.ts
+++ b/tests/credits-admin/accounts-list.integration.test.ts
@@ -1,0 +1,86 @@
+import type { Express } from "express";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "@/utils/prisma";
+import {
+  adminRequest,
+  buildCreditsAdminApp,
+  cleanupAdminAccounts,
+  seedAccount,
+  seedPlusMonthlySubscription,
+} from "./helpers";
+
+type Row = { accountId: string; balanceCredits: string; tier?: string };
+type Body = { mode: string; page: number; hasMore: boolean; rows: Row[] };
+
+const setBalance = async (accountId: string, balance: bigint) => {
+  await prisma.userCredits.upsert({
+    where: { accountId },
+    update: { balance },
+    create: { accountId, balance },
+  });
+};
+
+describe("GET /api/v2/credits-admin/accounts", () => {
+  let app: Express;
+  const tracker: string[] = [];
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("401 without bearer token", async () => {
+    const res = await adminRequest(app, false).get(
+      "/api/v2/credits-admin/accounts?mode=balance",
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("balance mode returns stringified balances, sorted", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    await setBalance(a, 4242n);
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=balance&min=1&sort=desc&limit=100",
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as Body;
+    expect(body.mode).toBe("balance");
+    expect(typeof body.rows[0].balanceCredits).toBe("string");
+    const seededRow = body.rows.find((r) => r.accountId === a);
+    expect(seededRow).toBeDefined();
+    expect(seededRow?.balanceCredits).toBe("4242");
+  });
+
+  it("broken mode surfaces entitled sub with balance 0", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    await seedPlusMonthlySubscription(a);
+    await setBalance(a, 0n);
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=broken&maxBalance=0&limit=100",
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as Body;
+    const seededRow = body.rows.find((r) => r.accountId === a);
+    expect(seededRow).toBeDefined();
+    expect(seededRow?.tier).toBeTruthy();
+  });
+
+  it("400 on invalid mode", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=nonsense",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_request" });
+  });
+
+  it("400 on grantKind without kind", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=grantKind",
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/credits-admin/accounts-list.integration.test.ts
+++ b/tests/credits-admin/accounts-list.integration.test.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { Express } from "express";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { MAX_ACCOUNTS_PAGE } from "@/api/v2/credits-admin/schemas/requests";
 import { prisma } from "@/utils/prisma";
 import {
   adminRequest,
@@ -9,8 +11,23 @@ import {
   seedPlusMonthlySubscription,
 } from "./helpers";
 
-type Row = { accountId: string; balanceCredits: string; tier?: string };
+type Row = {
+  accountId: string;
+  balanceCredits: string;
+  tier?: string;
+  latestGrantAt?: string;
+  lastConsumeAt?: string | null;
+};
 type Body = { mode: string; page: number; hasMore: boolean; rows: Row[] };
+
+const DAY_MS = 86400000;
+
+/**
+ * Distinctive so `min=max=BALANCE` selects essentially only the seeded row —
+ * this is a GLOBAL query against a shared DB. Deliberately not a round number
+ * another fixture might reuse.
+ */
+const BALANCE = 8675309n;
 
 const setBalance = async (accountId: string, balance: bigint) => {
   await prisma.userCredits.upsert({
@@ -20,16 +37,59 @@ const setBalance = async (accountId: string, balance: bigint) => {
   });
 };
 
+const addLedger = async (
+  accountId: string,
+  reason: "grant" | "consume" | "adjust",
+  delta: bigint,
+  grantKindId: string | null,
+  createdAt: Date,
+) => {
+  await prisma.creditLedger.create({
+    data: {
+      accountId,
+      delta,
+      reason,
+      grantKindId,
+      idempotencyKey: `k_${accountId}_${createdAt.getTime()}_${Math.abs(Number(delta))}`,
+      createdAt,
+    },
+  });
+};
+
 describe("GET /api/v2/credits-admin/accounts", () => {
   let app: Express;
   const tracker: string[] = [];
+  const kindTracker: string[] = [];
   beforeAll(() => {
     app = buildCreditsAdminApp();
   });
   afterEach(async () => {
     await cleanupAdminAccounts(tracker);
     tracker.length = 0;
+    for (const kind of kindTracker) {
+      await prisma.grantKind.deleteMany({ where: { id: kind } });
+    }
+    kindTracker.length = 0;
   });
+
+  /**
+   * `activity` admits no self-selecting filter (dormant is a global scan over
+   * UserCredits, and NULLS LAST sorts never-consumed rows last), so walk pages
+   * rather than assume the seeded row lands on page 0 of a shared DB.
+   */
+  const findAcrossPages = async (query: string, accountId: string) => {
+    for (let page = 0; page <= 20; page++) {
+      const res = await adminRequest(app).get(
+        `/api/v2/credits-admin/accounts?${query}&limit=100&page=${page}`,
+      );
+      expect(res.status).toBe(200);
+      const body = res.body as Body;
+      const hit = body.rows.find((r) => r.accountId === accountId);
+      if (hit) return hit;
+      if (!body.hasMore) return undefined;
+    }
+    return undefined;
+  };
 
   it("401 without bearer token", async () => {
     const res = await adminRequest(app, false).get(
@@ -41,17 +101,17 @@ describe("GET /api/v2/credits-admin/accounts", () => {
   it("balance mode returns stringified balances, sorted", async () => {
     const a = await seedAccount();
     tracker.push(a);
-    await setBalance(a, 4242n);
+    await setBalance(a, BALANCE);
+    const v = BALANCE.toString();
     const res = await adminRequest(app).get(
-      "/api/v2/credits-admin/accounts?mode=balance&min=1&sort=desc&limit=100",
+      `/api/v2/credits-admin/accounts?mode=balance&min=${v}&max=${v}&sort=desc`,
     );
     expect(res.status).toBe(200);
     const body = res.body as Body;
     expect(body.mode).toBe("balance");
-    expect(typeof body.rows[0].balanceCredits).toBe("string");
+    expect(body.page).toBe(0);
     const seededRow = body.rows.find((r) => r.accountId === a);
-    expect(seededRow).toBeDefined();
-    expect(seededRow?.balanceCredits).toBe("4242");
+    expect(seededRow?.balanceCredits).toBe(v);
   });
 
   it("broken mode surfaces entitled sub with balance 0", async () => {
@@ -69,6 +129,51 @@ describe("GET /api/v2/credits-admin/accounts", () => {
     expect(seededRow?.tier).toBeTruthy();
   });
 
+  it("grantKind mode returns the latest grant for that kind as an ISO string", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    const kind = `t_al_${randomUUID().slice(0, 8)}`;
+    await prisma.grantKind.create({
+      data: { id: kind, name: "accounts-list test kind" },
+    });
+    kindTracker.push(kind);
+    await setBalance(a, 555n);
+    const older = new Date(Date.now() - 2 * DAY_MS);
+    const latest = new Date(Date.now() - 1 * DAY_MS);
+    await addLedger(a, "grant", 100n, kind, older);
+    await addLedger(a, "grant", 200n, kind, latest);
+
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts?mode=grantKind&kind=${kind}`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as Body;
+    // Kind is unique to this test, so the result set is exactly this row.
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].accountId).toBe(a);
+    expect(body.rows[0].balanceCredits).toBe("555");
+    expect(body.rows[0].latestGrantAt).toBe(latest.toISOString());
+  });
+
+  it("activity dormant mode serializes lastConsumeAt as ISO string, or null when never consumed", async () => {
+    const neverConsumed = await seedAccount();
+    const staleConsumer = await seedAccount();
+    tracker.push(neverConsumed, staleConsumer);
+    await setBalance(neverConsumed, 111n);
+    await setBalance(staleConsumer, 222n);
+    const staleAt = new Date(Date.now() - 60 * DAY_MS);
+    await addLedger(staleConsumer, "consume", -5n, null, staleAt);
+
+    const query = "mode=activity&state=dormant&days=30";
+    const neverRow = await findAcrossPages(query, neverConsumed);
+    const staleRow = await findAcrossPages(query, staleConsumer);
+
+    // Pins the `?.toISOString() ?? null` ternary on the wire: key present and
+    // JSON null, not undefined and not omitted.
+    expect(neverRow).toHaveProperty("lastConsumeAt", null);
+    expect(staleRow?.lastConsumeAt).toBe(staleAt.toISOString());
+  });
+
   it("400 on invalid mode", async () => {
     const res = await adminRequest(app).get(
       "/api/v2/credits-admin/accounts?mode=nonsense",
@@ -82,5 +187,28 @@ describe("GET /api/v2/credits-admin/accounts", () => {
       "/api/v2/credits-admin/accounts?mode=grantKind",
     );
     expect(res.status).toBe(400);
+  });
+
+  it("400 on over-cap page rather than a Postgres-range 500", async () => {
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts?mode=balance&page=${MAX_ACCOUNTS_PAGE + 1}`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_request" });
+  });
+
+  it("400 on bigint-overflow-scale page, min and maxBalance", async () => {
+    const page = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=balance&page=1e21",
+    );
+    expect(page.status).toBe(400);
+    const min = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=balance&min=1e21",
+    );
+    expect(min.status).toBe(400);
+    const maxBalance = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=broken&maxBalance=1e21",
+    );
+    expect(maxBalance.status).toBe(400);
   });
 });

--- a/tests/credits-admin/accounts-repository.test.ts
+++ b/tests/credits-admin/accounts-repository.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listBrokenSubscribers,
+  listByActivity,
+  listByBalance,
+  listByGrantKind,
+} from "@/api/v2/credits-admin/accounts-repository";
+import { prisma } from "@/utils/prisma";
+import {
+  cleanupAdminAccounts,
+  seedAccount,
+  seedPlusMonthlySubscription,
+} from "./helpers";
+
+const setBalance = async (accountId: string, balance: bigint) => {
+  await prisma.userCredits.upsert({
+    where: { accountId },
+    update: { balance },
+    create: { accountId, balance },
+  });
+};
+
+const addLedger = async (
+  accountId: string,
+  reason: "grant" | "consume" | "adjust",
+  delta: bigint,
+  grantKindId: string | null,
+  createdAt: Date,
+) => {
+  await prisma.creditLedger.create({
+    data: {
+      accountId,
+      delta,
+      reason,
+      grantKindId,
+      idempotencyKey: `k_${accountId}_${createdAt.getTime()}_${Math.abs(Number(delta))}`,
+      createdAt,
+    },
+  });
+};
+
+describe("accounts-repository", () => {
+  const tracker: string[] = [];
+  afterEach(async () => {
+    for (const a of tracker) {
+      await prisma.creditLedger.deleteMany({ where: { accountId: a } });
+      await prisma.userCredits.deleteMany({ where: { accountId: a } });
+      // BillingReceipt FKs to Subscription; must go first or the delete
+      // below throws (seedPlusMonthlySubscription writes both rows).
+      // Mirrors tests/credits/helpers.ts cleanupAccounts' order.
+      await prisma.billingReceipt.deleteMany({
+        where: { subscription: { accountId: a } },
+      });
+      await prisma.subscription.deleteMany({ where: { accountId: a } });
+    }
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("listByBalance filters by min/max and sorts", async () => {
+    const a = await seedAccount();
+    const b = await seedAccount();
+    const c = await seedAccount();
+    tracker.push(a, b, c);
+    await setBalance(a, 100n);
+    await setBalance(b, -50n);
+    await setBalance(c, 5000n);
+    // scope to the seeded ids — this is a GLOBAL query and the test DB is shared.
+    const desc = await listByBalance({ sort: "desc", limit: 1000 });
+    const ids = desc.rows
+      .map((r) => r.accountId)
+      .filter((id) => [a, b, c].includes(id));
+    expect(ids).toEqual([c, a, b]); // 5000, 100, -50
+    const ranged = await listByBalance({ min: 0, max: 1000, limit: 1000 });
+    const rIds = ranged.rows.map((r) => r.accountId);
+    expect(rIds).toContain(a);
+    expect(rIds).not.toContain(b);
+    expect(rIds).not.toContain(c);
+  });
+
+  it("listByBalance paginates with hasMore", async () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const x = await seedAccount();
+      ids.push(x);
+      tracker.push(x);
+      await setBalance(x, BigInt(i));
+    }
+    const p0 = await listByBalance({ sort: "asc", page: 0, limit: 2 });
+    expect(p0.rows).toHaveLength(2);
+    expect(p0.hasMore).toBe(true);
+  });
+
+  it("listBrokenSubscribers finds entitled sub with balance <= maxBalance (incl. 0)", async () => {
+    const broken = await seedAccount();
+    const healthy = await seedAccount();
+    tracker.push(broken, healthy);
+    await seedPlusMonthlySubscription(broken);
+    await seedPlusMonthlySubscription(healthy);
+    await setBalance(broken, 0n);
+    await setBalance(healthy, 100000n);
+    const res = await listBrokenSubscribers({ maxBalance: 0, limit: 10 });
+    const ids = res.rows.map((r) => r.accountId);
+    expect(ids).toContain(broken); // balance == 0 must appear
+    expect(ids).not.toContain(healthy);
+    expect(res.rows.find((r) => r.accountId === broken)?.tier).toBeTruthy();
+  });
+
+  it("listByGrantKind lists accounts with that kind, latest-first", async () => {
+    const a = await seedAccount();
+    const b = await seedAccount();
+    tracker.push(a, b);
+    await setBalance(a, 0n);
+    await setBalance(b, 0n);
+    await addLedger(
+      a,
+      "grant",
+      10n,
+      "signup_bonus",
+      new Date("2026-07-01T00:00:00Z"),
+    );
+    await addLedger(
+      b,
+      "grant",
+      10n,
+      "signup_bonus",
+      new Date("2026-07-10T00:00:00Z"),
+    );
+    await addLedger(
+      a,
+      "grant",
+      10n,
+      "daily_refill",
+      new Date("2026-07-11T00:00:00Z"),
+    );
+    const res = await listByGrantKind({ kind: "signup_bonus", limit: 1000 });
+    // scope to seeded ids — global query on a shared DB.
+    const ids = res.rows
+      .map((r) => r.accountId)
+      .filter((id) => [a, b].includes(id));
+    expect(ids).toEqual([b, a]); // b's signup_bonus is newer
+  });
+
+  it("listByActivity active vs dormant split on last consume", async () => {
+    const active = await seedAccount();
+    const dormant = await seedAccount();
+    const never = await seedAccount();
+    tracker.push(active, dormant, never);
+    await setBalance(active, 0n);
+    await setBalance(dormant, 0n);
+    await setBalance(never, 0n);
+    const now = new Date();
+    await addLedger(
+      active,
+      "consume",
+      -5n,
+      null,
+      new Date(now.getTime() - 2 * 86400000),
+    );
+    await addLedger(
+      dormant,
+      "consume",
+      -5n,
+      null,
+      new Date(now.getTime() - 90 * 86400000),
+    );
+    // `never` has no consume rows
+    const act = await listByActivity({
+      state: "active",
+      days: 30,
+      limit: 1000,
+    });
+    const dor = await listByActivity({
+      state: "dormant",
+      days: 30,
+      limit: 1000,
+    });
+    const actIds = act.rows.map((r) => r.accountId);
+    const dorIds = dor.rows.map((r) => r.accountId);
+    expect(actIds).toContain(active);
+    expect(actIds).not.toContain(dormant);
+    expect(dorIds).toContain(dormant);
+    expect(dorIds).toContain(never); // never-consumed is dormant
+    expect(dorIds).not.toContain(active);
+  });
+});

--- a/tests/credits-admin/accounts-repository.test.ts
+++ b/tests/credits-admin/accounts-repository.test.ts
@@ -1,3 +1,8 @@
+import {
+  BillingProvider,
+  SubscriptionPeriod,
+  SubscriptionStatus,
+} from "@prisma/client";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   listBrokenSubscribers,
@@ -11,6 +16,41 @@ import {
   seedAccount,
   seedPlusMonthlySubscription,
 } from "./helpers";
+
+const DAY_MS = 86400000;
+
+/**
+ * Hand-seeds a Subscription in a specific entitlement state. The shared
+ * seedPlusMonthlySubscription only ever writes `active`, so the grace /
+ * billingRetry / expired branches of the listBrokenSubscribers LATERAL are
+ * unreachable through it. Writes the row directly (no BillingReceipt) rather
+ * than widening the shared helper, which ~64 other credits-admin tests use.
+ *
+ * Dates are anchored relative to now() — handlers judge entitlement against
+ * wall-clock now(), so absolute dates time-bomb CI.
+ */
+const seedSubscriptionInState = async (
+  accountId: string,
+  status: SubscriptionStatus,
+  opts: { currentPeriodEnd: Date; gracePeriodEnd?: Date },
+) => {
+  const start = new Date(Date.now() - 35 * DAY_MS);
+  await prisma.subscription.create({
+    data: {
+      accountId,
+      provider: BillingProvider.apple,
+      productId: "app.convos.subs.monthly",
+      tier: "plus",
+      period: SubscriptionPeriod.monthly,
+      status,
+      originalTransactionId: `otid-state-${accountId}`,
+      startedAt: start,
+      currentPeriodStart: start,
+      currentPeriodEnd: opts.currentPeriodEnd,
+      gracePeriodEnd: opts.gracePeriodEnd ?? null,
+    },
+  });
+};
 
 const setBalance = async (accountId: string, balance: bigint) => {
   await prisma.userCredits.upsert({
@@ -99,11 +139,53 @@ describe("accounts-repository", () => {
     await seedPlusMonthlySubscription(healthy);
     await setBalance(broken, 0n);
     await setBalance(healthy, 100000n);
-    const res = await listBrokenSubscribers({ maxBalance: 0, limit: 10 });
+    // limit: 1000 — this is a GLOBAL query on a shared DB; a small limit would
+    // let concurrent fixtures push the seeded row off page 1 and flake.
+    const res = await listBrokenSubscribers({ maxBalance: 0, limit: 1000 });
     const ids = res.rows.map((r) => r.accountId);
     expect(ids).toContain(broken); // balance == 0 must appear
     expect(ids).not.toContain(healthy);
     expect(res.rows.find((r) => r.accountId === broken)?.tier).toBeTruthy();
+  });
+
+  it("listBrokenSubscribers includes a grace sub whose gracePeriodEnd is future", async () => {
+    const graced = await seedAccount();
+    tracker.push(graced);
+    // Period already ended; the grace window is what still entitles them —
+    // so this also pins the COALESCE(gracePeriodEnd, currentPeriodEnd) arm.
+    await seedSubscriptionInState(graced, SubscriptionStatus.grace, {
+      currentPeriodEnd: new Date(Date.now() - 2 * DAY_MS),
+      gracePeriodEnd: new Date(Date.now() + 14 * DAY_MS),
+    });
+    await setBalance(graced, 0n);
+    const res = await listBrokenSubscribers({ maxBalance: 0, limit: 1000 });
+    expect(res.rows.map((r) => r.accountId)).toContain(graced);
+  });
+
+  it("listBrokenSubscribers includes a billingRetry sub regardless of period end", async () => {
+    const retrying = await seedAccount();
+    tracker.push(retrying);
+    // billingRetry has no TTL check in the LATERAL — a past currentPeriodEnd
+    // must NOT disqualify it.
+    await seedSubscriptionInState(retrying, SubscriptionStatus.billingRetry, {
+      currentPeriodEnd: new Date(Date.now() - 10 * DAY_MS),
+    });
+    await setBalance(retrying, 0n);
+    const res = await listBrokenSubscribers({ maxBalance: 0, limit: 1000 });
+    expect(res.rows.map((r) => r.accountId)).toContain(retrying);
+  });
+
+  it("listBrokenSubscribers excludes a lapsed sub (active status, period ended)", async () => {
+    const lapsed = await seedAccount();
+    tracker.push(lapsed);
+    // Stale `active` row whose period has run out — the active/trial arm's
+    // `currentPeriodEnd > now()` guard must exclude it despite balance 0.
+    await seedSubscriptionInState(lapsed, SubscriptionStatus.active, {
+      currentPeriodEnd: new Date(Date.now() - 1 * DAY_MS),
+    });
+    await setBalance(lapsed, 0n);
+    const res = await listBrokenSubscribers({ maxBalance: 0, limit: 1000 });
+    expect(res.rows.map((r) => r.accountId)).not.toContain(lapsed);
   });
 
   it("listByGrantKind lists accounts with that kind, latest-first", async () => {

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -74,5 +74,8 @@ describe("credits-admin page (console shell)", () => {
     expect(res.text).toContain('value="grantKind"');
     expect(res.text).toContain('id="accounts-table"');
     expect(res.text).toContain("loadAccounts");
+    // setView() retitles this per view; pins the element's existence only —
+    // the label swap itself is runtime behaviour a string assertion can't reach.
+    expect(res.text).toContain('id="center-title"');
   });
 });

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -61,4 +61,18 @@ describe("credits-admin page (console shell)", () => {
     expect(res.text).toContain("usage-spark");
     expect(res.text).toContain("perPeriodCredits");
   });
+
+  it("wires the accounts view selector + modes + /accounts endpoint", async () => {
+    const res = await adminRequest(app, false).get("/api/v2/credits-admin/");
+    expect(res.text).toContain('id="view-mode"');
+    // the URL is built by concatenation ("/accounts" + "?mode=" + ...); assert the
+    // rendered literals, not the runtime-concatenated whole.
+    expect(res.text).toContain('guardFetch("/accounts"');
+    expect(res.text).toContain('"?mode="');
+    expect(res.text).toContain('value="balance"');
+    expect(res.text).toContain('value="broken"');
+    expect(res.text).toContain('value="grantKind"');
+    expect(res.text).toContain('id="accounts-table"');
+    expect(res.text).toContain("loadAccounts");
+  });
 });

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -74,6 +74,10 @@ describe("credits-admin page (console shell)", () => {
     expect(res.text).toContain('value="grantKind"');
     expect(res.text).toContain('id="accounts-table"');
     expect(res.text).toContain("loadAccounts");
+    // setView() hides the activity feed by this id. It used to walk
+    // #activity-table.parentNode, which silently broke if the markup grew a
+    // wrapper. Pin the id so a restyle can't reintroduce that coupling.
+    expect(res.text).toContain('id="activity-wrap"');
     // setView() retitles this per view; pins the element's existence only —
     // the label swap itself is runtime behaviour a string assertion can't reach.
     expect(res.text).toContain('id="center-title"');


### PR DESCRIPTION
Fast-follow to #371. Adds an accounts-filter center mode to the credits-admin console — four read-only ops queries behind one new endpoint, surfaced as clickable account lists that reuse the shipped slide-over detail — then a visual pass across the console.

## Summary

- **`GET /api/v2/credits-admin/accounts`** — bearer-gated, read-only, offset-paginated, mode-discriminated (`balance` | `broken` | `grantKind` | `activity`). Reads only; no ledger writes, no money-path change.
- **Four ops queries** (`accounts-repository.ts`): balance threshold+sort · broken subscribers (entitled sub × balance ≤ 0) · by grant kind · active/dormant by last consume.
- **Client**: rail View selector routing `currentView` between the shipped activity feed and the new account lists, per-mode controls, per-view center heading, rows reuse `openDetail`.
- **Restyle**: custom palette + typographic pass. Still a single inline nonce'd script/style under strict CSP — zero external assets.
- **Indexes**: `UserCredits([balance])`, `CreditLedger([grantKindId, createdAt])` (replaces the bare `[grantKindId]`), `CreditLedger([reason, accountId, createdAt])`.

`broken` mode matches the full 3-branch `effectiveSubscriptionStatus`: `billingRetry` (no TTL) OR `active`/`trial` with `currentPeriodEnd > now()` OR `grace` with `COALESCE(gracePeriodEnd, currentPeriodEnd) > now()`. Threshold is `<=` so the canonical balance-0 broken subscriber is caught.

## Notes for reviewers

- **credits-admin is an internal admin surface** — the served page deploys in lockstep with the API, so the `src/api/v2/**` append-only client-contract rule does not apply. The new query schema is a discriminated union.
- **Migration briefly locks `CreditLedger`/`UserCredits` for writes** during `CREATE INDEX` (not `CONCURRENTLY` — Prisma wraps migrations in a transaction). Expected negligible at current table size; noting it rather than burying it.
- **`script.ts` is an untypechecked string and there's no jsdom**, so the page tests can only assert rendered-HTML substrings — they cannot execute anything. Several ids are load-bearing but unpinned; a restyle that drops one fails silently at runtime with a green suite. `el("activity-table").parentNode` was converted to an explicit `#activity-wrap` for this reason.

## Test Plan

Automated: credits-admin suite 82/82. Full suite 1541 passed / 1 pre-existing flake (`agent-templates.executor` "timeout race" — passes 28/28 isolated). typecheck + prettier + repo-wide lint clean. Browser JS `node --check` clean. Zero external refs in the rendered page.

Manual browser walk (seed: accounts at varied balances incl. negative/zero, an entitled sub at balance 0, a healthy high-balance sub, a lapsed sub at 0, ledger rows across grant kinds, consumes recent and >30d, one never-consumed account):

- [ ] Unlock → View selector defaults to "Activity feed"; facets visible; no mode controls.
- [ ] Each of the 6 views renders its own columns; center heading tracks the view.
- [ ] Balance: min/max + sort applied; negative balances included when min is blank/low.
- [ ] Broken subs (maxBalance 0): entitled-at-0, grace, and billingRetry accounts appear with Tier/Status; healthy high-balance subscriber and lapsed sub do NOT.
- [ ] Grant kind: accounts appear newest-grant-first; switching kind re-queries.
- [ ] Active vs Dormant: dormant includes the never-consumed account, Last-consume renders `—`.
- [ ] Row click → slide-over detail opens for that account.
- [ ] Load more appends without reset in both Activity and an accounts view; hides on last page.
- [ ] Empty state copy matches the current view.
- [ ] Grant/adjust performed **from an accounts view** does not clobber the footer.
- [ ] Grant/adjust button visibly reads disabled while in-flight (double-submit guard).
- [ ] Rapid view switching under throttled network: the final view's rows are what render.
- [ ] 768px: rail stacks above center, no horizontal body scroll.
- [ ] Rail selects render their chevron and open correctly (`appearance:none` — **check Safari**).
- [ ] DevTools console clean (a `null` element error means a dropped marker).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786730292&installation_id=128169237&pr_number=372&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F372&signature=b30d238d0f5c5373547d1934efb4b061a90d249ccce62e298aa8ac8eb0fb92e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add accounts-filter views and restyle the credits admin console
> - Adds a new `GET /api/v2/credits-admin/accounts` endpoint with four query modes: `balance` (filter/sort by balance), `broken` (entitled subscribers below a balance threshold), `grantKind` (accounts by grant type), and `activity` (active/dormant by consume events).
> - Adds repository functions in [accounts-repository.ts](https://github.com/ephemeraHQ/convos-backend/pull/372/files#diff-f13a84c26f2e662a9d3e35d5b0be5122eedf21bf7958631a299eb7c56a687593) backed by new composite indexes on `CreditLedger` and `UserCredits` for efficient filtering and sorting.
> - Updates the admin console UI in [console-view.ts](https://github.com/ephemeraHQ/convos-backend/pull/372/files#diff-8085ce47f11ae91c45730ea39d6a944df6f95bafd5a3b7b248d82a1e77879843) and [script.ts](https://github.com/ephemeraHQ/convos-backend/pull/372/files#diff-844a156bfa71da599e144b212b165c23ac52ea81f39c5ccb0fdef12591fa5b6a) with a switchable view selector, mode-specific filter controls, and a dedicated accounts table pane.
> - Overhauls the admin console visual design in [styles.ts](https://github.com/ephemeraHQ/convos-backend/pull/372/files#diff-5026cdeef3d31917458c32b473b8379af53c676e7e57bb27ef7028c0d1d0918a) with a new color palette, typography, shadows, and component styles (buttons, tables, cards, detail slide-over).
> - Behavioral Change: existing `CreditLedger_grantKindId_idx` index is dropped and replaced by composite indexes; query plans for any direct use of that index will change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95824a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accounts view to the Credits Admin console.
  * Added filtering by balance, subscription status, grant type, and recent activity.
  * Added pagination and “Load more” support for account results.
  * Added account details including balances, subscriptions, ledger activity, and audit information.
  * Added a protected accounts listing endpoint with request validation.

* **Style**
  * Refreshed the admin console layout, controls, tables, cards, responsive behavior, and login screen styling.

* **Bug Fixes**
  * Improved empty states, loading behavior, and view-specific data rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->