### PR TITLE
fix(credits-admin): guard detail render against stale account responses

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -244,8 +244,8 @@ export const clientScript = (): string => `
     el("detail-body").innerHTML='<div class="muted-note">Loading…</div>';
     el("detail").classList.add("open"); el("detail").setAttribute("aria-hidden","false"); el("detail-scrim").classList.remove("hidden");
     guardFetch("/accounts/"+encodeURIComponent(accountId)).then(function(r){ if(r.status===404){ throw new Error("not_found"); } return r.json(); })
-      .then(function(j){ renderDetail(j); loadAudit(accountId); })
-      .catch(function(e){ if(e.message==="not_found"){ el("detail-body").innerHTML='<div class="badge badge-no">Account not found</div>'; } else if(e.message!=="reauth"){ toast("Failed to load account","error"); } });
+      .then(function(j){ if(accountId!==currentAccountId) return; renderDetail(j); loadAudit(accountId); })
+      .catch(function(e){ if(accountId!==currentAccountId) return; if(e.message==="not_found"){ el("detail-body").innerHTML='<div class="badge badge-no">Account not found</div>'; } else if(e.message!=="reauth"){ toast("Failed to load account","error"); } });
   }
   function mutate(kind){
     if(!currentAccountId) return;


### PR DESCRIPTION
## The bug

`openDetail` commits `currentAccountId` at **dispatch** and renders the response with **no guard**. `mutate()` (grant/adjust) reads `currentAccountId`. So the panel and the mutation target can disagree:

1. Click account **A** → `currentAccountId = A`, fetch A (slow).
2. Click account **B** → `currentAccountId = B`, fetch B (fast). B's panel renders.
3. A's slow response lands → `renderDetail(A)` repaints the panel to **A**.
4. Operator reads A's balance, clicks Grant → `POST /accounts/**B**/grant`.

**Credits land on the account the operator is not looking at.** The `.catch` had the same hole — a stale 404 would paint "Account not found" over whichever account is currently open.

This is **pre-existing**, shipped in #371 and live on `otr-dev`. It is not introduced by the accounts-filter work (#372); it surfaced while reviewing that PR under a "state committed at dispatch vs. on success" lens.

## The fix

Guard the **render**, not the assignment — moving the assignment would just invert which account is wrong:

```js
.then(function(j){ if(accountId!==currentAccountId) return; renderDetail(j); loadAudit(accountId); })
.catch(function(e){ if(accountId!==currentAccountId) return; ... })
```

This matches the guard pattern already used by `loadActivity`/`loadAccounts` (`if(view!==currentView) return;`).

## Proof

The repo has no jsdom (`environment: "node"`) and `clientScript()` is an untypechecked string, so this is not reachable by the existing page tests — they can only assert HTML substrings. I drove the **real** `clientScript()` through a DOM stub with a deferred fetch queue so response ordering is controllable, and confirmed the harness reproduces the bug **before** trusting that it validates the fix:

**Before (unfixed):**
```
panel shows B (correct)?         : false
panel shows A (stale repaint)?   : true
currentAccountId (mutate target) : B
grant POSTed to                  : B
BUG REPRODUCED: reads A, credits land on B
```

**After:**
```
panel shows B (correct)?         : true
panel shows A (stale repaint)?   : false
grant POSTed to                  : B
OK: no wrong-account mutation
```

Harness is not committed — wiring it into vitest needs a jsdom/environment decision that's still open. This is the 3rd bug of this class in this file (after the cross-feed footer race and the pagination-page-number race, both in #372), so promoting it is worth considering separately.

## Test Plan

- [x] credits-admin suite 82/82
- [x] `node --check` on extracted browser JS → OK
- [x] typecheck + prettier + repo-wide lint clean
- [x] Harness reproduces the bug on unfixed code and passes on fixed code
- [ ] Browser: open account A on a throttled network, click account B before A resolves, confirm the panel that ends up displayed matches the account any subsequent grant/adjust targets

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786733008&installation_id=128169237&pr_number=373&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F373&signature=8a1317fbc148ebefead2731f4ef38fb3d6ed2def9eac88f948bc2f4c7b06faff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale detail panel updates in credits admin when switching accounts quickly
> When a user switches accounts before a pending `openDetail` request completes, the success and error handlers now no-op if the response's `accountId` no longer matches `currentAccountId`. Previously, `renderDetail`, `loadAudit`, and error UI updates executed unconditionally for whichever request finished last, causing stale data to appear in the detail panel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 007cbe9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->