### PR TITLE
feat(credits-admin): brand restyle + smart search + sortable tables

### DIFF
--- a/src/api/v2/credits-admin/accounts-repository.ts
+++ b/src/api/v2/credits-admin/accounts-repository.ts
@@ -1,5 +1,8 @@
-import type { Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/utils/prisma";
+
+const dirSql = (dir: "asc" | "desc"): Prisma.Sql =>
+  dir === "asc" ? Prisma.sql`ASC` : Prisma.sql`DESC`;
 
 export const ACCOUNTS_LIST_LIMIT = 50;
 
@@ -40,17 +43,19 @@ export const listByBalance = async (args: {
   min?: number | null;
   max?: number | null;
   sort?: "asc" | "desc";
+  sortDir?: "asc" | "desc";
   page?: number;
   limit?: number;
 }): Promise<Page<BalanceRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
+  const dir = args.sortDir ?? args.sort ?? "desc";
   const balance: Prisma.BigIntFilter = {};
   if (args.min != null) balance.gte = BigInt(args.min);
   if (args.max != null) balance.lte = BigInt(args.max);
   const rows = await prisma.userCredits.findMany({
     where: Object.keys(balance).length ? { balance } : {},
-    orderBy: [{ balance: args.sort ?? "desc" }, { accountId: "asc" }],
+    orderBy: [{ balance: dir }, { accountId: "asc" }],
     take: limit + 1,
     skip,
     select: { accountId: true, balance: true },
@@ -63,12 +68,21 @@ export const listByBalance = async (args: {
 
 export const listBrokenSubscribers = async (args: {
   maxBalance?: number;
+  sortBy?: "balance" | "currentPeriodEnd" | "tier";
+  sortDir?: "asc" | "desc";
   page?: number;
   limit?: number;
 }): Promise<Page<BrokenRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
   const maxBalance = BigInt(args.maxBalance ?? 0);
+  const d = dirSql(args.sortDir ?? "asc");
+  const orderBy =
+    args.sortBy === "currentPeriodEnd"
+      ? Prisma.sql`ORDER BY sub."currentPeriodEnd" ${d}, uc."accountId"`
+      : args.sortBy === "tier"
+        ? Prisma.sql`ORDER BY sub.tier ${d}, uc."accountId"`
+        : Prisma.sql`ORDER BY uc.balance ${d}, uc."accountId"`;
   const rows = await prisma.$queryRaw<BrokenRow[]>`
     SELECT uc."accountId", uc.balance,
            sub.tier, sub.status AS "effectiveStatus", sub."currentPeriodEnd"
@@ -86,7 +100,7 @@ export const listBrokenSubscribers = async (args: {
       LIMIT 1
     ) sub ON true
     WHERE uc.balance <= ${maxBalance}
-    ORDER BY uc.balance ASC, uc."accountId"
+    ${orderBy}
     LIMIT ${limit + 1} OFFSET ${skip}
   `;
   return page(
@@ -103,18 +117,25 @@ export const listBrokenSubscribers = async (args: {
 
 export const listByGrantKind = async (args: {
   kind: string;
+  sortBy?: "latestGrantAt" | "balance";
+  sortDir?: "asc" | "desc";
   page?: number;
   limit?: number;
 }): Promise<Page<GrantKindRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
+  const d = dirSql(args.sortDir ?? "desc");
+  const orderBy =
+    args.sortBy === "balance"
+      ? Prisma.sql`ORDER BY uc.balance ${d}, cl."accountId"`
+      : Prisma.sql`ORDER BY "latestGrantAt" ${d}, cl."accountId"`;
   const rows = await prisma.$queryRaw<GrantKindRow[]>`
     SELECT cl."accountId", uc.balance, MAX(cl."createdAt") AS "latestGrantAt"
     FROM "CreditLedger" cl
     JOIN "UserCredits" uc ON uc."accountId" = cl."accountId"
     WHERE cl."grantKindId" = ${args.kind}
     GROUP BY cl."accountId", uc.balance
-    ORDER BY "latestGrantAt" DESC, cl."accountId"
+    ${orderBy}
     LIMIT ${limit + 1} OFFSET ${skip}
   `;
   return page(
@@ -130,12 +151,21 @@ export const listByGrantKind = async (args: {
 export const listByActivity = async (args: {
   state: "active" | "dormant";
   days?: number;
+  sortBy?: "lastConsumeAt" | "balance";
+  sortDir?: "asc" | "desc";
   page?: number;
   limit?: number;
 }): Promise<Page<ActivityRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
   const days = args.days ?? 30;
+  const d = dirSql(args.sortDir ?? "desc");
+  // Tiebreaker must be the output-column "accountId", not uc."accountId": the
+  // active branch groups by cl."accountId" and would 42803 on uc."accountId".
+  const orderBy =
+    args.sortBy === "balance"
+      ? Prisma.sql`ORDER BY uc.balance ${d}, "accountId"`
+      : Prisma.sql`ORDER BY "lastConsumeAt" ${d} NULLS LAST, "accountId"`;
   const rows =
     args.state === "active"
       ? await prisma.$queryRaw<
@@ -147,7 +177,7 @@ export const listByActivity = async (args: {
           WHERE cl.reason = 'consume'
             AND cl."createdAt" >= now() - (${days} * interval '1 day')
           GROUP BY cl."accountId", uc.balance
-          ORDER BY "lastConsumeAt" DESC, cl."accountId"
+          ${orderBy}
           LIMIT ${limit + 1} OFFSET ${skip}
         `
       : await prisma.$queryRaw<ActivityRow[]>`
@@ -160,7 +190,7 @@ export const listByActivity = async (args: {
             WHERE cl."accountId" = uc."accountId" AND cl.reason = 'consume'
               AND cl."createdAt" >= now() - (${days} * interval '1 day')
           )
-          ORDER BY "lastConsumeAt" DESC NULLS LAST, uc."accountId"
+          ${orderBy}
           LIMIT ${limit + 1} OFFSET ${skip}
         `;
   return page(

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -1,7 +1,7 @@
 export const consoleView = (): string => `
 <div id="console" class="hidden">
   <header class="header">
-    <span class="brand" id="brand">💳 Credits Admin</span>
+    <span class="brand" id="brand"><svg viewBox="0 0 28 36" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M27.7736 13.8868C27.7736 21.5563 21.5563 27.7736 13.8868 27.7736C6.21733 27.7736 0 21.5563 0 13.8868C0 6.21733 6.21733 0 13.8868 0C21.5563 0 27.7736 6.21733 27.7736 13.8868Z" fill="var(--color-brand)"/><path d="M13.8868 27.7736L18.0699 35.0189H9.70373L13.8868 27.7736Z" fill="var(--color-brand)"/></svg>Convos Credits <span class="brand-suffix">Admin</span></span>
     <div class="header-right">
       <span id="identity"></span>
       <button id="lock" class="btn btn-secondary btn-sm">Lock</button>

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -37,7 +37,6 @@ export const consoleView = (): string => `
       <div id="ctl-balance" class="mode-ctl hidden">
         <input id="bal-min" type="number" placeholder="Min credits">
         <input id="bal-max" type="number" placeholder="Max credits">
-        <div class="select-wrap"><select id="bal-sort"><option value="desc">High → low</option><option value="asc">Low → high</option></select>${CHEV}</div>
       </div>
       <div id="ctl-broken" class="mode-ctl hidden">
         <input id="broken-max" type="number" value="0" placeholder="Max balance (≤)">

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -1,3 +1,5 @@
+const CHEV = `<svg class="chev" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+
 export const consoleView = (): string => `
 <div id="console" class="hidden">
   <header class="header">
@@ -11,20 +13,20 @@ export const consoleView = (): string => `
     <aside class="rail">
       <div class="rail-sec">
         <label for="search-value">Find account</label>
-        <select id="search-key"><option value="accountId">accountId</option><option value="wallet">wallet</option></select>
-        <input id="search-value" placeholder="accountId or wallet">
+        <input id="search-value" placeholder="Account ID or wallet address">
         <button id="search-btn" class="btn btn-primary btn-block">Search</button>
+        <div class="hint">Paste a wallet (0x…) or an account UUID — it detects which.</div>
       </div>
       <div class="rail-sec">
         <label for="view-mode">View</label>
-        <select id="view-mode">
+        <div class="select-wrap"><select id="view-mode">
           <option value="activity">Activity feed</option>
           <option value="balance">Balance</option>
           <option value="broken">Broken subs</option>
           <option value="grantKind">Grant kind</option>
           <option value="active">Active users</option>
           <option value="dormant">Dormant users</option>
-        </select>
+        </select>${CHEV}</div>
       </div>
       <div id="facet-group">
         <div class="rail-label">Filter activity</div>
@@ -33,24 +35,24 @@ export const consoleView = (): string => `
         <span class="facet" data-action="adjust">Adjusts</span>
       </div>
       <div id="ctl-balance" class="mode-ctl hidden">
-        <input id="bal-min" type="number" placeholder="min credits">
-        <input id="bal-max" type="number" placeholder="max credits">
-        <select id="bal-sort"><option value="desc">High → low</option><option value="asc">Low → high</option></select>
+        <input id="bal-min" type="number" placeholder="Min credits">
+        <input id="bal-max" type="number" placeholder="Max credits">
+        <div class="select-wrap"><select id="bal-sort"><option value="desc">High → low</option><option value="asc">Low → high</option></select>${CHEV}</div>
       </div>
       <div id="ctl-broken" class="mode-ctl hidden">
-        <input id="broken-max" type="number" value="0" placeholder="max balance (≤)">
+        <input id="broken-max" type="number" value="0" placeholder="Max balance (≤)">
       </div>
       <div id="ctl-grantKind" class="mode-ctl hidden">
-        <select id="gk-kind">
+        <div class="select-wrap"><select id="gk-kind">
           <option value="signup_bonus">signup_bonus</option>
           <option value="daily_refill">daily_refill</option>
           <option value="manual">manual</option>
           <option value="sub_grant">sub_grant</option>
           <option value="sub_forfeit">sub_forfeit</option>
-        </select>
+        </select>${CHEV}</div>
       </div>
       <div id="ctl-activity" class="mode-ctl hidden">
-        <input id="act-days" type="number" value="30" placeholder="days">
+        <input id="act-days" type="number" value="30" placeholder="Days">
       </div>
     </aside>
     <section class="center">

--- a/src/api/v2/credits-admin/handlers/admin-page/login-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/login-view.ts
@@ -1,10 +1,10 @@
 export const loginView = (): string => `
 <div id="login">
   <div class="login-card">
-    <h1>💳 Credits Admin</h1>
+    <h1><svg viewBox="0 0 28 36" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M27.7736 13.8868C27.7736 21.5563 21.5563 27.7736 13.8868 27.7736C6.21733 27.7736 0 21.5563 0 13.8868C0 6.21733 6.21733 0 13.8868 0C21.5563 0 27.7736 6.21733 27.7736 13.8868Z" fill="var(--color-brand)"/><path d="M13.8868 27.7736L18.0699 35.0189H9.70373L13.8868 27.7736Z" fill="var(--color-brand)"/></svg>Convos Credits Admin</h1>
     <div class="login-sub">Restricted — internal operations</div>
     <label for="token-input">Admin token</label>
-    <input id="token-input" type="password" placeholder="paste CREDITS_ADMIN_API_TOKEN" autocomplete="off">
+    <input id="token-input" type="password" placeholder="Paste CREDITS_ADMIN_API_TOKEN" autocomplete="off">
     <div id="login-error"></div>
     <button id="unlock" class="btn btn-primary btn-block">Unlock</button>
   </div>

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -186,8 +186,8 @@ export const clientScript = (): string => `
   var currentAccountId=null;
   function subChip(j){
     var state=j.subscription?j.subscription.effectiveStatus:"none";
-    var cls=!j.subscription?"badge-none":(j.isEntitled?"badge-yes":"badge-no");
-    return '<span class="badge '+cls+'">'+esc(state)+"</span>";
+    var cls=!j.subscription?"pill-none":(j.isEntitled?"pill-ok":"pill-bad");
+    return '<span class="pill '+cls+'">'+esc(state)+"</span>";
   }
   function renderSpark(usage){
     if(!usage||!usage.length) return '<span class="muted-note">No usage in the last 30 days.</span>';
@@ -245,7 +245,7 @@ export const clientScript = (): string => `
     el("detail").classList.add("open"); el("detail").setAttribute("aria-hidden","false"); el("detail-scrim").classList.remove("hidden");
     guardFetch("/accounts/"+encodeURIComponent(accountId)).then(function(r){ if(r.status===404){ throw new Error("not_found"); } return r.json(); })
       .then(function(j){ if(accountId!==currentAccountId) return; renderDetail(j); loadAudit(accountId); })
-      .catch(function(e){ if(accountId!==currentAccountId) return; if(e.message==="not_found"){ el("detail-body").innerHTML='<div class="badge badge-no">Account not found</div>'; } else if(e.message!=="reauth"){ toast("Failed to load account","error"); } });
+      .catch(function(e){ if(accountId!==currentAccountId) return; if(e.message==="not_found"){ el("detail-body").innerHTML='<div class="pill pill-bad">Account not found</div>'; } else if(e.message!=="reauth"){ toast("Failed to load account","error"); } });
   }
   function mutate(kind){
     if(!currentAccountId) return;

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -90,9 +90,9 @@ export const clientScript = (): string => `
     });
   });
   function doSearch(){
-    var key=el("search-key").value, value=el("search-value").value.trim();
+    var value=el("search-value").value.trim();
     if(!value) return;
-    guardFetch("/search?key="+encodeURIComponent(key)+"&value="+encodeURIComponent(value))
+    guardFetch("/search?value="+encodeURIComponent(value))
       .then(function(r){ return r.json(); })
       .then(function(j){ if(!j.accountId){ toast("No account found","error"); return; } openDetail(j.accountId); })
       .catch(function(e){ if(e.message!=="reauth") toast("Search failed","error"); });

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -8,7 +8,6 @@ export const clientScript = (): string => `
   function fmtDate(iso){ if(!iso) return "—"; var d=new Date(iso); return d.toLocaleDateString()+" "+d.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"}); }
   function usdHint(c){ c=Number(c); if(!CREDITS_PER_USD||!isFinite(c)||!c) return ""; return "≈ $"+(c/CREDITS_PER_USD).toLocaleString(undefined,{maximumFractionDigits:2}); }
   function newKey(p){ return p+"_"+crypto.randomUUID(); }
-  function shortId(id){ return id ? String(id).slice(0,8)+"…" : "—"; }
   var toastTimer=null;
   function toast(msg,type){ var t=el("toast"); if(!t){ t=document.createElement("div"); t.id="toast"; document.body.appendChild(t);} t.textContent=msg; t.className="toast toast-"+(type||"success")+" show"; if(toastTimer)clearTimeout(toastTimer); toastTimer=setTimeout(function(){t.className="toast";},3200); }
 
@@ -57,7 +56,7 @@ export const clientScript = (): string => `
     var tb=document.querySelector("#activity-table tbody");
     var html=rows.map(function(r){
       return '<tr class="row-clickable" data-account="'+esc(r.accountId)+'">'
-        +'<td class="nowrap">'+fmtDate(r.createdAt)+"</td><td>"+esc(r.actorEmail)+'</td><td class="mono">'+esc(shortId(r.accountId))
+        +'<td class="nowrap">'+fmtDate(r.createdAt)+"</td><td>"+esc(r.actorEmail)+'</td><td class="mono">'+esc(r.accountId)
         +"</td><td>"+esc(r.action)+'</td><td class="num">'+esc(r.deltaCredits)+"</td><td>"+esc(r.reason)+"</td></tr>";
     }).join("");
     if(append){ tb.insertAdjacentHTML("beforeend", html); } else { tb.innerHTML=html; }
@@ -113,22 +112,24 @@ export const clientScript = (): string => `
   }
   function accountsQuery(view, pageNo){
     var qs="?mode="+encodeURIComponent(accountsMode[view])+"&page="+pageNo;
+    var st=accountsSort[view];
+    if(st){ qs+="&sortBy="+encodeURIComponent(st.by)+"&sortDir="+encodeURIComponent(st.dir); }
     if(view==="balance"){ var mn=el("bal-min").value, mx=el("bal-max").value;
-      if(mn!=="") qs+="&min="+encodeURIComponent(mn); if(mx!=="") qs+="&max="+encodeURIComponent(mx);
-      qs+="&sort="+encodeURIComponent(el("bal-sort").value); }
+      if(mn!=="") qs+="&min="+encodeURIComponent(mn); if(mx!=="") qs+="&max="+encodeURIComponent(mx); }
     else if(view==="broken"){ qs+="&maxBalance="+encodeURIComponent(el("broken-max").value||"0"); }
     else if(view==="grantKind"){ qs+="&kind="+encodeURIComponent(el("gk-kind").value); }
     else if(view==="active"||view==="dormant"){ qs+="&state="+(view==="active"?"active":"dormant")+"&days="+encodeURIComponent(el("act-days").value||"30"); }
     return qs;
   }
   var accountsPageNo=0;
-  var colAccount=["Account",function(r){return shortId(r.accountId);},"mono"];
-  var colBalance=["Balance",function(r){return fmtCredits(r.balanceCredits);},"num"];
-  var userListCols=[colAccount,colBalance,["Last consume",function(r){return fmtDate(r.lastConsumeAt);},"nowrap"]];
+  var accountsSort={ balance:{by:"balance",dir:"desc"}, broken:{by:"balance",dir:"asc"}, grantKind:{by:"latestGrantAt",dir:"desc"}, active:{by:"lastConsumeAt",dir:"desc"}, dormant:{by:"lastConsumeAt",dir:"desc"} };
+  var colAccount=["Account",function(r){return r.accountId;},"mono"];
+  var colBalance=["Balance",function(r){return fmtCredits(r.balanceCredits);},"num","balance"];
+  var userListCols=[colAccount,colBalance,["Last consume",function(r){return fmtDate(r.lastConsumeAt);},"nowrap","lastConsumeAt"]];
   var accountCols={
     balance:[colAccount,colBalance],
-    broken:[colAccount,colBalance,["Tier",function(r){return r.tier||"—";}],["Status",function(r){return r.effectiveStatus||"—";}]],
-    grantKind:[colAccount,colBalance,["Latest grant",function(r){return fmtDate(r.latestGrantAt);},"nowrap"]],
+    broken:[colAccount,colBalance,["Tier",function(r){return r.tier||"—";},null,"tier"],["Status",function(r){return r.effectiveStatus||"—";}],["Period end",function(r){return fmtDate(r.currentPeriodEnd);},"nowrap","currentPeriodEnd"]],
+    grantKind:[colAccount,colBalance,["Latest grant",function(r){return fmtDate(r.latestGrantAt);},"nowrap","latestGrantAt"]],
     active:userListCols,
     dormant:userListCols
   };
@@ -142,8 +143,21 @@ export const clientScript = (): string => `
   };
   function renderAccountRows(rows, view, append){
     var cols=accountCols[view];
+    var st=accountsSort[view]||{};
     function colCls(c){ return c[2]?' class="'+c[2]+'"':""; }
-    el("accounts-head").innerHTML=cols.map(function(c){ return "<th"+colCls(c)+">"+esc(c[0])+"</th>"; }).join("");
+    if(!append){
+      el("accounts-head").innerHTML=cols.map(function(c){
+        var key=c[3];
+        var sortable = !!key;
+        var isSorted = sortable && st.by===key;
+        var arrow = isSorted ? '<span class="arrow">'+(st.dir==="asc"?"▲":"▼")+"</span>" : "";
+        var cls = (c[2]?c[2]+" ":"") + (sortable?"sortable ":"") + (isSorted?"sorted":"");
+        cls = cls.trim();
+        return "<th"+(cls?' class="'+cls+'"':"")+(sortable?' data-sort="'+esc(key)+'"':"")+">"+esc(c[0])+arrow+'<span class="rz" data-rz="1"></span></th>';
+      }).join("");
+      wireHeaderSort(view);
+      wireColumnResize();
+    }
     var tb=document.querySelector("#accounts-table tbody");
     var html=(rows||[]).map(function(r){
       return '<tr class="row-clickable" data-account="'+esc(r.accountId)+'">'
@@ -152,6 +166,27 @@ export const clientScript = (): string => `
     if(append){ tb.insertAdjacentHTML("beforeend", html); } else { tb.innerHTML=html; }
     Array.prototype.forEach.call(document.querySelectorAll("#accounts-table tbody tr.row-clickable"), function(tr){
       tr.onclick=function(){ openDetail(tr.getAttribute("data-account")); };
+    });
+  }
+  function wireHeaderSort(view){
+    Array.prototype.forEach.call(document.querySelectorAll("#accounts-head th.sortable"), function(th){
+      th.addEventListener("click", function(e){
+        if(e.target && e.target.getAttribute && e.target.getAttribute("data-rz")) return;
+        var key=th.getAttribute("data-sort"), st=accountsSort[view];
+        if(st.by===key){ st.dir = st.dir==="asc"?"desc":"asc"; } else { st.by=key; st.dir="desc"; }
+        loadAccounts(true);
+      });
+    });
+  }
+  function wireColumnResize(){
+    Array.prototype.forEach.call(document.querySelectorAll("#accounts-head .rz"), function(h){
+      h.addEventListener("mousedown", function(e){
+        e.preventDefault(); e.stopPropagation();
+        var th=h.parentNode, startX=e.pageX, startW=th.offsetWidth;
+        function move(ev){ var w=Math.max(48,startW+(ev.pageX-startX)); th.style.width=w+"px"; th.style.minWidth=w+"px"; }
+        function up(){ document.removeEventListener("mousemove",move); document.removeEventListener("mouseup",up); }
+        document.addEventListener("mousemove",move); document.addEventListener("mouseup",up);
+      });
     });
   }
   function loadAccounts(reset){
@@ -215,13 +250,13 @@ export const clientScript = (): string => `
         +"</tbody></table>"
       : '<div class="muted-note">No subscription on record.</div>';
     el("detail-body").innerHTML =
-      '<h2 class="detail-title">Account <span class="mono">'+esc(shortId(j.accountId))+'</span></h2>'
+      '<h2 class="detail-title">Account <span class="mono">'+esc(j.accountId)+'</span></h2>'
       +'<div class="card"><h3 class="tight">Balance</h3><div class="balance-value">'+fmtCredits(j.balanceCredits)+'</div>'
       +'<div class="balance-hint">'+usdHint(j.balanceCredits)+'</div>'
       +'<div class="sub-line">Subscription: '+subChip(j)+'</div></div>'
       +'<div class="card"><h3>Subscription</h3>'+subBlock+'</div>'
-      +'<div class="card"><h3>Grant</h3><input id="d-grant-credits" type="number" min="1" placeholder="credits"><input id="d-grant-reason" placeholder="reason"><button id="d-grant-btn" class="btn btn-primary">Grant</button></div>'
-      +'<div class="card"><h3>Adjust</h3><input id="d-adjust-delta" type="number" placeholder="±credits"><input id="d-adjust-reason" placeholder="reason"><button id="d-adjust-btn" class="btn btn-danger">Adjust</button></div>'
+      +'<div class="card"><h3>Grant</h3><input id="d-grant-credits" type="number" min="1" placeholder="Credits"><input id="d-grant-reason" placeholder="Reason"><button id="d-grant-btn" class="btn btn-primary">Grant</button></div>'
+      +'<div class="card"><h3>Adjust</h3><input id="d-adjust-delta" type="number" placeholder="±credits"><input id="d-adjust-reason" placeholder="Reason"><button id="d-adjust-btn" class="btn btn-danger">Adjust</button></div>'
       +'<div class="card"><h3>Usage (30d)</h3><div id="usage-spark" class="spark"></div></div>'
       +'<div class="card"><h3>Daily refills</h3><div class="tablewrap"><table><tbody id="d-refills"></tbody></table></div></div>'
       +'<div class="card"><h3>Recent ledger</h3><div class="tablewrap"><table><tbody id="d-ledger"></tbody></table></div></div>'

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -1,244 +1,157 @@
 export const STYLES = `
-  :root {
-    --brand: #283a75; --brand-strong: #1d2b58; --brand-weak: #e8e9f2;
-    --brand-ring: rgba(40,58,117,.30);
-    --fg: #211f1a; --fg-2: #3f3a32; --muted: #6b6455;
-    --surface: #fbfaf6; --surface-2: #f2efe6; --bg: #e9e5da;
-    --edge: #dcd7c9; --edge-2: #c3bca8;
-    --ok: #17603d; --ok-bg: #e4eddf;
-    --bad: #97231a; --bad-bg: #f7e2dc; --bad-solid: #bf2d1e; --bad-strong: #8f1f14;
-    --rail-w: 260px; --header-h: 60px; --center-max: 1160px; --control-h: 36px;
-    --radius-sm: 8px; --radius: 12px; --radius-lg: 16px;
-    --shadow-1: 0 1px 2px rgba(33,31,26,.05), 0 1px 3px rgba(33,31,26,.07);
-    --shadow-2: 0 2px 4px -1px rgba(33,31,26,.06), 0 8px 16px -4px rgba(33,31,26,.10);
-    --shadow-pop: 0 12px 24px -8px rgba(33,31,26,.20), 0 32px 64px -16px rgba(33,31,26,.24);
-    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
-    --ease: cubic-bezier(0.22, 1, 0.36, 1);
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin:0; font-family:var(--sans); color:var(--fg); background:var(--bg);
-    -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
-  }
-  .hidden { display:none !important; }
-  :focus-visible { outline:2px solid var(--brand); outline-offset:2px; }
+:root{
+  --color-brand:#FC4F37; --color-brand-hover:#D9412D;
+  --color-brand-strong:#CE3A23; --color-brand-strong-hover:#B5331D;
+  --brand-ring:color-mix(in srgb, #FC4F37 22%, transparent);
+  --fg:#000; --fg-2:#666; --fg-3:#B2B2B2; --fg-muted:#6E6E6E; --fg-inv:#fff;
+  --surface:#fff; --surface-muted:#F5F5F5; --surface-hover:#FAFAFA;
+  --edge:#EBEBEB; --edge-2:#F0F0F0;
+  --ok:#16A34A; --ok-bg:#F0FDF4; --ok-fg:#065F46;
+  --bad:#DC2626; --bad-bg:#FEE2E2; --bad-fg:#991B1B;
+  --none-bg:#E5E7EB; --none-fg:#4B5563;
+  --rail-w:240px; --header-h:53px; --center-max:1160px; --control-h:38px;
+  --radius-sm:6px; --radius:8px; --radius-lg:12px; --radius-full:999px;
+  --shadow-pop:0 10px 32px rgba(0,0,0,.14), 0 2px 6px rgba(0,0,0,.06);
+  --shadow-detail:-18px 0 56px rgba(0,0,0,.16);
+  --shadow-toast:0 8px 24px rgba(0,0,0,.18);
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Arial,sans-serif;
+  --mono:"SF Mono",Monaco,ui-monospace,Menlo,"Courier New",monospace;
+  --ease:cubic-bezier(0.23,1,0.32,1);
+}
+*{box-sizing:border-box;}
+body{margin:0;font-family:var(--sans);color:var(--fg);background:var(--surface-muted);font-size:13px;line-height:1.5;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}
+.hidden{display:none !important;}
+:focus-visible{outline:2px solid var(--color-brand);outline-offset:2px;}
 
-  /* Login */
-  #login {
-    min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px;
-    background:
-      radial-gradient(120% 90% at 50% -10%, var(--surface) 0%, rgba(251,250,246,0) 60%),
-      radial-gradient(80% 60% at 85% 110%, var(--brand-weak) 0%, rgba(232,233,242,0) 70%),
-      var(--bg);
-  }
-  .login-card {
-    background:var(--surface); border:1px solid var(--edge); border-radius:var(--radius-lg);
-    padding:32px; width:min(400px,92vw); box-shadow:var(--shadow-2);
-  }
-  .login-card h1 { font-size:20px; font-weight:650; letter-spacing:-0.02em; margin:0 0 4px; }
-  .login-sub { font-size:12px; color:var(--muted); margin:0 0 24px; }
-  .login-card label {
-    display:block; font-size:11px; font-weight:600; text-transform:uppercase;
-    letter-spacing:.06em; color:var(--muted); margin-bottom:6px;
-  }
-  #token-input { font-family:var(--mono); font-size:14px; }
-  #login-error { color:var(--bad); font-size:12px; margin-top:6px; min-height:16px; }
-  #unlock { margin-top:8px; }
+/* Login */
+#login{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px;}
+.login-card{width:100%;max-width:360px;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius-lg);padding:28px 24px;}
+.login-card h1{display:flex;align-items:center;gap:9px;margin:0 0 4px;font-size:18px;font-weight:700;letter-spacing:-0.3px;}
+.login-card h1 svg{width:20px;height:26px;display:block;}
+.login-sub{font-size:12px;color:var(--fg-2);margin-bottom:20px;}
+.login-card label{display:block;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;color:var(--fg-2);margin-bottom:8px;}
+#token-input{width:100%;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:10px 14px;font-family:var(--mono);font-size:13px;color:var(--fg);}
+#token-input::placeholder{color:var(--fg-3);font-family:var(--sans);}
+#token-input:focus{outline:none;border-color:var(--fg-3);}
+#login-error{min-height:18px;margin:8px 0;font-size:12px;color:var(--bad);}
 
-  /* Header */
-  .header {
-    position:sticky; top:0; height:var(--header-h); display:flex; align-items:center; gap:12px;
-    padding:0 20px; background:rgba(251,250,246,.82); backdrop-filter:saturate(1.6) blur(10px);
-    -webkit-backdrop-filter:saturate(1.6) blur(10px);
-    border-bottom:1px solid var(--edge); z-index:20;
-  }
-  .brand { font-weight:650; font-size:14px; letter-spacing:-0.01em; cursor:pointer; user-select:none; }
-  .header-right { margin-left:auto; display:flex; align-items:center; gap:14px; }
-  #identity { font-size:12px; font-family:var(--mono); color:var(--muted); }
+/* Header */
+.header{height:var(--header-h);background:var(--surface);border-bottom:1px solid var(--edge);display:flex;align-items:center;justify-content:space-between;padding:0 20px;position:sticky;top:0;z-index:10;}
+.brand{display:flex;align-items:center;gap:9px;cursor:pointer;font-size:16px;font-weight:700;letter-spacing:-0.3px;}
+.brand svg{width:22px;height:28px;display:block;}
+.brand .brand-suffix{font-weight:400;color:var(--fg-2);}
+.header-right{display:flex;align-items:center;gap:14px;}
+#identity{font-size:12px;color:var(--fg-2);}
 
-  /* Console grid */
-  .console-grid { display:grid; grid-template-columns:var(--rail-w) 1fr; height:calc(100vh - var(--header-h)); }
-  .rail {
-    background:var(--surface); border-right:1px solid var(--edge); padding:20px 16px;
-    overflow:auto; display:flex; flex-direction:column; gap:22px;
-  }
-  .rail-sec { display:flex; flex-direction:column; gap:8px; }
-  .rail label, .rail-label {
-    display:block; font-size:11px; font-weight:600; text-transform:uppercase;
-    letter-spacing:.06em; color:var(--muted);
-  }
-  .rail input, .rail select, .login-card input {
-    width:100%; min-height:var(--control-h); padding:9px 10px;
-    border:1px solid var(--edge-2); border-radius:var(--radius-sm);
-    font-family:var(--sans); font-size:13px; color:var(--fg); background:var(--surface);
-    transition:border-color .15s, box-shadow .15s;
-  }
-  .rail select {
-    appearance:none; -webkit-appearance:none; padding-right:30px;
-    background-image:
-      linear-gradient(45deg, transparent 50%, var(--muted) 50%),
-      linear-gradient(135deg, var(--muted) 50%, transparent 50%);
-    background-position: calc(100% - 15px) 50%, calc(100% - 11px) 50%;
-    background-size: 5px 5px, 5px 5px;
-    background-repeat: no-repeat;
-  }
-  .rail input:focus, .rail select:focus, .login-card input:focus, .card input:focus {
-    outline:none; border-color:var(--brand); box-shadow:0 0 0 3px var(--brand-ring);
-  }
-  input[type=number] { font-variant-numeric:tabular-nums; }
-  #facet-group { display:flex; flex-wrap:wrap; gap:6px; }
-  #facet-group .rail-label { flex:1 0 100%; }
-  .facet {
-    display:inline-flex; align-items:center; padding:6px 12px; border-radius:999px;
-    border:1px solid var(--edge-2); background:var(--surface); color:var(--fg-2);
-    cursor:pointer; font-size:12px; font-weight:600; user-select:none;
-    transition:background .15s, color .15s, border-color .15s;
-  }
-  .facet:hover { background:var(--surface-2); }
-  .facet.active { background:var(--brand); color:#fff; border-color:var(--brand); box-shadow:var(--shadow-1); }
-  .mode-ctl { display:flex; flex-direction:column; gap:8px; }
+/* Console grid + rail */
+.console-grid{display:grid;grid-template-columns:var(--rail-w) 1fr;min-height:calc(100vh - var(--header-h));}
+.rail{background:var(--surface);border-right:1px solid var(--edge);padding:18px 16px;overflow-y:auto;}
+.rail-sec{margin-bottom:22px;}
+.rail label,.rail-label{display:block;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;color:var(--fg-2);margin-bottom:8px;}
+.rail input,.rail select,.mode-ctl input,.mode-ctl select{width:100%;min-height:var(--control-h);background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:9px 12px;font-family:var(--sans);font-size:13px;color:var(--fg);transition:border-color .16s var(--ease),box-shadow .16s var(--ease);}
+.rail input::placeholder,.mode-ctl input::placeholder{color:var(--fg-3);}
+.rail input:focus,.rail select:focus,.mode-ctl input:focus,.mode-ctl select:focus{outline:none;border-color:var(--fg-3);}
+.rail input+input,.rail .select-wrap,.rail button{margin-top:9px;}
+#search-value:focus{border-color:var(--color-brand);box-shadow:0 0 0 3px var(--brand-ring);}
+.rail .hint{font-size:11px;color:var(--fg-3);margin-top:7px;line-height:1.45;}
 
-  /* Center pane */
-  .center { overflow:auto; padding:24px; display:flex; flex-direction:column; gap:16px; }
-  .center > * { width:100%; max-width:var(--center-max); align-self:center; }
-  .center-title { font-size:17px; font-weight:650; letter-spacing:-0.01em; margin:0; }
-  .empty {
-    color:var(--muted); font-size:13px; padding:28px; text-align:center;
-    background:var(--surface); border:1px dashed var(--edge-2); border-radius:var(--radius);
-  }
-  #load-more { align-self:center; width:auto; max-width:none; min-width:180px; }
+/* Select chevron — CSP-safe: inline SVG in a wrapper, NOT a data-URI background */
+.select-wrap{position:relative;}
+.select-wrap select{appearance:none;-webkit-appearance:none;padding-right:34px;cursor:pointer;}
+.select-wrap .chev{position:absolute;right:11px;top:50%;transform:translateY(-50%);pointer-events:none;color:var(--fg-2);display:flex;}
 
-  /* Buttons */
-  .btn {
-    display:inline-flex; align-items:center; justify-content:center; gap:6px;
-    padding:9px 16px; border:1px solid transparent; border-radius:var(--radius-sm);
-    font-family:var(--sans); font-size:13px; font-weight:600; letter-spacing:.01em;
-    cursor:pointer; box-shadow:var(--shadow-1);
-    transition:background .15s, border-color .15s, box-shadow .15s, transform .06s, opacity .15s;
-  }
-  .btn:active:not(:disabled) { transform:translateY(1px); box-shadow:none; }
-  .btn:disabled {
-    background:var(--surface-2); color:var(--muted); border-color:var(--edge-2);
-    cursor:not-allowed; box-shadow:none; transform:none; filter:none; opacity:1;
-  }
-  .btn-primary { background:var(--brand); color:#fff; }
-  .btn-primary:hover:not(:disabled) { background:var(--brand-strong); }
-  .btn-secondary { background:var(--surface); color:var(--fg-2); border-color:var(--edge-2); }
-  .btn-secondary:hover:not(:disabled) { background:var(--surface-2); }
-  .btn-danger { background:var(--bad-solid); color:#fff; }
-  .btn-danger:hover:not(:disabled) { background:var(--bad-strong); }
-  .btn-block { width:100%; }
-  .btn-sm { padding:6px 12px; font-size:12px; }
+/* Activity facet chips */
+#facet-group{margin-bottom:22px;}
+.facet{display:inline-flex;align-items:center;font-size:11px;font-weight:600;border:1px solid var(--edge);border-radius:var(--radius-full);padding:4px 11px;margin:6px 6px 0 0;cursor:pointer;background:var(--surface);color:var(--fg-2);transition:all .12s var(--ease);}
+.facet:hover{border-color:var(--fg-3);}
+.facet.active{background:var(--color-brand);border-color:var(--color-brand);color:#fff;}
 
-  /* Badges */
-  .badge {
-    display:inline-flex; align-items:center; padding:3px 10px; border-radius:999px;
-    border:1px solid transparent; font-size:11px; font-weight:600; letter-spacing:.02em;
-  }
-  .badge-yes { background:var(--ok-bg); color:var(--ok); border-color:rgba(23,96,61,.22); }
-  .badge-no { background:var(--bad-bg); color:var(--bad); border-color:rgba(151,35,26,.22); }
-  .badge-none { background:var(--surface-2); color:var(--muted); border-color:var(--edge-2); }
+/* Center pane */
+.center{padding:16px 20px 24px;overflow:hidden;}
+.center-title{font-size:16px;font-weight:700;letter-spacing:-0.3px;margin:0 0 12px;}
+.empty{padding:28px 8px;color:var(--fg-3);font-size:13px;}
+#load-more{margin-top:14px;}
 
-  /* Tables */
-  table { width:100%; border-collapse:collapse; font-size:13px; }
-  thead th {
-    text-align:left; padding:10px 14px; font-size:11px; font-weight:600; text-transform:uppercase;
-    letter-spacing:.06em; color:var(--muted); background:var(--surface-2);
-    border-bottom:1px solid var(--edge); white-space:nowrap;
-  }
-  tbody td { padding:11px 14px; border-bottom:1px solid var(--edge); color:var(--fg-2); vertical-align:top; }
-  tbody tr:last-child td, tbody tr:last-child th { border-bottom:none; }
-  tbody th {
-    text-align:left; padding:11px 14px; border-bottom:1px solid var(--edge);
-    font-weight:600; color:var(--muted); white-space:nowrap; width:40%;
-  }
-  .num { text-align:right; white-space:nowrap; }
-  .mono { font-family:var(--mono); }
-  .nowrap { white-space:nowrap; }
-  thead th.mono, thead th.num { font-family:var(--sans); font-variant-numeric:normal; }
-  tbody td.num { font-family:var(--mono); font-variant-numeric:tabular-nums; }
-  tbody td.mono { color:var(--fg); }
-  .center .tablewrap {
-    overflow-x:auto; background:var(--surface); border:1px solid var(--edge);
-    border-radius:var(--radius); box-shadow:var(--shadow-1);
-  }
-  .card .tablewrap { overflow-x:auto; }
-  .row-clickable { cursor:pointer; transition:background .12s; }
-  .row-clickable:hover td { background:var(--surface-2); }
+/* Buttons */
+.btn{font-family:var(--sans);font-weight:600;border:1px solid transparent;border-radius:var(--radius);cursor:pointer;transition:background .16s var(--ease),border-color .16s var(--ease),color .16s var(--ease),transform .08s var(--ease);}
+.btn:active{transform:scale(0.97);}
+.btn[disabled]{opacity:.55;cursor:default;}
+.btn-primary{background:var(--color-brand-strong);color:#fff;font-size:12px;padding:8px 14px;}
+.btn-primary:hover{background:var(--color-brand-strong-hover);}
+.btn-secondary,.btn-sm{background:var(--surface);color:var(--fg);border-color:var(--edge);font-size:11px;padding:6px 12px;}
+.btn-secondary:hover,.btn-sm:hover{border-color:var(--fg-3);}
+.btn-danger{background:var(--surface);color:var(--bad);border-color:var(--edge);font-size:12px;padding:8px 14px;}
+.btn-danger:hover{background:var(--bad-bg);border-color:var(--bad);}
+.btn-block{display:block;width:100%;}
 
-  /* Sparkline */
-  .spark { display:flex; align-items:flex-end; gap:3px; height:64px; }
-  .spark .bar {
-    flex:1 1 0; min-width:3px; min-height:2px; border-radius:3px 3px 1px 1px;
-    background:linear-gradient(180deg, #46589c 0%, var(--brand) 100%);
-    transition:opacity .15s;
-  }
-  .spark .bar:hover { opacity:.65; }
+/* Status pills */
+.pill{display:inline-flex;align-items:center;font-size:11px;font-weight:600;border-radius:var(--radius-sm);padding:2px 8px;}
+.pill-ok{background:var(--ok-bg);color:var(--ok-fg);}
+.pill-bad{background:var(--bad-bg);color:var(--bad-fg);}
+.pill-none{background:var(--none-bg);color:var(--none-fg);}
 
-  /* Cards */
-  .card {
-    background:var(--surface); border:1px solid var(--edge); border-radius:var(--radius);
-    padding:18px; margin-bottom:14px; box-shadow:var(--shadow-1);
-  }
-  .card h3 {
-    font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.06em;
-    color:var(--muted); margin:0 0 12px;
-  }
-  .card h3.tight { margin-bottom:4px; }
-  .card input {
-    display:block; width:100%; padding:9px 10px; margin-bottom:8px;
-    border:1px solid var(--edge-2); border-radius:var(--radius-sm);
-    font-family:var(--sans); font-size:13px; color:var(--fg); background:var(--surface);
-    transition:border-color .15s, box-shadow .15s;
-  }
-  .card .btn { min-width:160px; }
-  .balance-value { font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:30px; font-weight:650; letter-spacing:-0.02em; line-height:1.1; margin-bottom:4px; }
-  .balance-hint { font-size:12px; color:var(--muted); }
-  .sub-line { display:flex; align-items:center; gap:8px; margin-top:14px; font-size:13px; color:var(--fg-2); }
-  .muted-note { color:var(--muted); font-size:13px; }
+/* Tables */
+.tablewrap{overflow:auto;border:1px solid var(--edge);border-radius:var(--radius-lg);background:var(--surface);}
+table{border-collapse:collapse;width:100%;table-layout:auto;}
+thead th{position:sticky;top:0;background:var(--surface-hover);font-size:10px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;color:var(--fg-2);text-align:left;padding:10px 14px;white-space:nowrap;border-bottom:1px solid var(--edge);position:relative;}
+thead th.num{text-align:right;}
+thead th.sortable{cursor:pointer;user-select:none;}
+thead th.sortable:hover{color:var(--fg);}
+thead th.sorted{color:var(--fg);}
+thead th .arrow{color:var(--color-brand);margin-left:5px;font-size:9px;}
+thead th .rz{position:absolute;top:0;right:0;width:7px;height:100%;cursor:col-resize;user-select:none;}
+tbody td{padding:11px 14px;border-bottom:1px solid var(--surface-muted);white-space:nowrap;vertical-align:middle;}
+td.num{text-align:right;font-variant-numeric:tabular-nums;}
+td.mono{font-family:var(--mono);font-size:11px;color:var(--fg-2);}
+td.nowrap{white-space:nowrap;}
+tbody tr.row-clickable{cursor:pointer;transition:background .1s var(--ease);}
+tbody tr.row-clickable:hover{background:var(--surface-hover);}
+tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 
-  /* Toast */
-  .toast {
-    position:fixed; bottom:24px; right:24px; padding:12px 18px; border-radius:var(--radius-sm);
-    color:#fff; font-size:13px; font-weight:600; box-shadow:var(--shadow-2);
-    opacity:0; transform:translateY(6px); transition:opacity .2s, transform .2s var(--ease);
-    pointer-events:none; z-index:50;
-  }
-  .toast.show { opacity:1; transform:none; }
-  .toast-success { background:var(--ok); } .toast-error { background:var(--bad-solid); }
+/* Sparkline */
+.spark{display:flex;align-items:flex-end;gap:3px;height:56px;}
+.spark .bar{flex:1;min-height:2px;background:var(--color-brand);border-radius:2px 2px 0 0;opacity:.85;}
 
-  /* Detail slide-over */
-  .detail-scrim {
-    position:fixed; inset:0; background:rgba(33,31,26,.42);
-    backdrop-filter:blur(2px); -webkit-backdrop-filter:blur(2px); z-index:30;
-  }
-  .detail {
-    position:fixed; top:0; right:0; bottom:0; width:min(720px,64vw); background:var(--bg);
-    border-left:1px solid var(--edge); box-shadow:var(--shadow-pop);
-    transform:translateX(102%); transition:transform .28s var(--ease);
-    z-index:40; overflow:auto; padding:24px;
-  }
-  .detail.open { transform:none; }
-  .detail-close { float:right; }
-  .detail-title { font-size:17px; font-weight:650; letter-spacing:-0.01em; margin:0 0 16px; }
+/* Cards */
+.card{background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius-lg);padding:16px 18px;margin-bottom:16px;}
+.card h3{margin:0 0 12px;font-size:14px;font-weight:700;letter-spacing:-0.2px;}
+.card h3.tight{margin-bottom:6px;}
+.card input{width:100%;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:9px 12px;font-size:13px;color:var(--fg);margin-bottom:9px;}
+.card input::placeholder{color:var(--fg-3);}
+.card input:focus{outline:none;border-color:var(--fg-3);}
+.card table{font-size:12px;}
+.card th{text-align:left;font-weight:600;color:var(--fg-2);padding:6px 10px;white-space:nowrap;}
+.balance-value{font-size:24px;font-weight:700;letter-spacing:-0.4px;}
+.balance-hint{font-size:12px;color:var(--fg-2);margin-top:2px;}
+.sub-line{margin-top:12px;font-size:12px;color:var(--fg-2);display:flex;align-items:center;gap:8px;}
+.muted-note{font-size:12px;color:var(--fg-3);}
+.detail-title{font-size:16px;font-weight:700;letter-spacing:-0.3px;margin:0 0 16px;}
+.detail-title .mono{font-family:var(--mono);font-size:13px;color:var(--fg-2);}
 
-  /* Responsive */
-  @media (max-width:768px) {
-    .console-grid { grid-template-columns:1fr; height:auto; }
-    .rail { border-right:none; border-bottom:1px solid var(--edge); }
-    .center { padding:16px; }
-    .detail { width:100vw; padding:16px; }
-    thead th { padding:8px 10px; }
-    tbody td, tbody th { padding:9px 10px; font-size:12px; }
-  }
-  @media (pointer:coarse) {
-    .btn,.facet { min-height:44px; }
-    tbody td, tbody th { padding-top:14px; padding-bottom:14px; line-height:16px; }
-    .rail input, .rail select, .card input { min-height:44px; font-size:16px; }
-  }
-  @media (prefers-reduced-motion:reduce) {
-    * { transition:none !important; }
-    .detail { transition:none; }
-  }
+/* Toast */
+.toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%) translateY(20px);background:var(--fg);color:var(--fg-inv);font-size:13px;font-weight:500;padding:10px 16px;border-radius:var(--radius-lg);box-shadow:var(--shadow-toast);opacity:0;pointer-events:none;transition:opacity .2s var(--ease),transform .2s var(--ease);z-index:50;}
+.toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
+.toast-error{background:var(--bad);}
+
+/* Detail slide-over */
+.detail-scrim{position:fixed;inset:0;background:rgba(0,0,0,.28);z-index:40;}
+.detail{position:fixed;top:0;right:0;height:100vh;width:min(670px,64vw);background:var(--surface);border-left:1px solid var(--edge);box-shadow:var(--shadow-detail);padding:24px;overflow-y:auto;transform:translateX(102%);transition:transform .24s cubic-bezier(0.22,1,0.36,1);z-index:41;}
+.detail.open{transform:none;}
+.detail-close{position:absolute;top:16px;right:16px;}
+
+/* Responsive */
+@media (max-width:768px){
+  .console-grid{grid-template-columns:1fr;}
+  .rail{border-right:none;border-bottom:1px solid var(--edge);}
+  .detail{width:100vw;}
+}
+@media (pointer:coarse){
+  .rail input,.rail select,.mode-ctl input,.mode-ctl select{min-height:44px;font-size:16px;}
+  .btn{min-height:40px;}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none !important;}
+  .detail{transition:none;}
+  .btn:active{transform:none;}
+}
 `;

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -93,7 +93,7 @@ body{margin:0;font-family:var(--sans);color:var(--fg);background:var(--surface-m
 /* Tables */
 .tablewrap{overflow:auto;border:1px solid var(--edge);border-radius:var(--radius-lg);background:var(--surface);}
 table{border-collapse:collapse;width:100%;table-layout:auto;}
-thead th{position:sticky;top:0;background:var(--surface-hover);font-size:10px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;color:var(--fg-2);text-align:left;padding:10px 14px;white-space:nowrap;border-bottom:1px solid var(--edge);position:relative;}
+thead th{background:var(--surface-hover);font-size:10px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;color:var(--fg-2);text-align:left;padding:10px 14px;white-space:nowrap;border-bottom:1px solid var(--edge);position:relative;}
 thead th.num{text-align:right;}
 thead th.sortable{cursor:pointer;user-select:none;}
 thead th.sortable:hover{color:var(--fg);}

--- a/src/api/v2/credits-admin/handlers/search-get.ts
+++ b/src/api/v2/credits-admin/handlers/search-get.ts
@@ -16,8 +16,14 @@ export const searchGetHandler = async (
   }
   const { key, value } = parsed.data;
 
-  if (key === "accountId") {
-    if (!accountIdSchema.safeParse(value).success) {
+  // When key is omitted (single smart search box) infer the lane: a UUID is an
+  // accountId, anything else is treated as a SIWE wallet externalKey. UUID and
+  // 0x-wallet shapes never collide, so this is unambiguous.
+  const isAccountId = accountIdSchema.safeParse(value).success;
+  const lane = key ?? (isAccountId ? "accountId" : "wallet");
+
+  if (lane === "accountId") {
+    if (!isAccountId) {
       res.status(200).json({ accountId: null });
       return;
     }
@@ -29,6 +35,9 @@ export const searchGetHandler = async (
     return;
   }
 
+  // Wallet lane. externalKey is matched exactly (current behavior); do NOT add a
+  // blind .toLowerCase() — SIWE externalKey storage case is unverified and a
+  // lowercase would regress a checksummed row.
   const authMethod = await prisma.authMethod.findUnique({
     where: { type_externalKey: { type: "SIWE", externalKey: value } },
     select: { accountId: true },

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -49,17 +49,23 @@ const accountsPageLimit = {
   limit: z.coerce.number().int().min(1).max(100).default(50),
 };
 
+const sortDir = z.enum(["asc", "desc"]);
+
 export const accountsListQuerySchema = z.discriminatedUnion("mode", [
   z.object({
     mode: z.literal("balance"),
     min: balanceFilterCredits.optional(),
     max: balanceFilterCredits.optional(),
     sort: z.enum(["asc", "desc"]).default("desc"),
+    sortBy: z.enum(["balance"]).default("balance"),
+    sortDir: sortDir.optional(),
     ...accountsPageLimit,
   }),
   z.object({
     mode: z.literal("broken"),
     maxBalance: balanceFilterCredits.default(0),
+    sortBy: z.enum(["balance", "currentPeriodEnd", "tier"]).default("balance"),
+    sortDir: sortDir.default("asc"),
     ...accountsPageLimit,
   }),
   z.object({
@@ -68,12 +74,16 @@ export const accountsListQuerySchema = z.discriminatedUnion("mode", [
       .string()
       .trim()
       .regex(/^[A-Za-z0-9_-]{1,64}$/),
+    sortBy: z.enum(["latestGrantAt", "balance"]).default("latestGrantAt"),
+    sortDir: sortDir.default("desc"),
     ...accountsPageLimit,
   }),
   z.object({
     mode: z.literal("activity"),
     state: z.enum(["active", "dormant"]),
     days: z.coerce.number().int().min(1).max(365).default(30),
+    sortBy: z.enum(["lastConsumeAt", "balance"]).default("lastConsumeAt"),
+    sortDir: sortDir.default("desc"),
     ...accountsPageLimit,
   }),
 ]);

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -5,7 +5,7 @@ import { accountIdSchema } from "@/utils/account-id";
 export const MAX_ADMIN_GRANT_CREDITS = 100_000_000;
 
 export const searchQuerySchema = z.object({
-  key: z.enum(["accountId", "wallet"]),
+  key: z.enum(["accountId", "wallet"]).optional(),
   value: z.string().trim().min(1).max(256),
 });
 

--- a/tests/credits-admin/accounts-list.integration.test.ts
+++ b/tests/credits-admin/accounts-list.integration.test.ts
@@ -174,6 +174,33 @@ describe("GET /api/v2/credits-admin/accounts", () => {
     expect(staleRow?.lastConsumeAt).toBe(staleAt.toISOString());
   });
 
+  it("balance view honors sortBy=balance&sortDir=asc", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    await setBalance(a, 8675311n);
+    const b = await seedAccount();
+    tracker.push(b);
+    await setBalance(b, 8675313n);
+    const ids = new Set([a, b]);
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=balance&sortBy=balance&sortDir=asc&min=8675310&max=8675314&limit=100",
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as Body;
+    const ours = body.rows
+      .filter((r) => ids.has(r.accountId))
+      .map((r) => r.balanceCredits);
+    expect(ours).toEqual(["8675311", "8675313"]);
+  });
+
+  it("400 on a foreign sortBy for the mode", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts?mode=balance&sortBy=tier",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_request" });
+  });
+
   it("400 on invalid mode", async () => {
     const res = await adminRequest(app).get(
       "/api/v2/credits-admin/accounts?mode=nonsense",

--- a/tests/credits-admin/accounts-repository.test.ts
+++ b/tests/credits-admin/accounts-repository.test.ts
@@ -265,4 +265,53 @@ describe("accounts-repository", () => {
     expect(dorIds).toContain(never); // never-consumed is dormant
     expect(dorIds).not.toContain(active);
   });
+
+  describe("listByBalance — sortDir", () => {
+    it("sortDir asc returns ascending balances, desc returns descending", async () => {
+      const a = await seedAccount();
+      tracker.push(a);
+      await setBalance(a, 10n);
+      const b = await seedAccount();
+      tracker.push(b);
+      await setBalance(b, 30n);
+      const c = await seedAccount();
+      tracker.push(c);
+      await setBalance(c, 20n);
+      const ids = new Set([a, b, c]);
+
+      const asc = await listByBalance({ sortDir: "asc", limit: 1000 });
+      const ascOurs = asc.rows
+        .filter((r) => ids.has(r.accountId))
+        .map((r) => r.balance);
+      expect(ascOurs).toEqual([10n, 20n, 30n]);
+
+      const desc = await listByBalance({ sortDir: "desc", limit: 1000 });
+      const descOurs = desc.rows
+        .filter((r) => ids.has(r.accountId))
+        .map((r) => r.balance);
+      expect(descOurs).toEqual([30n, 20n, 10n]);
+    });
+  });
+
+  describe("listByActivity — sortBy=balance keeps NULLS-LAST stability", () => {
+    it("dormant sortBy=balance asc does not throw and orders by balance", async () => {
+      const a = await seedAccount();
+      tracker.push(a);
+      await setBalance(a, 5n);
+      const b = await seedAccount();
+      tracker.push(b);
+      await setBalance(b, 15n);
+      const ids = new Set([a, b]);
+      const p = await listByActivity({
+        state: "dormant",
+        sortBy: "balance",
+        sortDir: "asc",
+        limit: 1000,
+      });
+      const ours = p.rows
+        .filter((r) => ids.has(r.accountId))
+        .map((r) => r.balance);
+      expect(ours).toEqual([5n, 15n]);
+    });
+  });
 });

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -58,7 +58,7 @@ describe("credits-admin page (console shell)", () => {
     const res = await adminRequest(app, false).get("/api/v2/credits-admin/");
     expect(res.text).toContain("/grant");
     expect(res.text).toContain("/adjust");
-    expect(res.text).toContain("badge-none"); // sub-state chip (none/entitled/lapsed)
+    expect(res.text).toContain("pill-none"); // sub-state chip (none/entitled/lapsed)
     expect(res.text).toContain("usage-spark");
     expect(res.text).toContain("perPeriodCredits");
   });
@@ -82,6 +82,33 @@ describe("credits-admin page (console shell)", () => {
     // setView() retitles this per view; pins the element's existence only —
     // the label swap itself is runtime behaviour a string assertion can't reach.
     expect(res.text).toContain('id="center-title"');
+  });
+});
+
+describe("admin page — brand", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("uses the Lava brand token and drops the old navy token", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("--color-brand:#FC4F37");
+    expect(res.text).not.toContain("#283a75");
+    expect(res.text).not.toContain("💳");
+  });
+
+  it("renders the chat-bubble SVG mark and wordmark", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("M27.7736 13.8868");
+    expect(res.text).toContain("Convos Credits");
+  });
+
+  it("uses .pill status classes, not legacy .badge", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("pill-none");
+    expect(res.text).not.toContain('class="badge');
   });
 });
 

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -131,6 +131,29 @@ describe("admin page — single search box", () => {
   });
 });
 
+describe("admin page — tables", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("no longer truncates account ids with shortId", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).not.toContain("function shortId");
+    expect(res.text).not.toContain("slice(0,8)");
+  });
+  it("wires server-side sort params and a resize handle", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("sortBy=");
+    expect(res.text).toContain("sortDir=");
+    expect(res.text).toContain('"rz"');
+  });
+  it("broken view defines a Period end column", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("Period end");
+  });
+});
+
 describe("admin client script — syntax", () => {
   it("clientScript() is syntactically valid JS", () => {
     // new Function parses the body without executing it — catches syntax errors

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -112,6 +112,25 @@ describe("admin page — brand", () => {
   });
 });
 
+describe("admin page — single search box", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("removes the search-key select and keeps a single search input", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).not.toContain('id="search-key"');
+    expect(res.text).toContain('id="search-value"');
+    expect(res.text).toContain('placeholder="Account ID or wallet address"');
+  });
+  it("wraps view-mode select in a chevron wrapper", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("select-wrap");
+    expect(res.text).toContain('class="chev"');
+  });
+});
+
 describe("admin client script — syntax", () => {
   it("clientScript() is syntactically valid JS", () => {
     // new Function parses the body without executing it — catches syntax errors

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -1,5 +1,6 @@
 import type { Express } from "express";
 import { beforeAll, describe, expect, it } from "vitest";
+import { clientScript } from "@/api/v2/credits-admin/handlers/admin-page/script";
 import { adminRequest, buildCreditsAdminApp } from "./helpers";
 
 describe("credits-admin page (console shell)", () => {
@@ -81,5 +82,14 @@ describe("credits-admin page (console shell)", () => {
     // setView() retitles this per view; pins the element's existence only —
     // the label swap itself is runtime behaviour a string assertion can't reach.
     expect(res.text).toContain('id="center-title"');
+  });
+});
+
+describe("admin client script — syntax", () => {
+  it("clientScript() is syntactically valid JS", () => {
+    // new Function parses the body without executing it — catches syntax errors
+    // in the template-string JS that string assertions miss.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    expect(() => new Function(clientScript())).not.toThrow();
   });
 });

--- a/tests/credits-admin/requests.schema.test.ts
+++ b/tests/credits-admin/requests.schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { accountsListQuerySchema } from "@/api/v2/credits-admin/schemas/requests";
+
+describe("accountsListQuerySchema — sort allowlist", () => {
+  it("balance accepts sortBy=balance", () => {
+    const p = accountsListQuerySchema.safeParse({
+      mode: "balance",
+      sortBy: "balance",
+      sortDir: "asc",
+    });
+    expect(p.success).toBe(true);
+  });
+
+  it("balance rejects a foreign sortBy (tier)", () => {
+    const p = accountsListQuerySchema.safeParse({
+      mode: "balance",
+      sortBy: "tier",
+    });
+    expect(p.success).toBe(false);
+  });
+
+  it("rejects a SQL-injection sortBy on every mode", () => {
+    const evil = 'balance"; DROP TABLE "UserCredits"; --';
+    for (const mode of ["balance", "broken", "grantKind"] as const) {
+      const base = mode === "grantKind" ? { mode, kind: "manual" } : { mode };
+      expect(
+        accountsListQuerySchema.safeParse({ ...base, sortBy: evil }).success,
+      ).toBe(false);
+    }
+    expect(
+      accountsListQuerySchema.safeParse({
+        mode: "activity",
+        state: "active",
+        sortBy: evil,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("broken accepts currentPeriodEnd and tier", () => {
+    for (const sortBy of ["balance", "currentPeriodEnd", "tier"]) {
+      expect(
+        accountsListQuerySchema.safeParse({ mode: "broken", sortBy }).success,
+      ).toBe(true);
+    }
+  });
+
+  it("defaults are applied when sort params omitted", () => {
+    const p = accountsListQuerySchema.safeParse({
+      mode: "grantKind",
+      kind: "manual",
+    });
+    expect(p.success).toBe(true);
+    if (p.success && p.data.mode === "grantKind") {
+      expect(p.data.sortBy).toBe("latestGrantAt");
+      expect(p.data.sortDir).toBe("desc");
+    }
+  });
+});

--- a/tests/credits-admin/search.integration.test.ts
+++ b/tests/credits-admin/search.integration.test.ts
@@ -72,4 +72,44 @@ describe("GET /api/v2/credits-admin/search", () => {
     );
     expect(res.status).toBe(401);
   });
+
+  it("auto-detects a UUID value as an accountId (no key param)", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/search?value=${accountId}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId });
+  });
+
+  it("auto-detects a 0x wallet value as a SIWE lookup (no key param)", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const wallet = "0x1122334455667788990011223344556677889900";
+    await seedSiweAuthMethod(accountId, wallet);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/search?value=${wallet}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId });
+  });
+
+  it("auto-detect: non-UUID non-matching value returns null", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/search?value=0xdeadbeef00000000000000000000000000000000",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId: null });
+  });
+
+  it("still honors an explicit key=accountId (back-compat)", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/search?key=accountId&value=${accountId}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountId });
+  });
 });


### PR DESCRIPTION
## Summary

Re-skins the credits-admin console into the convos-assistants "Quiet Instrument" brand and fixes six primitive/UX defects.

- **Brand**: navy/parchment → Lava accent (`#FC4F37`) on a true-gray field, white panels, system fonts. `💳` emoji logo → the Lava chat-bubble SVG mark + "Convos Credits Admin" wordmark. Every primitive rebuilt (buttons w/ press-scale, cards, wash **pills** replacing `.badge`, slide-over, toast, focus rings, reduced-motion).
- **Single smart search box**: removed the accountId/wallet `<select>` toggle. `/search` now auto-detects the lane when `key` is omitted — a UUID → account lookup, else → SIWE wallet lookup (unambiguous; `key` kept optional for back-compat).
- **Server-side sortable tables**: click any allowlisted column header → refetches ordered server-side (true global order, not just the loaded page). Full account IDs (dropped 8-char `shortId` truncation), monospace, no wrap, horizontal scroll, **resizable columns** (drag handle). Broken-subs view gains a "Period end" column.
- **Selects**: CSP-safe inline-`<svg>` chevron (the strict CSP has no `img-src`, so a data-URI chevron would be blocked), 13px text.
- **Placeholders**: sentence-cased throughout.

### Safety / correctness
- Server sort ORDER BY is built by a **fixed switch on a zod-validated `sortBy` enum → literal `Prisma.sql` fragment** — no string interpolation, no `Prisma.raw`. Injection rejected at the schema (400). Balance view stays on the identifier-safe Prisma `orderBy` object.
- `listByActivity` tiebreaker uses the output-column `"accountId"` to avoid a Postgres 42803 under the active branch's `GROUP BY`.
- Read-only: no money/ledger path touched, no migration.
- Preserve-list intact: #373 `openDetail` stale-response race guard, #370 sub-state chip semantics (none/entitled/lapsed), allotment row + dailyRefills + usageDaily spark.
- Request-contract-safe: `key` loosened to optional; new sort fields are optional + server-defaulted.

## Test plan

**Automated (green):**
- [x] `tests/credits-admin/` — 104/104 (search auto-detect incl. back-compat; sort allowlist + SQL-injection rejection; repo ordering + 42803-safe active branch; `new Function(clientScript())` syntax gate; served-HTML brand/markup assertions)
- [x] `pnpm typecheck` + `pnpm lint` clean

**Static visual (rendered in Chrome, verified):**
- [x] Brand palette + Lava SVG logo render correctly (incl. `fill="var(--color-brand)"` paints Lava)
- [x] Login gate look; select chevrons; status pills (green/red/gray); full-field mono IDs no-wrap; Period-end column + Lava sort arrow

**Interactive browser walk — REQUIRED before merge (not yet run):**
- [ ] Search box resolves a pasted **wallet** `0x…` → opens that account's detail
- [ ] Search box resolves a pasted **UUID** → opens that account; non-match → "No account found" toast
- [ ] Click a column header → network refetch `/accounts?...&sortBy=&sortDir=`, arrow flips, TRUE global order (not page-local)
- [ ] Column drag-resize feels right and does not trigger a sort
- [ ] Slide-over motion + scrim; then OS "Reduce Motion" → no animation

> Local dev walk was blocked by a missing `PAYMENTS_GRANT_PLUS_MONTHLY` env var (unrelated to this change). The 5 interactive cases above are the mandatory human gate — please run them before merging.

Spec + plan (local, gitignored): `docs/superpowers/{specs,plans}/2026-07-16-credits-admin-brand-restyle*`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786804567&installation_id=128169237&pr_number=375&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F375&signature=ca811596f6f4887d1617bc23a84279806dd55347bda512bc7cff10216df08f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add smart search auto-detection, sortable tables, and brand restyle to credits admin
> - The `/search` endpoint now auto-detects whether a value is an `accountId` (UUID) or wallet address when `key` is omitted; explicit `key` continues to work.
> - Account list endpoints (`listByBalance`, `listBrokenSubscribers`, `listByGrantKind`, `listByActivity`) accept `sortBy` and `sortDir` query params; the schema rejects invalid sort keys per mode with a 400.
> - The admin console client renders clickable sortable table headers with direction toggling, a column resize handle, and displays full account IDs instead of short IDs.
> - The UI is restyled with new brand SVG/wordmark, a single search box (key selector removed), chevron-wrapped selects, and new `.pill` status classes replacing badge classes.
> - Behavioral Change: the balance sidebar no longer renders a sort select; sort direction is now controlled via table header clicks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 139fa56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smart search that automatically detects account IDs or wallet addresses.
  * Added sortable account lists with selectable columns and sort direction.
  * Added interactive table column resizing.
  * Added clearer account details, status indicators, and full account IDs.

* **UI Improvements**
  * Refreshed the Credits Admin branding, layout, controls, responsive behavior, and visual styling.
  * Simplified account search to a single input with guidance.
  * Improved dropdown controls and mobile accessibility.

* **Bug Fixes**
  * Invalid search formats now return a safe, successful response without an account match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->