### PR TITLE
fix(credits-admin): brand dropdown menus + labeled usage chart

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -19,14 +19,14 @@ export const consoleView = (): string => `
       </div>
       <div class="rail-sec">
         <label for="view-mode">View</label>
-        <div class="select-wrap"><select id="view-mode">
+        <div class="dd" data-dd="view-mode"><select id="view-mode" class="dd-native">
           <option value="activity">Activity feed</option>
           <option value="balance">Balance</option>
           <option value="broken">Broken subs</option>
           <option value="grantKind">Grant kind</option>
           <option value="active">Active users</option>
           <option value="dormant">Dormant users</option>
-        </select>${CHEV}</div>
+        </select><button type="button" class="dd-btn" aria-haspopup="listbox" aria-expanded="false"><span class="dd-label"></span>${CHEV}</button><div class="dd-menu" role="listbox"></div></div>
       </div>
       <div id="facet-group">
         <div class="rail-label">Filter activity</div>
@@ -42,13 +42,13 @@ export const consoleView = (): string => `
         <input id="broken-max" type="number" value="0" placeholder="Max balance (≤)">
       </div>
       <div id="ctl-grantKind" class="mode-ctl hidden">
-        <div class="select-wrap"><select id="gk-kind">
+        <div class="dd" data-dd="gk-kind"><select id="gk-kind" class="dd-native">
           <option value="signup_bonus">signup_bonus</option>
           <option value="daily_refill">daily_refill</option>
           <option value="manual">manual</option>
           <option value="sub_grant">sub_grant</option>
           <option value="sub_forfeit">sub_forfeit</option>
-        </select>${CHEV}</div>
+        </select><button type="button" class="dd-btn" aria-haspopup="listbox" aria-expanded="false"><span class="dd-label"></span>${CHEV}</button><div class="dd-menu" role="listbox"></div></div>
       </div>
       <div id="ctl-activity" class="mode-ctl hidden">
         <input id="act-days" type="number" value="30" placeholder="Days">

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -224,11 +224,17 @@ export const clientScript = (): string => `
     var cls=!j.subscription?"pill-none":(j.isEntitled?"pill-ok":"pill-bad");
     return '<span class="pill '+cls+'">'+esc(state)+"</span>";
   }
-  function renderSpark(usage){
+  function renderUsage(usage){
     if(!usage||!usage.length) return '<span class="muted-note">No usage in the last 30 days.</span>';
     var max=usage.reduce(function(m,u){ var c=Number(u.consumed); return c>m?c:m; },0);
-    return usage.map(function(u){ var c=Number(u.consumed); var h=max>0?Math.max(2,Math.round(c/max*100)):2;
-      return '<div class="bar" style="height:'+h+'%" title="'+esc(u.bucketStart+" · "+fmtCredits(u.consumed)+" credits")+'"></div>'; }).join("");
+    var total=usage.reduce(function(s,u){ return s+Number(u.consumed); },0);
+    var bars=usage.map(function(u){ var c=Number(u.consumed); var h=max>0?Math.max(2,Math.round(c/max*100)):2;
+      return '<div class="bar'+(max>0&&c===max?" peak":"")+'" style="height:'+h+'%" data-val="'+esc(fmtCredits(c))+'" title="'+esc(u.bucketStart+" · "+fmtCredits(c)+" credits")+'"></div>'; }).join("");
+    var firstDate=fmtDate(usage[0].bucketStart).split(" ")[0];
+    var lastDate=fmtDate(usage[usage.length-1].bucketStart).split(" ")[0];
+    return '<div class="usage-head"><span>Peak <b>'+esc(fmtCredits(max))+'</b>/day</span><span>Total <b>'+esc(fmtCredits(total))+'</b> · 30d</span></div>'
+      +'<div class="usage-chart"><div class="usage-ymax">'+esc(fmtCredits(max))+'</div><div class="usage-grid"></div><div class="usage-bars">'+bars+'</div></div>'
+      +'<div class="usage-axis"><span>'+esc(firstDate)+'</span><span>'+esc(lastDate)+'</span></div>';
   }
   function rowsHtml(rows, cols){
     return (rows||[]).map(function(r){ return "<tr>"+cols.map(function(c){
@@ -257,11 +263,11 @@ export const clientScript = (): string => `
       +'<div class="card"><h3>Subscription</h3>'+subBlock+'</div>'
       +'<div class="card"><h3>Grant</h3><input id="d-grant-credits" type="number" min="1" placeholder="Credits"><input id="d-grant-reason" placeholder="Reason"><button id="d-grant-btn" class="btn btn-primary">Grant</button></div>'
       +'<div class="card"><h3>Adjust</h3><input id="d-adjust-delta" type="number" placeholder="±credits"><input id="d-adjust-reason" placeholder="Reason"><button id="d-adjust-btn" class="btn btn-danger">Adjust</button></div>'
-      +'<div class="card"><h3>Usage (30d)</h3><div id="usage-spark" class="spark"></div></div>'
+      +'<div class="card"><h3>Usage (30d)</h3><div id="usage-spark"></div></div>'
       +'<div class="card"><h3>Daily refills</h3><div class="tablewrap"><table><tbody id="d-refills"></tbody></table></div></div>'
       +'<div class="card"><h3>Recent ledger</h3><div class="tablewrap"><table><tbody id="d-ledger"></tbody></table></div></div>'
       +'<div class="card"><h3>Admin audit</h3><div class="tablewrap"><table><tbody id="d-audit"></tbody></table></div></div>';
-    el("usage-spark").innerHTML = renderSpark(j.usageDaily);
+    el("usage-spark").innerHTML = renderUsage(j.usageDaily);
     el("d-refills").innerHTML = (j.dailyRefills&&j.dailyRefills.length)
       ? rowsHtml(j.dailyRefills,[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.note||"");}])
       : '<tr><td class="muted-note">No daily refills.</td></tr>';
@@ -299,6 +305,33 @@ export const clientScript = (): string => `
       .catch(function(e){ if(btn) btn.disabled=false; if(e.message!=="reauth") toast("Failed","error"); });
   }
   function closeDetail(){ var d=el("detail"); if(d){ d.classList.remove("open"); d.setAttribute("aria-hidden","true"); } var s=el("detail-scrim"); if(s) s.classList.add("hidden"); }
+
+  // Custom dropdown: brand popover over a hidden native <select> that stays the
+  // value source, so existing change-listeners keep working via dispatchEvent.
+  function initDropdown(dd){
+    var sel=dd.querySelector(".dd-native"), btn=dd.querySelector(".dd-btn"), menu=dd.querySelector(".dd-menu"), label=dd.querySelector(".dd-label"), hl=-1;
+    function syncLabel(){ label.textContent=sel.options[sel.selectedIndex].text; }
+    function buildMenu(){ menu.innerHTML=Array.prototype.map.call(sel.options,function(o,i){
+      return '<div class="dd-opt'+(i===sel.selectedIndex?" active":"")+'" role="option" data-i="'+i+'"><span class="dd-check">✓</span>'+esc(o.text)+"</div>"; }).join(""); }
+    function opts(){ return menu.querySelectorAll(".dd-opt"); }
+    function highlight(i){ var os=opts(); if(!os.length) return; hl=(i+os.length)%os.length; Array.prototype.forEach.call(os,function(x,j){ x.classList.toggle("hl", j===hl); }); os[hl].scrollIntoView({block:"nearest"}); }
+    function open(){ buildMenu(); dd.classList.add("open"); btn.setAttribute("aria-expanded","true"); highlight(sel.selectedIndex); }
+    function close(){ dd.classList.remove("open"); btn.setAttribute("aria-expanded","false"); }
+    function choose(i){ if(sel.selectedIndex!==i){ sel.selectedIndex=i; sel.dispatchEvent(new Event("change")); } syncLabel(); close(); btn.focus(); }
+    btn.addEventListener("click", function(){ dd.classList.contains("open")?close():open(); });
+    menu.addEventListener("click", function(e){ var o=e.target.closest?e.target.closest(".dd-opt"):null; if(o) choose(Number(o.getAttribute("data-i"))); });
+    dd.addEventListener("keydown", function(e){
+      var isOpen=dd.classList.contains("open");
+      if(e.key==="Escape"){ if(isOpen){ e.preventDefault(); close(); btn.focus(); } return; }
+      if(!isOpen){ if(e.key==="ArrowDown"||e.key==="Enter"||e.key===" "){ e.preventDefault(); open(); } return; }
+      if(e.key==="ArrowDown"){ e.preventDefault(); highlight(hl+1); }
+      else if(e.key==="ArrowUp"){ e.preventDefault(); highlight(hl-1); }
+      else if(e.key==="Enter"||e.key===" "){ e.preventDefault(); if(hl>=0) choose(hl); }
+    });
+    document.addEventListener("click", function(e){ if(!dd.contains(e.target)) close(); });
+    syncLabel();
+  }
+  Array.prototype.forEach.call(document.querySelectorAll(".dd"), initDropdown);
 
   // --- boot: silent re-auth if a token is already stored ---
   (function boot(){ var t=getToken(); if(t){ attemptLogin(t); } else { showLogin(); } })();

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -51,14 +51,26 @@ body{margin:0;font-family:var(--sans);color:var(--fg);background:var(--surface-m
 .rail input,.rail select,.mode-ctl input,.mode-ctl select{width:100%;min-height:var(--control-h);background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:9px 12px;font-family:var(--sans);font-size:13px;color:var(--fg);transition:border-color .16s var(--ease),box-shadow .16s var(--ease);}
 .rail input::placeholder,.mode-ctl input::placeholder{color:var(--fg-3);}
 .rail input:focus,.rail select:focus,.mode-ctl input:focus,.mode-ctl select:focus{outline:none;border-color:var(--fg-3);}
-.rail input+input,.rail .select-wrap,.rail button{margin-top:9px;}
+.rail input+input,.rail .dd,.rail button{margin-top:9px;}
 #search-value:focus{border-color:var(--color-brand);box-shadow:0 0 0 3px var(--brand-ring);}
 .rail .hint{font-size:11px;color:var(--fg-3);margin-top:7px;line-height:1.45;}
 
-/* Select chevron — CSP-safe: inline SVG in a wrapper, NOT a data-URI background */
-.select-wrap{position:relative;}
-.select-wrap select{appearance:none;-webkit-appearance:none;padding-right:34px;cursor:pointer;}
-.select-wrap .chev{position:absolute;right:11px;top:50%;transform:translateY(-50%);pointer-events:none;color:var(--fg-2);display:flex;}
+/* Custom dropdown — brand popover; native <select> kept hidden as state + wiring source */
+.dd{position:relative;}
+.dd-native{display:none;}
+.dd-btn{width:100%;min-height:var(--control-h);display:flex;align-items:center;justify-content:space-between;gap:8px;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:9px 12px;font-family:var(--sans);font-size:13px;color:var(--fg);cursor:pointer;text-align:left;transition:border-color .16s var(--ease),box-shadow .16s var(--ease);}
+.dd-btn:hover{border-color:var(--fg-3);}
+.dd-btn:focus-visible{outline:none;border-color:var(--color-brand);box-shadow:0 0 0 3px var(--brand-ring);}
+.dd-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.dd-btn .chev{flex:none;color:var(--fg-2);transition:transform .16s var(--ease);}
+.dd.open .dd-btn .chev{transform:rotate(180deg);}
+.dd-menu{position:absolute;top:calc(100% + 4px);left:0;right:0;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius-lg);box-shadow:var(--shadow-pop);padding:5px;z-index:30;opacity:0;transform:scale(0.97);transform-origin:top center;pointer-events:none;transition:opacity .14s var(--ease),transform .14s var(--ease);max-height:288px;overflow-y:auto;}
+.dd.open .dd-menu{opacity:1;transform:scale(1);pointer-events:auto;}
+.dd-opt{display:flex;align-items:center;gap:8px;padding:7px 9px;border-radius:var(--radius-sm);font-size:13px;color:var(--fg);cursor:pointer;}
+.dd-opt:hover,.dd-opt.hl{background:var(--surface-hover);}
+.dd-opt .dd-check{width:13px;flex:none;color:var(--color-brand);font-size:11px;visibility:hidden;}
+.dd-opt.active{font-weight:600;}
+.dd-opt.active .dd-check{visibility:visible;}
 
 /* Activity facet chips */
 #facet-group{margin-bottom:22px;}
@@ -108,9 +120,17 @@ tbody tr.row-clickable{cursor:pointer;transition:background .1s var(--ease);}
 tbody tr.row-clickable:hover{background:var(--surface-hover);}
 tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 
-/* Sparkline */
-.spark{display:flex;align-items:flex-end;gap:3px;height:56px;}
-.spark .bar{flex:1;min-height:2px;background:var(--color-brand);border-radius:2px 2px 0 0;opacity:.85;}
+/* Usage chart — single-series magnitude over time */
+.usage-head{display:flex;gap:16px;font-size:12px;color:var(--fg-2);margin-bottom:12px;}
+.usage-head b{color:var(--fg);font-weight:600;}
+.usage-chart{position:relative;padding-top:16px;}
+.usage-ymax{position:absolute;top:0;left:0;font-size:10px;color:var(--fg-3);letter-spacing:0.3px;}
+.usage-grid{position:absolute;top:15px;left:0;right:0;height:0;border-top:1px dashed var(--edge);}
+.usage-bars{position:relative;display:flex;align-items:flex-end;gap:2px;height:76px;}
+.usage-bars .bar{flex:1;min-width:3px;min-height:2px;background:var(--color-brand);border-radius:3px 3px 0 0;position:relative;transition:opacity .1s var(--ease);}
+.usage-bars .bar:hover{opacity:.7;}
+.usage-bars .bar.peak::after{content:attr(data-val);position:absolute;top:-13px;left:50%;transform:translateX(-50%);font-size:9px;font-weight:600;color:var(--color-brand-strong);white-space:nowrap;}
+.usage-axis{display:flex;justify-content:space-between;margin-top:7px;font-size:10px;color:var(--fg-3);}
 
 /* Cards */
 .card{background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius-lg);padding:16px 18px;margin-bottom:16px;}

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -124,9 +124,13 @@ describe("admin page — single search box", () => {
     expect(res.text).toContain('id="search-value"');
     expect(res.text).toContain('placeholder="Account ID or wallet address"');
   });
-  it("wraps view-mode select in a chevron wrapper", async () => {
+  it("renders view-mode as a custom brand dropdown over a hidden native select", async () => {
     const res = await adminRequest(app).get("/api/v2/credits-admin/");
-    expect(res.text).toContain("select-wrap");
+    expect(res.text).not.toContain("select-wrap");
+    expect(res.text).toContain('class="dd" data-dd="view-mode"');
+    expect(res.text).toContain("dd-btn");
+    expect(res.text).toContain('class="dd-native"');
+    expect(res.text).toContain('role="listbox"');
     expect(res.text).toContain('class="chev"');
   });
 });


### PR DESCRIPTION
Follow-up to #375, from live dev testing. Two console UI defects.

## Summary

- **Dropdown menus were out of brand.** A native `<select>`'s open option-list is OS-rendered and unstyleable. Replaced the View + Grant-kind selects with a custom brand dropdown: a hidden native `<select class="dd-native">` stays the value/state source (so every existing `change` listener keeps firing via `dispatchEvent`), fronted by a brand popover — Surface panel, 1px edge, `shadow-pop`, scale-in, Lava check on the active item. Keyboard (↑/↓/Enter/Esc), click-outside, CSP-safe (no inline handlers). `initDropdown` runs over every `.dd` at boot.
- **Usage 30d chart was unusable — no visible quantities** (values were only in hover tooltips). Rebuilt `renderSpark`→`renderUsage` as a labeled bar chart: a Peak/Total header, a y-axis max label, a gridline, Lava rounded bars, the peak bar direct-labeled, and the date range on the x-axis. Readable without hover. (Single-series magnitude-over-time; one hue, selective peak label, recessive axis.)

No backend/money changes; frontend template strings + one test file only.

## Test plan

**Automated (green):**
- [x] `tests/credits-admin/` 104/104 (incl. the `new Function(clientScript())` syntax gate over the rewritten JS; the view-mode dropdown-markup assertion updated to the custom-dropdown shape)
- [x] `pnpm typecheck` + `pnpm lint` clean

**Verified live on local dev (`:4000`, seeded accounts + wallet):**
- [x] Custom dropdown renders the brand popover open (Chrome render), active item Lava-checked
- [x] Usage chart shows Peak/Total/y-max/date-axis + peak label (Chrome render)
- [x] (regression check, unchanged from #375) search-by-wallet / search-by-UUID / non-match→null, balance sort desc↔asc global flip, `sortBy=tier`→400

**Human click-through (pure UI interaction):**
- [ ] Open the **View** dropdown: click, keyboard ↑/↓/Enter/Esc, click-outside to close
- [ ] Usage chart hover tooltips still show per-day credits

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786810166&installation_id=128169237&pr_number=376&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F376&signature=c69b7c508613c2f06e2fe687e11eba79db338f6e8f7a808b1b42b154448c0a9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace native select elements with custom dropdowns and redesign usage chart in credits admin
> - Wraps the `#view-mode` and `#gk-kind` native `<select>` elements in a custom `.dd` dropdown structure with a button, listbox popover, and hidden native select in [console-view.ts](https://github.com/ephemeraHQ/convos-backend/pull/376/files#diff-8085ce47f11ae91c45730ea39d6a944df6f95bafd5a3b7b248d82a1e77879843).
> - Adds `initDropdown` in [script.ts](https://github.com/ephemeraHQ/convos-backend/pull/376/files#diff-844a156bfa71da599e144b212b165c23ac52ea81f39c5ccb0fdef12591fa5b6a) to wire up the custom dropdowns with full keyboard navigation (ArrowUp/Down, Enter, Space, Escape), mouse selection, and `change` event propagation via the hidden native select.
> - Replaces the plain sparkline renderer (`renderSpark`) with `renderUsage`, which renders a labeled bar chart showing peak and total usage with a highlighted peak bar and date axis.
> - Updates [styles.ts](https://github.com/ephemeraHQ/convos-backend/pull/376/files#diff-5026cdeef3d31917458c32b473b8379af53c676e7e57bb27ef7028c0d1d0918a) with new `.dd-*` dropdown styles and `.usage-*` chart styles, removing the old `.spark` and `.select-wrap` styles.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3dd04fb. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive custom dropdowns for view mode and grant type selection.
  - Added keyboard navigation, focus states, and click-outside handling for dropdown menus.
  - Added a 30-day usage chart showing daily activity, totals, peak usage, and date ranges.

- **Style**
  - Updated admin page controls with improved dropdown styling, hover states, and visual feedback.
  - Replaced the compact usage sparkline with a clearer bar chart presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->