### PR TITLE
feat(credits-admin): centered detail modal + full history + cohesive balance table

### DIFF
--- a/src/api/v2/credits-admin/accounts-repository.ts
+++ b/src/api/v2/credits-admin/accounts-repository.ts
@@ -9,6 +9,8 @@ export const ACCOUNTS_LIST_LIMIT = 50;
 export type BalanceRow = {
   accountId: string;
   balance: bigint;
+  wallet: string | null;
+  lastConsumeAt: Date | null;
 };
 
 export type BrokenRow = {
@@ -49,19 +51,30 @@ export const listByBalance = async (args: {
 }): Promise<Page<BalanceRow>> => {
   const limit = args.limit ?? ACCOUNTS_LIST_LIMIT;
   const skip = (args.page ?? 0) * limit;
-  const dir = args.sortDir ?? args.sort ?? "desc";
-  const balance: Prisma.BigIntFilter = {};
-  if (args.min != null) balance.gte = BigInt(args.min);
-  if (args.max != null) balance.lte = BigInt(args.max);
-  const rows = await prisma.userCredits.findMany({
-    where: Object.keys(balance).length ? { balance } : {},
-    orderBy: [{ balance: dir }, { accountId: "asc" }],
-    take: limit + 1,
-    skip,
-    select: { accountId: true, balance: true },
-  });
+  const d = dirSql(args.sortDir ?? args.sort ?? "desc");
+  const min = args.min != null ? BigInt(args.min) : null;
+  const max = args.max != null ? BigInt(args.max) : null;
+  const rows = await prisma.$queryRaw<BalanceRow[]>`
+    SELECT uc."accountId", uc.balance,
+      (SELECT am."externalKey" FROM "AuthMethod" am
+       WHERE am."accountId" = uc."accountId" AND am.type = 'SIWE'
+       ORDER BY am."addedAt" DESC LIMIT 1) AS wallet,
+      (SELECT MAX(cl."createdAt") FROM "CreditLedger" cl
+       WHERE cl."accountId" = uc."accountId" AND cl.reason = 'consume')
+       AS "lastConsumeAt"
+    FROM "UserCredits" uc
+    WHERE (${min}::bigint IS NULL OR uc.balance >= ${min}::bigint)
+      AND (${max}::bigint IS NULL OR uc.balance <= ${max}::bigint)
+    ORDER BY uc.balance ${d}, uc."accountId" ASC
+    LIMIT ${limit + 1} OFFSET ${skip}
+  `;
   return page(
-    rows.map((r) => ({ accountId: r.accountId, balance: r.balance })),
+    rows.map((r) => ({
+      accountId: r.accountId,
+      balance: r.balance,
+      wallet: r.wallet,
+      lastConsumeAt: r.lastConsumeAt,
+    })),
     limit,
   );
 };

--- a/src/api/v2/credits-admin/audit-repository.ts
+++ b/src/api/v2/credits-admin/audit-repository.ts
@@ -38,6 +38,9 @@ export const listAdminAuditByAccount = async (
 
 export type RecentAuditCursor = { createdAt: Date; id: string };
 
+const CURSOR_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // Delimiter-safe: neither field can contain "|" (ISO timestamp + UUID id).
 export const encodeAuditCursor = (r: { createdAt: Date; id: string }): string =>
   Buffer.from(`${r.createdAt.toISOString()}|${r.id}`).toString("base64url");
@@ -49,7 +52,10 @@ export const decodeAuditCursor = (raw: string): RecentAuditCursor | null => {
     if (idx < 0) return null;
     const createdAt = new Date(decoded.slice(0, idx));
     const id = decoded.slice(idx + 1);
-    if (Number.isNaN(createdAt.getTime()) || !id) return null;
+    // id must be a UUID: the keyset compares it against the uuid `id` column, so
+    // a non-uuid would raise a Postgres 22P02 (500) instead of a clean 400.
+    if (Number.isNaN(createdAt.getTime()) || !CURSOR_ID_RE.test(id))
+      return null;
     return { createdAt, id };
   } catch {
     return null;

--- a/src/api/v2/credits-admin/audit-repository.ts
+++ b/src/api/v2/credits-admin/audit-repository.ts
@@ -83,3 +83,28 @@ export const listRecentAdminAudit = async (args: {
   const nextCursor = hasMore && last ? encodeAuditCursor(last) : null;
   return { rows: page, nextCursor };
 };
+
+export const listAdminAuditPageByAccount = async (args: {
+  accountId: string;
+  cursor?: RecentAuditCursor | null;
+  limit?: number;
+}): Promise<{ rows: AdminAudit[]; nextCursor: string | null }> => {
+  const limit = args.limit ?? AUDIT_LIST_LIMIT;
+  const where: Prisma.AdminAuditWhereInput = { accountId: args.accountId };
+  if (args.cursor) {
+    where.OR = [
+      { createdAt: { lt: args.cursor.createdAt } },
+      { createdAt: args.cursor.createdAt, id: { lt: args.cursor.id } },
+    ];
+  }
+  const rows = await prisma.adminAudit.findMany({
+    where,
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: limit + 1,
+  });
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page.at(-1);
+  const nextCursor = hasMore && last ? encodeAuditCursor(last) : null;
+  return { rows: page, nextCursor };
+};

--- a/src/api/v2/credits-admin/credits-admin.router.ts
+++ b/src/api/v2/credits-admin/credits-admin.router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { meGuard } from "@/api/v2/accounts/middleware/meGuard";
+import { accountLedgerGetHandler } from "./handlers/account-ledger-get";
 import { accountViewGetHandler } from "./handlers/account-view-get";
 import { accountsListGetHandler } from "./handlers/accounts-list-get";
 import { adjustPostHandler } from "./handlers/adjust-post";
@@ -41,6 +42,12 @@ creditsAdminRouter.get(
   creditsAdminTokenAuth,
   meGuard,
   accountViewGetHandler,
+);
+creditsAdminRouter.get(
+  "/accounts/:accountId/ledger",
+  creditsAdminTokenAuth,
+  meGuard,
+  accountLedgerGetHandler,
 );
 
 // Audited mutations — token gate, then verified CF identity, then UUID guard.

--- a/src/api/v2/credits-admin/handlers/account-ledger-get.ts
+++ b/src/api/v2/credits-admin/handlers/account-ledger-get.ts
@@ -1,0 +1,28 @@
+import type { Request, Response } from "express";
+import { decodeAuditCursor } from "../audit-repository";
+import { listLedgerPageByAccount, serializeLedger } from "../ledger-repository";
+import { ledgerQuerySchema } from "../schemas/requests";
+
+export const accountLedgerGetHandler = async (
+  req: Request<{ accountId: string }>,
+  res: Response,
+): Promise<void> => {
+  const parsed = ledgerQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ code: "invalid_request", details: parsed.error.errors });
+    return;
+  }
+  const rawCursor = parsed.data.cursor;
+  const cursor = rawCursor ? decodeAuditCursor(rawCursor) : null;
+  if (rawCursor && !cursor) {
+    res.status(400).json({ code: "invalid_cursor" });
+    return;
+  }
+  const { rows, nextCursor } = await listLedgerPageByAccount({
+    accountId: req.params.accountId,
+    cursor,
+  });
+  res.status(200).json({ rows: rows.map(serializeLedger), nextCursor });
+};

--- a/src/api/v2/credits-admin/handlers/account-view-get.ts
+++ b/src/api/v2/credits-admin/handlers/account-view-get.ts
@@ -1,4 +1,3 @@
-import type { CreditLedger } from "@prisma/client";
 import type { Request, Response } from "express";
 import { getBalance, getBucketedConsumption } from "@/payments";
 import { sumPeriodConsumes } from "@/payments/spendable";
@@ -10,22 +9,12 @@ import {
 import { tierGrant } from "@/subscriptions/tier-config";
 import { requireSubscriptionTier } from "@/subscriptions/tiers";
 import { prisma } from "@/utils/prisma";
+import { serializeLedger } from "../ledger-repository";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const LEDGER_LIMIT = 50;
 const REFILL_LIMIT = 20;
 const USAGE_WINDOW_DAYS = 30;
-
-const serializeLedger = (r: CreditLedger) => ({
-  id: r.id,
-  delta: r.delta.toString(),
-  reason: r.reason,
-  grantKindId: r.grantKindId,
-  note: r.note,
-  idempotencyKey: r.idempotencyKey,
-  balanceAfter: r.balanceAfter?.toString() ?? null,
-  createdAt: r.createdAt.toISOString(),
-});
 
 export const accountViewGetHandler = async (
   req: Request<{ accountId: string }>,

--- a/src/api/v2/credits-admin/handlers/account-view-get.ts
+++ b/src/api/v2/credits-admin/handlers/account-view-get.ts
@@ -9,10 +9,9 @@ import {
 import { tierGrant } from "@/subscriptions/tier-config";
 import { requireSubscriptionTier } from "@/subscriptions/tiers";
 import { prisma } from "@/utils/prisma";
-import { serializeLedger } from "../ledger-repository";
+import { listLedgerPageByAccount, serializeLedger } from "../ledger-repository";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const LEDGER_LIMIT = 50;
 const REFILL_LIMIT = 20;
 const USAGE_WINDOW_DAYS = 30;
 
@@ -75,13 +74,9 @@ export const accountViewGetHandler = async (
     };
   }
 
-  const [balance, ledgerRows, refillRows, usage] = await Promise.all([
+  const [balance, ledgerPage, refillRows, usage] = await Promise.all([
     getBalance(accountId),
-    prisma.creditLedger.findMany({
-      where: { accountId },
-      orderBy: { createdAt: "desc" },
-      take: LEDGER_LIMIT,
-    }),
+    listLedgerPageByAccount({ accountId }),
     prisma.creditLedger.findMany({
       where: { accountId, grantKindId: "daily_refill" },
       orderBy: { createdAt: "desc" },
@@ -101,7 +96,8 @@ export const accountViewGetHandler = async (
     isEntitled: subView?.isEntitled ?? false,
     balanceCredits: balance.toString(),
     periodConsumesCredits,
-    ledger: ledgerRows.map(serializeLedger),
+    ledger: ledgerPage.rows.map(serializeLedger),
+    ledgerNextCursor: ledgerPage.nextCursor,
     dailyRefills: refillRows.map(serializeLedger),
     usageDaily: usage.map((u) => ({
       bucketStart: u.bucketStart,

--- a/src/api/v2/credits-admin/handlers/accounts-list-get.ts
+++ b/src/api/v2/credits-admin/handlers/accounts-list-get.ts
@@ -28,7 +28,14 @@ export const accountsListGetHandler = async (
     switch (q.mode) {
       case "balance": {
         const p = await listByBalance(q);
-        return { hasMore: p.hasMore, rows: p.rows.map(base) };
+        return {
+          hasMore: p.hasMore,
+          rows: p.rows.map((r) => ({
+            ...base(r),
+            wallet: r.wallet,
+            lastConsumeAt: r.lastConsumeAt?.toISOString() ?? null,
+          })),
+        };
       }
       case "broken": {
         const p = await listBrokenSubscribers(q);

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -69,9 +69,10 @@ export const consoleView = (): string => `
       <button id="load-more" class="btn btn-secondary hidden">Load more</button>
     </section>
   </div>
-  <div id="detail-scrim" class="detail-scrim hidden"></div>
-  <aside id="detail" class="detail" aria-hidden="true">
-    <button id="detail-close" class="btn btn-secondary detail-close">Close</button>
-    <div id="detail-body"></div>
-  </aside>
+  <div id="detail-scrim" class="detail-scrim hidden">
+    <aside id="detail" class="detail" role="dialog" aria-modal="true" aria-hidden="true">
+      <button id="detail-close" class="btn btn-secondary detail-close">Close</button>
+      <div id="detail-body"></div>
+    </aside>
+  </div>
 </div>`;

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -223,6 +223,7 @@ export const clientScript = (): string => `
   });
   var currentAccountId=null;
   var ledgerCursor=null, auditCursor=null;
+  var detailGen=0;
   function subChip(j){
     var state=j.subscription?j.subscription.effectiveStatus:"none";
     var cls=!j.subscription?"pill-none":(j.isEntitled?"pill-ok":"pill-bad");
@@ -261,10 +262,10 @@ export const clientScript = (): string => `
   function loadLedgerMore(){
     if(!ledgerCursor||!currentAccountId) return;
     var btn=el("d-ledger-foot")&&el("d-ledger-foot").querySelector("button"); if(btn&&btn.disabled) return; if(btn) btn.disabled=true;
-    var acct=currentAccountId;
+    var acct=currentAccountId, gen=detailGen;
     guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger?cursor="+encodeURIComponent(ledgerCursor))
       .then(function(r){ if(!r.ok) throw new Error("more_failed"); return r.json(); })
-      .then(function(j){ if(acct!==currentAccountId) return;
+      .then(function(j){ if(acct!==currentAccountId||gen!==detailGen) return;
         el("d-ledger").insertAdjacentHTML("beforeend", rowsHtml(j.rows, ledgerCols));
         ledgerCursor=j.nextCursor||null;
         paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); });
@@ -316,10 +317,10 @@ export const clientScript = (): string => `
   function loadAuditMore(){
     if(!auditCursor||!currentAccountId) return;
     var btn=el("d-audit-foot")&&el("d-audit-foot").querySelector("button"); if(btn&&btn.disabled) return; if(btn) btn.disabled=true;
-    var acct=currentAccountId;
+    var acct=currentAccountId, gen=detailGen;
     guardFetch("/audit?accountId="+encodeURIComponent(acct)+"&cursor="+encodeURIComponent(auditCursor))
       .then(function(r){ if(!r.ok) throw new Error("more_failed"); return r.json(); })
-      .then(function(j){ if(acct!==currentAccountId) return;
+      .then(function(j){ if(acct!==currentAccountId||gen!==detailGen) return;
         el("d-audit").insertAdjacentHTML("beforeend", rowsHtml(j.audit, auditCols));
         auditCursor=j.nextCursor||null;
         paintFoot("d-audit-foot", true, auditCursor, function(){ loadAuditMore(); });
@@ -328,6 +329,7 @@ export const clientScript = (): string => `
   }
   function openDetail(accountId){
     currentAccountId=accountId;
+    detailGen++;
     el("detail-body").innerHTML='<div class="muted-note">Loading…</div>';
     el("detail").setAttribute("aria-hidden","false"); el("detail-scrim").classList.remove("hidden");
     guardFetch("/accounts/"+encodeURIComponent(accountId)).then(function(r){ if(r.status===404){ throw new Error("not_found"); } return r.json(); })

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -126,9 +126,11 @@ export const clientScript = (): string => `
   var accountsSort={ balance:{by:"balance",dir:"desc"}, broken:{by:"balance",dir:"asc"}, grantKind:{by:"latestGrantAt",dir:"desc"}, active:{by:"lastConsumeAt",dir:"desc"}, dormant:{by:"lastConsumeAt",dir:"desc"} };
   var colAccount=["Account",function(r){return r.accountId;},"mono"];
   var colBalance=["Balance",function(r){return fmtCredits(r.balanceCredits);},"num","balance"];
+  var colWallet=["Wallet",function(r){return r.wallet||"—";},"mono"];
+  var colLastActivity=["Last activity",function(r){return fmtDate(r.lastConsumeAt);},"nowrap"];
   var userListCols=[colAccount,colBalance,["Last consume",function(r){return fmtDate(r.lastConsumeAt);},"nowrap","lastConsumeAt"]];
   var accountCols={
-    balance:[colAccount,colBalance],
+    balance:[colAccount,colWallet,colLastActivity,colBalance],
     broken:[colAccount,colBalance,["Tier",function(r){return r.tier||"—";},null,"tier"],["Status",function(r){return r.effectiveStatus||"—";}],["Period end",function(r){return fmtDate(r.currentPeriodEnd);},"nowrap","currentPeriodEnd"]],
     grantKind:[colAccount,colBalance,["Latest grant",function(r){return fmtDate(r.latestGrantAt);},"nowrap","latestGrantAt"]],
     active:userListCols,

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -46,7 +46,8 @@ export const clientScript = (): string => `
   el("lock").addEventListener("click", lock);
   el("brand").addEventListener("click", function(){ closeDetail(); });
   el("detail-close").addEventListener("click", closeDetail);
-  el("detail-scrim").addEventListener("click", closeDetail);
+  el("detail-scrim").addEventListener("click", function(e){ if(e.target===el("detail-scrim")) closeDetail(); });
+  document.addEventListener("keydown", function(e){ if(e.key==="Escape" && el("detail-scrim") && !el("detail-scrim").classList.contains("hidden")) closeDetail(); });
 
   // --- stubs completed in later tasks ---
   var activityAction="all";
@@ -283,7 +284,7 @@ export const clientScript = (): string => `
   function openDetail(accountId){
     currentAccountId=accountId;
     el("detail-body").innerHTML='<div class="muted-note">Loading…</div>';
-    el("detail").classList.add("open"); el("detail").setAttribute("aria-hidden","false"); el("detail-scrim").classList.remove("hidden");
+    el("detail").setAttribute("aria-hidden","false"); el("detail-scrim").classList.remove("hidden");
     guardFetch("/accounts/"+encodeURIComponent(accountId)).then(function(r){ if(r.status===404){ throw new Error("not_found"); } return r.json(); })
       .then(function(j){ if(accountId!==currentAccountId) return; renderDetail(j); loadAudit(accountId); })
       .catch(function(e){ if(accountId!==currentAccountId) return; if(e.message==="not_found"){ el("detail-body").innerHTML='<div class="pill pill-bad">Account not found</div>'; } else if(e.message!=="reauth"){ toast("Failed to load account","error"); } });
@@ -304,7 +305,7 @@ export const clientScript = (): string => `
         toast(res.j.replayed?"Already applied":(kind==="grant"?"Granted":"Adjusted"),"success"); openDetail(currentAccountId); loadActivity(true); })
       .catch(function(e){ if(btn) btn.disabled=false; if(e.message!=="reauth") toast("Failed","error"); });
   }
-  function closeDetail(){ var d=el("detail"); if(d){ d.classList.remove("open"); d.setAttribute("aria-hidden","true"); } var s=el("detail-scrim"); if(s) s.classList.add("hidden"); }
+  function closeDetail(){ var d=el("detail"); if(d){ d.setAttribute("aria-hidden","true"); } var s=el("detail-scrim"); if(s) s.classList.add("hidden"); }
 
   // Custom dropdown: brand popover over a hidden native <select> that stays the
   // value source, so existing change-listeners keep working via dispatchEvent.

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -220,6 +220,7 @@ export const clientScript = (): string => `
     c.addEventListener("change", function(){ if(currentView!=="activity") loadAccounts(true); });
   });
   var currentAccountId=null;
+  var ledgerCursor=null, auditCursor=null;
   function subChip(j){
     var state=j.subscription?j.subscription.effectiveStatus:"none";
     var cls=!j.subscription?"pill-none":(j.isEntitled?"pill-ok":"pill-bad");
@@ -242,6 +243,31 @@ export const clientScript = (): string => `
       var fn = typeof c==="function" ? c : c[0], cls = typeof c==="function" ? "" : c[1];
       return "<td"+(cls?' class="'+cls+'"':"")+">"+fn(r)+"</td>";
     }).join("")+"</tr>"; }).join("");
+  }
+  var ledgerCols=[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.reason);},[function(r){return esc(r.grantKindId||"—");},"mono"],function(r){return esc(r.note||"");}];
+  function paintFoot(footId, hasRows, nextCursor, moreFn){
+    var foot=el(footId); if(!foot) return;
+    if(!hasRows){ foot.innerHTML='<div class="muted-note">Nothing here yet.</div>'; return; }
+    if(nextCursor){ foot.innerHTML='<button class="btn btn-secondary btn-more">Load more</button>'; foot.querySelector("button").onclick=moreFn; }
+    else { foot.innerHTML=""; }
+  }
+  function renderLedgerFirst(j){
+    ledgerCursor=j.ledgerNextCursor||null;
+    el("d-ledger").innerHTML = rowsHtml(j.ledger, ledgerCols);
+    paintFoot("d-ledger-foot", (j.ledger&&j.ledger.length>0), ledgerCursor, function(){ loadLedgerMore(); });
+  }
+  function loadLedgerMore(){
+    if(!ledgerCursor||!currentAccountId) return;
+    var btn=el("d-ledger-foot")&&el("d-ledger-foot").querySelector("button"); if(btn&&btn.disabled) return; if(btn) btn.disabled=true;
+    var acct=currentAccountId;
+    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger?cursor="+encodeURIComponent(ledgerCursor))
+      .then(function(r){ if(!r.ok) throw new Error("more_failed"); return r.json(); })
+      .then(function(j){ if(acct!==currentAccountId) return;
+        el("d-ledger").insertAdjacentHTML("beforeend", rowsHtml(j.rows, ledgerCols));
+        ledgerCursor=j.nextCursor||null;
+        paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); });
+      })
+      .catch(function(e){ paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); }); if(e.message!=="reauth") toast("Failed to load more","error"); });
   }
   function renderDetail(j){
     var sub=j.subscription;
@@ -266,20 +292,37 @@ export const clientScript = (): string => `
       +'<div class="card"><h3>Adjust</h3><input id="d-adjust-delta" type="number" placeholder="±credits"><input id="d-adjust-reason" placeholder="Reason"><button id="d-adjust-btn" class="btn btn-danger">Adjust</button></div>'
       +'<div class="card"><h3>Usage (30d)</h3><div id="usage-spark"></div></div>'
       +'<div class="card"><h3>Daily refills</h3><div class="tablewrap"><table><tbody id="d-refills"></tbody></table></div></div>'
-      +'<div class="card"><h3>Recent ledger</h3><div class="tablewrap"><table><tbody id="d-ledger"></tbody></table></div></div>'
-      +'<div class="card"><h3>Admin audit</h3><div class="tablewrap"><table><tbody id="d-audit"></tbody></table></div></div>';
+      +'<div class="card"><h3>Recent ledger</h3><div class="tablewrap"><table><tbody id="d-ledger"></tbody></table></div><div id="d-ledger-foot"></div></div>'
+      +'<div class="card"><h3>Admin audit</h3><div class="tablewrap"><table><tbody id="d-audit"></tbody></table></div><div id="d-audit-foot"></div></div>';
     el("usage-spark").innerHTML = renderUsage(j.usageDaily);
     el("d-refills").innerHTML = (j.dailyRefills&&j.dailyRefills.length)
       ? rowsHtml(j.dailyRefills,[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.note||"");}])
       : '<tr><td class="muted-note">No daily refills.</td></tr>';
-    el("d-ledger").innerHTML = rowsHtml(j.ledger,[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.reason);},[function(r){return esc(r.grantKindId||"—");},"mono"],function(r){return esc(r.note||"");}]);
+    renderLedgerFirst(j);
     el("d-grant-btn").addEventListener("click", function(){ mutate("grant"); });
     el("d-adjust-btn").addEventListener("click", function(){ mutate("adjust"); });
   }
+  var auditCols=[[function(r){return fmtDate(r.createdAt);},"nowrap"],function(r){return esc(r.actorEmail);},function(r){return esc(r.action);},[function(r){return esc(r.deltaCredits);},"num"],function(r){return esc(r.reason);}];
   function loadAudit(accountId){
     guardFetch("/audit?accountId="+encodeURIComponent(accountId)).then(function(r){ return r.json(); }).then(function(j){
-      el("d-audit").innerHTML = rowsHtml(j.audit,[[function(r){return fmtDate(r.createdAt);},"nowrap"],function(r){return esc(r.actorEmail);},function(r){return esc(r.action);},[function(r){return esc(r.deltaCredits);},"num"],function(r){return esc(r.reason);}]);
+      if(accountId!==currentAccountId) return;
+      auditCursor=j.nextCursor||null;
+      el("d-audit").innerHTML = rowsHtml(j.audit, auditCols);
+      paintFoot("d-audit-foot", (j.audit&&j.audit.length>0), auditCursor, function(){ loadAuditMore(); });
     }).catch(function(){});
+  }
+  function loadAuditMore(){
+    if(!auditCursor||!currentAccountId) return;
+    var btn=el("d-audit-foot")&&el("d-audit-foot").querySelector("button"); if(btn&&btn.disabled) return; if(btn) btn.disabled=true;
+    var acct=currentAccountId;
+    guardFetch("/audit?accountId="+encodeURIComponent(acct)+"&cursor="+encodeURIComponent(auditCursor))
+      .then(function(r){ if(!r.ok) throw new Error("more_failed"); return r.json(); })
+      .then(function(j){ if(acct!==currentAccountId) return;
+        el("d-audit").insertAdjacentHTML("beforeend", rowsHtml(j.audit, auditCols));
+        auditCursor=j.nextCursor||null;
+        paintFoot("d-audit-foot", true, auditCursor, function(){ loadAuditMore(); });
+      })
+      .catch(function(e){ paintFoot("d-audit-foot", true, auditCursor, function(){ loadAuditMore(); }); if(e.message!=="reauth") toast("Failed to load more","error"); });
   }
   function openDetail(accountId){
     currentAccountId=accountId;

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -96,6 +96,7 @@ body{margin:0;font-family:var(--sans);color:var(--fg);background:var(--surface-m
 .btn-danger{background:var(--surface);color:var(--bad);border-color:var(--edge);font-size:12px;padding:8px 14px;}
 .btn-danger:hover{background:var(--bad-bg);border-color:var(--bad);}
 .btn-block{display:block;width:100%;}
+.btn-more{width:100%;margin-top:10px;}
 
 /* Status pills */
 .pill{display:inline-flex;align-items:center;font-size:11px;font-weight:600;border-radius:var(--radius-sm);padding:2px 8px;}

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -13,6 +13,7 @@ export const STYLES = `
   --radius-sm:6px; --radius:8px; --radius-lg:12px; --radius-full:999px;
   --shadow-pop:0 10px 32px rgba(0,0,0,.14), 0 2px 6px rgba(0,0,0,.06);
   --shadow-detail:-18px 0 56px rgba(0,0,0,.16);
+  --shadow-modal:0 24px 68px rgba(0,0,0,.28), 0 4px 14px rgba(0,0,0,.12);
   --shadow-toast:0 8px 24px rgba(0,0,0,.18);
   --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Arial,sans-serif;
   --mono:"SF Mono",Monaco,ui-monospace,Menlo,"Courier New",monospace;
@@ -153,17 +154,18 @@ tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 .toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
 .toast-error{background:var(--bad);}
 
-/* Detail slide-over */
-.detail-scrim{position:fixed;inset:0;background:rgba(0,0,0,.28);z-index:40;}
-.detail{position:fixed;top:0;right:0;height:100vh;width:min(670px,64vw);background:var(--surface);border-left:1px solid var(--edge);box-shadow:var(--shadow-detail);padding:24px;overflow-y:auto;transform:translateX(102%);transition:transform .24s cubic-bezier(0.22,1,0.36,1);z-index:41;}
-.detail.open{transform:none;}
+/* Detail modal — centered dialog over a scrim */
+.detail-scrim{position:fixed;inset:0;background:rgba(0,0,0,.34);z-index:40;display:flex;align-items:flex-start;justify-content:center;padding:48px 20px;overflow-y:auto;}
+.detail{position:relative;width:min(720px,100%);background:var(--surface);border:1px solid var(--edge);border-radius:16px;box-shadow:var(--shadow-modal);padding:24px 26px 26px;z-index:41;animation:pop .2s var(--ease);}
+@keyframes pop{from{opacity:0;transform:translateY(8px) scale(.98);}to{opacity:1;transform:none;}}
 .detail-close{position:absolute;top:16px;right:16px;}
 
 /* Responsive */
 @media (max-width:768px){
   .console-grid{grid-template-columns:1fr;}
   .rail{border-right:none;border-bottom:1px solid var(--edge);}
-  .detail{width:100vw;}
+  .detail{width:100%;}
+  .detail-scrim{padding:24px 12px;}
 }
 @media (pointer:coarse){
   .rail input,.rail select,.mode-ctl input,.mode-ctl select{min-height:44px;font-size:16px;}
@@ -171,7 +173,7 @@ tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 }
 @media (prefers-reduced-motion:reduce){
   *{transition:none !important;}
-  .detail{transition:none;}
+  .detail{animation:none;}
   .btn:active{transform:none;}
 }
 `;

--- a/src/api/v2/credits-admin/handlers/audit-get.ts
+++ b/src/api/v2/credits-admin/handlers/audit-get.ts
@@ -1,5 +1,8 @@
 import type { Request, Response } from "express";
-import { listAdminAuditByAccount } from "../audit-repository";
+import {
+  decodeAuditCursor,
+  listAdminAuditPageByAccount,
+} from "../audit-repository";
 import { auditQuerySchema } from "../schemas/requests";
 
 export const auditGetHandler = async (
@@ -13,7 +16,16 @@ export const auditGetHandler = async (
       .json({ code: "invalid_request", details: parsed.error.errors });
     return;
   }
-  const rows = await listAdminAuditByAccount(parsed.data.accountId);
+  const { accountId, cursor: rawCursor } = parsed.data;
+  const cursor = rawCursor ? decodeAuditCursor(rawCursor) : null;
+  if (rawCursor && !cursor) {
+    res.status(400).json({ code: "invalid_cursor" });
+    return;
+  }
+  const { rows, nextCursor } = await listAdminAuditPageByAccount({
+    accountId,
+    cursor,
+  });
   res.status(200).json({
     audit: rows.map((r) => ({
       id: r.id,
@@ -24,5 +36,6 @@ export const auditGetHandler = async (
       idempotencyKey: r.idempotencyKey,
       createdAt: r.createdAt.toISOString(),
     })),
+    nextCursor,
   });
 };

--- a/src/api/v2/credits-admin/ledger-repository.ts
+++ b/src/api/v2/credits-admin/ledger-repository.ts
@@ -1,0 +1,52 @@
+import type { CreditLedger, Prisma } from "@prisma/client";
+import { prisma } from "@/utils/prisma";
+import { encodeAuditCursor, type RecentAuditCursor } from "./audit-repository";
+
+export const LEDGER_PAGE_LIMIT = 50;
+
+export type SerializedLedger = {
+  id: string;
+  delta: string;
+  reason: string;
+  grantKindId: string | null;
+  note: string | null;
+  idempotencyKey: string;
+  balanceAfter: string | null;
+  createdAt: string;
+};
+
+export const serializeLedger = (r: CreditLedger): SerializedLedger => ({
+  id: r.id,
+  delta: r.delta.toString(),
+  reason: r.reason,
+  grantKindId: r.grantKindId,
+  note: r.note,
+  idempotencyKey: r.idempotencyKey,
+  balanceAfter: r.balanceAfter?.toString() ?? null,
+  createdAt: r.createdAt.toISOString(),
+});
+
+export const listLedgerPageByAccount = async (args: {
+  accountId: string;
+  cursor?: RecentAuditCursor | null;
+  limit?: number;
+}): Promise<{ rows: CreditLedger[]; nextCursor: string | null }> => {
+  const limit = args.limit ?? LEDGER_PAGE_LIMIT;
+  const where: Prisma.CreditLedgerWhereInput = { accountId: args.accountId };
+  if (args.cursor) {
+    where.OR = [
+      { createdAt: { lt: args.cursor.createdAt } },
+      { createdAt: args.cursor.createdAt, id: { lt: args.cursor.id } },
+    ];
+  }
+  const rows = await prisma.creditLedger.findMany({
+    where,
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: limit + 1,
+  });
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page.at(-1);
+  const nextCursor = hasMore && last ? encodeAuditCursor(last) : null;
+  return { rows: page, nextCursor };
+};

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -18,6 +18,10 @@ export const auditRecentQuerySchema = z.object({
   action: z.enum(["all", "grant", "adjust"]).default("all"),
 });
 
+export const ledgerQuerySchema = z.object({
+  cursor: z.string().trim().min(1).max(512).optional(),
+});
+
 export const grantBodySchema = z.object({
   credits: z.number().int().positive().max(MAX_ADMIN_GRANT_CREDITS),
   reason: z.string().trim().min(1).max(256),

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -11,6 +11,7 @@ export const searchQuerySchema = z.object({
 
 export const auditQuerySchema = z.object({
   accountId: accountIdSchema,
+  cursor: z.string().trim().min(1).max(512).optional(),
 });
 
 export const auditRecentQuerySchema = z.object({

--- a/tests/credits-admin/account-ledger.integration.test.ts
+++ b/tests/credits-admin/account-ledger.integration.test.ts
@@ -95,4 +95,17 @@ describe("GET /api/v2/credits-admin/accounts/:accountId/ledger", () => {
     expect(res.status).toBe(400);
     expect(res.body).toMatchObject({ code: "invalid_cursor" });
   });
+
+  it("400 (not 500) on a decodable cursor whose id is not a uuid", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    const cursor = Buffer.from("2026-07-14T00:00:00.000Z|not-a-uuid").toString(
+      "base64url",
+    );
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?cursor=${encodeURIComponent(cursor)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_cursor" });
+  });
 });

--- a/tests/credits-admin/account-ledger.integration.test.ts
+++ b/tests/credits-admin/account-ledger.integration.test.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from "node:crypto";
+import type { Express } from "express";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "@/utils/prisma";
+import {
+  adminRequest,
+  buildCreditsAdminApp,
+  cleanupAdminAccounts,
+  seedAccount,
+} from "./helpers";
+
+type LedgerRow = { id: string; delta: string; createdAt: string };
+type LedgerResponse = { rows: LedgerRow[]; nextCursor: string | null };
+
+const addLedger = async (accountId: string, delta: bigint, createdAt: Date) => {
+  await prisma.creditLedger.create({
+    data: {
+      accountId,
+      delta,
+      reason: "grant",
+      grantKindId: null,
+      idempotencyKey: `al_${accountId}_${createdAt.getTime()}_${delta}`,
+      createdAt,
+    },
+  });
+};
+
+describe("GET /api/v2/credits-admin/accounts/:accountId/ledger", () => {
+  let app: Express;
+  const tracker: string[] = [];
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("401 without bearer token", async () => {
+    const res = await adminRequest(app, false).get(
+      `/api/v2/credits-admin/accounts/${randomUUID()}/ledger`,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("400 on an invalid-shape accountId (meGuard)", async () => {
+    const res = await adminRequest(app).get(
+      "/api/v2/credits-admin/accounts/not-a-uuid/ledger",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("valid-but-unknown accountId returns an empty page (not 404)", async () => {
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${randomUUID()}/ledger`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ rows: [], nextCursor: null });
+  });
+
+  it("pages 55 rows newest-first, then exhausts", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    const base = Date.now() - 200 * 86400000;
+    for (let i = 0; i < 55; i++) {
+      await addLedger(a, BigInt(i + 1), new Date(base + i * 60000));
+    }
+    const p1 = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger`,
+    );
+    expect(p1.status).toBe(200);
+    const b1 = p1.body as LedgerResponse;
+    expect(b1.rows).toHaveLength(50);
+    expect(b1.rows[0].delta).toBe("55");
+    expect(b1.nextCursor).toBeTruthy();
+
+    const p2 = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?cursor=${encodeURIComponent(
+        b1.nextCursor as string,
+      )}`,
+    );
+    const b2 = p2.body as LedgerResponse;
+    expect(b2.rows).toHaveLength(5);
+    expect(b2.nextCursor).toBeNull();
+    const ids = new Set(b1.rows.map((r) => r.id));
+    expect(b2.rows.every((r) => !ids.has(r.id))).toBe(true);
+  });
+
+  it("400 on an undecodable cursor", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?cursor=notacursor`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_cursor" });
+  });
+});

--- a/tests/credits-admin/account-view.integration.test.ts
+++ b/tests/credits-admin/account-view.integration.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Express } from "express";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "@/utils/prisma";
 import {
   adminRequest,
   buildCreditsAdminApp,
@@ -38,6 +39,7 @@ type AccountViewBody = {
     idempotencyKey: string;
     createdAt: string;
   }[];
+  ledgerNextCursor: string | null;
   dailyRefills: unknown[];
   usageDaily: unknown[];
 };
@@ -100,5 +102,47 @@ describe("GET /api/v2/credits-admin/accounts/:accountId", () => {
     );
     expect(res.status).toBe(400);
     expect(res.body).toMatchObject({ code: "invalid_account_id" });
+  });
+
+  const seedLedger = async (accountId: string, n: number) => {
+    const base = Date.now() - 300 * 86400000;
+    for (let i = 0; i < n; i++) {
+      await prisma.creditLedger.create({
+        data: {
+          accountId,
+          delta: BigInt(i + 1),
+          reason: "grant",
+          grantKindId: null,
+          idempotencyKey: `av_${accountId}_${i}`,
+          createdAt: new Date(base + i * 60000),
+        },
+      });
+    }
+  };
+
+  it("returns ledgerNextCursor when more than 50 ledger rows exist", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    await seedLedger(a, 51);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${a}`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as AccountViewBody;
+    expect(body.ledger).toHaveLength(50);
+    expect(body.ledgerNextCursor).toBeTruthy();
+  });
+
+  it("ledgerNextCursor is null when 50 or fewer ledger rows exist", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    await seedLedger(a, 5);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts/${a}`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as AccountViewBody;
+    expect(body.ledger).toHaveLength(5);
+    expect(body.ledgerNextCursor).toBeNull();
   });
 });

--- a/tests/credits-admin/accounts-list.integration.test.ts
+++ b/tests/credits-admin/accounts-list.integration.test.ts
@@ -9,6 +9,7 @@ import {
   cleanupAdminAccounts,
   seedAccount,
   seedPlusMonthlySubscription,
+  seedSiweAuthMethod,
 } from "./helpers";
 
 type Row = {
@@ -237,5 +238,48 @@ describe("GET /api/v2/credits-admin/accounts", () => {
       "/api/v2/credits-admin/accounts?mode=broken&maxBalance=1e21",
     );
     expect(maxBalance.status).toBe(400);
+  });
+
+  it("balance mode returns wallet (SIWE externalKey) and lastConsumeAt", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    const bal = 8675331n;
+    await setBalance(a, bal);
+    await seedSiweAuthMethod(a, `0xWALLET_${a.slice(0, 8)}`);
+    const consumedAt = new Date(Date.now() - 3 * DAY_MS);
+    await addLedger(a, "consume", -7n, null, consumedAt);
+
+    const v = bal.toString();
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts?mode=balance&min=${v}&max=${v}`,
+    );
+    expect(res.status).toBe(200);
+    const row = (res.body as Body).rows.find(
+      (r) => r.accountId === a,
+    ) as Row & {
+      wallet?: string | null;
+      lastConsumeAt?: string | null;
+    };
+    expect(row.wallet).toBe(`0xWALLET_${a.slice(0, 8)}`);
+    expect(row.lastConsumeAt).toBe(consumedAt.toISOString());
+  });
+
+  it("balance mode returns null wallet + null lastConsumeAt when absent", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    const bal = 8675333n;
+    await setBalance(a, bal);
+    const v = bal.toString();
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/accounts?mode=balance&min=${v}&max=${v}`,
+    );
+    const row = (res.body as Body).rows.find(
+      (r) => r.accountId === a,
+    ) as Row & {
+      wallet?: string | null;
+      lastConsumeAt?: string | null;
+    };
+    expect(row.wallet).toBeNull();
+    expect(row.lastConsumeAt).toBeNull();
   });
 });

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -158,6 +158,35 @@ describe("admin page — tables", () => {
   });
 });
 
+describe("admin page — centered detail modal", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("nests the detail dialog inside the scrim with dialog ARIA", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    const scrimIdx = res.text.indexOf('id="detail-scrim"');
+    const detailIdx = res.text.indexOf('id="detail"');
+    expect(scrimIdx).toBeGreaterThan(-1);
+    expect(detailIdx).toBeGreaterThan(scrimIdx);
+    expect(res.text).toContain('role="dialog"');
+    expect(res.text).toContain('aria-modal="true"');
+  });
+
+  it("wires Esc-to-close and a scrim-target close guard", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain('e.key==="Escape"');
+    expect(res.text).toContain("e.target===");
+  });
+
+  it("uses a centered modal, not a right slide-over transform", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("@keyframes pop");
+    expect(res.text).not.toContain("translateX(102%)");
+  });
+});
+
 describe("admin client script — syntax", () => {
   it("clientScript() is syntactically valid JS", () => {
     // new Function parses the body without executing it — catches syntax errors

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -187,6 +187,31 @@ describe("admin page — centered detail modal", () => {
   });
 });
 
+describe("admin page — full history load-more", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("wires a paginated ledger endpoint fetch and seeds from ledgerNextCursor", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("/ledger");
+    expect(res.text).toContain("ledgerNextCursor");
+  });
+
+  it("renders Load more controls and an empty-history note", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("Load more");
+    expect(res.text).toContain("Nothing here yet");
+  });
+
+  it("defines the ledger + audit load-more functions", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("loadLedgerMore");
+    expect(res.text).toContain("loadAuditMore");
+  });
+});
+
 describe("admin client script — syntax", () => {
   it("clientScript() is syntactically valid JS", () => {
     // new Function parses the body without executing it — catches syntax errors

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -210,6 +210,13 @@ describe("admin page — full history load-more", () => {
     expect(res.text).toContain("loadLedgerMore");
     expect(res.text).toContain("loadAuditMore");
   });
+
+  it("guards load-more appends with a detail-generation counter", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("detailGen");
+    // in-flight appends bail when the detail was re-rendered (e.g. after a grant)
+    expect(res.text).toContain("gen!==detailGen");
+  });
 });
 
 describe("admin page — balance table columns", () => {

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -212,6 +212,21 @@ describe("admin page — full history load-more", () => {
   });
 });
 
+describe("admin page — balance table columns", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+
+  it("balance view defines Wallet and Last activity columns", async () => {
+    const res = await adminRequest(app).get("/api/v2/credits-admin/");
+    expect(res.text).toContain("Wallet");
+    expect(res.text).toContain("Last activity");
+    expect(res.text).toContain("r.wallet");
+    expect(res.text).toContain("r.lastConsumeAt");
+  });
+});
+
 describe("admin client script — syntax", () => {
   it("clientScript() is syntactically valid JS", () => {
     // new Function parses the body without executing it — catches syntax errors

--- a/tests/credits-admin/audit-repository.test.ts
+++ b/tests/credits-admin/audit-repository.test.ts
@@ -167,14 +167,21 @@ describe("listRecentAdminAudit (global, keyset)", () => {
     expect(seen.size).toBe(4); // no skips
   });
 
-  it("round-trips the cursor and rejects garbage", () => {
+  it("round-trips the cursor and rejects garbage + non-uuid ids", () => {
+    const id = "11111111-1111-4111-8111-111111111111";
     const c = encodeAuditCursor({
       createdAt: new Date("2026-07-14T00:00:00.000Z"),
-      id: "abc",
+      id,
     });
     const d = decodeAuditCursor(c);
-    expect(d?.id).toBe("abc");
+    expect(d?.id).toBe(id);
     expect(d?.createdAt.toISOString()).toBe("2026-07-14T00:00:00.000Z");
     expect(decodeAuditCursor("not-a-cursor%%%")).toBeNull();
+    // A valid timestamp with a non-uuid id must be rejected — otherwise the
+    // keyset compares it against the uuid `id` column and 500s (22P02).
+    const nonUuid = Buffer.from("2026-07-14T00:00:00.000Z|not-a-uuid").toString(
+      "base64url",
+    );
+    expect(decodeAuditCursor(nonUuid)).toBeNull();
   });
 });

--- a/tests/credits-admin/audit.integration.test.ts
+++ b/tests/credits-admin/audit.integration.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Express } from "express";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { writeAdminAudit } from "@/api/v2/credits-admin/audit-repository";
 import {
   adminRequest,
   buildCreditsAdminApp,
@@ -65,5 +66,54 @@ describe("GET /api/v2/credits-admin/audit", () => {
       "/api/v2/credits-admin/audit?accountId=not-a-uuid",
     );
     expect(res.status).toBe(400);
+  });
+
+  it("paginates per-account audit with a nextCursor, then exhausts", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    for (let i = 0; i < 55; i++) {
+      await writeAdminAudit({
+        accountId,
+        actorEmail: "admin@test",
+        action: "grant",
+        deltaCredits: BigInt(i + 1),
+        reason: `seed_${i}`,
+        idempotencyKey: `ap_${i}`,
+      });
+    }
+    const p1 = await adminRequest(app).get(
+      `/api/v2/credits-admin/audit?accountId=${accountId}`,
+    );
+    expect(p1.status).toBe(200);
+    const b1 = p1.body as {
+      audit: { id: string }[];
+      nextCursor: string | null;
+    };
+    expect(b1.audit).toHaveLength(50);
+    expect(b1.nextCursor).toBeTruthy();
+
+    const p2 = await adminRequest(app).get(
+      `/api/v2/credits-admin/audit?accountId=${accountId}&cursor=${encodeURIComponent(
+        b1.nextCursor as string,
+      )}`,
+    );
+    const b2 = p2.body as {
+      audit: { id: string }[];
+      nextCursor: string | null;
+    };
+    expect(b2.audit).toHaveLength(5);
+    expect(b2.nextCursor).toBeNull();
+    const ids = new Set(b1.audit.map((r) => r.id));
+    expect(b2.audit.every((r) => !ids.has(r.id))).toBe(true);
+  });
+
+  it("400 on an undecodable audit cursor", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/audit?accountId=${accountId}&cursor=notacursor`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_cursor" });
   });
 });

--- a/tests/credits-admin/audit.integration.test.ts
+++ b/tests/credits-admin/audit.integration.test.ts
@@ -116,4 +116,17 @@ describe("GET /api/v2/credits-admin/audit", () => {
     expect(res.status).toBe(400);
     expect(res.body).toMatchObject({ code: "invalid_cursor" });
   });
+
+  it("400 (not 500) on an audit cursor whose id is not a uuid", async () => {
+    const accountId = await seedAccount();
+    tracker.push(accountId);
+    const cursor = Buffer.from("2026-07-14T00:00:00.000Z|not-a-uuid").toString(
+      "base64url",
+    );
+    const res = await adminRequest(app).get(
+      `/api/v2/credits-admin/audit?accountId=${accountId}&cursor=${encodeURIComponent(cursor)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_cursor" });
+  });
 });

--- a/tests/credits-admin/ledger-repository.test.ts
+++ b/tests/credits-admin/ledger-repository.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { decodeAuditCursor } from "@/api/v2/credits-admin/audit-repository";
+import {
+  listLedgerPageByAccount,
+  serializeLedger,
+} from "@/api/v2/credits-admin/ledger-repository";
+import { prisma } from "@/utils/prisma";
+import { cleanupAdminAccounts, seedAccount } from "./helpers";
+
+const addLedger = async (accountId: string, delta: bigint, createdAt: Date) => {
+  await prisma.creditLedger.create({
+    data: {
+      accountId,
+      delta,
+      reason: "grant",
+      grantKindId: null,
+      idempotencyKey: `lr_${accountId}_${createdAt.getTime()}_${delta}`,
+      createdAt,
+    },
+  });
+};
+
+describe("ledger-repository", () => {
+  const tracker: string[] = [];
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker);
+    tracker.length = 0;
+  });
+
+  it("pages newest-first with a nextCursor, then exhausts", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    const base = Date.now() - 100 * 86400000;
+    for (let i = 0; i < 3; i++) {
+      await addLedger(a, BigInt(i + 1), new Date(base + i * 86400000));
+    }
+    const p1 = await listLedgerPageByAccount({ accountId: a, limit: 2 });
+    expect(p1.rows).toHaveLength(2);
+    expect(p1.rows[0].delta).toBe(3n);
+    expect(p1.nextCursor).toBeTruthy();
+
+    const cursor = decodeAuditCursor(p1.nextCursor as string);
+    expect(cursor).not.toBeNull();
+    const p2 = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 2,
+      cursor,
+    });
+    expect(p2.rows).toHaveLength(1);
+    expect(p2.rows[0].delta).toBe(1n);
+    expect(p2.nextCursor).toBeNull();
+  });
+
+  it("serializeLedger stringifies bigints and ISO-dates", async () => {
+    const a = await seedAccount();
+    tracker.push(a);
+    await addLedger(a, 42n, new Date(Date.now() - 86400000));
+    const { rows } = await listLedgerPageByAccount({ accountId: a, limit: 10 });
+    const s = serializeLedger(rows[0]);
+    expect(s.delta).toBe("42");
+    expect(typeof s.createdAt).toBe("string");
+    expect(s.createdAt).toMatch(/T.*Z$/);
+  });
+});


### PR DESCRIPTION
## Summary

Three UX improvements to the credits-admin console (all under `src/api/v2/credits-admin/`). No money-movement logic changes — new code is read/display plus two read-only paginated endpoints.

- **Centered detail modal** — the account detail is now a centered dialog over a scrim instead of a right-edge slide-over. Esc, scrim-click, and Close all dismiss; clicks inside the dialog don't. Scale/fade-in, `prefers-reduced-motion` respected.
- **Full account history (`Load more`)** — the detail's "Recent ledger" and "Admin audit" cards paginate the entire history via keyset cursor; empty history shows "Nothing here yet." with no button. Adds `GET /accounts/:id/ledger?cursor=` (new) and an additive optional `cursor` on `GET /audit`. Page-1 is seeded inline by the same repository fn the endpoint uses, so page boundaries match exactly. In-flight double-click guarded.
- **Cohesive Balance table** — the Balance view gains two columns: **Account · Wallet · Last activity · Balance** (fills the wide pane instead of flinging Balance to the far right). `listByBalance` moves to a read-only `$queryRaw` with a SIWE-wallet subquery + last-consume subquery (both nullable → "—").

Money-domain: reads only. Balance list `$queryRaw` is SELECT-only; no `UserCredits`/`CreditLedger` writes. Cursor helpers are reused (`encode/decodeAuditCursor`) for both ledger and audit.

## Test plan

Automated (green): `pnpm test tests/credits-admin/` → 124/124; `tsc` + `eslint` + `prettier` clean on the diff.

Browser walk (human gate — not yet run):
- [ ] W1 — detail opens centered over a dimmed scrim (not sliding from the right) and scales/fades in
- [ ] W2 — Esc and scrim-click dismiss; a click inside the dialog does NOT dismiss; header `Lock` reachable after close
- [ ] W3 — ledger `Load more` appends the next page in place and disappears at the end
- [ ] W4 — an account with no admin actions shows "Nothing here yet." (no button); one with audit shows `Load more` only when >50
- [ ] W5 — Balance view shows 4 columns with no far-right gap on a wide screen; column resize still works; null wallet / never-consumed show "—"
- [ ] W6 — with reduced-motion enabled, the modal appears without the entry animation

## Notes

- Pre-existing full-suite failures in `tests/subscriptions/account-credits.test.ts` are a local-env gap (subscription tier config) and reproduce identically on `otr-dev` — not introduced by this branch.
- Optional follow-up: `listAdminAuditByAccount` is now only used by its own test (production switched to the paginated variant); left in deliberately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786820307&installation_id=128169237&pr_number=378&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F378&signature=09824f5c87c149d485b9db9b013909b0f69a9a792171875aaca85abcf5fb5cab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add paginated ledger/audit endpoints and centered modal to credits admin UI
> - Adds a new `GET /accounts/:accountId/ledger` endpoint with cursor-based pagination, backed by `listLedgerPageByAccount` in [ledger-repository.ts](https://github.com/ephemeraHQ/convos-backend/pull/378/files#diff-5facb0b08f1476a26f79934d1746492984fcc77662cf5a063574eda922a2ff51).
> - Extends the audit endpoint to support cursor pagination via `listAdminAuditPageByAccount`; invalid or non-UUID cursors now return 400 instead of causing DB errors.
> - The account view endpoint now returns up to 50 ledger rows with a `ledgerNextCursor` for further pages.
> - Balance listing gains `wallet` and `lastConsumeAt` columns, fetched via raw SQL subqueries in [accounts-repository.ts](https://github.com/ephemeraHQ/convos-backend/pull/378/files#diff-f13a84c26f2e662a9d3e35d5b0be5122eedf21bf7958631a299eb7c56a687593).
> - The admin detail UI is restructured from a slide-over to a centered modal (`role="dialog"`) with Esc/backdrop-close and load-more buttons for ledger and audit entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cc75ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated account ledger and audit history endpoints with cursor-based navigation.
  * Enhanced account balance results with wallet and last activity details.
  * Added ledger and audit history panels with “Load more” controls in the admin interface.
  * Redesigned account details as an accessible centered modal with Escape and scrim-click dismissal.

* **Bug Fixes**
  * Improved handling of missing wallet and activity data.
  * Added clear validation responses for invalid requests and cursors.

* **Tests**
  * Added coverage for ledger and audit pagination, account details, balance data, and modal interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->