### PR TITLE
feat(credits-admin): Ledger movements filter (kind/reason/date)

### DIFF
--- a/src/api/v2/credits-admin/handlers/account-ledger-get.ts
+++ b/src/api/v2/credits-admin/handlers/account-ledger-get.ts
@@ -23,6 +23,12 @@ export const accountLedgerGetHandler = async (
   const { rows, nextCursor } = await listLedgerPageByAccount({
     accountId: req.params.accountId,
     cursor,
+    filter: {
+      kind: parsed.data.kind,
+      reason: parsed.data.reason,
+      from: parsed.data.from,
+      to: parsed.data.to,
+    },
   });
   res.status(200).json({ rows: rows.map(serializeLedger), nextCursor });
 };

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -310,7 +310,7 @@ export const clientScript = (): string => `
         ledgerCursor=j.nextCursor||null;
         paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); });
       })
-      .catch(function(e){ paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); }); if(e.message!=="reauth") toast("Failed to load more","error"); });
+      .catch(function(e){ if(acct!==currentAccountId||gen!==detailGen||myGen!==ledgerGen) return; paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); }); if(e.message!=="reauth") toast("Failed to load more","error"); });
   }
   function renderDetail(j){
     var sub=j.subscription;

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -224,6 +224,7 @@ export const clientScript = (): string => `
   var currentAccountId=null;
   var ledgerCursor=null, auditCursor=null;
   var ledgerFilter={kind:"",reason:"",from:"",to:""};
+  var ledgerGen=0;
   var detailGen=0;
   function subChip(j){
     var state=j.subscription?j.subscription.effectiveStatus:"none";
@@ -248,30 +249,32 @@ export const clientScript = (): string => `
       return "<td"+(cls?' class="'+cls+'"':"")+">"+fn(r)+"</td>";
     }).join("")+"</tr>"; }).join("");
   }
-  function readLedgerFilter(){
-    ledgerFilter={
-      kind: el("d-lf-kind")?el("d-lf-kind").value:"",
-      reason: el("d-lf-reason")?el("d-lf-reason").value:"",
-      from: el("d-lf-from")?el("d-lf-from").value:"",
-      to: el("d-lf-to")?el("d-lf-to").value:""
+  function currentFilterFromControls(){
+    return {
+      kind: el("d-lf-kind").value,
+      reason: el("d-lf-reason").value,
+      from: el("d-lf-from").value,
+      to: el("d-lf-to").value
     };
   }
-  function buildLedgerQuery(cursor){
+  function buildLedgerQuery(filter, cursor){
     var p=[];
-    if(ledgerFilter.kind) p.push("kind="+encodeURIComponent(ledgerFilter.kind));
-    if(ledgerFilter.reason) p.push("reason="+encodeURIComponent(ledgerFilter.reason));
-    if(ledgerFilter.from) p.push("from="+encodeURIComponent(ledgerFilter.from));
-    if(ledgerFilter.to) p.push("to="+encodeURIComponent(ledgerFilter.to));
+    if(filter.kind) p.push("kind="+encodeURIComponent(filter.kind));
+    if(filter.reason) p.push("reason="+encodeURIComponent(filter.reason));
+    if(filter.from) p.push("from="+encodeURIComponent(filter.from));
+    if(filter.to) p.push("to="+encodeURIComponent(filter.to));
     if(cursor) p.push("cursor="+encodeURIComponent(cursor));
     return p.length?("?"+p.join("&")):"";
   }
   function applyLedgerFilter(){
     if(!currentAccountId) return;
-    readLedgerFilter();
-    var acct=currentAccountId, gen=detailGen;
-    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger"+buildLedgerQuery(null))
+    var f=currentFilterFromControls();
+    var acct=currentAccountId, gen=detailGen, myGen=++ledgerGen;
+    el("d-ledger-foot").innerHTML="";
+    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger"+buildLedgerQuery(f,null))
       .then(function(r){ if(!r.ok) throw new Error("filter_failed"); return r.json(); })
-      .then(function(j){ if(acct!==currentAccountId||gen!==detailGen) return;
+      .then(function(j){ if(acct!==currentAccountId||gen!==detailGen||myGen!==ledgerGen) return;
+        ledgerFilter=f;
         var rows=j.rows||[];
         ledgerCursor=j.nextCursor||null;
         if(rows.length===0){
@@ -299,10 +302,10 @@ export const clientScript = (): string => `
   function loadLedgerMore(){
     if(!ledgerCursor||!currentAccountId) return;
     var btn=el("d-ledger-foot")&&el("d-ledger-foot").querySelector("button"); if(btn&&btn.disabled) return; if(btn) btn.disabled=true;
-    var acct=currentAccountId, gen=detailGen;
-    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger"+buildLedgerQuery(ledgerCursor))
+    var acct=currentAccountId, gen=detailGen, myGen=ledgerGen;
+    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger"+buildLedgerQuery(ledgerFilter,ledgerCursor))
       .then(function(r){ if(!r.ok) throw new Error("more_failed"); return r.json(); })
-      .then(function(j){ if(acct!==currentAccountId||gen!==detailGen) return;
+      .then(function(j){ if(acct!==currentAccountId||gen!==detailGen||myGen!==ledgerGen) return;
         el("d-ledger").insertAdjacentHTML("beforeend", rowsHtml(j.rows, ledgerCols));
         ledgerCursor=j.nextCursor||null;
         paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); });

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -285,7 +285,7 @@ export const clientScript = (): string => `
         el("d-ledger").innerHTML=rowsHtml(rows, ledgerCols);
         paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); });
       })
-      .catch(function(e){ if(e.message!=="reauth") toast("Failed to filter ledger","error"); });
+      .catch(function(e){ if(acct!==currentAccountId||gen!==detailGen||myGen!==ledgerGen) return; paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); }); if(e.message!=="reauth") toast("Failed to filter ledger","error"); });
   }
   var ledgerCols=[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.reason);},[function(r){return esc(r.grantKindId||"—");},"mono"],function(r){return esc(r.note||"");}];
   function paintFoot(footId, hasRows, nextCursor, moreFn){

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -223,6 +223,7 @@ export const clientScript = (): string => `
   });
   var currentAccountId=null;
   var ledgerCursor=null, auditCursor=null;
+  var ledgerFilter={kind:"",reason:"",from:"",to:""};
   var detailGen=0;
   function subChip(j){
     var state=j.subscription?j.subscription.effectiveStatus:"none";
@@ -247,6 +248,42 @@ export const clientScript = (): string => `
       return "<td"+(cls?' class="'+cls+'"':"")+">"+fn(r)+"</td>";
     }).join("")+"</tr>"; }).join("");
   }
+  function readLedgerFilter(){
+    ledgerFilter={
+      kind: el("d-lf-kind")?el("d-lf-kind").value:"",
+      reason: el("d-lf-reason")?el("d-lf-reason").value:"",
+      from: el("d-lf-from")?el("d-lf-from").value:"",
+      to: el("d-lf-to")?el("d-lf-to").value:""
+    };
+  }
+  function buildLedgerQuery(cursor){
+    var p=[];
+    if(ledgerFilter.kind) p.push("kind="+encodeURIComponent(ledgerFilter.kind));
+    if(ledgerFilter.reason) p.push("reason="+encodeURIComponent(ledgerFilter.reason));
+    if(ledgerFilter.from) p.push("from="+encodeURIComponent(ledgerFilter.from));
+    if(ledgerFilter.to) p.push("to="+encodeURIComponent(ledgerFilter.to));
+    if(cursor) p.push("cursor="+encodeURIComponent(cursor));
+    return p.length?("?"+p.join("&")):"";
+  }
+  function applyLedgerFilter(){
+    if(!currentAccountId) return;
+    readLedgerFilter();
+    var acct=currentAccountId, gen=detailGen;
+    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger"+buildLedgerQuery(null))
+      .then(function(r){ if(!r.ok) throw new Error("filter_failed"); return r.json(); })
+      .then(function(j){ if(acct!==currentAccountId||gen!==detailGen) return;
+        var rows=j.rows||[];
+        ledgerCursor=j.nextCursor||null;
+        if(rows.length===0){
+          el("d-ledger").innerHTML='<tr><td class="muted-note">No movements match this filter.</td></tr>';
+          el("d-ledger-foot").innerHTML="";
+          return;
+        }
+        el("d-ledger").innerHTML=rowsHtml(rows, ledgerCols);
+        paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); });
+      })
+      .catch(function(e){ if(e.message!=="reauth") toast("Failed to filter ledger","error"); });
+  }
   var ledgerCols=[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.reason);},[function(r){return esc(r.grantKindId||"—");},"mono"],function(r){return esc(r.note||"");}];
   function paintFoot(footId, hasRows, nextCursor, moreFn){
     var foot=el(footId); if(!foot) return;
@@ -263,7 +300,7 @@ export const clientScript = (): string => `
     if(!ledgerCursor||!currentAccountId) return;
     var btn=el("d-ledger-foot")&&el("d-ledger-foot").querySelector("button"); if(btn&&btn.disabled) return; if(btn) btn.disabled=true;
     var acct=currentAccountId, gen=detailGen;
-    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger?cursor="+encodeURIComponent(ledgerCursor))
+    guardFetch("/accounts/"+encodeURIComponent(acct)+"/ledger"+buildLedgerQuery(ledgerCursor))
       .then(function(r){ if(!r.ok) throw new Error("more_failed"); return r.json(); })
       .then(function(j){ if(acct!==currentAccountId||gen!==detailGen) return;
         el("d-ledger").insertAdjacentHTML("beforeend", rowsHtml(j.rows, ledgerCols));
@@ -295,7 +332,28 @@ export const clientScript = (): string => `
       +'<div class="card"><h3>Adjust</h3><input id="d-adjust-delta" type="number" placeholder="±credits"><input id="d-adjust-reason" placeholder="Reason"><button id="d-adjust-btn" class="btn btn-danger">Adjust</button></div>'
       +'<div class="card"><h3>Usage (30d)</h3><div id="usage-spark"></div></div>'
       +'<div class="card"><h3>Daily refills</h3><div class="tablewrap"><table><tbody id="d-refills"></tbody></table></div></div>'
-      +'<div class="card"><h3>Recent ledger</h3><div class="tablewrap"><table><tbody id="d-ledger"></tbody></table></div><div id="d-ledger-foot"></div></div>'
+      +'<div class="card"><h3>Ledger movements</h3>'
+      +'<div class="ledger-filter">'
+      +'<select id="d-lf-kind">'
+      +'<option value="">Kind: all</option>'
+      +'<option value="subscription">Subscription (grants + forfeits)</option>'
+      +'<option value="sub_grant">Sub grant</option>'
+      +'<option value="sub_forfeit">Sub forfeit</option>'
+      +'<option value="signup_bonus">Signup bonus</option>'
+      +'<option value="daily_refill">Daily refill</option>'
+      +'<option value="manual">Manual</option>'
+      +'</select>'
+      +'<select id="d-lf-reason">'
+      +'<option value="">Reason: all</option>'
+      +'<option value="consume">consume</option>'
+      +'<option value="grant">grant</option>'
+      +'<option value="adjust">adjust</option>'
+      +'</select>'
+      +'<input id="d-lf-from" type="date" aria-label="From date">'
+      +'<input id="d-lf-to" type="date" aria-label="To date">'
+      +'<button id="d-lf-clear" class="btn btn-secondary">Clear</button>'
+      +'</div>'
+      +'<div class="tablewrap"><table><tbody id="d-ledger"></tbody></table></div><div id="d-ledger-foot"></div></div>'
       +'<div class="card"><h3>Admin audit</h3><div class="tablewrap"><table><tbody id="d-audit"></tbody></table></div><div id="d-audit-foot"></div></div>';
     el("usage-spark").innerHTML = renderUsage(j.usageDaily);
     el("d-refills").innerHTML = (j.dailyRefills&&j.dailyRefills.length)
@@ -304,6 +362,14 @@ export const clientScript = (): string => `
     renderLedgerFirst(j);
     el("d-grant-btn").addEventListener("click", function(){ mutate("grant"); });
     el("d-adjust-btn").addEventListener("click", function(){ mutate("adjust"); });
+    ["d-lf-kind","d-lf-reason","d-lf-from","d-lf-to"].forEach(function(id){
+      el(id).addEventListener("change", applyLedgerFilter);
+    });
+    el("d-lf-clear").addEventListener("click", function(){
+      el("d-lf-kind").value=""; el("d-lf-reason").value="";
+      el("d-lf-from").value=""; el("d-lf-to").value="";
+      applyLedgerFilter();
+    });
   }
   var auditCols=[[function(r){return fmtDate(r.createdAt);},"nowrap"],function(r){return esc(r.actorEmail);},function(r){return esc(r.action);},[function(r){return esc(r.deltaCredits);},"num"],function(r){return esc(r.reason);}];
   function loadAudit(accountId){
@@ -329,6 +395,7 @@ export const clientScript = (): string => `
   }
   function openDetail(accountId){
     currentAccountId=accountId;
+    ledgerFilter={kind:"",reason:"",from:"",to:""};
     detailGen++;
     el("detail-body").innerHTML='<div class="muted-note">Loading…</div>';
     el("detail").setAttribute("aria-hidden","false"); el("detail-scrim").classList.remove("hidden");

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -161,6 +161,11 @@ tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 @keyframes pop{from{opacity:0;transform:translateY(8px) scale(.98);}to{opacity:1;transform:none;}}
 .detail-close{position:absolute;top:16px;right:16px;}
 
+.ledger-filter{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;}
+.ledger-filter select,.ledger-filter input{flex:0 0 auto;width:auto;min-height:var(--control-h);margin-bottom:0;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:8px 10px;font-family:var(--sans);font-size:12px;color:var(--fg);}
+.ledger-filter select:focus,.ledger-filter input:focus{outline:none;border-color:var(--fg-3);}
+.ledger-filter .btn{min-height:var(--control-h);}
+
 /* Responsive */
 @media (max-width:768px){
   .console-grid{grid-template-columns:1fr;}

--- a/src/api/v2/credits-admin/ledger-repository.ts
+++ b/src/api/v2/credits-admin/ledger-repository.ts
@@ -26,13 +26,47 @@ export const serializeLedger = (r: CreditLedger): SerializedLedger => ({
   createdAt: r.createdAt.toISOString(),
 });
 
+export type LedgerFilter = {
+  kind?:
+    | "subscription"
+    | "sub_grant"
+    | "sub_forfeit"
+    | "signup_bonus"
+    | "daily_refill"
+    | "manual";
+  reason?: "consume" | "grant" | "adjust";
+  from?: Date;
+  to?: Date;
+};
+
+// Whole-`to`-day-inclusive upper bound. UTC accessors only — never local time —
+// so the boundary does not drift by the server's timezone.
+const startOfNextUtcDay = (d: Date): Date =>
+  new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1));
+
 export const listLedgerPageByAccount = async (args: {
   accountId: string;
   cursor?: RecentAuditCursor | null;
   limit?: number;
+  filter?: LedgerFilter;
 }): Promise<{ rows: CreditLedger[]; nextCursor: string | null }> => {
   const limit = args.limit ?? LEDGER_PAGE_LIMIT;
   const where: Prisma.CreditLedgerWhereInput = { accountId: args.accountId };
+  const f = args.filter;
+  if (f?.kind === "subscription") {
+    where.grantKindId = { in: ["sub_grant", "sub_forfeit"] };
+  } else if (f?.kind) {
+    where.grantKindId = f.kind;
+  }
+  if (f?.reason) {
+    where.reason = f.reason;
+  }
+  if (f?.from || f?.to) {
+    where.createdAt = {
+      ...(f.from ? { gte: f.from } : {}),
+      ...(f.to ? { lt: startOfNextUtcDay(f.to) } : {}),
+    };
+  }
   if (args.cursor) {
     where.OR = [
       { createdAt: { lt: args.cursor.createdAt } },

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -21,6 +21,19 @@ export const auditRecentQuerySchema = z.object({
 
 export const ledgerQuerySchema = z.object({
   cursor: z.string().trim().min(1).max(512).optional(),
+  kind: z
+    .enum([
+      "subscription",
+      "sub_grant",
+      "sub_forfeit",
+      "signup_bonus",
+      "daily_refill",
+      "manual",
+    ])
+    .optional(),
+  reason: z.enum(["consume", "grant", "adjust"]).optional(),
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
 });
 
 export const grantBodySchema = z.object({

--- a/tests/credits-admin/account-ledger.integration.test.ts
+++ b/tests/credits-admin/account-ledger.integration.test.ts
@@ -116,7 +116,7 @@ describe("GET /api/v2/credits-admin/accounts/:accountId/ledger", () => {
   });
 });
 
-describe("GET …/ledger — filter params", () => {
+describe("GET /api/v2/credits-admin/accounts/:accountId/ledger — filter params", () => {
   let app2: Express;
   const t2: string[] = [];
   beforeAll(() => {
@@ -246,5 +246,50 @@ describe("GET …/ledger — filter params", () => {
     );
     expect(res.status).toBe(200);
     expect((res.body as LedgerResponse).rows).toHaveLength(2);
+  });
+
+  it("reason=adjust narrows to adjust-reason rows via HTTP", async () => {
+    const a = await seedAccount();
+    t2.push(a);
+    await addLedger(
+      a,
+      100n,
+      new Date("2026-07-10T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addLedger(
+      a,
+      -40n,
+      new Date("2026-07-11T00:00:00Z"),
+      "adjust",
+      "sub_forfeit",
+    );
+    await addLedger(a, -7n, new Date("2026-07-12T00:00:00Z"), "adjust", null);
+    const res = await adminRequest(app2).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?reason=adjust`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as LedgerResponse;
+    expect(body.rows).toHaveLength(2);
+    expect(new Set(body.rows.map((r) => r.delta))).toEqual(
+      new Set(["-40", "-7"]),
+    );
+  });
+
+  it("from/to date range narrows via HTTP, whole to-day inclusive", async () => {
+    const a = await seedAccount();
+    t2.push(a);
+    await addLedger(a, 1n, new Date("2026-07-09T00:00:00Z"), "grant", "manual"); // before from
+    await addLedger(a, 2n, new Date("2026-07-10T06:00:00Z"), "grant", "manual"); // in range
+    await addLedger(a, 3n, new Date("2026-07-12T23:59:00Z"), "grant", "manual"); // whole to-day
+    await addLedger(a, 4n, new Date("2026-07-13T00:00:00Z"), "grant", "manual"); // after to
+    const res = await adminRequest(app2).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?from=2026-07-10&to=2026-07-12`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as LedgerResponse;
+    expect(body.rows).toHaveLength(2);
+    expect(new Set(body.rows.map((r) => r.delta))).toEqual(new Set(["2", "3"]));
   });
 });

--- a/tests/credits-admin/account-ledger.integration.test.ts
+++ b/tests/credits-admin/account-ledger.integration.test.ts
@@ -12,13 +12,19 @@ import {
 type LedgerRow = { id: string; delta: string; createdAt: string };
 type LedgerResponse = { rows: LedgerRow[]; nextCursor: string | null };
 
-const addLedger = async (accountId: string, delta: bigint, createdAt: Date) => {
+const addLedger = async (
+  accountId: string,
+  delta: bigint,
+  createdAt: Date,
+  reason: "consume" | "grant" | "adjust" = "grant",
+  grantKindId: string | null = null,
+) => {
   await prisma.creditLedger.create({
     data: {
       accountId,
       delta,
-      reason: "grant",
-      grantKindId: null,
+      reason,
+      grantKindId,
       idempotencyKey: `al_${accountId}_${createdAt.getTime()}_${delta}`,
       createdAt,
     },
@@ -107,5 +113,138 @@ describe("GET /api/v2/credits-admin/accounts/:accountId/ledger", () => {
     );
     expect(res.status).toBe(400);
     expect(res.body).toMatchObject({ code: "invalid_cursor" });
+  });
+});
+
+describe("GET …/ledger — filter params", () => {
+  let app2: Express;
+  const t2: string[] = [];
+  beforeAll(() => {
+    app2 = buildCreditsAdminApp();
+  });
+  afterEach(async () => {
+    await cleanupAdminAccounts(t2);
+    t2.length = 0;
+  });
+
+  it("kind=subscription returns only sub_grant + sub_forfeit", async () => {
+    const a = await seedAccount();
+    t2.push(a);
+    await addLedger(
+      a,
+      100n,
+      new Date("2026-07-10T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addLedger(
+      a,
+      -40n,
+      new Date("2026-07-11T00:00:00Z"),
+      "adjust",
+      "sub_forfeit",
+    );
+    await addLedger(
+      a,
+      500n,
+      new Date("2026-07-12T00:00:00Z"),
+      "grant",
+      "manual",
+    );
+    const res = await adminRequest(app2).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?kind=subscription`,
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as LedgerResponse;
+    expect(body.rows).toHaveLength(2);
+    expect(new Set(body.rows.map((r) => r.delta))).toEqual(
+      new Set(["100", "-40"]),
+    );
+  });
+
+  it("filters to a single kind with no off-filter leak", async () => {
+    const a = await seedAccount();
+    t2.push(a);
+    // 3 sub_grant + 3 manual, interleaved by day. (The cursor+filter page-2
+    // interaction is covered directly at limit:2 in ledger-repository.test.ts;
+    // the HTTP endpoint's limit is server-fixed at 50, so here we assert the
+    // single filtered page holds exactly the 3 sub_grants and no manual leaks.)
+    await addLedger(
+      a,
+      1n,
+      new Date("2026-07-01T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addLedger(a, 9n, new Date("2026-07-02T00:00:00Z"), "grant", "manual");
+    await addLedger(
+      a,
+      2n,
+      new Date("2026-07-03T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addLedger(a, 9n, new Date("2026-07-04T00:00:00Z"), "grant", "manual");
+    await addLedger(
+      a,
+      3n,
+      new Date("2026-07-05T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addLedger(a, 9n, new Date("2026-07-06T00:00:00Z"), "grant", "manual");
+
+    const res = await adminRequest(app2).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?kind=sub_grant`,
+    );
+    const body = res.body as LedgerResponse;
+    expect(body.rows).toHaveLength(3);
+    expect(new Set(body.rows.map((r) => r.delta))).toEqual(
+      new Set(["1", "2", "3"]),
+    );
+  });
+
+  it("400 on an unknown kind", async () => {
+    const a = await seedAccount();
+    t2.push(a);
+    const res = await adminRequest(app2).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?kind=bogus`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_request" });
+  });
+
+  it("400 on an unparseable date", async () => {
+    const a = await seedAccount();
+    t2.push(a);
+    const res = await adminRequest(app2).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger?to=not-a-date`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_request" });
+  });
+
+  it("back-compat: no filter params returns the full page", async () => {
+    const a = await seedAccount();
+    t2.push(a);
+    await addLedger(
+      a,
+      100n,
+      new Date("2026-07-10T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addLedger(
+      a,
+      500n,
+      new Date("2026-07-12T00:00:00Z"),
+      "grant",
+      "manual",
+    );
+    const res = await adminRequest(app2).get(
+      `/api/v2/credits-admin/accounts/${a}/ledger`,
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as LedgerResponse).rows).toHaveLength(2);
   });
 });

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -242,3 +242,42 @@ describe("admin client script — syntax", () => {
     expect(() => new Function(clientScript())).not.toThrow();
   });
 });
+
+describe("admin page — ledger movements filter", () => {
+  let app: Express;
+  beforeAll(() => {
+    app = buildCreditsAdminApp();
+  });
+  const get = () => adminRequest(app).get("/api/v2/credits-admin/");
+
+  it("renames the card to Ledger movements and drops Recent ledger", async () => {
+    const res = await get();
+    expect(res.text).toContain("Ledger movements");
+    expect(res.text).not.toContain("Recent ledger");
+  });
+
+  it("renders the Kind, Reason, date, and Clear filter controls", async () => {
+    const res = await get();
+    expect(res.text).toContain('id="d-lf-kind"');
+    expect(res.text).toContain('id="d-lf-reason"');
+    expect(res.text).toContain('id="d-lf-from"');
+    expect(res.text).toContain('id="d-lf-to"');
+    expect(res.text).toContain('id="d-lf-clear"');
+    expect(res.text).toContain('value="subscription"');
+    // dead refill value must never be offered as a filter
+    expect(res.text).not.toContain('value="refill"');
+  });
+
+  it("defines the filter apply + query builder and carries the filter into load-more", async () => {
+    const res = await get();
+    expect(res.text).toContain("applyLedgerFilter");
+    expect(res.text).toContain("buildLedgerQuery");
+    // load-more must build its URL through buildLedgerQuery (filter carry-forward),
+    // not the old cursor-only concatenation.
+    expect(res.text).toContain("buildLedgerQuery(ledgerCursor)");
+    expect(res.text).not.toContain(
+      '/ledger?cursor="+encodeURIComponent(ledgerCursor)',
+    );
+    expect(res.text).toContain("No movements match this filter");
+  });
+});

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -274,7 +274,9 @@ describe("admin page — ledger movements filter", () => {
     expect(res.text).toContain("buildLedgerQuery");
     // load-more must build its URL through buildLedgerQuery (filter carry-forward),
     // not the old cursor-only concatenation.
-    expect(res.text).toContain("buildLedgerQuery(ledgerCursor)");
+    expect(res.text).toContain("buildLedgerQuery(ledgerFilter,ledgerCursor)");
+    // race guard: a per-apply generation token invalidates in-flight load-more.
+    expect(res.text).toContain("ledgerGen");
     expect(res.text).not.toContain(
       '/ledger?cursor="+encodeURIComponent(ledgerCursor)',
     );

--- a/tests/credits-admin/ledger-repository.test.ts
+++ b/tests/credits-admin/ledger-repository.test.ts
@@ -20,6 +20,28 @@ const addLedger = async (accountId: string, delta: bigint, createdAt: Date) => {
   });
 };
 
+const addKinded = async (
+  accountId: string,
+  delta: bigint,
+  createdAt: Date,
+  reason: "consume" | "grant" | "adjust",
+  grantKindId: string | null,
+) => {
+  await prisma.creditLedger.create({
+    data: {
+      accountId,
+      delta,
+      reason,
+      grantKindId,
+      idempotencyKey: `lrk_${accountId}_${createdAt.getTime()}_${delta}`,
+      createdAt,
+    },
+  });
+};
+
+const kindsOf = (rows: { grantKindId: string | null }[]) =>
+  new Set(rows.map((r) => r.grantKindId));
+
 describe("ledger-repository", () => {
   const tracker: string[] = [];
   afterEach(async () => {
@@ -60,5 +82,182 @@ describe("ledger-repository", () => {
     expect(s.delta).toBe("42");
     expect(typeof s.createdAt).toBe("string");
     expect(s.createdAt).toMatch(/T.*Z$/);
+  });
+});
+
+describe("listLedgerPageByAccount — filter", () => {
+  const tracker2: string[] = [];
+  afterEach(async () => {
+    await cleanupAdminAccounts(tracker2);
+    tracker2.length = 0;
+  });
+
+  // Seed one row per movement class, each on its own UTC day for deterministic order.
+  const seedMix = async (a: string) => {
+    await addKinded(
+      a,
+      100n,
+      new Date("2026-07-10T12:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addKinded(
+      a,
+      -40n,
+      new Date("2026-07-11T12:00:00Z"),
+      "adjust",
+      "sub_forfeit",
+    );
+    await addKinded(
+      a,
+      500n,
+      new Date("2026-07-12T12:00:00Z"),
+      "grant",
+      "manual",
+    );
+    await addKinded(a, -7n, new Date("2026-07-13T12:00:00Z"), "adjust", null);
+    await addKinded(a, -3n, new Date("2026-07-14T12:00:00Z"), "consume", null);
+    await addKinded(
+      a,
+      20n,
+      new Date("2026-07-15T12:00:00Z"),
+      "grant",
+      "daily_refill",
+    );
+  };
+
+  it("kind=subscription returns only sub_grant + sub_forfeit", async () => {
+    const a = await seedAccount();
+    tracker2.push(a);
+    await seedMix(a);
+    const { rows } = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 50,
+      filter: { kind: "subscription" },
+    });
+    expect(rows).toHaveLength(2);
+    expect(kindsOf(rows)).toEqual(new Set(["sub_grant", "sub_forfeit"]));
+  });
+
+  it("kind=sub_forfeit isolates just forfeits", async () => {
+    const a = await seedAccount();
+    tracker2.push(a);
+    await seedMix(a);
+    const { rows } = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 50,
+      filter: { kind: "sub_forfeit" },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].grantKindId).toBe("sub_forfeit");
+  });
+
+  it("reason=adjust surfaces admin-adjust (null kind) AND sub_forfeit", async () => {
+    const a = await seedAccount();
+    tracker2.push(a);
+    await seedMix(a);
+    const { rows } = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 50,
+      filter: { reason: "adjust" },
+    });
+    expect(rows).toHaveLength(2);
+    expect(kindsOf(rows)).toEqual(new Set(["sub_forfeit", null]));
+  });
+
+  it("from-only excludes rows before the from UTC day", async () => {
+    const a = await seedAccount();
+    tracker2.push(a);
+    await seedMix(a);
+    const { rows } = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 50,
+      filter: { from: new Date("2026-07-13") },
+    });
+    // 07-13, 07-14, 07-15 kept; 07-10..07-12 dropped.
+    expect(rows).toHaveLength(3);
+  });
+
+  it("to-only includes the whole to UTC day and excludes after", async () => {
+    const a = await seedAccount();
+    tracker2.push(a);
+    await addKinded(a, 1n, new Date("2026-07-17T23:59:00Z"), "grant", "manual");
+    await addKinded(a, 2n, new Date("2026-07-18T00:00:00Z"), "grant", "manual");
+    const { rows } = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 50,
+      filter: { to: new Date("2026-07-17") },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].delta).toBe(1n);
+  });
+
+  it("combines kind + reason + date (AND)", async () => {
+    const a = await seedAccount();
+    tracker2.push(a);
+    await seedMix(a);
+    const { rows } = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 50,
+      filter: {
+        kind: "subscription",
+        reason: "grant",
+        from: new Date("2026-07-01"),
+        to: new Date("2026-07-31"),
+      },
+    });
+    // Only sub_grant (reason=grant); sub_forfeit is reason=adjust so excluded.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].grantKindId).toBe("sub_grant");
+  });
+
+  it("keyset page 2 preserves the filter — no off-filter rows leak", async () => {
+    const a = await seedAccount();
+    tracker2.push(a);
+    // 3 sub_grant rows (target) interleaved with 3 manual rows (must never appear).
+    await addKinded(
+      a,
+      1n,
+      new Date("2026-07-01T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addKinded(a, 9n, new Date("2026-07-02T00:00:00Z"), "grant", "manual");
+    await addKinded(
+      a,
+      2n,
+      new Date("2026-07-03T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addKinded(a, 9n, new Date("2026-07-04T00:00:00Z"), "grant", "manual");
+    await addKinded(
+      a,
+      3n,
+      new Date("2026-07-05T00:00:00Z"),
+      "grant",
+      "sub_grant",
+    );
+    await addKinded(a, 9n, new Date("2026-07-06T00:00:00Z"), "grant", "manual");
+
+    const p1 = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 2,
+      filter: { kind: "sub_grant" },
+    });
+    expect(p1.rows).toHaveLength(2);
+    expect(kindsOf(p1.rows)).toEqual(new Set(["sub_grant"]));
+    expect(p1.nextCursor).toBeTruthy();
+
+    const cursor = decodeAuditCursor(p1.nextCursor as string);
+    const p2 = await listLedgerPageByAccount({
+      accountId: a,
+      limit: 2,
+      cursor,
+      filter: { kind: "sub_grant" },
+    });
+    expect(p2.rows).toHaveLength(1);
+    expect(kindsOf(p2.rows)).toEqual(new Set(["sub_grant"]));
+    expect(p2.nextCursor).toBeNull();
   });
 });

--- a/tests/credits-admin/requests.schema.test.ts
+++ b/tests/credits-admin/requests.schema.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { accountsListQuerySchema } from "@/api/v2/credits-admin/schemas/requests";
+import {
+  accountsListQuerySchema,
+  ledgerQuerySchema,
+} from "@/api/v2/credits-admin/schemas/requests";
 
 describe("accountsListQuerySchema — sort allowlist", () => {
   it("balance accepts sortBy=balance", () => {
@@ -54,5 +57,52 @@ describe("accountsListQuerySchema — sort allowlist", () => {
       expect(p.data.sortBy).toBe("latestGrantAt");
       expect(p.data.sortDir).toBe("desc");
     }
+  });
+});
+
+describe("ledgerQuerySchema — ledger filter", () => {
+  it("accepts no params (back-compat)", () => {
+    expect(ledgerQuerySchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts kind=subscription and every grant kind", () => {
+    for (const kind of [
+      "subscription",
+      "sub_grant",
+      "sub_forfeit",
+      "signup_bonus",
+      "daily_refill",
+      "manual",
+    ]) {
+      expect(ledgerQuerySchema.safeParse({ kind }).success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(ledgerQuerySchema.safeParse({ kind: "bogus" }).success).toBe(false);
+  });
+
+  it("accepts reason consume/grant/adjust and rejects the dead refill value", () => {
+    for (const reason of ["consume", "grant", "adjust"]) {
+      expect(ledgerQuerySchema.safeParse({ reason }).success).toBe(true);
+    }
+    expect(ledgerQuerySchema.safeParse({ reason: "refill" }).success).toBe(
+      false,
+    );
+  });
+
+  it("coerces YYYY-MM-DD dates to Date and rejects garbage", () => {
+    const ok = ledgerQuerySchema.safeParse({
+      from: "2026-07-01",
+      to: "2026-07-17",
+    });
+    expect(ok.success).toBe(true);
+    if (ok.success) {
+      expect(ok.data.from).toBeInstanceOf(Date);
+      expect(ok.data.to).toBeInstanceOf(Date);
+    }
+    expect(ledgerQuerySchema.safeParse({ to: "not-a-date" }).success).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Renames the credits-admin account-detail **Recent ledger** card to **Ledger movements** and adds a field filter so an admin can isolate categories of ledger activity — e.g. all subscription grants and forfeits of one account.

- **Kind** filter (`grantKindId`): combined **Subscription (grants + forfeits)** plus individual `sub_grant` / `sub_forfeit` / `signup_bonus` / `daily_refill` / `manual`.
- **Reason** filter (`LedgerReason`): `consume` / `grant` / `adjust`. (`refill` is a dead enum value — never written — so it is deliberately not offered.)
- **Date range**: UTC-day, `to` whole-day-inclusive.
- **Clear** resets to the full ledger.

### Design / safety
- Backend params are **optional + additive** on `GET /accounts/:accountId/ledger`; the modal bootstrap (`account-view-get`) stays unfiltered, so bare `/ledger` behavior is unchanged (back-compat). Not a mobile-client contract (admin-only, token + CF-identity gated).
- `kind=subscription` is a meta-value mapped in the repo to `grantKindId IN (sub_grant, sub_forfeit)` — not a stored kind.
- Filtering rides the existing `[grantKindId, createdAt]` / `[accountId, createdAt]` indexes — no migration.
- **Read-only**: pure `findMany` over `CreditLedger`. No balance/ledger write path, no `getBalance`/`consume`/`grant`/`adjust` touched.
- **Load-more carries the active filter**, and all async ledger paths (`applyLedgerFilter` + `loadLedgerMore`, both `.then` and `.catch`) guard shared-state mutation on the confirmed-current `acct` / `detailGen` / `ledgerGen` triple — closing a commit-on-intent stale-response race.

## Test plan
- [x] `pnpm vitest run tests/credits-admin/` — 149/149 green
- [x] `pnpm typecheck` + `pnpm lint` — clean
- [x] Backend filter matrix covered at schema + repo + HTTP layers (kind incl. subscription isolation, reason overlap, partial + full date ranges, combined AND, keyset page-2 preserves filter, unknown-kind/bad-date 400, bare-/ledger back-compat)
- [ ] **Browser walk (human gate — not confirmable by unit tests):**
  - [ ] W1: card reads "Ledger movements"; Kind/Reason/from/to/Clear controls render
  - [ ] W2: Kind=Subscription refetches to only sub_grant/sub_forfeit rows
  - [ ] W3: Load-more keeps the active filter on page 2
  - [ ] W4: no-match filter shows a single "No movements match this filter." row (no double empty-state)
  - [ ] W5: Clear resets all controls to the full ledger
  - [ ] W6: Reason + date combine (adjust rows within the UTC-day range)

## Follow-up (out of scope, tracked separately)
Pre-existing `openDetail` / `loadAudit` re-entrancy gap (same commit-on-intent class, GET-only, self-healing) — deferred, not touched by this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786841912&installation_id=128169237&pr_number=379&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F379&signature=050e15a5d0b3248c569ac1625d4aedfdfa558d8aad71a2c4784da21c0b74e793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add kind, reason, and date range filters to the credits-admin ledger movements UI
> - Adds `kind`, `reason`, `from`, and `to` query params to the GET account-ledger endpoint, validated via `ledgerQuerySchema` in [requests.ts](https://github.com/ephemeraHQ/convos-backend/pull/379/files#diff-276041216132ac1c7fdba4e981a12549f93c3185893eadcaf65949f936060325).
> - Extends `listLedgerPageByAccount` in [ledger-repository.ts](https://github.com/ephemeraHQ/convos-backend/pull/379/files#diff-5facb0b08f1476a26f79934d1746492984fcc77662cf5a063574eda922a2ff51) to filter by grant kind (including a `subscription` alias for `sub_grant`/`sub_forfeit`), reason, and a UTC date range with an inclusive `to` boundary.
> - Replaces the 'Recent ledger' card in the admin page with a 'Ledger movements' card containing Kind, Reason, From, To filter controls and a Clear button; uses a generation token to cancel in-flight 'load more' requests when filters change.
> - 'Load more' pagination carries the active filter forward in subsequent requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aee56d8. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ledger movement filters for kind, reason, and date range.
  * Added Clear controls and filtered pagination in the account detail view.
  * Added an empty state when no ledger movements match the selected filters.
* **Bug Fixes**
  * Ensured filtered results remain consistent when loading additional pages.
  * Added validation for unsupported filter values and invalid dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->