### PR TITLE
feat(credits-admin): brand ledger filter dropdowns + instant usage tooltip

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -1,4 +1,4 @@
-const CHEV = `<svg class="chev" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+export const CHEV = `<svg class="chev" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
 
 export const consoleView = (): string => `
 <div id="console" class="hidden">

--- a/src/api/v2/credits-admin/handlers/admin-page/script.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/script.ts
@@ -1,6 +1,9 @@
+import { CHEV } from "./console-view";
+
 export const clientScript = (): string => `
   var TOKEN_KEY = "credits_admin_token";
   var CREDITS_PER_USD = null; // set from whoami; usdHint guards on falsy
+  var DD_CHEV = ${JSON.stringify(CHEV)};
 
   function el(id){ return document.getElementById(id); }
   function esc(s){ if(s==null) return ""; return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;"); }
@@ -236,7 +239,7 @@ export const clientScript = (): string => `
     var max=usage.reduce(function(m,u){ var c=Number(u.consumed); return c>m?c:m; },0);
     var total=usage.reduce(function(s,u){ return s+Number(u.consumed); },0);
     var bars=usage.map(function(u){ var c=Number(u.consumed); var h=max>0?Math.max(2,Math.round(c/max*100)):2;
-      return '<div class="bar'+(max>0&&c===max?" peak":"")+'" style="height:'+h+'%" data-val="'+esc(fmtCredits(c))+'" title="'+esc(u.bucketStart+" · "+fmtCredits(c)+" credits")+'"></div>'; }).join("");
+      return '<div class="bar'+(max>0&&c===max?" peak":"")+'" style="height:'+h+'%" data-val="'+esc(fmtCredits(c))+'" data-tip="'+esc(u.bucketStart+" · "+fmtCredits(c)+" credits")+'"></div>'; }).join("");
     var firstDate=fmtDate(usage[0].bucketStart).split(" ")[0];
     var lastDate=fmtDate(usage[usage.length-1].bucketStart).split(" ")[0];
     return '<div class="usage-head"><span>Peak <b>'+esc(fmtCredits(max))+'</b>/day</span><span>Total <b>'+esc(fmtCredits(total))+'</b> · 30d</span></div>'
@@ -286,6 +289,12 @@ export const clientScript = (): string => `
         paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); });
       })
       .catch(function(e){ if(acct!==currentAccountId||gen!==detailGen||myGen!==ledgerGen) return; paintFoot("d-ledger-foot", true, ledgerCursor, function(){ loadLedgerMore(); }); if(e.message!=="reauth") toast("Failed to filter ledger","error"); });
+  }
+  function resetLedgerDd(id){
+    var s=el(id); if(!s) return;
+    s.selectedIndex=0;
+    var dd=s.parentNode;
+    if(dd&&dd.__sync) dd.__sync();
   }
   var ledgerCols=[[function(r){return fmtDate(r.createdAt);},"nowrap"],[function(r){return esc(r.delta);},"num"],function(r){return esc(r.reason);},[function(r){return esc(r.grantKindId||"—");},"mono"],function(r){return esc(r.note||"");}];
   function paintFoot(footId, hasRows, nextCursor, moreFn){
@@ -337,7 +346,7 @@ export const clientScript = (): string => `
       +'<div class="card"><h3>Daily refills</h3><div class="tablewrap"><table><tbody id="d-refills"></tbody></table></div></div>'
       +'<div class="card"><h3>Ledger movements</h3>'
       +'<div class="ledger-filter">'
-      +'<select id="d-lf-kind">'
+      +'<div class="dd" data-dd="d-lf-kind"><select id="d-lf-kind" class="dd-native">'
       +'<option value="">Kind: all</option>'
       +'<option value="subscription">Subscription (grants + forfeits)</option>'
       +'<option value="sub_grant">Sub grant</option>'
@@ -345,13 +354,13 @@ export const clientScript = (): string => `
       +'<option value="signup_bonus">Signup bonus</option>'
       +'<option value="daily_refill">Daily refill</option>'
       +'<option value="manual">Manual</option>'
-      +'</select>'
-      +'<select id="d-lf-reason">'
+      +'</select><button type="button" class="dd-btn" aria-haspopup="listbox" aria-expanded="false"><span class="dd-label"></span>'+DD_CHEV+'</button><div class="dd-menu" role="listbox"></div></div>'
+      +'<div class="dd" data-dd="d-lf-reason"><select id="d-lf-reason" class="dd-native">'
       +'<option value="">Reason: all</option>'
       +'<option value="consume">consume</option>'
       +'<option value="grant">grant</option>'
       +'<option value="adjust">adjust</option>'
-      +'</select>'
+      +'</select><button type="button" class="dd-btn" aria-haspopup="listbox" aria-expanded="false"><span class="dd-label"></span>'+DD_CHEV+'</button><div class="dd-menu" role="listbox"></div></div>'
       +'<input id="d-lf-from" type="date" aria-label="From date">'
       +'<input id="d-lf-to" type="date" aria-label="To date">'
       +'<button id="d-lf-clear" class="btn btn-secondary">Clear</button>'
@@ -365,11 +374,12 @@ export const clientScript = (): string => `
     renderLedgerFirst(j);
     el("d-grant-btn").addEventListener("click", function(){ mutate("grant"); });
     el("d-adjust-btn").addEventListener("click", function(){ mutate("adjust"); });
+    Array.prototype.forEach.call(el("detail-body").querySelectorAll(".dd"), initDropdown);
     ["d-lf-kind","d-lf-reason","d-lf-from","d-lf-to"].forEach(function(id){
       el(id).addEventListener("change", applyLedgerFilter);
     });
     el("d-lf-clear").addEventListener("click", function(){
-      el("d-lf-kind").value=""; el("d-lf-reason").value="";
+      resetLedgerDd("d-lf-kind"); resetLedgerDd("d-lf-reason");
       el("d-lf-from").value=""; el("d-lf-to").value="";
       applyLedgerFilter();
     });
@@ -448,6 +458,7 @@ export const clientScript = (): string => `
     });
     document.addEventListener("click", function(e){ if(!dd.contains(e.target)) close(); });
     syncLabel();
+    dd.__sync=syncLabel;
   }
   Array.prototype.forEach.call(document.querySelectorAll(".dd"), initDropdown);
 

--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -130,8 +130,9 @@ tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 .usage-grid{position:absolute;top:15px;left:0;right:0;height:0;border-top:1px dashed var(--edge);}
 .usage-bars{position:relative;display:flex;align-items:flex-end;gap:2px;height:76px;}
 .usage-bars .bar{flex:1;min-width:3px;min-height:2px;background:var(--color-brand);border-radius:3px 3px 0 0;position:relative;transition:opacity .1s var(--ease);}
-.usage-bars .bar:hover{opacity:.7;}
+.usage-bars .bar:hover{opacity:.85;}
 .usage-bars .bar.peak::after{content:attr(data-val);position:absolute;top:-13px;left:50%;transform:translateX(-50%);font-size:9px;font-weight:600;color:var(--color-brand-strong);white-space:nowrap;}
+.usage-bars .bar:hover::before{content:attr(data-tip);position:absolute;bottom:calc(100% + 7px);left:50%;transform:translateX(-50%);background:var(--surface);color:var(--fg);border:1px solid var(--edge);box-shadow:var(--shadow-pop);font-size:11px;font-weight:500;line-height:1;white-space:nowrap;padding:6px 9px;border-radius:var(--radius-sm);pointer-events:none;z-index:40;}
 .usage-axis{display:flex;justify-content:space-between;margin-top:7px;font-size:10px;color:var(--fg-3);}
 
 /* Cards */
@@ -161,10 +162,12 @@ tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 @keyframes pop{from{opacity:0;transform:translateY(8px) scale(.98);}to{opacity:1;transform:none;}}
 .detail-close{position:absolute;top:16px;right:16px;}
 
-.ledger-filter{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;}
-.ledger-filter select,.ledger-filter input{flex:0 0 auto;width:auto;min-height:var(--control-h);margin-bottom:0;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:8px 10px;font-family:var(--sans);font-size:12px;color:var(--fg);}
-.ledger-filter select:focus,.ledger-filter input:focus{outline:none;border-color:var(--fg-3);}
-.ledger-filter .btn{min-height:var(--control-h);}
+.ledger-filter{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:12px;}
+.ledger-filter .dd[data-dd="d-lf-kind"]{flex:1 1 210px;min-width:180px;}
+.ledger-filter .dd[data-dd="d-lf-reason"]{flex:0 0 150px;}
+.ledger-filter input{flex:0 0 auto;width:auto;min-height:var(--control-h);margin-bottom:0;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:9px 12px;font-family:var(--sans);font-size:13px;color:var(--fg);}
+.ledger-filter input:focus{outline:none;border-color:var(--fg-3);}
+.ledger-filter .btn{flex:0 0 auto;min-height:var(--control-h);}
 
 /* Responsive */
 @media (max-width:768px){

--- a/tests/credits-admin/admin-page.test.ts
+++ b/tests/credits-admin/admin-page.test.ts
@@ -282,4 +282,25 @@ describe("admin page — ledger movements filter", () => {
     );
     expect(res.text).toContain("No movements match this filter");
   });
+
+  it("renders the Kind/Reason filters as branded .dd dropdowns, not native selects", async () => {
+    const res = await get();
+    // same branded custom-dropdown component as the rail view-mode/gk-kind
+    expect(res.text).toContain('class="dd" data-dd="d-lf-kind"');
+    expect(res.text).toContain('class="dd" data-dd="d-lf-reason"');
+    expect(res.text).toContain('id="d-lf-kind" class="dd-native"');
+    expect(res.text).toContain('id="d-lf-reason" class="dd-native"');
+    // the injected modal dropdowns get initialised on open (not just boot-time)
+    expect(res.text).toContain(
+      'el("detail-body").querySelectorAll(".dd"), initDropdown',
+    );
+  });
+
+  it("uses an instant brand tooltip on usage bars, not the native title attribute", async () => {
+    const res = await get();
+    // usage bars carry data-tip (CSS :hover tooltip), no native title= (OS-grey + delay)
+    expect(res.text).toContain('data-tip="');
+    expect(res.text).not.toContain('" title="');
+    expect(res.text).toContain(".usage-bars .bar:hover::before");
+  });
 });


### PR DESCRIPTION
Follow-up polish on the credits-admin account-detail modal (on top of #379).

## Summary

- **Ledger filter dropdowns now on-brand.** The `Kind` / `Reason` filters were plain native `<select>`s; they now use the **same branded `.dd` popover component** as the rail `view-mode` / `gk-kind` dropdowns — shared inline chevron SVG (CSP-safe), `initDropdown` run on modal open, hidden native `<select>` kept as the value/wiring source (so `change` still drives the filter), and the branded menu with the lava active-check. `Clear` resyncs the branded label via a `dd.__sync` handle (no extra fetch).
- **Usage (30d) tooltip is on-brand and instant.** The bars used the native `title=` attribute (OS-grey chrome, ~1s hover delay). Swapped to a `data-tip` + CSS `:hover::before` popover matching `.dd-menu` (surface + edge + shadow-pop). Appears instantly.

Dropdown audit: all four dropdowns in the console (`view-mode`, `gk-kind`, `d-lf-kind`, `d-lf-reason`) are now the branded component.

## Verification

- `pnpm vitest run tests/credits-admin/` — 151/151 (2 new static assertions: branded `.dd` structure on the filters; `data-tip` tooltip, no native `title=`).
- `pnpm typecheck` + `pnpm lint` + prettier — clean; `new Function(clientScript())` syntax check green.
- **Rendered headless (Chrome)** and eyeballed both: the Kind menu is pixel-consistent with the rail dropdowns; the tooltip matches the popover style and fires with no delay. Console is intentionally light-only (no dark theme).

## Notes / not in scope

- `from` / `to` are `<input type="date">` — the closed boxes are styled to match, but the native OS calendar popup isn't brandable without a full custom date-picker. Left as native (they're inputs, not dropdowns).
- Reusing `initDropdown` per modal-open registers a document click-listener each open (harmless no-op on detached nodes; accumulates over a session). Fine for an admin tool; can add a teardown if desired.

## Test plan (browser walk)
- [ ] Open an account detail modal: Kind + Reason render as branded dropdowns (not native), open/select works, Clear resets their labels + the ledger.
- [ ] Hover a usage bar: branded tooltip appears instantly (no OS-grey delayed tooltip).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786843895&installation_id=128169237&pr_number=380&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F380&signature=84d80bcfc9bf64fdeb4175b00241191af9ab7ffcddcac2e9a62c41ec4eb8505d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add branded dropdown filters and CSS tooltip to credits admin ledger view
> - Replaces native `<select>` controls for the ledger 'Kind' and 'Reason' filters with custom `.dd` dropdown components, including a chevron icon, a hidden native select, and a styled menu; dropdowns are initialized on modal open and reset via `resetLedgerDd` when clearing filters.
> - Swaps the native `title` attribute on usage chart bars for a `data-tip` attribute, rendering an instant CSS `::before` tooltip instead of the browser-native one.
> - Exports `CHEV` from [console-view.ts](https://github.com/ephemeraHQ/convos-backend/pull/380/files#diff-8085ce47f11ae91c45730ea39d6a944df6f95bafd5a3b7b248d82a1e77879843) so it can be injected into the generated client script as `DD_CHEV`.
> - Updates [styles.ts](https://github.com/ephemeraHQ/convos-backend/pull/380/files#diff-5026cdeef3d31917458c32b473b8379af53c676e7e57bb27ef7028c0d1d0918a) to style the new dropdown components and the CSS tooltip on hover.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3320fb8. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->