### PR TITLE
fix(credits-admin): fit ledger filter row on one line, equal-width controls

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -162,10 +162,10 @@ tbody tr.row-clickable:hover td.mono{color:var(--fg);}
 @keyframes pop{from{opacity:0;transform:translateY(8px) scale(.98);}to{opacity:1;transform:none;}}
 .detail-close{position:absolute;top:16px;right:16px;}
 
-.ledger-filter{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:12px;}
-.ledger-filter .dd[data-dd="d-lf-kind"]{flex:1 1 210px;min-width:180px;}
-.ledger-filter .dd[data-dd="d-lf-reason"]{flex:0 0 150px;}
-.ledger-filter input{flex:0 0 auto;width:auto;min-height:var(--control-h);margin-bottom:0;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:9px 12px;font-family:var(--sans);font-size:13px;color:var(--fg);}
+.ledger-filter{display:flex;flex-wrap:nowrap;align-items:center;gap:8px;margin-bottom:12px;}
+.ledger-filter .dd,.ledger-filter input{flex:1 1 0;min-width:0;}
+.ledger-filter .dd-menu{right:auto;min-width:260px;}
+.ledger-filter input{width:auto;min-height:var(--control-h);margin-bottom:0;background:var(--surface);border:1px solid var(--edge);border-radius:var(--radius);padding:9px 10px;font-family:var(--sans);font-size:13px;color:var(--fg);}
 .ledger-filter input:focus{outline:none;border-color:var(--fg-3);}
 .ledger-filter .btn{flex:0 0 auto;min-height:var(--control-h);}
 


### PR DESCRIPTION
Follow-up on #380.

## Problem
In the Ledger movements filter row, the `Kind` dropdown was wider than the other controls and the row wrapped onto a second line.

Cause (from #380's CSS): `Kind` had `flex:1 1 210px` (grew larger than `Reason`), and `.ledger-filter` was `flex-wrap:wrap`, so `from` / `to` / `Clear` spilled to a second line.

## Fix (CSS only, `styles.ts`)
- `.ledger-filter` → `flex-wrap:nowrap` (always one line).
- `Kind`, `Reason`, and both date inputs → `flex:1 1 0; min-width:0` — they share the row width equally, so `Kind` is no longer bigger than the others and everything shrinks to fit.
- `Clear` stays `flex:0 0 auto`.
- `.ledger-filter .dd-menu` → `min-width:260px` so the compact `Kind` button still opens a menu wide enough to keep "Subscription (grants + forfeits)" on one line.

## Verification
- Rendered headless (Chrome) and eyeballed: one line, `Kind` / `Reason` / dates equal width, `Clear` compact, and the open Kind menu keeps the long option on one line.
- `pnpm typecheck` + `pnpm lint` + prettier clean; `tests/credits-admin/admin-page.test.ts` 29/29.

## Test plan (browser walk)
- [ ] Open an account detail modal: the Ledger movements filter row sits on one line; Kind and Reason are the same width; opening Kind shows all options with the long one un-wrapped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786868602&installation_id=128169237&pr_number=381&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F381&signature=cc7ed18c3799edd7731d88c4d7ab873d02b03cf0ecb084a94f18d027091b6c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix credits admin ledger filter row to display on one line with equal-width controls
> Updates `.ledger-filter` styles in [styles.ts](https://github.com/ephemeraHQ/convos-backend/pull/381/files#diff-5026cdeef3d31917458c32b473b8379af53c676e7e57bb27ef7028c0d1d0918a) so all controls stay on a single row and share available space equally.
>
> - Sets `flex-wrap: nowrap` and applies `flex: 1 1 0` with `min-width: 0` to all dropdowns and inputs, replacing per-element flex overrides.
> - Aligns dropdown menus to the left (`right: auto`) with a minimum width of 260px.
> - Behavioral Change: inputs can now shrink below their previous minimum widths, and horizontal padding is slightly reduced from 12px to 10px.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 148f421.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved ledger filter layout consistency and responsiveness.
  * Prevented filter controls from wrapping unexpectedly.
  * Standardized control sizing and adjusted dropdown alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->