### PR TITLE
fix(credits-admin): wrap ledger filter on narrow screens, constrain menu

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page/styles.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/styles.ts
@@ -176,6 +176,12 @@ tbody tr.row-clickable:hover td.mono{color:var(--fg);}
   .detail{width:100%;}
   .detail-scrim{padding:24px 12px;}
 }
+@media (max-width:600px){
+  /* One line is a wide-screen goal; on narrow screens wrap so controls stay usable */
+  .ledger-filter{flex-wrap:wrap;}
+  .ledger-filter .dd,.ledger-filter input{flex:1 1 140px;}
+  .ledger-filter .dd-menu{left:0;right:0;min-width:0;}
+}
 @media (pointer:coarse){
   .rail input,.rail select,.mode-ctl input,.mode-ctl select{min-height:44px;font-size:16px;}
   .btn{min-height:40px;}


### PR DESCRIPTION
Follow-up to #381 (addresses the CodeRabbit review comment on it).

## Problem
#381 set the Ledger movements filter row to `flex-wrap:nowrap` so it stays on one line at desktop widths. On narrow screens that shrank the four controls to unusable sizes, and the `260px` dropdown menu `min-width` could overflow the viewport (notably the Reason menu).

## Fix (CSS only, `styles.ts`)
Add a `@media (max-width:600px)` block:
- `.ledger-filter` → `flex-wrap:wrap` (one line is a wide-screen goal; wrapping is correct on narrow screens).
- `.ledger-filter .dd, .ledger-filter input` → `flex:1 1 140px` so controls stay a usable size instead of collapsing.
- `.ledger-filter .dd-menu` → `left:0;right:0;min-width:0` so the branded menu is constrained to the control width and can't overflow the viewport.

Desktop behavior (one line, equal-width controls) is unchanged.

## Verification
- Rendered headless (Chrome) at desktop and ~440px: desktop stays one line; narrow wraps cleanly with usable controls and a viewport-constrained menu.
- `pnpm typecheck` + `pnpm lint` + prettier clean; `tests/credits-admin/admin-page.test.ts` 29/29.

## Test plan (browser walk)
- [ ] Detail modal at a narrow viewport (<600px): filter controls wrap to multiple usable rows; opening Kind/Reason keeps the menu inside the viewport.
- [ ] Desktop width: filters still on one line, equal width.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786869835&installation_id=128169237&pr_number=382&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F382&signature=dc58955a8336c550651ee76aea59474f63922059994e77ab69a2e20aee9e0b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ledger filter layout on narrow screens in credits admin
> Adds a `@media (max-width: 600px)` rule in [styles.ts](https://github.com/ephemeraHQ/convos-backend/pull/382/files#diff-5026cdeef3d31917458c32b473b8379af53c676e7e57bb27ef7028c0d1d0918a) so the ledger filter row wraps on small viewports. The dropdown and input flex with a 140px basis, and the dropdown menu stretches to full container width with `left: 0; right: 0; min-width: 0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63f3dfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->