### PR TITLE
fix(subscriptions): forfeit prior period on renewal (no credit carryover)

### DIFF
--- a/src/api/v2/credits-admin/handlers/admin-page/AGENTS.md
+++ b/src/api/v2/credits-admin/handlers/admin-page/AGENTS.md
@@ -14,12 +14,12 @@ The whole page is one server-rendered HTML document — **no framework, no build
 step, no external assets**. Four files, assembled by `index.ts`
 (`adminPageHandler`):
 
-| File | Role |
-| --- | --- |
+| File              | Role                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------- |
 | `console-view.ts` | Static HTML shell (`consoleView()`), plus `login-view.ts`. Exposes the shared inline-SVG chevron `CHEV`. |
-| `script.ts` | All client JS, returned as a **template string** by `clientScript()`. Runtime DOM lives here. |
-| `styles.ts` | All CSS, as the `STYLES` string. Design tokens in `:root`. |
-| `index.ts` | Sets CSP + assembles `<style>${STYLES}</style>` + shell + `<script nonce>${clientScript()}</script>`. |
+| `script.ts`       | All client JS, returned as a **template string** by `clientScript()`. Runtime DOM lives here.            |
+| `styles.ts`       | All CSS, as the `STYLES` string. Design tokens in `:root`.                                               |
+| `index.ts`        | Sets CSP + assembles `<style>${STYLES}</style>` + shell + `<script nonce>${clientScript()}</script>`.    |
 
 ## Hard constraints (CSP) — these bite
 
@@ -69,7 +69,7 @@ Defined in `:root` in `styles.ts`. Load-bearing ones:
   it, so existing `change` listeners keep working. Build the option list on the
   native select; the branded menu mirrors it.
 - **Floating panels (menus, tooltips, popovers): `background:var(--surface);
-  border:1px solid var(--edge); box-shadow:var(--shadow-pop); border-radius`.**
+border:1px solid var(--edge); box-shadow:var(--shadow-pop); border-radius`.**
   Match `.dd-menu`. This is the single popover look.
 - **Tooltips: never use the native `title=` attribute.** It's OS-grey chrome and
   has a ~1s hover delay. Use `data-tip="…"` + a CSS `:hover::before` (or
@@ -98,7 +98,7 @@ Defined in `:root` in `styles.ts`. Load-bearing ones:
   at load over `document.querySelectorAll(".dd")`. Anything rendered later — e.g.
   a `.dd` inside the detail modal built on click — **must be initialized
   explicitly** after injection: `Array.prototype.forEach.call(
-  el("detail-body").querySelectorAll(".dd"), initDropdown)`. (Per-open init
+el("detail-body").querySelectorAll(".dd"), initDropdown)`. (Per-open init
   registers one document click-listener each open — a harmless minor leak in an
   admin tool.) Programmatic `select.value = …` won't resync the branded label;
   `initDropdown` stashes `dd.__sync` for that.
@@ -119,7 +119,7 @@ Defined in `:root` in `styles.ts`. Load-bearing ones:
     dispatch (a failed fetch must leave the visible state consistent);
   - when an action supersedes a control (e.g. applying a filter), clear/disable
     the superseded affordance at dispatch so no interleaved action starts.
-  See `applyLedgerFilter` / `loadLedgerMore` for the worked pattern.
+    See `applyLedgerFilter` / `loadLedgerMore` for the worked pattern.
 
 ## Responsive
 
@@ -141,7 +141,7 @@ narrow-screen media query that re-wraps and constrains popover width
   CI, so screenshot a standalone harness that pulls the real `STYLES` and runs
   the real `initDropdown` over representative markup, via headless Chrome
   (`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless
-  --screenshot=out.png file://harness.html`). Render both wide and narrow. This
+--screenshot=out.png file://harness.html`). Render both wide and narrow. This
   is how brand match / layout / a tooltip is actually confirmed.
 - **Behavior (render timing, hover feel, async races):** browser-walk only — the
   human gate. Static tests can't reach it; call it out in the PR test plan.

--- a/src/subscriptions/grants.ts
+++ b/src/subscriptions/grants.ts
@@ -159,10 +159,10 @@ export type ForfeitSubscriptionPeriodResult =
 
 /**
  * On expiry/refund/revoke, write ONE bounded `sub_forfeit` adjustment
- * that removes only the unused subscription portion of the current period:
+ * that removes only the unused subscription portion of the passed period:
  *
  *   periodGrant    = the sub_grant delta we wrote for this period
- *   periodConsumes = |consume deltas| since currentPeriodStart
+ *   periodConsumes = |consume deltas| since periodStart
  *   unusedSub      = max(0, periodGrant − periodConsumes)
  *   forfeitDelta   = −min(lockedBalance, unusedSub)        # clamp ≥ 0
  *
@@ -174,7 +174,7 @@ export type ForfeitSubscriptionPeriodResult =
  * drive the wallet negative. A `floorCheck: { minBalance: 0n }` on the apply is
  * a belt-and-suspenders guard that throws (rather than silently writing a
  * negative balance) should the clamp ever be defeated. Idempotent on
- * `sub_forfeit:{subscription.id}:{periodStartEpoch}` so a duplicate
+ * `sub_forfeit:{subscription.id}:{periodStart epoch}` so a duplicate
  * EXPIRED/REVOKE webhook doesn't double-claw.
  *
  * Cancel-while-active (auto-renew off, period still running) must NOT call this
@@ -182,10 +182,9 @@ export type ForfeitSubscriptionPeriodResult =
  */
 export const forfeitSubscriptionPeriod = async (
   tx: TxClient,
-  args: { subscription: Subscription },
+  args: { subscription: Subscription; periodStart: Date },
 ): Promise<ForfeitSubscriptionPeriodResult> => {
-  const { subscription } = args;
-  const periodStart = subscription.currentPeriodStart;
+  const { subscription, periodStart } = args;
   const forfeitKey = subForfeitKey(subscription.id, periodStart);
 
   const priorForfeit = await findLedgerRow(

--- a/src/subscriptions/grants.ts
+++ b/src/subscriptions/grants.ts
@@ -49,7 +49,12 @@ const findLedgerRow = (
   });
 
 /**
- * |consume deltas| since `since` (period start), as a positive credit total.
+ * |consume deltas| in `[since, until)` (defaulting to open-ended when `until` is
+ * omitted), as a positive credit total. Renewal forfeits pass `until = the new
+ * period start` so spends made after the ending period are attributed to the new
+ * period, not clawed back against the old one; the terminal (expiry) forfeit
+ * omits `until` — that period has no successor, so every spend since its start
+ * belongs to it.
  *
  * S1 KNOWN APPROXIMATION (n=1, safe direction): the wallet is commingled —
  * `consume` rows carry no funding-source/bucket metadata, so we cannot tell a
@@ -64,16 +69,18 @@ const findLedgerRow = (
  * each consume with its funding bucket — over-engineering for n=1 and tracked as
  * a follow-up if subscription volume grows.
  */
-const sumConsumesSince = async (
+const sumConsumesBetween = async (
   tx: TxClient,
   accountId: string,
   since: Date,
+  until?: Date,
 ): Promise<number> => {
   const agg = await tx.creditLedger.aggregate({
     where: {
       accountId,
       reason: LedgerReason.consume,
-      createdAt: { gte: since },
+      createdAt:
+        until === undefined ? { gte: since } : { gte: since, lt: until },
     },
     _sum: { delta: true },
   });
@@ -162,9 +169,15 @@ export type ForfeitSubscriptionPeriodResult =
  * that removes only the unused subscription portion of the passed period:
  *
  *   periodGrant    = the sub_grant delta we wrote for this period
- *   periodConsumes = |consume deltas| since periodStart
+ *   periodConsumes = |consume deltas| in [periodStart, consumesUntil)
  *   unusedSub      = max(0, periodGrant − periodConsumes)
  *   forfeitDelta   = −min(lockedBalance, unusedSub)        # clamp ≥ 0
+ *
+ * `consumesUntil` bounds the consume window to the ending period: renewal
+ * callers pass the NEW period's start so spends made after the ending period are
+ * not attributed to it (which would shrink this forfeit and let the wallet keep
+ * more than one period's credits). The terminal (expiry) forfeit omits it — that
+ * period has no successor, so all spends since its start are its own.
  *
  * The `min(lockedBalance, unusedSub)` clamp guarantees the forfeit never drives
  * the wallet below the admin/promo/signup credits sharing it, and never below
@@ -182,9 +195,9 @@ export type ForfeitSubscriptionPeriodResult =
  */
 export const forfeitSubscriptionPeriod = async (
   tx: TxClient,
-  args: { subscription: Subscription; periodStart: Date },
+  args: { subscription: Subscription; periodStart: Date; consumesUntil?: Date },
 ): Promise<ForfeitSubscriptionPeriodResult> => {
-  const { subscription, periodStart } = args;
+  const { subscription, periodStart, consumesUntil } = args;
   const forfeitKey = subForfeitKey(subscription.id, periodStart);
 
   const priorForfeit = await findLedgerRow(
@@ -219,10 +232,11 @@ export const forfeitSubscriptionPeriod = async (
     subscription.accountId,
   );
 
-  const periodConsumes = await sumConsumesSince(
+  const periodConsumes = await sumConsumesBetween(
     tx,
     subscription.accountId,
     periodStart,
+    consumesUntil,
   );
   const unusedSub = Math.max(0, periodGrant - periodConsumes);
   if (unusedSub <= 0) {

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -812,9 +812,18 @@ export const applyNotification = async (
         updated.currentPeriodStart.getTime() >
           subscription.currentPeriodStart.getTime()
       ) {
-        // A renewal advanced the period start → materialize the new period's
-        // allotment. Guarding on "the start advanced" means a grace/billing-
-        // retry transition that keeps the same period does not re-grant.
+        // A renewal advanced the period start → forfeit the ending period's
+        // unused allotment (no carryover), then materialize the new period.
+        // `subscription` is the pre-update row, so its currentPeriodStart is
+        // the ending period. Guarding on "the start advanced" means a grace/
+        // billing-retry transition that keeps the same period neither forfeits
+        // nor re-grants. Forfeit is idempotent per (sub, period) and fenced by
+        // the preceding subscription.update row lock, so a racing verify for
+        // the same advance no-ops on the forfeit key.
+        await forfeitSubscriptionPeriod(tx, {
+          subscription,
+          periodStart: subscription.currentPeriodStart,
+        });
         const grantResult = await grantSubscriptionPeriod(tx, {
           subscription: updated,
           periodStart: updated.currentPeriodStart,

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -473,6 +473,27 @@ export const upsertFromVerify = async (
       // subscription … wallet credits persist until forfeit"). Switching this
       // to the effective check would break that pinned semantic for nothing.
       if (!isStaleVerify && isEntitledSubscriptionStatus(subscription.status)) {
+        // Renewal observed via verify: if the period start advanced past the
+        // stored one, forfeit the ending period's unused allotment (no
+        // carryover) before granting the new period. Guard strictly on
+        // start-advance so a re-verify of the SAME period does not claw the
+        // live period. The compare is ms-precise and relies on the provider
+        // returning a STABLE per-period currentPeriodStart (Apple purchaseDate /
+        // Play startTime are byte-identical across verify + S2S for one period);
+        // a same-period re-verify therefore does not trip this guard. `existing`
+        // is the pre-update row (ending period); the subscription.update above
+        // holds the row lock that fences a racing S2S renewal onto the same
+        // idempotent per-period forfeit key.
+        if (
+          existing !== null &&
+          input.currentPeriodStart.getTime() >
+            existing.currentPeriodStart.getTime()
+        ) {
+          await forfeitSubscriptionPeriod(tx, {
+            subscription: existing,
+            periodStart: existing.currentPeriodStart,
+          });
+        }
         const grantResult = await grantSubscriptionPeriod(tx, {
           subscription,
           periodStart: subscription.currentPeriodStart,

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -475,16 +475,24 @@ export const upsertFromVerify = async (
       const isStaleVerify =
         locked !== null && input.currentPeriodEnd < locked.currentPeriodEnd;
 
-      const subscription = existing
-        ? isStaleVerify
-          ? existing
-          : await tx.subscription.update({
-              where: { id: existing.id },
-              data: subscriptionUpdateData(input),
-            })
-        : await tx.subscription.create({
-            data: subscriptionCreateData(input),
-          });
+      let subscription: Subscription;
+      if (existing === null) {
+        subscription = await tx.subscription.create({
+          data: subscriptionCreateData(input),
+        });
+      } else if (isStaleVerify) {
+        // Stale/out-of-order verify: don't roll the row back, but return its
+        // CURRENT committed state — a concurrent renewal may have advanced it
+        // since the pre-lock `existing` read.
+        subscription =
+          (await tx.subscription.findUnique({ where: { id: existing.id } })) ??
+          existing;
+      } else {
+        subscription = await tx.subscription.update({
+          where: { id: existing.id },
+          data: subscriptionUpdateData(input),
+        });
+      }
 
       await tx.billingReceipt.create({
         data: {
@@ -853,7 +861,16 @@ export const applyNotification = async (
         input.update.currentPeriodEnd.getTime() <
           locked.currentPeriodEnd.getTime()
       ) {
-        return { kind: "applied" as const, subscription };
+        // Stale/out-of-order: skip the state-apply, but return the row's CURRENT
+        // committed state — a concurrent renewal may have advanced it since the
+        // pre-lock `notificationLookup` snapshot.
+        const current = await tx.subscription.findUnique({
+          where: { id: subscription.id },
+        });
+        return {
+          kind: "applied" as const,
+          subscription: current ?? subscription,
+        };
       }
 
       const updated = await tx.subscription.update({

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -186,6 +186,36 @@ const providerSubscriptionId = (input: VerifyInput): string =>
     ? input.originalTransactionId
     : input.purchaseToken;
 
+type LockedSubscriptionPeriod = {
+  currentPeriodStart: Date;
+  currentPeriodEnd: Date;
+};
+
+/**
+ * Lock the Subscription row (FOR UPDATE) for the rest of the caller's
+ * transaction and return its CURRENT (pre-advance) period. Renewal decisions —
+ * staleness, whether the period advanced, and WHICH period to forfeit — must run
+ * against this serialized read, not a snapshot taken before the row lock: two
+ * concurrent renewals (A→B, A→C) would otherwise both read period A, and the
+ * second would forfeit A (a no-op replay) instead of the period the row actually
+ * advanced from, leaking a full period's credits. Locking here also fences the
+ * verify and S2S paths against each other on the same row. Lock order:
+ * Subscription then UserCredits (matching the forfeit/grant helpers) — no
+ * deadlock. Returns null only if the row vanished (never in practice).
+ */
+const lockSubscriptionPeriod = async (
+  tx: Prisma.TransactionClient,
+  id: string,
+): Promise<LockedSubscriptionPeriod | null> => {
+  const rows = await tx.$queryRaw<LockedSubscriptionPeriod[]>`
+    SELECT "currentPeriodStart", "currentPeriodEnd"
+    FROM "Subscription"
+    WHERE "id" = ${id}::uuid
+    FOR UPDATE
+  `;
+  return rows[0] ?? null;
+};
+
 const findExistingForVerify = async (
   tx: Prisma.TransactionClient,
   input: VerifyInput,
@@ -429,11 +459,21 @@ export const upsertFromVerify = async (
         };
       }
 
+      // Lock the row for the rest of the tx and read its TRUE current period, so
+      // staleness / advance / forfeit-target all judge against the serialized
+      // state — not the pre-lock `existing` snapshot a concurrent renewal may
+      // have already superseded. Only the update path (existing !== null) needs
+      // it; a first-time create has no prior period to lock.
+      const locked =
+        existing !== null
+          ? await lockSubscriptionPeriod(tx, existing.id)
+          : null;
+
       // A valid but old transaction can arrive after a later renewal/webhook.
       // Keep the audit row, but do not roll the subscription's entitlement
       // window or status backwards.
       const isStaleVerify =
-        existing !== null && input.currentPeriodEnd < existing.currentPeriodEnd;
+        locked !== null && input.currentPeriodEnd < locked.currentPeriodEnd;
 
       const subscription = existing
         ? isStaleVerify
@@ -474,24 +514,23 @@ export const upsertFromVerify = async (
       // to the effective check would break that pinned semantic for nothing.
       if (!isStaleVerify && isEntitledSubscriptionStatus(subscription.status)) {
         // Renewal observed via verify: if the period start advanced past the
-        // stored one, forfeit the ending period's unused allotment (no
-        // carryover) before granting the new period. Guard strictly on
-        // start-advance so a re-verify of the SAME period does not claw the
-        // live period. The compare is ms-precise and relies on the provider
-        // returning a STABLE per-period currentPeriodStart (Apple purchaseDate /
-        // Play startTime are byte-identical across verify + S2S for one period);
-        // a same-period re-verify therefore does not trip this guard. `existing`
-        // is the pre-update row (ending period); the subscription.update above
-        // holds the row lock that fences a racing S2S renewal onto the same
-        // idempotent per-period forfeit key.
+        // LOCKED current one, forfeit the ending period's unused allotment (no
+        // carryover) before granting the new period. Comparing against `locked`
+        // (read under the row lock) rather than the pre-lock snapshot means a
+        // concurrent renewal that already advanced the row is seen — we forfeit
+        // the period the row actually advanced FROM, and a same-period re-verify
+        // (identical stable provider start) does not trip the guard.
+        // `consumesUntil` bounds the clawed period's consumes to spends made
+        // before the new period began.
         if (
-          existing !== null &&
+          locked !== null &&
           input.currentPeriodStart.getTime() >
-            existing.currentPeriodStart.getTime()
+            locked.currentPeriodStart.getTime()
         ) {
           await forfeitSubscriptionPeriod(tx, {
-            subscription: existing,
-            periodStart: existing.currentPeriodStart,
+            subscription,
+            periodStart: locked.currentPeriodStart,
+            consumesUntil: input.currentPeriodStart,
           });
         }
         const grantResult = await grantSubscriptionPeriod(tx, {
@@ -773,6 +812,15 @@ export const applyNotification = async (
 
   try {
     return await prisma.$transaction(async (tx) => {
+      // Lock the row FIRST — before the receipt insert, whose Subscription FK
+      // takes a KEY SHARE lock. Requesting FOR UPDATE ahead of that avoids a
+      // KEY-SHARE→FOR-UPDATE upgrade deadlock between two concurrent
+      // notifications for the same subscription, and gives the staleness guard +
+      // renewal forfeit a serialized read of the TRUE current period rather than
+      // the pre-tx `subscription` snapshot a concurrent renewal may have
+      // superseded.
+      const locked = await lockSubscriptionPeriod(tx, subscription.id);
+
       await tx.billingReceipt.create({
         data: {
           subscriptionId: subscription.id,
@@ -800,9 +848,10 @@ export const applyNotification = async (
       // period to compare; updates that omit it (no period drift possible) fall
       // through and apply as before.
       if (
+        locked !== null &&
         input.update.currentPeriodEnd !== undefined &&
         input.update.currentPeriodEnd.getTime() <
-          subscription.currentPeriodEnd.getTime()
+          locked.currentPeriodEnd.getTime()
       ) {
         return { kind: "applied" as const, subscription };
       }
@@ -823,27 +872,30 @@ export const applyNotification = async (
         // period end. Idempotent per (subscription, periodStart). Stale
         // out-of-order terminal events were already short-circuited by the
         // staleness guard above, so this only fires for the current period
-        // (natural expiry or a legitimate mid-period refund/revoke).
+        // (natural expiry or a legitimate mid-period refund/revoke). Forfeit the
+        // LOCKED current period — the one the sub is actually in.
         await forfeitSubscriptionPeriod(tx, {
           subscription: updated,
-          periodStart: updated.currentPeriodStart,
+          periodStart: locked?.currentPeriodStart ?? updated.currentPeriodStart,
         });
       } else if (
         isEntitledSubscriptionStatus(updated.status) &&
+        locked !== null &&
         updated.currentPeriodStart.getTime() >
-          subscription.currentPeriodStart.getTime()
+          locked.currentPeriodStart.getTime()
       ) {
-        // A renewal advanced the period start → forfeit the ending period's
-        // unused allotment (no carryover), then materialize the new period.
-        // `subscription` is the pre-update row, so its currentPeriodStart is
-        // the ending period. Guarding on "the start advanced" means a grace/
-        // billing-retry transition that keeps the same period neither forfeits
-        // nor re-grants. Forfeit is idempotent per (sub, period) and fenced by
-        // the preceding subscription.update row lock, so a racing verify for
-        // the same advance no-ops on the forfeit key.
+        // A renewal advanced the period start past the LOCKED current one →
+        // forfeit the period the row actually advanced FROM (read under the row
+        // lock, so a concurrent renewal that already advanced is seen), bounding
+        // its consumes to spends made before the new period began, then grant the
+        // new period. A grace/billing-retry that keeps the same period does not
+        // advance `locked`, so it neither forfeits nor re-grants. The per-period
+        // forfeit key + the row lock make a racing verify for the same advance
+        // resolve to exactly one forfeit and one grant.
         await forfeitSubscriptionPeriod(tx, {
-          subscription,
-          periodStart: subscription.currentPeriodStart,
+          subscription: updated,
+          periodStart: locked.currentPeriodStart,
+          consumesUntil: updated.currentPeriodStart,
         });
         const grantResult = await grantSubscriptionPeriod(tx, {
           subscription: updated,

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -803,7 +803,10 @@ export const applyNotification = async (
         // out-of-order terminal events were already short-circuited by the
         // staleness guard above, so this only fires for the current period
         // (natural expiry or a legitimate mid-period refund/revoke).
-        await forfeitSubscriptionPeriod(tx, { subscription: updated });
+        await forfeitSubscriptionPeriod(tx, {
+          subscription: updated,
+          periodStart: updated.currentPeriodStart,
+        });
       } else if (
         isEntitledSubscriptionStatus(updated.status) &&
         updated.currentPeriodStart.getTime() >

--- a/tests/subscriptions/grants.integration.test.ts
+++ b/tests/subscriptions/grants.integration.test.ts
@@ -648,3 +648,184 @@ describe("B2: n=1 materialization writes the FULL perPeriod grant", () => {
     );
   });
 });
+
+describe("forfeit-on-renewal invariants", () => {
+  const renewViaNotification = (otid: string, newStart: Date, newEnd: Date) =>
+    applyNotification({
+      provider: BillingProvider.apple,
+      originalTransactionId: otid,
+      transactionId: `tx-renew-${randomUUID()}`,
+      notificationUUID: randomUUID(),
+      notificationType: "DID_RENEW",
+      signedPayload: "stub.jws",
+      update: {
+        status: SubscriptionStatus.active,
+        currentPeriodStart: newStart,
+        currentPeriodEnd: newEnd,
+        willRenew: true,
+      },
+    });
+
+  const countForfeits = (accountId: string) =>
+    prisma.creditLedger.count({
+      where: { accountId, grantKindId: "sub_forfeit" },
+    });
+  const countGrants = (accountId: string) =>
+    prisma.creditLedger.count({
+      where: { accountId, grantKindId: "sub_grant" },
+    });
+
+  it("renewal seen by S2S then verify forfeits the prior period exactly once", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    await verifyApple(accountId, { originalTransactionId: otid });
+
+    const newStart = new Date(Date.now() + 25 * DAY_MS);
+    const newEnd = new Date(newStart.getTime() + 30 * DAY_MS);
+    await renewViaNotification(otid, newStart, newEnd);
+    // iOS re-verifies the same, already-advanced period → no second forfeit.
+    await verifyApple(accountId, {
+      originalTransactionId: otid,
+      transactionId: `tx-${randomUUID()}`,
+      currentPeriodStart: newStart,
+      currentPeriodEnd: newEnd,
+    });
+
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+    expect(await countGrants(accountId)).toBe(2);
+    expect(await countForfeits(accountId)).toBe(1);
+  });
+
+  it("renewal seen by verify then S2S forfeits the prior period exactly once", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    const oldStart = new Date(Date.now() - 40 * DAY_MS);
+    const oldEnd = new Date(Date.now() - 10 * DAY_MS);
+    await verifyApple(accountId, {
+      originalTransactionId: otid,
+      currentPeriodStart: oldStart,
+      currentPeriodEnd: oldEnd,
+    });
+
+    const newStart = new Date(Date.now() - 5 * DAY_MS);
+    const newEnd = new Date(Date.now() + 25 * DAY_MS);
+    await verifyApple(accountId, {
+      originalTransactionId: otid,
+      transactionId: `tx-${randomUUID()}`,
+      currentPeriodStart: newStart,
+      currentPeriodEnd: newEnd,
+    });
+    // S2S DID_RENEW for the same already-advanced period → no second forfeit.
+    await renewViaNotification(otid, newStart, newEnd);
+
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+    expect(await countGrants(accountId)).toBe(2);
+    expect(await countForfeits(accountId)).toBe(1);
+  });
+
+  it("renewal forfeits only the UNUSED portion of the prior period", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    const { subscription } = await verifyApple(accountId, {
+      originalTransactionId: otid,
+    });
+    const spend = await consume({
+      accountId,
+      usdCostMicros: 50_000n, // 100 credits
+      idempotencyKey: `c-${randomUUID()}`,
+      requestId: "r",
+    });
+
+    const newStart = new Date(Date.now() + 25 * DAY_MS);
+    const newEnd = new Date(newStart.getTime() + 30 * DAY_MS);
+    await renewViaNotification(otid, newStart, newEnd);
+
+    const unusedSub = perPeriod() - spend.spent;
+    const forfeitKey = subForfeitKey(
+      subscription.id,
+      subscription.currentPeriodStart,
+    );
+    const forfeitRow = await prisma.creditLedger.findUnique({
+      where: {
+        accountId_idempotencyKey: { accountId, idempotencyKey: forfeitKey },
+      },
+    });
+    expect(forfeitRow?.delta).toBe(BigInt(-unusedSub));
+    // prior consumed portion already left the wallet; prior unused clawed;
+    // new full period granted → exactly one perPeriod.
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+  });
+
+  it("renewal forfeit never touches non-subscription credits", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    await verifyApple(accountId, { originalTransactionId: otid });
+    await grant({
+      accountId,
+      credits: 1000,
+      kind: "manual",
+      idempotencyKey: `admin-${randomUUID()}`,
+    });
+
+    const newStart = new Date(Date.now() + 25 * DAY_MS);
+    const newEnd = new Date(newStart.getTime() + 30 * DAY_MS);
+    await renewViaNotification(otid, newStart, newEnd);
+
+    // Prior sub period clawed, admin 1000 untouched, new period granted.
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()) + 1000n);
+  });
+
+  it("a renewal that skips intermediate periods forfeits only the last-recorded period", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    const { subscription } = await verifyApple(accountId, {
+      originalTransactionId: otid,
+    });
+
+    // Jump straight to a much later period (intermediate periods never observed).
+    const newStart = new Date(Date.now() + 60 * DAY_MS);
+    const newEnd = new Date(newStart.getTime() + 30 * DAY_MS);
+    await renewViaNotification(otid, newStart, newEnd);
+
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+    expect(await countGrants(accountId)).toBe(2);
+    expect(await countForfeits(accountId)).toBe(1);
+    // The single forfeit is keyed to the last-recorded (only granted) period.
+    const forfeitKey = subForfeitKey(
+      subscription.id,
+      subscription.currentPeriodStart,
+    );
+    const forfeitRow = await prisma.creditLedger.findUnique({
+      where: {
+        accountId_idempotencyKey: { accountId, idempotencyKey: forfeitKey },
+      },
+    });
+    expect(forfeitRow?.delta).toBe(BigInt(-perPeriod()));
+  });
+
+  it("terminal expiry after a renewal claws only the current period (no accumulation left)", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    await verifyApple(accountId, { originalTransactionId: otid });
+
+    const newStart = new Date(Date.now() + 25 * DAY_MS);
+    const newEnd = new Date(newStart.getTime() + 30 * DAY_MS);
+    await renewViaNotification(otid, newStart, newEnd);
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+
+    await applyNotification({
+      provider: BillingProvider.apple,
+      originalTransactionId: otid,
+      transactionId: `tx-exp-${randomUUID()}`,
+      notificationUUID: randomUUID(),
+      notificationType: "EXPIRED",
+      signedPayload: "stub.jws",
+      update: { status: SubscriptionStatus.expired, willRenew: false },
+    });
+
+    // Period 1 forfeited at renewal, period 2 forfeited at expiry → wallet 0,
+    // two forfeit rows total. No stacked prior periods survive.
+    expect(await getBalance(accountId)).toBe(0n);
+    expect(await countForfeits(accountId)).toBe(2);
+  });
+});

--- a/tests/subscriptions/grants.integration.test.ts
+++ b/tests/subscriptions/grants.integration.test.ts
@@ -828,4 +828,115 @@ describe("forfeit-on-renewal invariants", () => {
     expect(await getBalance(accountId)).toBe(0n);
     expect(await countForfeits(accountId)).toBe(2);
   });
+
+  it("renewal forfeit excludes spends that belong to the NEW period (bounded consume window)", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    const { subscription } = await verifyApple(accountId, {
+      originalTransactionId: otid,
+    });
+    // Admin credits lift the wallet above the forfeit clamp so the bound is
+    // observable (otherwise min(balance, unusedSub) would mask it).
+    await grant({
+      accountId,
+      credits: 1000,
+      kind: "manual",
+      idempotencyKey: `admin-${randomUUID()}`,
+    });
+    // A spend made "now" — it lands AFTER the new period's start below, so it is
+    // a NEW-period spend and must NOT reduce the OLD period's clawback.
+    const spend = await consume({
+      accountId,
+      usdCostMicros: 50_000n, // 100 credits
+      idempotencyKey: `c-${randomUUID()}`,
+      requestId: "r",
+    });
+
+    // Renew with a new period whose start is just before now (so it is > the old
+    // start, an advance) but before the spend's createdAt.
+    const newStart = new Date(Date.now() - 60_000);
+    const newEnd = new Date(Date.now() + 30 * DAY_MS);
+    await renewViaNotification(otid, newStart, newEnd);
+
+    // Old-period consumes bounded to [oldStart, newStart) = none (the spend is
+    // after newStart). Old period fully forfeited; the spend stays debited (not
+    // refunded via a shrunken forfeit). Final = admin − spend + one new period.
+    expect(await getBalance(accountId)).toBe(
+      1000n - BigInt(spend.spent) + BigInt(perPeriod()),
+    );
+    const forfeitKey = subForfeitKey(
+      subscription.id,
+      subscription.currentPeriodStart,
+    );
+    const forfeitRow = await prisma.creditLedger.findUnique({
+      where: {
+        accountId_idempotencyKey: { accountId, idempotencyKey: forfeitKey },
+      },
+    });
+    expect(forfeitRow?.delta).toBe(BigInt(-perPeriod()));
+  });
+
+  it("concurrent successive renewals never leave more than one period's credits (stress)", async () => {
+    const TRIALS = 25;
+    for (let i = 0; i < TRIALS; i++) {
+      const accountId = await newAccount();
+      const otid = `otid-${accountId}`;
+      await verifyApple(accountId, { originalTransactionId: otid }); // period A
+
+      // Two concurrent renewals advancing to DIFFERENT successive periods.
+      const bStart = new Date(Date.now() + 25 * DAY_MS);
+      const bEnd = new Date(bStart.getTime() + 30 * DAY_MS);
+      const cStart = new Date(Date.now() + 55 * DAY_MS);
+      const cEnd = new Date(cStart.getTime() + 30 * DAY_MS);
+
+      const renewB = renewViaNotification(otid, bStart, bEnd).catch(() => null);
+      const renewC = verifyApple(accountId, {
+        originalTransactionId: otid,
+        transactionId: `tx-${randomUUID()}`,
+        currentPeriodStart: cStart,
+        currentPeriodEnd: cEnd,
+      }).catch(() => null);
+      await Promise.all([renewB, renewC]);
+
+      // No carryover under concurrency: at most one period's credits remain,
+      // and the wallet always equals the exact ledger sum.
+      const balance = await getBalance(accountId);
+      expect(balance).toBeLessThanOrEqual(BigInt(perPeriod()));
+      const agg = await prisma.creditLedger.aggregate({
+        where: { accountId },
+        _sum: { delta: true },
+      });
+      expect(balance).toBe(agg._sum.delta ?? 0n);
+    }
+  });
+
+  it("concurrent S2S notifications for one subscription never deadlock (stress)", async () => {
+    const TRIALS = 12;
+    for (let i = 0; i < TRIALS; i++) {
+      const accountId = await newAccount();
+      const otid = `otid-${accountId}`;
+      await verifyApple(accountId, { originalTransactionId: otid });
+
+      const newStart = new Date(Date.now() + 25 * DAY_MS);
+      const newEnd = new Date(newStart.getTime() + 30 * DAY_MS);
+      // Two concurrent S2S notifications (distinct notificationUUIDs) for the
+      // SAME subscription. Each inserts a BillingReceipt (a KEY SHARE lock on the
+      // Subscription FK row) then takes the FOR UPDATE row lock. If the row lock
+      // were taken AFTER the receipt insert, both would hold KEY SHARE and
+      // deadlock on the upgrade (Postgres 40P01 → Prisma P2010). No `.catch()`:
+      // a deadlock rejects Promise.all and fails the test.
+      await Promise.all([
+        renewViaNotification(otid, newStart, newEnd),
+        renewViaNotification(otid, newStart, newEnd),
+      ]);
+
+      // Both applied cleanly, exactly one period materialized (no carryover).
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+      const agg = await prisma.creditLedger.aggregate({
+        where: { accountId },
+        _sum: { delta: true },
+      });
+      expect(await getBalance(accountId)).toBe(agg._sum.delta ?? 0n);
+    }
+  });
 });

--- a/tests/subscriptions/grants.integration.test.ts
+++ b/tests/subscriptions/grants.integration.test.ts
@@ -305,7 +305,10 @@ describe("subscription forfeit (bounded clawback)", () => {
     expect(await getBalance(accountId)).toBe(30n);
 
     const result = await prisma.$transaction((tx) =>
-      forfeitSubscriptionPeriod(tx, { subscription: sub }),
+      forfeitSubscriptionPeriod(tx, {
+        subscription: sub,
+        periodStart: sub.currentPeriodStart,
+      }),
     );
 
     // unusedSub = perPeriod - (perPeriod - 30) = 30; lockedBalance = 30; so
@@ -347,7 +350,10 @@ describe("subscription forfeit (bounded clawback)", () => {
       // the forfeit clamps against the balance it actually mutates.
       const forfeitP = prisma
         .$transaction((tx) =>
-          forfeitSubscriptionPeriod(tx, { subscription: sub }),
+          forfeitSubscriptionPeriod(tx, {
+            subscription: sub,
+            periodStart: sub.currentPeriodStart,
+          }),
         )
         .catch(() => null);
       const consumeP = consume({

--- a/tests/subscriptions/grants.integration.test.ts
+++ b/tests/subscriptions/grants.integration.test.ts
@@ -144,10 +144,10 @@ describe("subscription grant materialization (single-ledger)", () => {
     expect(grantRows).toBe(1);
   });
 
-  it("renewal advancing the period grants the new period again", async () => {
+  it("renewal forfeits the prior period and grants the new one (no carryover)", async () => {
     const accountId = await newAccount();
     const otid = `otid-${accountId}`;
-    await verifyApple(accountId, {
+    const { subscription } = await verifyApple(accountId, {
       originalTransactionId: otid,
     });
     expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
@@ -170,12 +170,26 @@ describe("subscription grant materialization (single-ledger)", () => {
     });
     expect(res.kind).toBe("applied");
 
-    // Two periods granted → wallet holds 2 × perPeriod.
-    expect(await getBalance(accountId)).toBe(BigInt(perPeriod() * 2));
+    // No carryover: prior period forfeited (nothing consumed), new period
+    // granted → wallet holds exactly one perPeriod, not two.
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
     const grantRows = await prisma.creditLedger.count({
       where: { accountId, grantKindId: "sub_grant" },
     });
     expect(grantRows).toBe(2);
+    // The ending period's forfeit is keyed to its OLD start and claws the full
+    // unused allotment.
+    const forfeitKey = subForfeitKey(
+      subscription.id,
+      subscription.currentPeriodStart,
+    );
+    const forfeitRow = await prisma.creditLedger.findUnique({
+      where: {
+        accountId_idempotencyKey: { accountId, idempotencyKey: forfeitKey },
+      },
+    });
+    expect(forfeitRow?.grantKindId).toBe("sub_forfeit");
+    expect(forfeitRow?.delta).toBe(BigInt(-perPeriod()));
   });
 });
 

--- a/tests/subscriptions/grants.integration.test.ts
+++ b/tests/subscriptions/grants.integration.test.ts
@@ -127,14 +127,27 @@ describe("subscription grant materialization (single-ledger)", () => {
     expect(row?.delta).toBe(BigInt(perPeriod()));
   });
 
-  it("re-verify of the same period is idempotent — no double grant", async () => {
+  it("re-verify of the same period is idempotent — no double grant, no forfeit", async () => {
     const accountId = await newAccount();
     const otid = `otid-${accountId}`;
-    await verifyApple(accountId, { originalTransactionId: otid });
+    // Pin the period window so BOTH verifies carry a byte-identical
+    // currentPeriodStart — exactly what Apple does (stable purchaseDate per
+    // period). Relying on verifyApple's Date.now() default would recompute the
+    // start a few ms later on the second call, which the ms-precise renewal
+    // advance-guard would misread as a new period and forfeit the live one.
+    const start = new Date(Date.now() - 5 * DAY_MS);
+    const end = new Date(Date.now() + 25 * DAY_MS);
+    await verifyApple(accountId, {
+      originalTransactionId: otid,
+      currentPeriodStart: start,
+      currentPeriodEnd: end,
+    });
     // Same period, different provider transactionId (e.g. a re-verify).
     await verifyApple(accountId, {
       originalTransactionId: otid,
       transactionId: `tx-${randomUUID()}`,
+      currentPeriodStart: start,
+      currentPeriodEnd: end,
     });
 
     expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
@@ -142,6 +155,12 @@ describe("subscription grant materialization (single-ledger)", () => {
       where: { accountId, grantKindId: "sub_grant" },
     });
     expect(grantRows).toBe(1);
+    // The advance guard must treat an identical-start re-verify as the SAME
+    // period → no forfeit of the live period.
+    const forfeitRows = await prisma.creditLedger.count({
+      where: { accountId, grantKindId: "sub_forfeit" },
+    });
+    expect(forfeitRows).toBe(0);
   });
 
   it("renewal forfeits the prior period and grants the new one (no carryover)", async () => {
@@ -183,6 +202,40 @@ describe("subscription grant materialization (single-ledger)", () => {
       subscription.id,
       subscription.currentPeriodStart,
     );
+    const forfeitRow = await prisma.creditLedger.findUnique({
+      where: {
+        accountId_idempotencyKey: { accountId, idempotencyKey: forfeitKey },
+      },
+    });
+    expect(forfeitRow?.grantKindId).toBe("sub_forfeit");
+    expect(forfeitRow?.delta).toBe(BigInt(-perPeriod()));
+  });
+
+  it("renewal via verify forfeits the prior period and grants the new one", async () => {
+    const accountId = await newAccount();
+    const otid = `otid-${accountId}`;
+    const oldStart = new Date(Date.now() - 40 * DAY_MS);
+    const oldEnd = new Date(Date.now() - 10 * DAY_MS);
+    const { subscription } = await verifyApple(accountId, {
+      originalTransactionId: otid,
+      currentPeriodStart: oldStart,
+      currentPeriodEnd: oldEnd,
+    });
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+
+    // iOS re-verifies with an ADVANCED period (renewal observed via /verify).
+    const newStart = new Date(Date.now() - 5 * DAY_MS);
+    const newEnd = new Date(Date.now() + 25 * DAY_MS);
+    await verifyApple(accountId, {
+      originalTransactionId: otid,
+      transactionId: `tx-${randomUUID()}`,
+      currentPeriodStart: newStart,
+      currentPeriodEnd: newEnd,
+    });
+
+    // Prior period forfeited, new period granted → one perPeriod.
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+    const forfeitKey = subForfeitKey(subscription.id, oldStart);
     const forfeitRow = await prisma.creditLedger.findUnique({
       where: {
         accountId_idempotencyKey: { accountId, idempotencyKey: forfeitKey },

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -863,7 +863,8 @@ describe("applyNotification", () => {
       },
     });
     expect(renew.kind).toBe("applied");
-    expect(await getBalance(accountId)).toBe(BigInt(perPeriod() * 2));
+    // Renewal forfeited period 1 and granted period 2 → one perPeriod.
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
 
     // Now a STALE EXPIRED for the OLD period (currentPeriodEnd = oldEnd < newEnd).
     const stale = await applyNotification({
@@ -887,12 +888,14 @@ describe("applyNotification", () => {
         newEnd.toISOString(),
       );
     }
-    // No forfeit — wallet untouched.
-    expect(await getBalance(accountId)).toBe(BigInt(perPeriod() * 2));
+    // Balance unchanged by the stale EXPIRED (still the single post-renewal period).
+    expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+    // The stale EXPIRED added NO forfeit; the single forfeit present is the
+    // one the renewal already wrote for period 1.
     const forfeitRows = await prisma.creditLedger.count({
       where: { accountId, grantKindId: "sub_forfeit" },
     });
-    expect(forfeitRows).toBe(0);
+    expect(forfeitRows).toBe(1);
     // The stale receipt is still recorded for audit.
     const receipt = await findReceiptByTransactionId(
       BillingProvider.apple,

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -515,7 +515,8 @@ describe("upsertFromVerify", () => {
           currentPeriodEnd: CURRENT_END,
         }),
       );
-      expect(await getBalance(accountId)).toBe(BigInt(perPeriod() * 2));
+      // Renewal forfeited period 1 (−perPeriod) and granted period 2 → one perPeriod.
+      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
 
       // Remove period 2's grant, then replay the OLD transaction. Its period
       // end predates the stored one → stale → must NOT backfill period 2.
@@ -526,7 +527,9 @@ describe("upsertFromVerify", () => {
       );
       const replay = await upsertFromVerify(oldInput);
       expect(replay.receiptCreated).toBe(false);
-      expect(await getBalance(accountId)).toBe(BigInt(perPeriod()));
+      // Period 1 was forfeited at renewal and period 2's grant was just
+      // stripped → wallet is 0. The stale replay must NOT re-materialize it.
+      expect(await getBalance(accountId)).toBe(0n);
       expect(await countSubGrants(accountId)).toBe(1);
     });
 


### PR DESCRIPTION
## Summary

Fixes subscription-credit **accumulation on renewal**. Previously each renewal granted a new period's credits but never forfeited the *ending* period, so an active subscriber's wallet stacked to 2×, 3×, … `perPeriod` over successive renewals, and a terminal expiry only reclaimed the final period — stranding the rest.

Both grant paths now **forfeit the ending period's unused allotment before granting the new one**:
- **S2S notification** renewal branch (`applyNotification`)
- **iOS `/verify`** renewal branch (`upsertFromVerify`), guarded on a *strict* period-start advance so same-period re-verifies and grace/billing-retry transitions neither forfeit nor re-grant

The forfeit reuses the existing bounded `forfeitSubscriptionPeriod` helper (now taking an explicit `periodStart`), keyed idempotently per `(subscription, period)` and fenced by the `Subscription` row lock, so a single renewal observed by **both** paths in either order produces **exactly one forfeit and one grant**. Non-subscription credits (admin/daily/signup) stay protected by the existing `min(balance, unusedSub)` clamp + zero-floor. Net: a renewed subscriber holds exactly one period's credits at any time, and terminal expiry now reclaims fully (closes the second defect where only the current period was ever clawed).

### Root cause
The only `forfeitSubscriptionPeriod` call site lived in the `expired||revoked` branch and forfeited only `currentPeriodStart`; both grant paths advanced the period and granted additively with no matching forfeit. Provider-agnostic, so Apple prod is affected too — sandbox just renews ~daily, making it visible in a week (observed sandbox subs: 10+ `sub_grant`, 0–1 `sub_forfeit`).

## Commits
1. `refactor` — explicit `periodStart` arg on `forfeitSubscriptionPeriod` (behavior-neutral; makes every caller name the period it forfeits)
2. `fix` — forfeit prior period on S2S renewal
3. `fix` — forfeit prior period on verify-observed renewal
4. `test` — cross-path + safety pinning invariants

## Money-law
Routed through the sanctioned `forfeitSubscriptionPeriod` / `grantSubscriptionPeriod` helpers (no direct `UserCredits`/`CreditLedger` writes); per-period underscore idempotency keys; no derived balance; **no new `GrantKind`/`LedgerReason`**. **No admin-page change owed** — this changes *when* an existing flow fires, not the balance model or entitlement math; the admin page reads real `getBalance` + ledger rows and reflects it automatically.

## Test Plan
- [x] `pnpm test tests/subscriptions/grants.integration.test.ts tests/subscriptions/repository.test.ts` — 46/46 green (incl. new cross-path/skip-renewal/partial-consume/non-sub-protection/terminal-after-renewal cases, all real-DB)
- [x] `pnpm test tests/payments/ tests/credits/` — 172/172 green (ledger primitives unaffected)
- [x] `pnpm typecheck` + `pnpm lint` — clean
- [x] TDD: each behavioral commit's tests fail on the prior code (`2×perPeriod`) and pass after

> **Note for reviewers:** the 7 failures in `tests/subscriptions/account-credits.test.ts` are **pre-existing on `otr-dev`** (local `.env` `PAYMENTS_GRANT_PLUS_MONTHLY` differs from the value that test hardcodes) — confirmed identical on base via worktree. Not touched by this PR.

## Out of scope (follow-up)
- **Remediation of already-accumulated balances** on existing subs (sandbox + any prod) — needs a `sub_grant`-vs-`sub_forfeit` per-sub query to quantify, then admin `adjust` / one-off reconcile. This PR stops the bleed; it does not retroactively claw stacked credits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786894112&installation_id=128169237&pr_number=384&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F384&signature=b6a3ddf45cff7eeb8c3baa0f84c4c665e3711068256fcf537e865b75486f8590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forfeit unused subscription credits on renewal to prevent balance carryover across periods
> - On renewal (when `currentPeriodStart` advances), the prior period's unused credits are now forfeited before the new period's credits are granted, eliminating carryover.
> - `forfeitSubscriptionPeriod` in [grants.ts](https://github.com/ephemeraHQ/convos-backend/pull/384/files#diff-6b5ad58e1a6c72452ce638255e77eabd3f349a7a4da90c70a0e3279848c23ae0) now accepts an explicit `periodStart` argument so callers can target a specific period; idempotency is keyed on this value.
> - Both the verify path (`upsertFromVerify`) and the S2S notification path (`applyNotification`) in [repository.ts](https://github.com/ephemeraHQ/convos-backend/pull/384/files#diff-16668c0e0aabb5ea30e88f32f8983171d113e2f6f072e791d726724e97461ee9) detect period advancement and perform the forfeit-then-grant sequence.
> - Behavioral Change: subscriptions that previously carried unused credits into a new billing period will now have those credits zeroed out at renewal.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #384 opened
>
> - Introduced row-level locking via `lockSubscriptionPeriod` in `subscriptions.repository` and modified `upsertFromVerify` and `applyNotification` methods to acquire `FOR UPDATE` locks on subscription rows, compare period staleness against locked values, and make renewal/forfeit decisions based on the locked state [c2dbe6c]
> - Modified `forfeitSubscriptionPeriod` in `subscriptions.grants` to accept optional `consumesUntil` parameter that bounds the forfeit calculation to exclude spends from the new period during renewal [c2dbe6c]
> - Renamed and expanded `sumConsumesSince` utility to `sumConsumesBetween` in `subscriptions.grants`, adding optional `until` parameter to support querying consumes within a bounded interval [c2dbe6c]
> - Added integration tests in `tests/subscriptions/grants.integration.test.ts` for renewal forfeit behavior, including tests verifying bounded consumes exclude new period spends and stress tests for concurrent renewals and notifications [c2dbe6c]
> - Adjusted documentation table formatting and whitespace in `AGENTS.md` [c2dbe6c]
> - Modified `subscriptions.repository.upsertFromVerify` and `subscriptions.repository.applyNotification` to return the subscription's current committed state from within the transaction when handling stale or out-of-order updates [963a5a6]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 67ad117. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription renewals now attribute consumptions to the correct period window and forfeit only unused credits from the ending period before granting the next period’s credits.
  * Prevented credit carryover across renewals and fixed bounded clawback behavior so new-period spends aren’t retroactively forfeited.
  * Improved replay and out-of-order/stale verification/expiration handling to avoid duplicate grants/forfeits.
  * Added stronger guarantees that non-subscription credits are unaffected and concurrent notifications/grants don’t deadlock.
* **Documentation**
  * Updated the credits-admin console agent/usage guide for clearer layout and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->