### PR TITLE
docs(dev): local app integration shortcuts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,18 @@ PORT=4000
 # For host `pnpm dev`: use localhost:5432. For Docker `./dev/run`: use convos_db:5432.
 DATABASE_URL=postgres://postgres:convos@localhost:5432/postgres?sslmode=disable
 
-# Firebase service account (optional — push fan-out is no-op if unset)
+# Firebase service account (optional — push fan-out is no-op if unset).
+#
+# Leaving it empty does NOT disable App Check. The client still sends an App
+# Check token and /v2/auth/nonce and /v2/auth/token still try to verify it,
+# which fails with "AppCheck verification failed" and a 500 — so a local app
+# build can never authenticate. To develop without Firebase, turn attestation
+# off at runtime instead:
+#   INSERT INTO "RuntimeConfig" (key, value, "updatedAt")
+#   VALUES ('app_attest_enabled','false',NOW())
+#   ON CONFLICT (key) DO UPDATE SET value='false', "updatedAt"=NOW();
+# (There is also POST /api/v2/dev/app-attest, but it needs DEV_API_TOKEN set.)
+# The flag is cached for 30s, so wait that long before retrying the app.
 FIREBASE_SERVICE_ACCOUNT=
 
 # REQUIRED — v2 JWT asymmetric ECDSA P-256 keys.
@@ -136,6 +147,16 @@ LIFECYCLE_TEST_TOKEN=
 # REQUIRED — SIWE / nonce-cookie auth. Backend refuses to start without these.
 # Domain pinned in SIWE messages; must match the deployed website host
 # (i.e. the host portion of WEBSITE_URL above).
+#
+# POINTING A LOCAL APP BUILD AT THIS BACKEND? Use dev.convos.org for BOTH of
+# these, not the values below. The iOS client signs SIWE with the domain from
+# its bundled config (Convos/Config/config.*.json -> siweDomain), which is
+# dev.convos.org for the Dev and Local schemes. A mismatch fails at signature
+# verification with a bare "SIWE verification failed" and a 401 on
+# /v2/auth/token, several steps after the thing that is actually wrong, so it
+# reads like a cookie or App Check problem. It is not.
+#   SIWE_DOMAIN=dev.convos.org
+#   SIWE_URI=https://dev.convos.org
 SIWE_DOMAIN=popup.convos.org
 # REQUIRED — URI field expected in SIWE messages (must align with SIWE_DOMAIN / WEBSITE_URL).
 SIWE_URI=https://popup.convos.org

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -163,7 +163,13 @@ tables directly — see `src/payments/AGENTS.md`):
 
 ```ts
 import { grant } from "@/payments";
-await grant({ accountId, credits: 1_000_000, idempotencyKey: `local-${accountId}`, kind: "manual" });
+
+await grant({
+  accountId,
+  credits: 1_000_000,
+  idempotencyKey: `local-${accountId}`,
+  kind: "manual",
+});
 ```
 
 `pnpm typecheck` fails on a fresh clone until the generated code exists. Run

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,8 +132,10 @@ shared assistant key), so agent features route app -> here -> assistants worker.
 To exercise that whole chain locally:
 
 1. `./dev/up` for Postgres, then `pnpm exec prisma migrate deploy`.
-2. Point `ASSISTANT_API_URL` at the local worker (`http://localhost:8787`, the
-   default here) and set `ASSISTANT_API_KEY` to that worker's `CONVOS_API_KEY`.
+2. Start the assistants worker and point `ASSISTANT_API_URL` at it
+   (`http://localhost:8787`, the default here); set `ASSISTANT_API_KEY` to that
+   worker's `CONVOS_API_KEY`. The worker lives in the `convos-assistants` repo
+   (`pnpm dev` in `workers/assistant/`) — nothing here starts it for you.
 3. Expose this backend over HTTPS — `ngrok http 4000`. The app will not talk to
    plain HTTP, and a deployed backend cannot reach a worker on your laptop, so
    the tunnel has to front the local backend rather than the other way round.
@@ -163,6 +165,9 @@ tables directly — see `src/payments/AGENTS.md`):
 
 ```ts
 import { grant } from "@/payments";
+
+// Your account id — copy it from the app (Settings) or query the local DB.
+const accountId = "<your-account-id>";
 
 await grant({
   accountId,

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -125,6 +125,51 @@ curl http://localhost:4000/healthcheck/details
 }
 ```
 
+## Driving the iOS app against this backend
+
+The app cannot reach the assistant control plane directly (that route holds the
+shared assistant key), so agent features route app -> here -> assistants worker.
+To exercise that whole chain locally:
+
+1. `./dev/up` for Postgres, then `pnpm exec prisma migrate deploy`.
+2. Point `ASSISTANT_API_URL` at the local worker (`http://localhost:8787`, the
+   default here) and set `ASSISTANT_API_KEY` to that worker's `CONVOS_API_KEY`.
+3. Expose this backend over HTTPS — `ngrok http 4000`. The app will not talk to
+   plain HTTP, and a deployed backend cannot reach a worker on your laptop, so
+   the tunnel has to front the local backend rather than the other way round.
+4. In the app repo, set `CONVOS_API_BASE_URL=https://<tunnel-host>/api` and
+   rebuild. Its build phase regenerates `Secrets.swift`, so a `.env` edit alone
+   changes nothing until you build.
+
+Four settings here fail somewhere other than where they are set, so they are
+worth knowing in advance:
+
+- **SIWE domain mismatch.** See the note on `SIWE_DOMAIN` in `.env.example`.
+  Local app builds sign `dev.convos.org`.
+- **App Check.** An empty `FIREBASE_SERVICE_ACCOUNT` does not disable it; see
+  that variable's note for the runtime-config switch.
+- **A cached JWT.** The app holds a token minted by whichever backend it last
+  talked to. This one signs with different keys, so authenticated calls 401 and
+  the app does not re-authenticate, because the token has not expired.
+  Reinstalling clears it, and forces the SIWE handshake you want to watch.
+- **Process lifecycle.** `pkill -f "tsx watch"` kills the watcher but leaves the
+  node child holding port 4000, so a restarted backend can keep serving the
+  previous environment. Confirm with `lsof -nP -iTCP:4000 -sTCP:LISTEN` before
+  drawing conclusions about a config change.
+
+A fresh database also means a zero credit balance, which the app surfaces as the
+agent having "lost power". Grant through the ledger (never write the credit
+tables directly — see `src/payments/AGENTS.md`):
+
+```ts
+import { grant } from "@/payments";
+await grant({ accountId, credits: 1_000_000, idempotencyKey: `local-${accountId}`, kind: "manual" });
+```
+
+`pnpm typecheck` fails on a fresh clone until the generated code exists. Run
+`pnpm exec prisma generate` and `pnpm buf:generate` before believing any type
+error you did not write.
+
 ## Additional Resources
 
 - [XMTP Push Notifications Guide](https://docs.xmtp.org/inboxes/push-notifs/pn-server)


### PR DESCRIPTION
Shortcuts for pointing a local iOS build at a local backend, recorded next to the settings they concern.

Agent features route app → backend → assistants worker, because the app cannot hold the shared assistant key. Getting that chain up locally involves four settings whose failure mode appears somewhere other than the setting itself.

## The setup

1. `./dev/up` for Postgres, then `pnpm exec prisma migrate deploy`.
2. Point `ASSISTANT_API_URL` at the local worker and set `ASSISTANT_API_KEY` to that worker's `CONVOS_API_KEY`.
3. `ngrok http 4000`. The tunnel fronts the local backend rather than the app pointing at a deployed one, because a deployed backend cannot reach a worker running on your machine.
4. Set `CONVOS_API_BASE_URL` in the app repo and rebuild — its build phase regenerates `Secrets.swift`, so an env edit alone changes nothing.

## Four things worth knowing in advance

**SIWE domain.** `.env.example` carries the deployed host, but local app builds sign `dev.convos.org`; the value comes from the client's bundled config. A mismatch fails inside signature verification, which surfaces as a bare `SIWE verification failed` and a 401 on `/v2/auth/token` — indistinguishable at first glance from a nonce-cookie or App Check problem.

**App Check with no Firebase.** An empty `FIREBASE_SERVICE_ACCOUNT` does not disable verification; the client still sends a token and the middleware still checks it. The switch is a `RuntimeConfig` row.

**Cached JWTs.** The app holds a token from whichever backend it last used. A local backend signs with different keys, so calls 401 and the app does not re-authenticate, because the token has not expired. Reinstalling clears it and forces the SIWE handshake.

**Process lifecycle.** `pkill -f "tsx watch"` leaves the node child holding port 4000, so a restarted backend can keep serving the previous environment. Worth confirming with `lsof` before drawing conclusions about a config change.

Also noted: a fresh database means a zero balance, which the app renders as the agent having "lost power" — granted through the ledger, not a direct table write. And `pnpm typecheck` reports errors on a fresh clone until `prisma generate` and `buf:generate` have run.

## Scope

Documentation and comments only. Worker-side notes are in convos-assistants#2903; app-side in convos-ios#1211.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded local development guidance for connecting the iOS app, backend, and assistants worker.
  * Added setup instructions for local services, HTTPS tunneling, app configuration, database credits, and generated code.
  * Added troubleshooting guidance for authentication, app attestation, cached settings, and port conflicts.
  * Clarified Firebase and SIWE configuration requirements in the environment template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local iOS app integration guide to development docs
> - Adds a new 'Driving the iOS app against this backend' section to [DEVELOPMENT.md](https://github.com/xmtplabs/convos-backend/pull/386/files#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33ece) with step-by-step setup covering DB, assistants worker, HTTPS tunnel, and mobile app config.
> - Documents four common failure points: SIWE domain mismatch, App Check not disabled by empty `FIREBASE_SERVICE_ACCOUNT`, cached JWT, and lingering node processes.
> - Includes a TypeScript snippet for granting credits via the ledger and notes on running `prisma generate` and `buf:generate` before typechecking.
> - Adds inline comments to [.env.example](https://github.com/xmtplabs/convos-backend/pull/386/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c) clarifying `FIREBASE_SERVICE_ACCOUNT` behavior and `SIWE_DOMAIN`/`SIWE_URI` requirements for local iOS builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bf3237.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->