### PR TITLE
ci: single deploy workflow — dev gate-blocks, prod reviewed promote (dispatch + vX.Y.Z tag)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,40 +1,18 @@
 name: Deploy to AWS
 
-run-name: ${{ (inputs.ref && format('[{0}] {1}', inputs.ref, inputs.commit_message)) || (github.event_name == 'repository_dispatch' && format('[{0}] {1}', github.event.client_payload.ref, github.event.client_payload.commit_message)) || format('Deploy to AWS ({0})', github.ref_name) }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Promote {0} to prod', inputs.image) || format('Deploy to AWS ({0})', github.ref_name) }}
 
 on:
   push:
     branches:
       - otr-dev
-      - otr-prod
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
   workflow_dispatch:
     inputs:
-      environment:
-        description: "Environment to deploy to"
-        required: true
-        type: choice
-        options:
-          - otr-dev
-          - otr-prod
-  repository_dispatch:
-    types: [deploy-otr-prod]
-  workflow_call:
-    inputs:
-      ref:
-        description: "Branch/ref to deploy"
-        required: true
-        type: string
-      commit_hash:
-        description: "Commit hash being deployed"
-        required: true
-        type: string
-      commit_message:
-        description: "Commit message"
-        required: true
-        type: string
-      triggered_by:
-        description: "What triggered this deployment"
+      image:
+        description: "Image to promote to PRODUCTION: a digest (ghcr.io/xmtplabs/convos-backend@sha256:...) or a tag (pr-387, latest, or a full sha-<40hex>)"
         required: true
         type: string
 
@@ -43,26 +21,23 @@ permissions:
   packages: write
 
 jobs:
+  gate:
+    name: Quality gate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/otr-dev'
+    uses: ./.github/workflows/validate-code-quality.yml
+    secrets: inherit
+
   push_to_registry:
     runs-on: ubuntu-latest
+    needs: [gate]
+    if: |
+      !cancelled() &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'push' && github.ref == 'refs/heads/otr-dev' && needs.gate.result == 'success'))
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
     steps:
-      - name: Display deployment info
-        if: inputs.ref || github.event_name == 'repository_dispatch'
-        run: |
-          echo "🚀 **Deployment triggered by sync workflow**" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Details:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Branch: \`${{ inputs.ref || github.event.client_payload.ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Commit: \`${{ inputs.commit_hash || github.event.client_payload.commit_hash }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Message: ${{ inputs.commit_message || github.event.client_payload.commit_message }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Triggered by: ${{ inputs.triggered_by || github.event.client_payload.triggered_by }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.ref || github.event_name == 'workflow_dispatch' && inputs.environment || github.event_name == 'workflow_call' && inputs.ref || github.ref }}
 
       - name: Log in to the container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -77,7 +52,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/convos-backend
           tags: |
-            type=raw,value=${{ github.event_name == 'repository_dispatch' && github.event.client_payload.ref || github.event_name == 'workflow_dispatch' && inputs.environment || github.event_name == 'workflow_call' && inputs.ref || github.ref_name }}
+            type=sha,prefix=sha-,format=long,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/otr-dev' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/otr-dev' }}
             type=ref,event=pr
 
       - name: Build and push Docker image
@@ -98,12 +74,10 @@ jobs:
     name: Deploy to OTR Development
     runs-on: ubuntu-latest
     needs: push_to_registry
-    if: (inputs.ref == 'otr-dev') || (inputs.environment == 'otr-dev') || (github.ref == 'refs/heads/otr-dev' && !inputs.ref && !inputs.environment)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/otr-dev'
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.ref || github.event_name == 'workflow_dispatch' && inputs.environment || github.event_name == 'workflow_call' && inputs.ref || github.ref }}
       - name: Deploy to OTR Dev Environment
         uses: xmtp-labs/terraform-deployer@341a5be3ad29108abcbeaacbae90b11ef43409c1 # v1
         timeout-minutes: 20

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: push_to_registry
     if: github.event_name == 'push' && github.ref == 'refs/heads/otr-dev'
+    environment: dev
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -142,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: resolve_prod_image
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag')
-    environment: otr-prod
+    environment: production
     concurrency:
       group: deploy-prod
       cancel-in-progress: false

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -90,17 +90,66 @@ jobs:
           variable-value: "ghcr.io/xmtplabs/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
           variable-value-required-prefix: "ghcr.io/xmtplabs/convos-backend@sha256:"
 
-  deploy_otr_prod:
-    name: Deploy to OTR Production
+  resolve_prod_image:
+    name: Resolve prod image
     runs-on: ubuntu-latest
-    needs: push_to_registry
-    if: (inputs.ref == 'otr-prod') || (inputs.environment == 'otr-prod') || (github.ref == 'refs/heads/otr-prod' && !inputs.ref && !inputs.environment) || (github.event_name == 'repository_dispatch' && github.event.client_payload.ref == 'otr-prod')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag')
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+    steps:
+      - name: Log in to the container registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve input to an immutable digest
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          DISPATCH_IMAGE: ${{ inputs.image }}
+          TAG_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/xmtplabs/convos-backend"
+          if [[ "$EVENT" == "push" ]]; then
+            # vX.Y.Z tag push: deploy the image built for the tagged commit.
+            INPUT="sha-${TAG_SHA}"
+          else
+            INPUT="$DISPATCH_IMAGE"
+          fi
+          if [[ "$INPUT" == *"@sha256:"* ]]; then
+            REF="$INPUT"
+          elif [[ "$INPUT" == sha256:* ]]; then
+            REF="${REPO}@${INPUT}"
+          else
+            REF="${REPO}:${INPUT}"
+          fi
+          if ! DIGEST=$(docker buildx imagetools inspect "$REF" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"'); then
+            echo "::error::could not resolve '$INPUT' to an image in ${REPO} (a tag release must point at a commit already built on otr-dev)"
+            exit 1
+          fi
+          if [[ "$DIGEST" != sha256:* ]]; then
+            echo "::error::resolved '$INPUT' to a non-digest value ('$DIGEST')"
+            exit 1
+          fi
+          echo "image=${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Resolved \`$INPUT\` -> \`${REPO}@${DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy_prod:
+    name: Promote to OTR Production
+    runs-on: ubuntu-latest
+    needs: resolve_prod_image
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag')
+    environment: otr-prod
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.ref || github.event_name == 'workflow_dispatch' && inputs.environment || github.event_name == 'workflow_call' && inputs.ref || github.ref }}
-      - name: Deploy to OTR Production Environment
+      - name: Deploy to OTR Prod Environment
         uses: xmtp-labs/terraform-deployer@341a5be3ad29108abcbeaacbae90b11ef43409c1 # v1
         timeout-minutes: 20
         with:
@@ -109,7 +158,7 @@ jobs:
           terraform-org: xmtp
           terraform-workspace: convos-otr-prod
           variable-name: api_image
-          variable-value: "ghcr.io/xmtplabs/convos-backend@${{ needs.push_to_registry.outputs.digest }}"
+          variable-value: "${{ needs.resolve_prod_image.outputs.image }}"
           variable-value-required-prefix: "ghcr.io/xmtplabs/convos-backend@sha256:"
 
   test_lifecycle_dev:
@@ -151,7 +200,7 @@ jobs:
   test_lifecycle_prod:
     name: Test S3 Lifecycle Renewal (Prod)
     runs-on: ubuntu-latest
-    needs: deploy_otr_prod
+    needs: deploy_prod
     steps:
       - name: Wait for deployment and verify health
         run: |

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -1,12 +1,8 @@
 name: Validate code quality
 
 on:
-  push:
-    branches:
-      - otr-dev
-      - otr-prod
-
   pull_request:
+  workflow_call:
 
 jobs:
   check:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,23 +1,44 @@
-# Release Process
+# Releasing convos-backend
 
-## Development
+## Dev (automatic)
 
-- Default branch: `otr-dev`
-- PRs merged to `otr-dev` trigger automatic backend deployment via workflow
+Merging a PR to `otr-dev` runs the quality gate, and on green builds the image
+and deploys it to the dev environment (Terraform Cloud workspace
+`convos-otr-dev`). A red gate blocks the deploy. Nothing else is required.
 
-## Production
+Every dev build is pushed to GHCR tagged `sha-<gitsha>` (immutable), `latest`
+(moves with `otr-dev`), and by digest. PR builds are tagged `pr-<n>`.
 
-- Merge `otr-dev` into `otr-prod` locally
-- Push directly to `otr-prod` - **deploys to production**
-- **Always use fast-forward merge** to maintain identical commit history
+## Production (reviewed, manual)
 
-```bash
-git checkout otr-prod
-git merge --ff-only otr-dev
-git push origin otr-prod
-```
+Production is a manual promotion of an already-tested image — not a branch push.
+Both ways below promote an image that already passed the gate (on its PR or on
+`otr-dev`), and both park on the `otr-prod` Environment reviewer gate: a required
+reviewer approves (or rejects — nothing rolls on reject), and on approval the
+image's digest is written to Terraform Cloud workspace `convos-otr-prod` and the
+ECS service rolls. Prod deliberately may lag dev.
 
-## Rules
+### A. Tag release (versioned — preferred)
 
-- **Never push commits to `otr-prod` that aren't on `otr-dev`**
-- All commits must exist on `otr-dev` first
+Tag a commit that is already on `otr-dev`, and push the tag:
+
+    git tag v1.4.0 <sha-on-otr-dev>
+    git push origin v1.4.0
+
+The workflow deploys the image built for that commit. The `vX.Y.Z` tag is the
+release name and the audit trail of what shipped. The tagged commit must already
+have been built on `otr-dev` (otherwise the run fails closed, "could not
+resolve"). Never re-point a released tag — cut a new version.
+
+### B. Dispatch (ad-hoc / rollback)
+
+Promote any pre-gated image directly, without cutting a version tag:
+
+    gh workflow run deploy-aws.yml -f image=pr-387
+
+`image` accepts a `pr-<n>` tag, `latest`, a `sha-<full-sha>` tag, or a full
+`...@sha256:...` digest. Use this to roll back to an older image or ship a
+specific PR build.
+
+There is no `otr-prod` branch; "what is live in prod" is the `otr-prod`
+Environment deployment history plus the `convos-otr-prod` `api_image` value.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,12 +11,12 @@ Every dev build is pushed to GHCR tagged `sha-<gitsha>` (immutable), `latest`
 
 ## Production (manual)
 
-Production is a manual promotion of an already-tested image — not a branch push.
-Both ways below promote an image that already passed the gate (on its PR or on
-`otr-dev`), and both deploy to the `production` GitHub Environment: the image's
-digest is written to Terraform Cloud workspace `convos-otr-prod` and the ECS
-service rolls. There is no approval gate — a prod deploy runs as soon as you
-trigger it, so trigger one only deliberately. Prod deliberately may lag dev.
+Production is a manual promotion of an already-tested image, triggered by a
+release tag or a dispatch (below). Both promote an image that already passed the
+gate (on its PR or on `otr-dev`) and deploy it to the `production` GitHub
+Environment: the image's digest is written to Terraform Cloud workspace
+`convos-otr-prod` and the ECS service rolls. A prod deploy runs as soon as you
+trigger it — you are the only gate, so trigger deliberately. Prod may lag dev.
 
 ### A. Tag release (versioned — preferred)
 
@@ -40,5 +40,6 @@ Promote any pre-gated image directly, without cutting a version tag:
 `...@sha256:...` digest. Use this to roll back to an older image or ship a
 specific PR build.
 
-There is no `otr-prod` branch; "what is live in prod" is the `production`
-Environment deployment history plus the `convos-otr-prod` `api_image` value.
+Prod is identified by its deployed image digest, recorded in two places: the
+`production` Environment's deployment history (GitHub) and the `api_image` value
+in the `convos-otr-prod` Terraform Cloud workspace.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,14 +9,14 @@ and deploys it to the dev environment (Terraform Cloud workspace
 Every dev build is pushed to GHCR tagged `sha-<gitsha>` (immutable), `latest`
 (moves with `otr-dev`), and by digest. PR builds are tagged `pr-<n>`.
 
-## Production (reviewed, manual)
+## Production (manual)
 
 Production is a manual promotion of an already-tested image — not a branch push.
 Both ways below promote an image that already passed the gate (on its PR or on
-`otr-dev`), and both park on the `otr-prod` Environment reviewer gate: a required
-reviewer approves (or rejects — nothing rolls on reject), and on approval the
-image's digest is written to Terraform Cloud workspace `convos-otr-prod` and the
-ECS service rolls. Prod deliberately may lag dev.
+`otr-dev`), and both deploy to the `production` GitHub Environment: the image's
+digest is written to Terraform Cloud workspace `convos-otr-prod` and the ECS
+service rolls. There is no approval gate — a prod deploy runs as soon as you
+trigger it, so trigger one only deliberately. Prod deliberately may lag dev.
 
 ### A. Tag release (versioned — preferred)
 
@@ -40,5 +40,5 @@ Promote any pre-gated image directly, without cutting a version tag:
 `...@sha256:...` digest. Use this to roll back to an older image or ship a
 specific PR build.
 
-There is no `otr-prod` branch; "what is live in prod" is the `otr-prod`
+There is no `otr-prod` branch; "what is live in prod" is the `production`
 Environment deployment history plus the `convos-otr-prod` `api_image` value.


### PR DESCRIPTION
Restructures `deploy-aws.yml` into one workflow: dev auto-deploys on push to `otr-dev` and now **blocks on the quality gate**; production becomes a **manual promotion** of an already-gated image by digest — triggered either by `workflow_dispatch` (pick any image) or a `vX.Y.Z` **tag push** (release a specific commit). Replaces the ungated `git push otr-prod` path.

## What changed (this PR — workflow + docs only)

- **`validate-code-quality.yml`** → reusable (`workflow_call` + `pull_request`; dropped the standalone `push`).
- **`deploy-aws.yml`**:
  - `gate` job (`uses:` the quality workflow) that the dev build/deploy `needs:` → **red gate = no dev roll** (closes the gap where the gate ran but didn't block).
  - Build tags `sha-<full-gitsha>` (immutable, `format=long`) + `latest` + digest; PR builds keep `pr-<n>`.
  - Prod path split: **`resolve_prod_image`** (ungated — resolves the input/tag to an immutable `@sha256:` digest) → **`deploy_prod`** writes it to Terraform Cloud `convos-otr-prod`.
  - Deployment records: `deploy_otr_dev` → `environment: dev`, `deploy_prod` → `environment: production` (the existing GitHub Environments).
  - Removed: `push: otr-prod`, `repository_dispatch`, old `workflow_dispatch(environment)`, `workflow_call`, and all dead `inputs.*` refs.
- **`RELEASE.md`** → new runbook (tag release / dispatch; no `otr-prod` branch).

Deploy stays digest-pinned; TFC serializes per workspace. Full design in the (gitignored) plan `docs/superpowers/plans/2026-07-23-deploy-single-workflow.md`.

## Production is ungated by design

Prod deploys to the existing **`production`** GitHub Environment, which has **no required reviewer** — a prod deploy runs as soon as it's triggered. Control is *who can trigger* (write access for `workflow_dispatch`, push access for a `v*` tag), run manually by the release owner. Both `dev` and `production` Environments already exist (unprotected); no Environment setup is needed for this to work.

## Not in this PR (follow-ups, human-driven)

- Cross-repo: retire the external prod-sync workflow that fired `repository_dispatch: deploy-otr-prod` (plan Task 6).
- Delete the `otr-prod` branch (plan Task 5 Step 4 — after the prod-tag walk passes).

## Test plan (deploy-walks — the real gate; static green ≠ shipped)

- [ ] W1 dev gate blocks a red build (throwaway branch)
- [ ] W2 dev happy-path deploys by digest (= merging this)
- [ ] W3 prod `workflow_dispatch` resolves → deploys the exact image to `convos-otr-prod`
- [ ] W5 bad input fails closed at resolve (no TFC write)
- [ ] W6 `vX.Y.Z` tag release deploys the tagged commit's image (+ never-built-commit fails closed)

(No approve/reject walk — prod is ungated.)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate AWS deploy into a single workflow with dev gate-blocking and prod digest promotion
> - On push to `otr-dev`, a quality gate (calling [validate-code-quality.yml](.github/workflows/validate-code-quality.yml)) must pass before the image is built and pushed to GHCR with `sha-<longsha>` and `latest` tags.
> - Production deploys are no longer triggered by pushes to `otr-prod`; they now require either a `vX.Y.Z` tag push or a manual `workflow_dispatch` with an explicit `image` input, both resolved to an immutable digest via `docker buildx imagetools inspect`.
> - A new `resolve_prod_image` job validates and resolves the image to a `sha256` digest before `deploy_prod` runs under the `production` environment and `deploy-prod` concurrency group.
> - [validate-code-quality.yml](.github/workflows/validate-code-quality.yml) drops its direct push triggers for `otr-dev`/`otr-prod` and adds `workflow_call` support so the gate job can invoke it.
> - Behavioral Change: the `otr-prod` branch no longer triggers any deployment; teams must use a versioned tag or dispatch to promote to production.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee60414.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated quality gate for development deployments.
  * Introduced manual production promotion that deploys an already-tested immutable image digest.
  * Enabled production promotion for release tags, pull-request images, specific commits, or direct image digests/rollbacks.
* **Bug Fixes**
  * Prevent production deployment if the requested image cannot be resolved to a valid immutable digest.
* **Documentation**
  * Rewrote the production/dev deployment runbook, including tagging behavior, promotion/rollback steps, and how “live in prod” is determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->