### PR TITLE
feat: ability catalog endpoint GET /v2/abilities

### DIFF
--- a/docs/schemas/abilities.schema.json
+++ b/docs/schemas/abilities.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://convos.org/schemas/abilities.schema.json",
+  "title": "GET /v2/abilities response",
+  "description": "The Connections V2 ability catalog merged with the caller's entitlement state. Backend-owned manifests with Composio action slugs stripped (slugs stay backend-only; clients persist only bundle ids). The `entitlement` key on each ability is an object (entitled; status says whether it is currently usable) or null (not entitled, or the JWT carries no account). When the caller has an account but entitlement state cannot be determined (Composio lookup failed), the response instead carries top-level `entitlementsUnavailable: true` and every ability omits its `entitlement` key — clients keep last-known state instead of rendering 'not connected'. Source of truth: src/api/v2/abilities/manifests.config.ts (getPublicAbilities) and src/api/v2/abilities/handlers/list.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["catalogVersion", "abilities"],
+  "properties": {
+    "catalogVersion": {
+      "description": "Computed: a manual base plus the sum of served ability versions, so manifest edits, service-side bundle changes, and newly launched abilities all bump it. Clients refetch on a mismatch (stale detection).",
+      "type": "integer",
+      "minimum": 0
+    },
+    "entitlementsUnavailable": {
+      "description": "Present (always true) only when the caller has an account and entitlement state could not be determined (Composio lookup failed). Every ability then omits its `entitlement` key; clients keep last-known state. Never present on the device-only or healthy account paths.",
+      "const": true
+    },
+    "abilities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Ability" }
+    }
+  },
+  "if": { "required": ["entitlementsUnavailable"] },
+  "then": {
+    "$comment": "State-unavailable response: no ability carries an entitlement key.",
+    "properties": {
+      "abilities": {
+        "items": { "not": { "required": ["entitlement"] } }
+      }
+    }
+  },
+  "else": {
+    "$comment": "Authoritative response: every ability carries entitlement (object or null).",
+    "properties": {
+      "abilities": {
+        "items": { "required": ["entitlement"] }
+      }
+    }
+  },
+  "$defs": {
+    "LocalizedString": {
+      "description": "A localized string map. MUST always carry an \"en\" key (the guaranteed fallback).",
+      "type": "object",
+      "required": ["en"],
+      "properties": {
+        "en": { "type": "string" }
+      },
+      "additionalProperties": { "type": "string" }
+    },
+    "PublicBundle": {
+      "description": "The user-facing permission unit inside an ability. Same shape as the connections-services contract; bundle ids persist on grants.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "description", "defaultEnabled"],
+      "properties": {
+        "id": {
+          "description": "Stable id persisted on the grant, e.g. \"calendar.events\".",
+          "type": "string"
+        },
+        "title": { "$ref": "#/$defs/LocalizedString" },
+        "description": { "$ref": "#/$defs/LocalizedString" },
+        "defaultEnabled": { "type": "boolean" }
+      }
+    },
+    "Entitlement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "extensionCount"],
+      "properties": {
+        "status": {
+          "description": "Backend-owned lifecycle state. The V1-derived adapter emits only pending_auth (Composio INITIALIZING/INITIATED), active (ACTIVE), and expired (every other Composio status — the credential cannot be used and OAuth must be re-run). needs_reauth and revoked are reserved for B2 (revalidation flow and the dedicated entitlement tables); the adapter never emits them.",
+          "enum": [
+            "pending_auth",
+            "active",
+            "needs_reauth",
+            "expired",
+            "revoked"
+          ]
+        },
+        "expiresAt": {
+          "description": "Optional entitlement expiry. Not emitted by the V1-derived adapter.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "extensionCount": {
+          "description": "Count of distinct conversations this entitlement is extended to via live grants (non-revoked, non-expired — the same predicate exec enforces).",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "Ability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version",
+        "displayName",
+        "subtitle",
+        "auth",
+        "bundles"
+      ],
+      "properties": {
+        "id": {
+          "description": "Stable ability id. For Composio-backed abilities equals the toolkit slug.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Composite: manifest version + the linked service catalog's version (0 when none), so any manifest, bundle, or copy change bumps it. Clients refetch on a mismatch.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "displayName": { "$ref": "#/$defs/LocalizedString" },
+        "subtitle": { "$ref": "#/$defs/LocalizedString" },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": { "enum": ["oauth", "none"] }
+          }
+        },
+        "icon": {
+          "description": "Per-platform icon URLs. Optional until the asset story lands; clients fall back to a local placeholder.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["iosUrl", "androidUrl"],
+          "properties": {
+            "iosUrl": { "type": "string", "format": "uri" },
+            "androidUrl": { "type": "string", "format": "uri" }
+          }
+        },
+        "bundles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PublicBundle" }
+        },
+        "entitlement": {
+          "description": "Object (entitled) or null (not entitled / no account on the JWT). Omitted only when the top-level entitlementsUnavailable flag is set.",
+          "oneOf": [{ "$ref": "#/$defs/Entitlement" }, { "type": "null" }]
+        }
+      }
+    }
+  }
+}

--- a/src/api/v2/abilities/abilities.router.ts
+++ b/src/api/v2/abilities/abilities.router.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { abilitiesListHandler } from "./handlers/list";
+
+// /v2/abilities — the Connections V2 ability surface. Auth is applied at the
+// mount point in src/api/v2/index.ts (authMiddleware, deliberately without
+// requireAccount — see the list handler's contract).
+export const abilitiesRouter = Router();
+
+abilitiesRouter.get("/", abilitiesListHandler);

--- a/src/api/v2/abilities/handlers/list.ts
+++ b/src/api/v2/abilities/handlers/list.ts
@@ -1,0 +1,173 @@
+import type { ConnectedAccountStatus } from "@composio/core";
+import type { Request, Response } from "express";
+import {
+  getCatalogVersion,
+  getPublicAbilities,
+  type PublicAbility,
+} from "@/api/v2/abilities/manifests.config";
+import { createComposioService } from "@/api/v2/connections/composio.service";
+import { prisma } from "@/utils/prisma";
+
+// GET /v2/abilities — the ability catalog merged with the caller's
+// entitlement state (docs/plans/abilities-entitlements.md, "Enumerate").
+//
+// JWT-only, NOT account-scoped: a device-only token gets the catalog with
+// `entitlement: null` everywhere (browsable, not entitleable). With an
+// account on the JWT, each ability carries the caller's entitlement state.
+//
+// Entitlement state is currently derived from the V1 stores (Composio
+// connected accounts + ConnectionGrant rows). The dedicated entitlement
+// tables will replace this adapter without changing the wire shape.
+//
+// Wire contract (see docs/schemas/abilities.schema.json):
+//   - `entitlement` object -> entitled; `status` says whether it is usable
+//   - `entitlement: null`  -> not entitled (or no account on the token)
+//   - top-level `entitlementsUnavailable: true` -> the caller has an account
+//     but entitlement state could not be determined (Composio lookup failed
+//     or was truncated); abilities then carry NO `entitlement` key and
+//     clients keep their last-known state instead of rendering
+//     "not connected".
+
+export type EntitlementStatus = "pending_auth" | "active" | "expired";
+
+type ServedEntitlement = {
+  status: EntitlementStatus;
+  extensionCount: number;
+};
+
+type ServedAbility = PublicAbility & {
+  entitlement?: ServedEntitlement | null;
+};
+
+// Composio status -> wire status, over the SDK's actual status union
+// (INITIALIZING | INITIATED | ACTIVE | FAILED | EXPIRED | INACTIVE | REVOKED).
+// The V1 adapter emits only pending_auth/active/expired: every non-active,
+// non-in-flight state (EXPIRED, REVOKED, FAILED, INACTIVE, or a value outside
+// the union from SDK drift) means the credential cannot be used and re-running
+// OAuth is the remedy, which is what `expired` means to the client.
+// needs_reauth is reserved for B2's revalidation flow and never emitted here.
+function toEntitlementStatus(
+  composioStatus: ConnectedAccountStatus,
+): EntitlementStatus {
+  switch (composioStatus) {
+    case "ACTIVE":
+      return "active";
+    case "INITIALIZING":
+    case "INITIATED":
+      return "pending_auth";
+    default:
+      return "expired";
+  }
+}
+
+const KNOWN_COMPOSIO_STATUSES: ReadonlySet<string> = new Set([
+  "INITIALIZING",
+  "INITIATED",
+  "ACTIVE",
+  "FAILED",
+  "EXPIRED",
+  "INACTIVE",
+  "REVOKED",
+]);
+
+// An account can hold several Composio connections for one toolkit; the most
+// usable one determines the ability's status.
+const STATUS_RANK: Record<EntitlementStatus, number> = {
+  active: 0,
+  pending_auth: 1,
+  expired: 2,
+};
+
+export async function abilitiesListHandler(req: Request, res: Response) {
+  const accountId = res.locals.accountId;
+  const catalog = getPublicAbilities();
+
+  // The same URL serves a different body depending on the JWT (device-only vs
+  // account), and iOS URLCache keys by URL — a cached device-only body could
+  // be replayed after sign-in. So unlike GET /v2/connections/services (whose
+  // response is identical for every caller), every response here is no-store.
+  res.setHeader("Cache-Control", "no-store");
+
+  if (!accountId) {
+    res.status(200).json({
+      catalogVersion: getCatalogVersion(),
+      abilities: catalog.map(
+        (ability): ServedAbility => ({ ...ability, entitlement: null }),
+      ),
+    });
+    return;
+  }
+
+  let statusByAbility: Map<string, EntitlementStatus> | null = null;
+  const service = createComposioService();
+  if (service) {
+    try {
+      const { items } = await service.listForUser(accountId);
+      statusByAbility = new Map();
+      for (const item of items) {
+        const id = item.toolkit.slug.toLowerCase();
+        if (!KNOWN_COMPOSIO_STATUSES.has(item.status)) {
+          req.log.warn(
+            { accountId, composioStatus: item.status },
+            "[Abilities] Unknown Composio status — mapping to expired",
+          );
+        }
+        const status = toEntitlementStatus(item.status);
+        const prev = statusByAbility.get(id);
+        if (!prev || STATUS_RANK[status] < STATUS_RANK[prev]) {
+          statusByAbility.set(id, status);
+        }
+      }
+    } catch (error) {
+      // Leave statusByAbility null: entitlement state is unknowable, so the
+      // response carries entitlementsUnavailable and omits every
+      // `entitlement` key per the contract.
+      req.log.error({ error, accountId }, "[Abilities] Composio list failed");
+    }
+  }
+
+  if (!statusByAbility) {
+    res.status(200).json({
+      catalogVersion: getCatalogVersion(),
+      entitlementsUnavailable: true,
+      abilities: catalog.map((ability): ServedAbility => ({ ...ability })),
+    });
+    return;
+  }
+
+  // Extension counts mirror exec's live-grant predicate: non-revoked and
+  // non-expired, so the catalog never counts a conversation exec would deny.
+  const now = new Date();
+  const grants = await prisma.connectionGrant.findMany({
+    where: {
+      ownerAccountId: accountId,
+      revokedAt: null,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+    },
+    select: { toolkit: true, conversationId: true },
+  });
+  const conversationsByAbility = new Map<string, Set<string>>();
+  for (const grant of grants) {
+    const id = grant.toolkit.toLowerCase();
+    const set = conversationsByAbility.get(id) ?? new Set<string>();
+    set.add(grant.conversationId);
+    conversationsByAbility.set(id, set);
+  }
+
+  const entitlementByAbility = statusByAbility;
+  res.status(200).json({
+    catalogVersion: getCatalogVersion(),
+    abilities: catalog.map((ability): ServedAbility => {
+      const status = entitlementByAbility.get(ability.id);
+      if (!status) return { ...ability, entitlement: null };
+      const conversations = conversationsByAbility.get(ability.id);
+      return {
+        ...ability,
+        entitlement: {
+          status,
+          extensionCount: conversations ? conversations.size : 0,
+        },
+      };
+    }),
+  });
+}

--- a/src/api/v2/abilities/manifests.config.ts
+++ b/src/api/v2/abilities/manifests.config.ts
@@ -1,0 +1,188 @@
+// Backend-owned ability catalog (Connections V2).
+//
+// An ability is one integration (Google Calendar, Spotify, ...) described by a
+// manifest: identity, copy, auth kind, and the permission bundles it offers.
+// This is the enumeration layer of the entitlements model (see
+// docs/plans/abilities-entitlements.md): GET /v2/abilities serves this catalog
+// merged with the caller's entitlement state, and clients render it with no
+// local knowledge of any service.
+//
+// Composio-backed abilities reference the service/bundle catalog in
+// bundles.config.ts rather than duplicating it: bundles stay the single
+// user-facing permission unit and action-slug resolution stays where it is.
+// The version a client sees for an ability is composite — manifest version
+// plus the linked service's version (0 when none) — so bundle or copy changes
+// made in bundles.config.ts bump the served ability version without anyone
+// having to remember to touch the manifest. The wire catalogVersion is
+// computed from the served versions (see getCatalogVersion), so it moves with
+// them and with launches.
+// Adding an ability is data work: add a manifest below (plus, for
+// Composio-backed ones, a service entry in bundles.config.ts).
+//
+// MCP tool schemas and action-queue schemas (`tools[]` / `actions[]` in the
+// plan) join the manifest when the gateway needs them; they are never served
+// to clients.
+
+import {
+  getServiceConfig,
+  toPublicServiceConfig,
+  type LocalizedString,
+  type PublicBundle,
+} from "@/api/v2/connections/bundles.config";
+import logger from "@/utils/logger";
+
+/**
+ * The manually-bumped base for the served catalog version: bump it for
+ * catalog-level changes no per-ability version captures (e.g. removing an
+ * ability). The wire `catalogVersion` is computed — see getCatalogVersion.
+ */
+export const CATALOG_VERSION = 1;
+
+export type AbilityAuthType = "oauth" | "none";
+
+export type AbilityManifest = {
+  /** Stable ability id. For Composio-backed abilities equals the toolkit slug. */
+  id: string;
+  /**
+   * Bumped whenever anything about this manifest changes (copy included).
+   * Clients see manifest version + linked service version (see
+   * getPublicAbilities), so service-side bundle changes bump the served
+   * version on their own.
+   */
+  version: number;
+  displayName: LocalizedString;
+  subtitle: LocalizedString;
+  auth: { type: AbilityAuthType };
+  /**
+   * Per-platform icon URLs. Optional until the asset/upload story lands (open
+   * question in the plan); clients fall back to a local placeholder.
+   */
+  icon?: { iosUrl: string; androidUrl: string };
+  /**
+   * Registered but not yet launched: excluded from the served catalog.
+   * Clearing this flag (once the ability's auth path works) is the launch
+   * switch — no client release involved.
+   */
+  hidden?: boolean;
+};
+
+// The first-round abilities are all registered up front so each launch is a
+// flag flip. Only googlecalendar is live: it is the one ability with a
+// working auth path and a service entry in bundles.config.ts.
+export const ABILITY_MANIFESTS: AbilityManifest[] = [
+  {
+    id: "googlecalendar",
+    version: 1,
+    displayName: { en: "Google Calendar" },
+    subtitle: { en: "View and edit events" },
+    auth: { type: "oauth" },
+  },
+  {
+    id: "coinbase",
+    version: 1,
+    displayName: { en: "Coinbase" },
+    subtitle: { en: "Check prices and balances" },
+    auth: { type: "oauth" },
+    hidden: true,
+  },
+  {
+    id: "shopify",
+    version: 1,
+    displayName: { en: "Shopify" },
+    subtitle: { en: "Manage your shop" },
+    auth: { type: "oauth" },
+    hidden: true,
+  },
+  {
+    id: "spotify",
+    version: 1,
+    displayName: { en: "Spotify" },
+    subtitle: { en: "Playlists, artists, and concerts" },
+    auth: { type: "oauth" },
+    hidden: true,
+  },
+  {
+    id: "youtube",
+    version: 1,
+    displayName: { en: "YouTube" },
+    subtitle: { en: "Search and share videos" },
+    auth: { type: "oauth" },
+    hidden: true,
+  },
+  {
+    id: "gmail",
+    version: 1,
+    displayName: { en: "Gmail" },
+    subtitle: { en: "Read and send email" },
+    auth: { type: "oauth" },
+    hidden: true,
+  },
+];
+
+/** An ability as served to clients — bundles carry no Composio slugs. */
+export type PublicAbility = {
+  id: string;
+  version: number;
+  displayName: LocalizedString;
+  subtitle: LocalizedString;
+  auth: { type: AbilityAuthType };
+  icon?: { iosUrl: string; androidUrl: string };
+  bundles: PublicBundle[];
+};
+
+/**
+ * The served catalog: hidden manifests dropped, bundles pulled from the
+ * service catalog for Composio-backed abilities (empty when no service entry
+ * exists yet — a registered-but-bundle-less ability renders, it just offers
+ * nothing to toggle). The served version is manifest version + service
+ * version (0 when none), so any change to either side bumps it.
+ */
+export function getPublicAbilities(): PublicAbility[] {
+  return ABILITY_MANIFESTS.filter((m) => !m.hidden).map((m) => {
+    const svc = getServiceConfig(m.id);
+    if (!svc && m.auth.type === "oauth") {
+      // A visible OAuth ability with no service entry serves zero bundles.
+      // Legitimate for future non-Composio-backed abilities, so this warns
+      // rather than throws — but for a Composio-backed one it means the
+      // launch flag was cleared before the bundles.config.ts entry landed.
+      warnOnceMissingService(m.id);
+    }
+    return {
+      id: m.id,
+      version: m.version + (svc?.version ?? 0),
+      displayName: m.displayName,
+      subtitle: m.subtitle,
+      auth: m.auth,
+      ...(m.icon ? { icon: m.icon } : {}),
+      bundles: svc ? toPublicServiceConfig(svc).bundles : [],
+    };
+  });
+}
+
+/**
+ * The served catalog version: the manual base plus the sum of served ability
+ * versions. Computed so it bumps on its own whenever an ability's composite
+ * version moves (manifest edits, service-side bundle/copy changes) and
+ * whenever an ability launches (unhiding adds its version to the sum).
+ */
+export function getCatalogVersion(): number {
+  return ABILITY_MANIFESTS.filter((m) => !m.hidden).reduce(
+    (sum: number, m: AbilityManifest): number =>
+      sum + m.version + (getServiceConfig(m.id)?.version ?? 0),
+    CATALOG_VERSION,
+  );
+}
+
+// A missing service entry is static configuration, not a transient condition;
+// one warning per process per ability is signal enough without flooding the
+// log on every catalog request.
+const warnedMissingServiceIds = new Set<string>();
+
+function warnOnceMissingService(abilityId: string) {
+  if (warnedMissingServiceIds.has(abilityId)) return;
+  warnedMissingServiceIds.add(abilityId);
+  logger.warn(
+    { abilityId },
+    "[Abilities] Visible OAuth ability has no service entry — serving zero bundles",
+  );
+}

--- a/src/api/v2/connections/composio.service.ts
+++ b/src/api/v2/connections/composio.service.ts
@@ -28,6 +28,11 @@ const TOOLKIT_ACTIONS_CACHE_TTL_MS = 60 * 60 * 1000;
 
 type ToolkitActionsCacheEntry = { slugs: Set<string>; expiresAt: number };
 
+// Safety bound on cursor-following in listForUser. Composio pages default to
+// tens of items, so 10 pages comfortably covers any real account; the bound
+// exists to keep a broken cursor chain from looping forever.
+const LIST_PAGE_LIMIT = 10;
+
 export class ComposioService {
   private composio: Composio;
   private authConfigCache = new Map<string, AuthConfigCacheEntry>();
@@ -223,15 +228,41 @@ export class ComposioService {
    * the caller's stable accountId.
    */
   async getIfOwned(args: { connectionId: string; userId: string }) {
-    const list = await this.composio.connectedAccounts.list({
-      userIds: [args.userId],
-    });
-    const items: ConnectedAccountListResponseItem[] = list.items;
+    const { items } = await this.listForUser(args.userId);
     return items.find((item) => item.id === args.connectionId) ?? null;
   }
 
-  async listForUser(userId: string) {
-    return this.composio.connectedAccounts.list({ userIds: [userId] });
+  /**
+   * Every connected account for a user, across all of Composio's result pages
+   * (the list endpoint is cursor-paginated). Bounded so a pathological cursor
+   * loop cannot hang a request; hitting the bound THROWS instead of returning
+   * a partial list, because truncated state must never be served as
+   * authoritative (callers treat the throw like any Composio failure — the
+   * abilities catalog surfaces entitlementsUnavailable, exec fails closed).
+   */
+  async listForUser(
+    userId: string,
+  ): Promise<{ items: ConnectedAccountListResponseItem[] }> {
+    const items: ConnectedAccountListResponseItem[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < LIST_PAGE_LIMIT; page++) {
+      const list = await this.composio.connectedAccounts.list({
+        userIds: [userId],
+        ...(cursor ? { cursor } : {}),
+      });
+      items.push(...list.items);
+      if (!list.nextCursor) {
+        return { items };
+      }
+      cursor = list.nextCursor;
+    }
+    logger.warn(
+      { userId, pages: LIST_PAGE_LIMIT, count: items.length },
+      "[Composio] listForUser: page bound hit — refusing truncated state",
+    );
+    throw new Error(
+      `Composio connected-account list exceeded ${LIST_PAGE_LIMIT} pages`,
+    );
   }
 
   async delete(connectionId: string) {
@@ -250,11 +281,8 @@ export class ComposioService {
     userId: string;
     toolkit: string;
   }): Promise<string | null> {
-    const list = await this.composio.connectedAccounts.list({
-      userIds: [args.userId],
-    });
+    const { items } = await this.listForUser(args.userId);
     const normalized = args.toolkit.toLowerCase();
-    const items: ConnectedAccountListResponseItem[] = list.items;
     const match = items.find(
       (item) => item.toolkit.slug.toLowerCase() === normalized,
     );

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -19,6 +19,7 @@ import {
   inviteCodeRedeemLimiter,
   telemetryLimiter,
 } from "@/middleware/rateLimit";
+import { abilitiesRouter } from "./abilities/abilities.router";
 import { accountsByIdRouter } from "./accounts/accountsByIdRouter";
 import { accountsMeRouter } from "./accounts/accountsMeRouter";
 import { meGuard } from "./accounts/middleware/meGuard";
@@ -143,6 +144,10 @@ v2Router.use(
 // limits. authMiddleware applies to the whole subtree.
 v2Router.use("/agents", authMiddleware, agentsRouter);
 v2Router.use("/attachments", authMiddleware, attachmentsRouter);
+// The Connections V2 ability catalog (docs/plans/abilities-entitlements.md).
+// JWT-only, deliberately without requireAccount: device-only tokens can browse
+// the catalog; entitlement state appears only when the JWT carries an account.
+v2Router.use("/abilities", authMiddleware, abilitiesRouter);
 // The connections-picker catalog is JWT-only (NOT account-scoped): the catalog
 // is identical for every user, so requireAccount is deliberately not applied.
 // Declared BEFORE the requireAccount-gated /connections mount so this more

--- a/tests/abilities.test.ts
+++ b/tests/abilities.test.ts
@@ -1,0 +1,429 @@
+import express from "express";
+import request from "supertest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { abilitiesRouter } from "@/api/v2/abilities/abilities.router";
+import {
+  ABILITY_MANIFESTS,
+  CATALOG_VERSION,
+  getCatalogVersion,
+} from "@/api/v2/abilities/manifests.config";
+import { getServiceConfig } from "@/api/v2/connections/bundles.config";
+import {
+  __resetComposioServiceForTests,
+  ComposioService,
+} from "@/api/v2/connections/composio.service";
+import { authMiddleware } from "@/middleware/auth";
+import { pinoMiddleware } from "@/middleware/pino";
+import { createJwtToken, validateJWTKeys } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+// Mirrors the production wiring: JWT-only (authMiddleware), NOT requireAccount.
+function makeApp() {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use("/abilities", authMiddleware, abilitiesRouter);
+  return app;
+}
+
+type AbilitiesResponse = {
+  catalogVersion: number;
+  entitlementsUnavailable?: true;
+  abilities: Array<{
+    id: string;
+    version: number;
+    displayName: { en: string };
+    subtitle: { en: string };
+    auth: { type: string };
+    bundles: Array<{ id: string; defaultEnabled: boolean }>;
+    entitlement?: { status: string; extensionCount: number } | null;
+  }>;
+};
+
+type StubbedConnection = {
+  id: string;
+  status: string;
+  toolkit: { slug: string };
+};
+
+function installService(stub: {
+  connectedAccounts: { list: (params?: unknown) => Promise<unknown> };
+}) {
+  const service = new ComposioService({
+    composio: stub as unknown as ConstructorParameters<
+      typeof ComposioService
+    >[0]["composio"],
+  });
+  __resetComposioServiceForTests(service);
+}
+
+// Installs a ComposioService whose connectedAccounts.list serves the given
+// items (or throws), following the stub pattern in connections.test.ts.
+function installListStub(items: StubbedConnection[] | Error) {
+  installService({
+    connectedAccounts: {
+      list: () =>
+        items instanceof Error
+          ? Promise.reject(items)
+          : Promise.resolve({ items }),
+    },
+  });
+}
+
+// Installs a stub whose list is cursor-paginated: each call serves the next
+// page and a nextCursor until the last page. Received cursors are recorded so
+// tests can pin that the pagination loop actually follows them.
+function installPagedListStub(
+  pages: StubbedConnection[][],
+  receivedCursors: Array<string | undefined>,
+) {
+  let call = 0;
+  installService({
+    connectedAccounts: {
+      list: (params?: unknown) => {
+        receivedCursors.push(
+          (params as { cursor?: string } | undefined)?.cursor,
+        );
+        const items = pages[call] ?? [];
+        call++;
+        return Promise.resolve({
+          items,
+          ...(call < pages.length ? { nextCursor: `cursor-${call}` } : {}),
+        });
+      },
+    },
+  });
+}
+
+let accountId: string;
+
+beforeAll(async () => {
+  await validateJWTKeys();
+  const account = await prisma.account.create({ data: {} });
+  accountId = account.id;
+});
+
+afterAll(async () => {
+  __resetComposioServiceForTests(null);
+  await prisma.connectionGrant.deleteMany({
+    where: { ownerAccountId: accountId },
+  });
+  await prisma.account.delete({ where: { id: accountId } });
+});
+
+beforeEach(async () => {
+  __resetComposioServiceForTests(null);
+  await prisma.connectionGrant.deleteMany({
+    where: { ownerAccountId: accountId },
+  });
+});
+
+function accountToken() {
+  return createJwtToken({ deviceId: "device-abilities", accountId });
+}
+
+describe("GET /v2/abilities", () => {
+  test("401 without a JWT", async () => {
+    const res = await request(makeApp()).get("/abilities");
+    expect(res.status).toBe(401);
+  });
+
+  test("device-only JWT: catalog with entitlement null everywhere, no-store", async () => {
+    const token = await createJwtToken({ deviceId: "device-abilities" });
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", token);
+    expect(res.status).toBe(200);
+    // Same URL serves account state after sign-in; never cache either body.
+    expect(res.headers["cache-control"]).toBe("no-store");
+
+    const body = res.body as AbilitiesResponse;
+    // Computed: base + sum of served ability versions, so a plain constant
+    // serve would fail the greater-than pin.
+    expect(body.catalogVersion).toBe(getCatalogVersion());
+    expect(body.catalogVersion).toBeGreaterThan(CATALOG_VERSION);
+    expect("entitlementsUnavailable" in body).toBe(false);
+    expect(body.abilities.length).toBeGreaterThan(0);
+    for (const ability of body.abilities) {
+      expect(ability.entitlement).toBeNull();
+    }
+
+    const gcal = body.abilities.find((a) => a.id === "googlecalendar");
+    expect(gcal).toBeDefined();
+    expect(gcal!.displayName.en).toBe("Google Calendar");
+    expect(typeof gcal!.subtitle.en).toBe("string");
+    expect(gcal!.auth.type).toBe("oauth");
+    // Bundles come from the shared service catalog: live ones only.
+    expect(gcal!.bundles.map((b) => b.id)).toEqual(["calendar.events"]);
+  });
+
+  test("served version is manifest version + linked service version", async () => {
+    const token = await createJwtToken({ deviceId: "device-abilities" });
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", token);
+    const body = res.body as AbilitiesResponse;
+    const gcal = body.abilities.find((a) => a.id === "googlecalendar");
+    const manifest = ABILITY_MANIFESTS.find((m) => m.id === "googlecalendar");
+    const svc = getServiceConfig("googlecalendar");
+    expect(manifest).toBeDefined();
+    expect(svc).toBeDefined();
+    expect(gcal!.version).toBe(manifest!.version + svc!.version);
+  });
+
+  test("hidden manifests are not served", async () => {
+    const token = await createJwtToken({ deviceId: "device-abilities" });
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", token);
+    const body = res.body as AbilitiesResponse;
+    const ids = body.abilities.map((a) => a.id);
+    for (const hidden of [
+      "coinbase",
+      "shopify",
+      "spotify",
+      "youtube",
+      "gmail",
+    ]) {
+      expect(ids).not.toContain(hidden);
+    }
+  });
+
+  test("no Composio action slug, connection id, or deprecated bundle leaks", async () => {
+    installListStub([
+      { id: "conn-1", status: "ACTIVE", toolkit: { slug: "googlecalendar" } },
+    ]);
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    expect(res.status).toBe(200);
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toMatch(/GOOGLECALENDAR_/);
+    expect(payload).not.toMatch(/composioActions/);
+    // The Composio connection id is a bearer capability and stays backend-side.
+    expect(payload).not.toContain("conn-1");
+    // Deprecated bundles are grant-resolvable but never served (mirrors the
+    // connections-services pin).
+    expect(payload).not.toContain("calendar.events.read");
+    expect(payload).not.toContain("deprecated");
+  });
+
+  test("account JWT + ACTIVE connection + grants: active with distinct conversation count", async () => {
+    installListStub([
+      { id: "conn-1", status: "ACTIVE", toolkit: { slug: "googlecalendar" } },
+    ]);
+    const base = {
+      ownerAccountId: accountId,
+      ownerInboxId: "inbox-owner",
+      granteeInboxId: "inbox-agent",
+      toolkit: "googlecalendar",
+      bundleIds: ["calendar.events"],
+    };
+    await prisma.connectionGrant.createMany({
+      data: [
+        { ...base, conversationId: "conv-b" },
+        { ...base, conversationId: "conv-a" },
+        // A second agent in the same conversation: one conversation counted.
+        { ...base, conversationId: "conv-a", granteeInboxId: "inbox-agent-2" },
+      ],
+    });
+
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("no-store");
+
+    const body = res.body as AbilitiesResponse;
+    const gcal = body.abilities.find((a) => a.id === "googlecalendar");
+    expect(gcal!.entitlement).toEqual({
+      status: "active",
+      extensionCount: 2,
+    });
+  });
+
+  test("revoked and expired grants do not count; future expiry does", async () => {
+    installListStub([
+      { id: "conn-1", status: "ACTIVE", toolkit: { slug: "googlecalendar" } },
+    ]);
+    const base = {
+      ownerAccountId: accountId,
+      ownerInboxId: "inbox-owner",
+      granteeInboxId: "inbox-agent",
+      toolkit: "googlecalendar",
+      bundleIds: ["calendar.events"],
+    };
+    await prisma.connectionGrant.createMany({
+      data: [
+        { ...base, conversationId: "conv-revoked", revokedAt: new Date() },
+        // Expired grants are dead to exec, so the catalog must not count them.
+        {
+          ...base,
+          conversationId: "conv-expired",
+          expiresAt: new Date(Date.now() - 60_000),
+        },
+        {
+          ...base,
+          conversationId: "conv-live",
+          expiresAt: new Date(Date.now() + 60_000),
+        },
+      ],
+    });
+
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    const body = res.body as AbilitiesResponse;
+    const gcal = body.abilities.find((a) => a.id === "googlecalendar");
+    expect(gcal!.entitlement).toEqual({
+      status: "active",
+      extensionCount: 1,
+    });
+  });
+
+  // The full SDK status union (INITIALIZING | INITIATED | ACTIVE | FAILED |
+  // EXPIRED | INACTIVE | REVOKED) plus a value outside it. The V1 adapter
+  // emits only pending_auth/active/expired; needs_reauth is B2-reserved.
+  test.each([
+    ["INITIALIZING", "pending_auth"],
+    ["INITIATED", "pending_auth"],
+    ["ACTIVE", "active"],
+    ["FAILED", "expired"],
+    ["EXPIRED", "expired"],
+    ["INACTIVE", "expired"],
+    ["REVOKED", "expired"],
+    ["SOME_FUTURE_STATUS", "expired"],
+  ])("Composio status %s maps to %s", async (composioStatus, wireStatus) => {
+    installListStub([
+      {
+        id: "conn-1",
+        status: composioStatus,
+        toolkit: { slug: "googlecalendar" },
+      },
+    ]);
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    const gcal = (res.body as AbilitiesResponse).abilities.find(
+      (a) => a.id === "googlecalendar",
+    );
+    expect(gcal!.entitlement!.status).toBe(wireStatus);
+  });
+
+  test("most usable connection wins regardless of list order", async () => {
+    // Worse then better: catches an inverted rank comparison.
+    installListStub([
+      { id: "conn-1", status: "EXPIRED", toolkit: { slug: "googlecalendar" } },
+      { id: "conn-2", status: "ACTIVE", toolkit: { slug: "googlecalendar" } },
+    ]);
+    let res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    let gcal = (res.body as AbilitiesResponse).abilities.find(
+      (a) => a.id === "googlecalendar",
+    );
+    expect(gcal!.entitlement!.status).toBe("active");
+
+    // Better then worse: catches an unconditional overwrite of the rank.
+    installListStub([
+      { id: "conn-1", status: "ACTIVE", toolkit: { slug: "googlecalendar" } },
+      { id: "conn-2", status: "EXPIRED", toolkit: { slug: "googlecalendar" } },
+    ]);
+    res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    gcal = (res.body as AbilitiesResponse).abilities.find(
+      (a) => a.id === "googlecalendar",
+    );
+    expect(gcal!.entitlement!.status).toBe("active");
+  });
+
+  test("connections past the first Composio page are seen", async () => {
+    const receivedCursors: Array<string | undefined> = [];
+    installPagedListStub(
+      [
+        [{ id: "conn-1", status: "EXPIRED", toolkit: { slug: "spotify" } }],
+        [
+          {
+            id: "conn-2",
+            status: "ACTIVE",
+            toolkit: { slug: "googlecalendar" },
+          },
+        ],
+      ],
+      receivedCursors,
+    );
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    expect(res.status).toBe(200);
+    expect(receivedCursors).toEqual([undefined, "cursor-1"]);
+    const gcal = (res.body as AbilitiesResponse).abilities.find(
+      (a) => a.id === "googlecalendar",
+    );
+    expect(gcal!.entitlement!.status).toBe("active");
+  });
+
+  test("Composio page-bound hit: truncated state is not served as authoritative", async () => {
+    const receivedCursors: Array<string | undefined> = [];
+    // One more page than the service's bound: every call advertises a next
+    // cursor, so the loop hits the cap and must refuse the partial result.
+    const pages: StubbedConnection[][] = Array.from({ length: 11 }, (_, i) => [
+      {
+        id: `conn-${i}`,
+        status: "ACTIVE",
+        toolkit: { slug: "googlecalendar" },
+      },
+    ]);
+    installPagedListStub(pages, receivedCursors);
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    expect(res.status).toBe(200);
+    expect(receivedCursors).toHaveLength(10);
+    const body = res.body as AbilitiesResponse;
+    expect(body.entitlementsUnavailable).toBe(true);
+    for (const ability of body.abilities) {
+      expect("entitlement" in ability).toBe(false);
+    }
+  });
+
+  test("connections outside the catalog do not add abilities", async () => {
+    installListStub([
+      { id: "conn-1", status: "ACTIVE", toolkit: { slug: "googledrive" } },
+    ]);
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    const body = res.body as AbilitiesResponse;
+    expect(body.abilities.map((a) => a.id)).not.toContain("googledrive");
+    const gcal = body.abilities.find((a) => a.id === "googlecalendar");
+    expect(gcal!.entitlement).toBeNull();
+  });
+
+  test("Composio outage: entitlementsUnavailable, no entitlement keys, catalog served", async () => {
+    installListStub(new Error("composio down"));
+    const res = await request(makeApp())
+      .get("/abilities")
+      .set("X-Convos-AuthToken", await accountToken());
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("no-store");
+    const body = res.body as AbilitiesResponse;
+    expect(body.entitlementsUnavailable).toBe(true);
+    expect(body.abilities.length).toBeGreaterThan(0);
+    for (const ability of body.abilities) {
+      expect("entitlement" in ability).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
First implementation slice of Abilities (Connections V2) — plan: #389.

Adds the enumeration layer: ability manifests as backend-owned code config, served by a new `GET /v2/abilities` merged with the caller's entitlement state. Purely additive — no schema migration, no change to any existing endpoint.

Contract highlights (documented in `docs/schemas/abilities.schema.json`):
- JWT-only, deliberately without `requireAccount`: device-only tokens browse the catalog with `entitlement: null`; entitlement state appears only when the JWT carries an account.
- Entitlement state is derived from the V1 stores (Composio connected accounts + `ConnectionGrant` rows) so the endpoint is live today; B2's dedicated tables swap in behind the same wire shape.
- `entitlement` is object or `null`; a top-level `entitlementsUnavailable: true` (with `entitlement` keys omitted) signals "state could not be derived — keep last-known state" on upstream outage or truncation. The JSON Schema encodes this invariant.
- Adapter emits `pending_auth` / `active` / `expired`; `needs_reauth` and `revoked` are reserved for B2's service-mediated lifecycle.
- `extensionCount` (distinct conversations) instead of unbounded id lists; composite served versions so bundle changes in `bundles.config.ts` bump abilities without touching manifests; computed `catalogVersion`.
- No Composio action slug or bearer connection id ever reaches a client (pinned by tests).
- Six first-round abilities registered; only `googlecalendar` is served — the rest sit behind `hidden` flags so each launch is a one-line flip, no client release.

Went through an adversarial cross-review + verification round before opening; 20 endpoint tests, 73 green across the touched suites.

Stacked next: B2 — `AbilityEntitlement` / `ConversationAbility` tables, lifecycle + extension endpoints, `checkEntitlement` with exec migrated onto it, and the V1 backfill (branch `feature/abilities-entitlements`, in progress).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787418092&installation_model_id=20076&pr_number=390&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F390&signature=9aa45100bdaca2569d594de2b44fde3f1fad7571d0c3d38fb84d55cbd8277586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GET /v2/abilities endpoint to serve the abilities catalog with entitlement state
> - Introduces `GET /v2/abilities`, protected by JWT auth but not requiring an account, returning a versioned catalog of abilities with per-ability entitlement information.
> - Device-only tokens (no `accountId`) receive `entitlement: null` on each ability; tokens with an account fetch Composio connected account status and map it to `pending_auth`, `active`, or `expired`.
> - If the Composio service is unavailable or pagination exceeds 10 pages, the response omits entitlement keys and sets `entitlementsUnavailable: true` instead of returning partial data.
> - Google Calendar is the only visible ability at launch; other abilities (coinbase, shopify, spotify, youtube, gmail) exist as hidden manifests that can be launched by clearing their `hidden` flag.
> - `ComposioService.listForUser` now paginates through all pages up to a hard limit of 10 before throwing, and `getIfOwned`/`resolveConnectionId` inherit this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc24b0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->