### PR TITLE
feat(agent-variants): store skipCredits and forward it in the variant descriptor

### DIFF
--- a/prisma/migrations/20260724050000_add_agent_variant_skip_credits/migration.sql
+++ b/prisma/migrations/20260724050000_add_agent_variant_skip_credits/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+-- Agents created from this variant skip the credit path (server-side admin
+-- signal via the join's variant descriptor). Defaults to true — the same
+-- credits-exempt default the worker applies to a descriptor without the flag.
+ALTER TABLE "AgentVariant" ADD COLUMN "skipCredits" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -526,6 +526,10 @@ model AgentVariant {
   assistantWorkerUrl String?
   /// A bench/Braintrust prompt slug, or null for the canonical generator.
   builderPromptSlug  String?
+  /// Agents created from this variant skip the credit path (server-side admin
+  /// signal via the join's variant descriptor). False opts the variant's
+  /// agents back into real credits.
+  skipCredits        Boolean   @default(true)
   prUrl              String
   branch             String
   commit             String

--- a/src/api/v2/agent-variants/schemas.ts
+++ b/src/api/v2/agent-variants/schemas.ts
@@ -40,6 +40,9 @@ export const AgentVariantUpsertSchema = z
     assistantWorkerUrl: z.string().url().nullable().optional(),
     // A bench/Braintrust prompt slug, or null for the canonical generator.
     builderPromptSlug: z.string().trim().min(1).nullable().optional(),
+    // Agents created from this variant skip the credit path. Same optionality
+    // contract as the fields above; the column defaults to true on create.
+    skipCredits: z.boolean().optional(),
     prUrl: z.string().url(),
     branch: z.string().trim().min(1).max(255),
     commit: z.string().trim().min(1).max(64),

--- a/src/api/v2/agent-variants/serialize.ts
+++ b/src/api/v2/agent-variants/serialize.ts
@@ -10,6 +10,7 @@ export function serializeAgentVariant(variant: AgentVariant) {
     status: variant.status,
     assistantWorkerUrl: variant.assistantWorkerUrl,
     builderPromptSlug: variant.builderPromptSlug,
+    skipCredits: variant.skipCredits,
     prUrl: variant.prUrl,
     branch: variant.branch,
     commit: variant.commit,

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -27,6 +27,7 @@ type VariantDescriptor = {
   label: string;
   whatToTest: string;
   prUrl: string;
+  skipCredits: boolean;
   assistantWorkerUrl: string | null;
 };
 
@@ -483,6 +484,7 @@ export async function joinHandler(req: Request, res: Response) {
           label: true,
           whatToTest: true,
           prUrl: true,
+          skipCredits: true,
           assistantWorkerUrl: true,
         },
       });
@@ -718,6 +720,7 @@ export async function joinHandler(req: Request, res: Response) {
           label: variant.label,
           whatToTest: variant.whatToTest,
           prUrl: variant.prUrl,
+          skipCredits: variant.skipCredits,
         }),
       };
     }

--- a/tests/agent-variants.schema.test.ts
+++ b/tests/agent-variants.schema.test.ts
@@ -104,7 +104,7 @@ describe("serializeAgentVariant", () => {
       status: "building",
       assistantWorkerUrl: null,
       builderPromptSlug: null,
-      skipCredits: true,
+      skipCredits: false,
       prUrl: "https://github.com/x/y/pull/9",
       branch: "b",
       commit: "c",
@@ -112,7 +112,7 @@ describe("serializeAgentVariant", () => {
       createdAt: new Date("2026-06-24T12:00:00.000Z"),
       updatedAt: new Date("2026-06-24T12:00:00.000Z"),
     });
-    expect(out.skipCredits).toBe(true);
+    expect(out.skipCredits).toBe(false);
     expect(out.assistantWorkerUrl).toBeNull();
     expect(out.expiresAt).toBeNull();
     expect(out.createdAt).toBe("2026-06-24T12:00:00.000Z");

--- a/tests/agent-variants.schema.test.ts
+++ b/tests/agent-variants.schema.test.ts
@@ -41,12 +41,27 @@ describe("AgentVariantUpsertSchema", () => {
     expect(parsed.status).toBeUndefined();
     expect(parsed.assistantWorkerUrl).toBeUndefined();
     expect(parsed.builderPromptSlug).toBeUndefined();
+    expect(parsed.skipCredits).toBeUndefined();
     expect(parsed.expiresAt).toBeUndefined();
   });
 
   test("rejects an unknown key (strict; server-to-server route)", () => {
     expect(() =>
       AgentVariantUpsertSchema.parse({ ...valid, bogus: 1 }),
+    ).toThrow();
+  });
+
+  test("accepts a boolean skipCredits and rejects other types", () => {
+    expect(
+      AgentVariantUpsertSchema.parse({ ...valid, skipCredits: false })
+        .skipCredits,
+    ).toBe(false);
+    expect(
+      AgentVariantUpsertSchema.parse({ ...valid, skipCredits: true })
+        .skipCredits,
+    ).toBe(true);
+    expect(() =>
+      AgentVariantUpsertSchema.parse({ ...valid, skipCredits: "false" }),
     ).toThrow();
   });
 
@@ -89,6 +104,7 @@ describe("serializeAgentVariant", () => {
       status: "building",
       assistantWorkerUrl: null,
       builderPromptSlug: null,
+      skipCredits: true,
       prUrl: "https://github.com/x/y/pull/9",
       branch: "b",
       commit: "c",
@@ -96,6 +112,7 @@ describe("serializeAgentVariant", () => {
       createdAt: new Date("2026-06-24T12:00:00.000Z"),
       updatedAt: new Date("2026-06-24T12:00:00.000Z"),
     });
+    expect(out.skipCredits).toBe(true);
     expect(out.assistantWorkerUrl).toBeNull();
     expect(out.expiresAt).toBeNull();
     expect(out.createdAt).toBe("2026-06-24T12:00:00.000Z");

--- a/tests/agents-join-variant.test.ts
+++ b/tests/agents-join-variant.test.ts
@@ -135,6 +135,9 @@ beforeAll(async () => {
         status: "ready",
         assistantWorkerUrl: VARIANT_URL,
         builderPromptSlug: "qa-flow-v2",
+        // Explicit opt-out into the real credit path: proves the stored value
+        // (not the column default) is what rides the descriptor stamp.
+        skipCredits: false,
         prUrl: "https://github.com/x/y/pull/1",
         branch: "b",
         commit: "c",
@@ -249,6 +252,7 @@ describe("POST /agents/join — agent variant runtime routing", () => {
       slug: VARIANT_SLUG,
       label: "Q+A",
       prUrl: "https://github.com/x/y/pull/1",
+      skipCredits: false,
     });
     // (3) variantId is NOT forwarded to the runtime; skipGreeting still is
     const opts = (dispatch.body?.options ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
The backend half of xmtplabs/convos-assistants#2898. The variant CI registers each variant with a `skipCredits` flag (default `true` — credits-exempt), but the upsert schema is `.strict()` and rejects the unknown key, so every variant registration on dev currently 400s. xmtplabs/convos-assistants#2964 is the CI-side interim that omits the field; once this deploys, the workflow can resume sending it and the flag becomes end-to-end effective.

- `AgentVariant.skipCredits` column, default `true` (existing rows backfill to the credits-exempt default the worker already applies to a descriptor without the flag).
- Upsert schema accepts `skipCredits` as optional-not-defaulted, matching the partial-re-POST convention of the other fields.
- The join's `metadata.variant` stamp carries the stored value, so the worker's admin decision (`descriptor.skipCredits !== false`) honors an explicit opt-out into the real credit path. A forged `false` only reduces privilege.
- Serializer exposes the flag to the picker/CI read path.

Verified locally: `prisma migrate deploy` from scratch, typecheck, and the agent-variants schema + join-variant test files (18 tests, including the stored `false` riding the descriptor stamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULTXgEXzig3qjsjkhoynjH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787470447&installation_model_id=20076&pr_number=391&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F391&signature=b7ce299894fb6d8a2908b4f01408fda20a6754be986e3bc8d0bd062d2b995041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store and forward `skipCredits` in agent variant descriptor
> - Adds a `skipCredits` boolean field to the `AgentVariant` model (defaulting to `true`) via a new [migration](https://github.com/xmtplabs/convos-backend/pull/391/files#diff-a1ee6734f2aa3fd1d3ad2786538a59045be496e76a061dcd1f7f1ac0882ea226) and schema update.
> - Exposes `skipCredits` in the upsert API schema and serialized variant responses.
> - Forwards `skipCredits` in the `metadata.variant` stamp sent during agent join dispatch, so downstream consumers receive the value when a variant is applied.
> - Behavioral Change: existing variants will default to `skipCredits: true`; set it to `false` to opt agents back into real credits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4314870.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `skipCredits` setting for agent variants.
  * Variant details now indicate whether agents created from them bypass credit usage.
  * Agent variant responses and join routing preserve this setting.
  * The setting defaults to enabled when not specified.

* **Tests**
  * Added coverage for valid and invalid `skipCredits` values.
  * Verified the setting is preserved during serialization and agent joining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->