### PR TITLE
chore(scripts): Apple subscription status checker CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "apple:sub-status": "tsx --env-file-if-exists=.env scripts/check-apple-subscription-status.ts",
     "buf:generate": "NODE_NO_WARNINGS=1 buf generate",
     "build": "tsup",
     "check": "pnpm typecheck && pnpm format:check && pnpm lint",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -61,3 +61,90 @@ WHERE d."pushTokenType" = 'apns' AND d."pushToken" IS NOT NULL;
 - **"No APNS devices found"** → User has no devices with APNS tokens
 - **"BadDeviceToken"** → Push token expired, device needs to re-register
 - **Environment mismatch** → Use `--sandbox` for dev builds, `--production` for App Store
+
+---
+
+# Apple Subscription Status Checker (`apple:sub-status`)
+
+Read-only CLI that asks Apple's App Store Server API for the current status
+of one or more auto-renewable subscriptions, by `originalTransactionId`
+(`GET /inApps/v1/subscriptions/{originalTransactionId}`). It is the manual
+version of what a reconcile job would do: useful for support incidents
+("user says they have a sub, server says they don't"). No database access;
+strictly read-only against Apple.
+
+## Usage
+
+```bash
+pnpm apple:sub-status <originalTransactionId...> [--sandbox]
+```
+
+- Defaults to the production host (`api.storekit.itunes.apple.com`).
+- `--sandbox` switches to `api.storekit-sandbox.itunes.apple.com`.
+- Accepts one or more `originalTransactionId`s.
+- Exits non-zero if any lookup fails (HTTP status + Apple `apiError` shown).
+
+## Required `.env` vars
+
+From the `# IAP Prod` block in `.env` (names only — never paste values):
+
+```bash
+APPLE_API_KEY_ID=...
+APPLE_API_ISSUER_ID=...
+APPLE_BUNDLE_ID=...
+APPLE_API_SIGNING_KEY="..."
+```
+
+Missing vars produce an actionable error; the tool never prints env values.
+
+## Decoding the output
+
+Subscription `status` codes:
+
+| Code | Meaning                                            |
+| ---- | -------------------------------------------------- |
+| 1    | active                                             |
+| 2    | expired                                            |
+| 3    | billing-retry (billing failed, Apple is retrying)  |
+| 4    | grace-period (billing failed, user still entitled) |
+| 5    | revoked                                            |
+
+`autoRenewStatus`: `0` = off (will not renew), `1` = on (will renew).
+
+`expirationIntent` (why it expired / will expire): `1` customer canceled,
+`2` billing error, `3` customer declined a price increase, `4` product not
+available at renewal, `5` other.
+
+`environment` in the output is decoded from Apple's signed payloads
+(`Sandbox` / `Production`).
+
+## Sandbox vs production
+
+TestFlight purchases live in Apple's **sandbox** environment. A sandbox
+`originalTransactionId` returns HTTP 404 with `apiError=4040010`
+("original transaction id not found") on the production host — retry the
+same id with `--sandbox`.
+
+## Finding originalTransactionIds
+
+Read-only SQL against the backend database (placeholders — substitute real
+ids when running; never commit real customer or transaction ids):
+
+```sql
+-- By subscription id(s)
+SELECT id, "accountId", "originalTransactionId"
+FROM "Subscription"
+WHERE id IN ('<subscriptionId>', '<anotherSubscriptionId>');
+
+-- All subscriptions for an account
+SELECT id, "accountId", "originalTransactionId", provider, environment, status
+FROM "Subscription"
+WHERE "accountId" = '<accountId>';
+
+-- Recent Apple sandbox subscriptions (e.g. TestFlight purchases)
+SELECT id, "accountId", "originalTransactionId", status, "updatedAt"
+FROM "Subscription"
+WHERE provider = 'apple' AND environment = 'sandbox'
+ORDER BY "updatedAt" DESC
+LIMIT 20;
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,8 +79,8 @@ strictly read-only against Apple.
 pnpm apple:sub-status <originalTransactionId...> [--sandbox]
 ```
 
-- Defaults to the production host (`api.storekit.itunes.apple.com`).
-- `--sandbox` switches to `api.storekit-sandbox.itunes.apple.com`.
+- Defaults to the production host (`api.storekit.apple.com`).
+- `--sandbox` switches to `api.storekit-sandbox.apple.com`.
 - Accepts one or more `originalTransactionId`s.
 - Exits non-zero if any lookup fails (HTTP status + Apple `apiError` shown).
 
@@ -123,7 +123,8 @@ available at renewal, `5` other.
 TestFlight purchases live in Apple's **sandbox** environment. A sandbox
 `originalTransactionId` returns HTTP 404 with `apiError=4040010`
 ("original transaction id not found") on the production host — retry the
-same id with `--sandbox`.
+same id with `--sandbox`. If it also 404s with `--sandbox`, check that the
+bundle ID, environment, and API key in `.env` match the app.
 
 ## Finding originalTransactionIds
 

--- a/scripts/check-apple-subscription-status.ts
+++ b/scripts/check-apple-subscription-status.ts
@@ -15,7 +15,7 @@
  *   APPLE_API_SIGNING_KEY
  *
  * Defaults to the PRODUCTION host. Pass --sandbox to query
- * api.storekit-sandbox.itunes.apple.com instead — TestFlight purchases live
+ * api.storekit-sandbox.apple.com instead — TestFlight purchases live
  * in the sandbox environment, so a 404/4040010 on production usually means
  * "retry with --sandbox".
  *
@@ -42,7 +42,7 @@ Checks App Store subscription status straight from Apple (read-only):
 GET /inApps/v1/subscriptions/{originalTransactionId}
 
 Options:
-  --sandbox   Query api.storekit-sandbox.itunes.apple.com instead of the
+  --sandbox   Query api.storekit-sandbox.apple.com instead of the
               production host (TestFlight purchases live in the sandbox
               environment).
   -h, --help  Show this help.
@@ -219,7 +219,7 @@ const main = async () => {
     sandbox ? Environment.SANDBOX : Environment.PRODUCTION,
   );
   console.log(
-    `Querying ${sandbox ? "SANDBOX (api.storekit-sandbox.itunes.apple.com)" : "PRODUCTION (api.storekit.itunes.apple.com)"} as bundle ${cfg.bundleId}`,
+    `Querying ${sandbox ? "SANDBOX (api.storekit-sandbox.apple.com)" : "PRODUCTION (api.storekit.apple.com)"} as bundle ${cfg.bundleId}`,
   );
 
   let failures = 0;
@@ -231,10 +231,13 @@ const main = async () => {
       failures += 1;
       console.error(`\n== ${otx} ==`);
       if (error instanceof APIException) {
+        const notFoundHint = sandbox
+          ? "4040010 = originalTransactionId not found on the sandbox host; " +
+            "check that the bundle ID, environment, and API key match"
+          : "4040010 = originalTransactionId not found on this host; " +
+            "TestFlight/sandbox purchases need --sandbox";
         console.error(
-          `  HTTP ${error.httpStatusCode} — apiError=${String(error.apiError ?? "none")}` +
-            ` (4040010 = originalTransactionId not found on this host; ` +
-            `TestFlight/sandbox purchases need --sandbox)`,
+          `  HTTP ${error.httpStatusCode} — apiError=${String(error.apiError ?? "none")} (${notFoundHint})`,
         );
       } else {
         console.error(

--- a/scripts/check-apple-subscription-status.ts
+++ b/scripts/check-apple-subscription-status.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env tsx
+
+/**
+ * Read-only CLI: check App Store subscription status for one or more
+ * originalTransactionIds, straight from Apple's App Store Server API
+ * (GET /inApps/v1/subscriptions/{originalTransactionId}) — the manual
+ * version of what a reconcile job would do.
+ *
+ * Usage:
+ *   pnpm apple:sub-status <originalTransactionId...> [--sandbox]
+ *
+ * Env (same vars the server uses — see src/subscriptions/apple-server-api.ts;
+ * in the local .env they live in the "# IAP Prod" block):
+ *   APPLE_API_KEY_ID, APPLE_API_ISSUER_ID, APPLE_BUNDLE_ID,
+ *   APPLE_API_SIGNING_KEY
+ *
+ * Defaults to the PRODUCTION host. Pass --sandbox to query
+ * api.storekit-sandbox.itunes.apple.com instead — TestFlight purchases live
+ * in the sandbox environment, so a 404/4040010 on production usually means
+ * "retry with --sandbox".
+ *
+ * Deliberately self-contained (no imports from src/): importing
+ * src/subscriptions/apple-server-api.ts drags in @/config, which throws at
+ * load time on unrelated missing env vars, and pins the environment to
+ * APPLE_ENV instead of a CLI flag. Same underlying library, same host logic.
+ *
+ * Strictly read-only against Apple. No database access. Never prints env
+ * values.
+ */
+import {
+  APIException,
+  AppStoreServerAPIClient,
+  Environment,
+  type StatusResponse,
+} from "@apple/app-store-server-library";
+
+const USAGE = `Usage:
+  pnpm apple:sub-status <originalTransactionId...> [--sandbox]
+  pnpm tsx --env-file-if-exists=.env scripts/check-apple-subscription-status.ts <originalTransactionId...> [--sandbox]
+
+Checks App Store subscription status straight from Apple (read-only):
+GET /inApps/v1/subscriptions/{originalTransactionId}
+
+Options:
+  --sandbox   Query api.storekit-sandbox.itunes.apple.com instead of the
+              production host (TestFlight purchases live in the sandbox
+              environment).
+  -h, --help  Show this help.
+
+Required env (in .env, "# IAP Prod" block — must be uncommented):
+  APPLE_API_KEY_ID, APPLE_API_ISSUER_ID, APPLE_BUNDLE_ID, APPLE_API_SIGNING_KEY
+
+Status codes: 1 active, 2 expired, 3 billing-retry, 4 grace-period, 5 revoked.`;
+
+const REQUIRED_ENV_KEYS = [
+  "APPLE_API_KEY_ID",
+  "APPLE_API_ISSUER_ID",
+  "APPLE_BUNDLE_ID",
+  "APPLE_API_SIGNING_KEY",
+] as const;
+
+const STATUS_LABELS = new Map<number, string>([
+  [1, "active"],
+  [2, "expired"],
+  [3, "billing-retry"],
+  [4, "grace-period"],
+  [5, "revoked"],
+]);
+
+const EXPIRATION_INTENT_LABELS = new Map<number, string>([
+  [1, "customer-canceled"],
+  [2, "billing-error"],
+  [3, "declined-price-increase"],
+  [4, "product-unavailable"],
+  [5, "other"],
+]);
+
+/** Fields we read from the decoded JWSTransaction payload. */
+type TransactionPayload = {
+  productId?: string;
+  expiresDate?: number;
+  environment?: string;
+};
+
+/** Fields we read from the decoded JWSRenewalInfo payload. */
+type RenewalPayload = {
+  autoRenewStatus?: number;
+  expirationIntent?: number;
+  environment?: string;
+};
+
+/**
+ * Decode the middle (payload) segment of a JWS: base64url-encoded JSON.
+ *
+ * We deliberately skip signature verification — this is a read-only
+ * diagnostic tool talking directly to Apple over TLS, not a trust boundary.
+ * The server-side flow (src/subscriptions/jws-verifier.ts) does full x5c
+ * chain verification before trusting these payloads.
+ */
+const decodeJwsPayload = (jws: string): Record<string, unknown> => {
+  const segments = jws.split(".");
+  if (segments.length !== 3) {
+    throw new Error(
+      `Malformed JWS: expected 3 segments, got ${segments.length}`,
+    );
+  }
+  return JSON.parse(
+    Buffer.from(segments[1], "base64url").toString("utf8"),
+  ) as Record<string, unknown>;
+};
+
+const readAppleEnv = () => {
+  const missing = REQUIRED_ENV_KEYS.filter((key) => !process.env[key]?.trim());
+  if (missing.length > 0) {
+    console.error(`Missing required env vars: ${missing.join(", ")}`);
+    console.error(
+      'Fix: uncomment the "# IAP Prod" block in .env, then run via ' +
+        "`pnpm apple:sub-status ...` (which loads .env). " +
+        "This tool never prints env values.",
+    );
+    process.exit(1);
+  }
+  const env = (key: string) => (process.env[key] ?? "").trim();
+  return {
+    keyId: env("APPLE_API_KEY_ID"),
+    issuerId: env("APPLE_API_ISSUER_ID"),
+    bundleId: env("APPLE_BUNDLE_ID"),
+    // .env stores the PEM double-quoted with "\n" escapes; node --env-file
+    // expands those to real newlines, but normalize anyway in case the var
+    // was exported by hand with literal backslash-n sequences.
+    signingKey: env("APPLE_API_SIGNING_KEY").replace(/\\n/g, "\n"),
+  };
+};
+
+const formatEpochMs = (ms: number | undefined) =>
+  ms === undefined ? "?" : new Date(ms).toISOString();
+
+const formatAutoRenewStatus = (value: number | undefined) =>
+  value === undefined
+    ? "?"
+    : `${value} (${value === 1 ? "on" : value === 0 ? "off" : "unknown"})`;
+
+const formatExpirationIntent = (value: number | undefined) =>
+  value === undefined
+    ? "(none)"
+    : `${value} (${EXPIRATION_INTENT_LABELS.get(value) ?? "unknown"})`;
+
+const printStatusResponse = (otx: string, response: StatusResponse) => {
+  console.log(`\n== ${otx} ==`);
+  console.log(
+    `  response environment: ${response.environment ?? "?"}  bundleId: ${response.bundleId ?? "?"}`,
+  );
+  const groups = response.data ?? [];
+  if (groups.length === 0) {
+    console.log("  (no subscription groups returned)");
+    return;
+  }
+  for (const group of groups) {
+    console.log(
+      `  subscription group ${group.subscriptionGroupIdentifier ?? "?"}:`,
+    );
+    for (const item of group.lastTransactions ?? []) {
+      const status = item.status;
+      const statusLabel =
+        status === undefined
+          ? "unknown"
+          : (STATUS_LABELS.get(status) ?? "unknown");
+      const txn = item.signedTransactionInfo
+        ? (decodeJwsPayload(item.signedTransactionInfo) as TransactionPayload)
+        : undefined;
+      const renewal = item.signedRenewalInfo
+        ? (decodeJwsPayload(item.signedRenewalInfo) as RenewalPayload)
+        : undefined;
+      console.log(
+        `    - originalTransactionId: ${item.originalTransactionId ?? "?"}`,
+      );
+      console.log(`      status: ${status ?? "?"} (${statusLabel})`);
+      console.log(`      productId: ${txn?.productId ?? "?"}`);
+      console.log(`      expiresDate: ${formatEpochMs(txn?.expiresDate)}`);
+      console.log(
+        `      autoRenewStatus: ${formatAutoRenewStatus(renewal?.autoRenewStatus)}`,
+      );
+      console.log(
+        `      expirationIntent: ${formatExpirationIntent(renewal?.expirationIntent)}`,
+      );
+      console.log(
+        `      environment: ${txn?.environment ?? renewal?.environment ?? "?"}`,
+      );
+    }
+  }
+};
+
+const main = async () => {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(USAGE);
+    return;
+  }
+  const flags = args.filter((arg) => arg.startsWith("-"));
+  const unknownFlags = flags.filter((arg) => arg !== "--sandbox");
+  if (unknownFlags.length > 0) {
+    console.error(`Unknown option(s): ${unknownFlags.join(", ")}\n`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+  const otxIds = args.filter((arg) => !arg.startsWith("-"));
+  if (otxIds.length === 0) {
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  const sandbox = flags.includes("--sandbox");
+  const cfg = readAppleEnv();
+  const client = new AppStoreServerAPIClient(
+    cfg.signingKey,
+    cfg.keyId,
+    cfg.issuerId,
+    cfg.bundleId,
+    sandbox ? Environment.SANDBOX : Environment.PRODUCTION,
+  );
+  console.log(
+    `Querying ${sandbox ? "SANDBOX (api.storekit-sandbox.itunes.apple.com)" : "PRODUCTION (api.storekit.itunes.apple.com)"} as bundle ${cfg.bundleId}`,
+  );
+
+  let failures = 0;
+  for (const otx of otxIds) {
+    try {
+      const response = await client.getAllSubscriptionStatuses(otx);
+      printStatusResponse(otx, response);
+    } catch (error) {
+      failures += 1;
+      console.error(`\n== ${otx} ==`);
+      if (error instanceof APIException) {
+        console.error(
+          `  HTTP ${error.httpStatusCode} — apiError=${String(error.apiError ?? "none")}` +
+            ` (4040010 = originalTransactionId not found on this host; ` +
+            `TestFlight/sandbox purchases need --sandbox)`,
+        );
+      } else {
+        console.error(
+          `  ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+  if (failures > 0) {
+    process.exit(1);
+  }
+};
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Read-only CLI to check App Store subscription status for one or more `originalTransactionId`s, straight from Apple's App Store Server API (`GET /inApps/v1/subscriptions/{originalTransactionId}`), plus a usage guide in `scripts/README.md` (status-code decode table, sandbox notes, and SQL snippets to find `originalTransactionId`s).

## Why

Manual version of the future reconcile job — support tooling for subscription incidents ("user says they have a sub, server says they don't"). No database access, nothing written anywhere; self-contained via the same `@apple/app-store-server-library` the server uses.

## Usage

```bash
pnpm apple:sub-status <originalTransactionId...> [--sandbox]
```

Defaults to the production host; `--sandbox` switches to `api.storekit-sandbox.itunes.apple.com` (TestFlight purchases live in the sandbox environment — a 404/4040010 on production means retry with `--sandbox`). Exits non-zero on HTTP errors with the status code shown.

## Validation

Validated against two known expired production subscriptions — output matched direct App Store Server API calls exactly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787914919&installation_model_id=20076&pr_number=393&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F393&signature=6e8a791f3d34f56c172a02584acf44c5ed8b09fbe210f9df10ea887ea6506f17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Apple subscription status checker CLI script
> - Adds [`scripts/check-apple-subscription-status.ts`](https://github.com/xmtplabs/convos-backend/pull/393/files#diff-c28e6b56fb0151f165fb3a9cd8d4cc52dce67b5b9374ed498e7be9c8018753d7), a read-only CLI that queries Apple's App Store Server API (`GET /inApps/v1/subscriptions/{originalTransactionId}`) and prints decoded subscription status details.
> - Accepts one or more `originalTransactionId` arguments, supports a `--sandbox` flag to target Apple's sandbox environment, and exits non-zero if any lookup fails.
> - Decodes `signedTransactionInfo` and `signedRenewalInfo` JWS payloads (without signature verification) to display fields like `productId`, `expiresDate`, `autoRenewStatus`, and `expirationIntent`.
> - Requires `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, `APPLE_BUNDLE_ID`, and `APPLE_API_SIGNING_KEY` env vars; fails fast with actionable errors if any are missing.
> - Documents usage, required env vars, and SQL snippets for locating transaction IDs in [`scripts/README.md`](https://github.com/xmtplabs/convos-backend/pull/393/files#diff-25b96aa16f8b9f68c692d0db061713707e9cfc67b296e0ea30908928fb3ffcd6).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #393 opened
>
> - Modified error handling for `APIException` in the main CLI function to provide context-specific hints for 4040010 errors based on the `--sandbox` flag [3f9bad1]
> - Updated Apple StoreKit API hostnames from `api.storekit.itunes.apple.com` and `api.storekit-sandbox.itunes.apple.com` to `api.storekit.apple.com` and `api.storekit-sandbox.apple.com` [3f9bad1]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3f9bad1. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only command to check Apple subscription statuses for one or more transaction IDs.
  * Supports production and sandbox lookups, structured status reporting, and actionable error messages.
  * Reports transaction, renewal, expiration, and environment details.

* **Documentation**
  * Added command usage, configuration requirements, output guidance, and examples for finding transaction IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->