### PR TITLE
SSN feed observability: lifecycle log events, persisted unknown-subscription drops, silent-feed alert

### DIFF
--- a/docs/observability/subscription-notifications.md
+++ b/docs/observability/subscription-notifications.md
@@ -72,6 +72,11 @@ provider-side identity in `providerSubscriptionId` (Apple
 existing `idempotencyKey` unique (`apple-ssn:{notificationUUID}` /
 `play-rtdn:{messageId}`), and keep the raw JWS in `signedPayload` for replay.
 
+Adoption: if the provider retries the same notification after `/verify` has
+created the Subscription row, the apply path claims the drop receipt (sets its
+`subscriptionId`) and applies the state change — so a receipt stays
+`subscriptionId IS NULL` only while the subscription is still unknown.
+
 ```sql
 -- SSNs arriving for subscriptions we don't know (newest first)
 SELECT "receivedAt", "provider", "providerSubscriptionId",

--- a/docs/observability/subscription-notifications.md
+++ b/docs/observability/subscription-notifications.md
@@ -1,0 +1,189 @@
+# Subscription provider-notification observability (Apple SSN / Play RTDN)
+
+Why this exists: the prod app record had **no** App Store Server Notification
+URL from launch until 2026-07-29 (~11:15 CEST) — prod received zero SSNs ever,
+and nothing noticed. This doc defines the stable log events the handlers emit,
+the DB audit surface for dropped deliveries, and the Datadog monitors that make
+a silent feed impossible to miss again.
+
+## Stable log events (log-explorer / monitor contract — do not rename)
+
+Emitted by `src/api/v2/subscriptions/handlers/apple-ssn.ts` as the pino `msg`:
+
+| Event                       | Level     | Meaning                                                                                                                                                                                                               |
+| --------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `subscription.ssn.received` | info      | A signature-verified Apple delivery arrived. Fires after the outer JWS verifies, so unverifiable garbage on this unauthenticated endpoint doesn't count as feed traffic. `received = applied + dropped-after-verify`. |
+| `subscription.ssn.applied`  | info      | A state change was applied (or replayed — see the `replayed` field).                                                                                                                                                  |
+| `subscription.ssn.dropped`  | warn/info | The delivery produced no state change. Always carries `reason`, plus `notificationType` / `notificationSubtype` / `notificationUUID` / `originalTransactionId` where they exist at the drop point.                    |
+
+The 500 path (`Failed to apply Apple S2S notification`) is neither applied nor
+dropped — Apple retries it.
+
+Fields on `applied`: `notificationType`, `notificationSubtype`,
+`notificationUUID`, `originalTransactionId`, `transactionId`, `environment`
+(Sandbox/Production — the daily sandbox canary shows up here), `accountId`,
+`subscriptionStatus`, `replayed`.
+
+`dropped` reasons:
+
+| `reason`                         | HTTP | Persisted? | Notes                                                                                                                                                   |
+| -------------------------------- | ---- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid_body`                   | 400  | no         | Not SSN-shaped; likely scanners.                                                                                                                        |
+| `invalid_notification_signature` | 400  | no         | Outer JWS failed verification. Unverified payloads are never persisted.                                                                                 |
+| `missing_notification_uuid`      | 400  | no         | Verified but malformed.                                                                                                                                 |
+| `no_transaction`                 | 200  | no         | Summary / externalPurchaseToken / appData branches.                                                                                                     |
+| `invalid_transaction_signature`  | 400  | no         | Inner transaction JWS failed.                                                                                                                           |
+| `missing_transaction_ids`        | 400  | no         | Verified transaction without OTX/transactionId.                                                                                                         |
+| `no_actionable_update`           | 200  | no         | TEST / CONSUMPTION_REQUEST / unmapped types.                                                                                                            |
+| `unknown_subscription`           | 200  | **yes**    | No Subscription row matched the OTX. **The orphan-detection signal** — persisted as a drop receipt (below), `receiptRecorded` false on provider replay. |
+
+Google Play mirrors the drop persistence via the shared `applyNotification`:
+`play.rtdn.applied` / `play.rtdn.unknown_subscription — acking` (now with
+`receiptRecorded`).
+
+## Log-explorer filters (Datadog, paste-ready)
+
+Base (Louis's saved view "Convos Prod Apple SSN" — all feed traffic):
+
+```
+env:convos-otr-prod service:(api OR notifications) @pathname:/api/v2/webhooks/apple/ssn
+```
+
+Per event (full-text match works regardless of the pino `msg` → `@msg`/`@message`
+attribute mapping; `@msg:"…"` is the precise form if the forwarder maps it):
+
+```
+env:convos-otr-prod @pathname:/api/v2/webhooks/apple/ssn "subscription.ssn.received"
+env:convos-otr-prod @pathname:/api/v2/webhooks/apple/ssn "subscription.ssn.applied"
+env:convos-otr-prod @pathname:/api/v2/webhooks/apple/ssn "subscription.ssn.dropped"
+```
+
+Drill-downs: facet `@reason` on the dropped stream
+(`… "subscription.ssn.dropped" @reason:unknown_subscription`), `@environment`
+on applied to split the sandbox canary from real production renewals.
+
+## DB audit surface — unmatched drop receipts
+
+`BillingReceipt.subscriptionId` is now nullable: NULL rows are verified
+provider notifications that matched no Subscription
+(migration `20260729130500_billing_receipt_unmatched_drops`). They carry the
+provider-side identity in `providerSubscriptionId` (Apple
+`originalTransactionId` / Google `purchaseToken`), are idempotent on the
+existing `idempotencyKey` unique (`apple-ssn:{notificationUUID}` /
+`play-rtdn:{messageId}`), and keep the raw JWS in `signedPayload` for replay.
+
+```sql
+-- SSNs arriving for subscriptions we don't know (newest first)
+SELECT "receivedAt", "provider", "providerSubscriptionId",
+       "notificationType", "notificationSubtype", "externalNotificationId"
+FROM "BillingReceipt"
+WHERE "subscriptionId" IS NULL
+ORDER BY "receivedAt" DESC;
+
+-- Feed liveness from the DB (complement to the log monitor):
+-- any Apple SSN receipt (matched or dropped) in the last 26h?
+SELECT count(*) FROM "BillingReceipt"
+WHERE "idempotencyKey" LIKE 'apple-ssn:%'
+  AND "receivedAt" > now() - interval '26 hours';
+```
+
+## Monitors (Datadog)
+
+Datadog monitors are Terraform-managed in the `infrastructure` repo
+(`plans/convos/monitors.tf`) — add the snippets below there. The `@msg` caveat
+from that file applies: pino emits `msg`; confirm the forwarder maps it to
+`@msg` (or swap for the quoted full-text form) by checking one real
+`subscription.ssn.applied` log line first.
+
+How to create by hand instead: Datadog → Monitors → New Monitor → Logs → paste
+the query → set the threshold/window → add the Slack handle.
+
+### 1. Silent Apple SSN feed (the one that would have caught the zero-SSN era)
+
+Invariant: at least one `subscription.ssn.applied` every 26h. Valid from day
+one — Louis's sandbox subscription renews roughly daily against prod (via the
+JWS environment fallback), so a healthy feed always produces ≥1 applied/day
+even with zero real customers. First production renewal wave lands Aug 8.
+
+- Query: `env:convos-otr-prod service:(api OR notifications) @msg:"subscription.ssn.applied"`
+- Condition: count `< 1` over the last `26h` ⇒ alert. (If the UI rejects a
+  custom 26h window, fall back to `1d` — expect occasional flap around the
+  canary's renewal time.)
+- A below-threshold log monitor evaluates an empty result as 0, so it fires on
+  total silence; `notify_no_data` stays off.
+
+```hcl
+resource "datadog_monitor" "backend_apple_ssn_feed_silent" {
+  name    = "convos-backend Apple SSN feed silent — no subscription.ssn.applied in 26h (${terraform.workspace})"
+  type    = "log alert"
+  message = <<-MSG
+    No `subscription.ssn.applied` event in 26 hours. The App Store Server
+    Notification feed is silent: URL deregistered/wrong in App Store Connect,
+    JWS verification broken, or the handler is failing before apply.
+    A daily sandbox renewal canary guarantees >=1 applied/day when healthy.
+
+    Check: [SSN traffic](https://app.datadoghq.com/logs?query=env%3Aconvos-otr-prod%20%40pathname%3A%2Fapi%2Fv2%2Fwebhooks%2Fapple%2Fssn)
+    — deliveries arriving but dropping? Look at `subscription.ssn.dropped`
+    `@reason`. No deliveries at all? Check App Store Connect notification URL.
+
+    ${local.backend_notify}
+  MSG
+
+  # If the forwarder maps pino msg to @message, replace @msg accordingly.
+  query = "logs(\"env:convos-otr-prod service:(api OR notifications) @msg:\\\"subscription.ssn.applied\\\"\").rollup(\"count\").last(\"26h\") < 1"
+
+  monitor_thresholds {
+    critical = 1
+  }
+
+  include_tags   = true
+  notify_no_data = false
+  priority       = 1
+}
+```
+
+### 2. Spike of dropped SSNs
+
+Baseline is ~zero. Any sustained `subscription.ssn.dropped` volume means
+deliveries are arriving and not landing — `@reason:unknown_subscription` in
+particular is the orphaned-subscription signal (row owned by a dead sibling
+account, or verify never ran).
+
+- Query: `env:convos-otr-prod service:(api OR notifications) @msg:"subscription.ssn.dropped"`
+- Condition: count `> 5` over the last `1h` ⇒ alert, warn at `> 1`.
+
+```hcl
+resource "datadog_monitor" "backend_apple_ssn_dropped_spike" {
+  name    = "convos-backend subscription.ssn.dropped spike (${terraform.workspace})"
+  type    = "log alert"
+  message = <<-MSG
+    Apple SSN deliveries are arriving but not applying. Facet `@reason`:
+    `unknown_subscription` = notifications for subscriptions we have no row
+    for (orphaned sub / verify never ran) — cross-check the DB drop receipts:
+    `SELECT * FROM "BillingReceipt" WHERE "subscriptionId" IS NULL ORDER BY "receivedAt" DESC;`
+    Signature reasons = verifier/root-cert trouble.
+
+    ${local.backend_notify}
+  MSG
+
+  query = "logs(\"env:convos-otr-prod service:(api OR notifications) @msg:\\\"subscription.ssn.dropped\\\"\").rollup(\"count\").last(\"1h\") > 5"
+
+  monitor_thresholds {
+    warning  = 1
+    critical = 5
+  }
+
+  include_tags   = true
+  notify_no_data = false
+  priority       = 2
+}
+```
+
+### 3. Related (suggested): verify account-mismatch
+
+`subscription.verify.account_mismatch`
+(`src/api/v2/accounts/handlers/subscription-verify.ts`) is today only a warn
+log, and it is the primary detection signal for orphaned subscriptions (it
+names `existingAccountId`). Same shape as monitor 2:
+`env:convos-otr-prod @msg:"subscription.verify.account_mismatch"`, count `> 0`
+over `1h` ⇒ warn.

--- a/prisma/migrations/20260729130500_billing_receipt_unmatched_drops/migration.sql
+++ b/prisma/migrations/20260729130500_billing_receipt_unmatched_drops/migration.sql
@@ -1,0 +1,22 @@
+-- BillingReceipt: support unmatched-drop receipts.
+--
+-- Provider notifications (Apple SSN / Play RTDN) that match no Subscription
+-- row were previously acked with a log line only — invisible outside logs.
+-- They are now persisted as BillingReceipt rows with subscriptionId NULL and
+-- the provider-side subscription identity (Apple originalTransactionId /
+-- Google purchaseToken) in providerSubscriptionId, so "notifications arriving
+-- for subscriptions we don't know" is queryable and auditable from the DB.
+-- The existing UNIQUE on idempotencyKey (apple-ssn:{notificationUUID} /
+-- play-rtdn:{messageId}) makes the drop write idempotent per notification.
+--
+-- The subscriptionId foreign key itself is untouched (stays ON DELETE
+-- RESTRICT): NULLs are always permitted by an FK constraint.
+
+-- AlterTable
+ALTER TABLE "BillingReceipt" ALTER COLUMN "subscriptionId" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "BillingReceipt" ADD COLUMN "providerSubscriptionId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "BillingReceipt_providerSubscriptionId_idx" ON "BillingReceipt"("providerSubscriptionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -454,7 +454,11 @@ model Subscription {
 
 model BillingReceipt {
   id                     String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  subscriptionId         String          @db.Uuid
+  // Nullable: NULL marks an unmatched-drop receipt — a verified provider
+  // notification that matched no Subscription row at receipt time
+  // (applyNotification's unknown_subscription path). Matched receipts always
+  // carry the subscription id.
+  subscriptionId         String?         @db.Uuid
   provider               BillingProvider
   // Explicit dedupe key. Apple verify rows use `apple-verify:{transactionId}`;
   // Apple S2S rows use `apple-ssn:{notificationUUID}`; Google verify rows use
@@ -470,16 +474,26 @@ model BillingReceipt {
   transactionId          String
   notificationType       String
   notificationSubtype    String?
+  // Provider-side subscription identity for unmatched-drop receipts
+  // (subscriptionId IS NULL): Apple originalTransactionId / Google
+  // purchaseToken. NULL on matched receipts — their identity lives on the
+  // Subscription row. Makes "notifications arriving for subs we don't know"
+  // queryable and joinable back once the subscription appears.
+  providerSubscriptionId String?
   // Raw payload from the provider — Apple JWS or the Google purchase JSON /
   // RTDN envelope. Kept for audit + replay.
   signedPayload          String          @db.Text
   receivedAt             DateTime        @default(now())
 
-  subscription Subscription @relation(fields: [subscriptionId], references: [id])
+  // onDelete pinned to Restrict: the optional relation would otherwise default
+  // to SetNull, and the live constraint (from 20260515093120) is RESTRICT —
+  // receipts must keep blocking Subscription row deletion (audit anchor).
+  subscription Subscription? @relation(fields: [subscriptionId], references: [id], onDelete: Restrict)
 
   @@index([transactionId])
   @@index([provider, transactionId])
   @@index([subscriptionId, receivedAt])
+  @@index([providerSubscriptionId])
 }
 
 model TelemetryBatch {

--- a/src/api/v2/subscriptions/handlers/apple-ssn.ts
+++ b/src/api/v2/subscriptions/handlers/apple-ssn.ts
@@ -27,10 +27,24 @@ const bodySchema = z
  * (duplicate Apple notificationUUID) and unknown_subscription both ack 200 —
  * Apple has no need to retry; either the dupe was harmless or our verify
  * endpoint will eventually create the Subscription row.
+ *
+ * Observability — stable log events (log-explorer / monitor contract; see
+ * docs/observability/subscription-notifications.md before renaming):
+ *   - `subscription.ssn.received`: a signature-verified delivery arrived
+ *     (fires after the outer JWS verifies, so unverifiable garbage on this
+ *     unauthenticated endpoint doesn't count as feed traffic).
+ *   - `subscription.ssn.applied`: a state change was applied (or replayed).
+ *   - `subscription.ssn.dropped`: the delivery produced no state change;
+ *     carries `reason` plus every identifier available at the drop point
+ *     (notificationType/notificationSubtype/notificationUUID/
+ *     originalTransactionId). reason=unknown_subscription drops are also
+ *     persisted as BillingReceipt rows with subscriptionId NULL.
+ * The 500 path is neither applied nor dropped — Apple retries it.
  */
 export async function appleSsnHandler(req: Request, res: Response) {
   const parsed = bodySchema.safeParse(req.body);
   if (!parsed.success) {
+    req.log.warn({ reason: "invalid_body" }, "subscription.ssn.dropped");
     res.status(400).json({ error: "Invalid request body" });
     return;
   }
@@ -49,6 +63,7 @@ export async function appleSsnHandler(req: Request, res: Response) {
     // signature failure (1).
     req.log.warn(
       {
+        reason: "invalid_notification_signature",
         errName: err instanceof Error ? err.constructor.name : undefined,
         errStatus: (err as { status?: number } | undefined)?.status,
         errMessage: err instanceof Error ? err.message : String(err),
@@ -61,17 +76,33 @@ export async function appleSsnHandler(req: Request, res: Response) {
             ? err.cause.message
             : undefined,
       },
-      "Apple S2S notification JWS verification failed",
+      "subscription.ssn.dropped",
     );
     res.status(400).json({ error: "Invalid signed notification" });
     return;
   }
 
+  // Feed-liveness marker: one per signature-verified delivery, regardless of
+  // what processing decides below (received = applied + dropped-after-verify).
+  req.log.info(
+    {
+      notificationType: notification.notificationType,
+      notificationSubtype: notification.subtype,
+      notificationUUID: notification.notificationUUID,
+      environment: notification.data?.environment,
+    },
+    "subscription.ssn.received",
+  );
+
   const notificationUUID = notification.notificationUUID;
   if (!notificationUUID) {
     req.log.warn(
-      { notificationType: notification.notificationType },
-      "Apple S2S notification missing notificationUUID",
+      {
+        reason: "missing_notification_uuid",
+        notificationType: notification.notificationType,
+        notificationSubtype: notification.subtype,
+      },
+      "subscription.ssn.dropped",
     );
     res.status(400).json({ error: "Malformed notification payload" });
     return;
@@ -83,10 +114,12 @@ export async function appleSsnHandler(req: Request, res: Response) {
     // We don't act on those today; ack so Apple stops retrying.
     req.log.info(
       {
+        reason: "no_transaction",
         notificationType: notification.notificationType,
-        notificationUUID: notification.notificationUUID,
+        notificationSubtype: notification.subtype,
+        notificationUUID,
       },
-      "Apple S2S notification has no transaction — skipping",
+      "subscription.ssn.dropped",
     );
     res.status(200).json({ ok: true, skipped: "no_transaction" });
     return;
@@ -98,6 +131,7 @@ export async function appleSsnHandler(req: Request, res: Response) {
   } catch (err) {
     req.log.warn(
       {
+        reason: "invalid_transaction_signature",
         errName: err instanceof Error ? err.constructor.name : undefined,
         errStatus: (err as { status?: number } | undefined)?.status,
         errMessage: err instanceof Error ? err.message : String(err),
@@ -109,9 +143,11 @@ export async function appleSsnHandler(req: Request, res: Response) {
           err instanceof Error && err.cause instanceof Error
             ? err.cause.message
             : undefined,
-        notificationUUID: notification.notificationUUID,
+        notificationType: notification.notificationType,
+        notificationSubtype: notification.subtype,
+        notificationUUID,
       },
-      "Apple S2S inner transaction JWS verification failed",
+      "subscription.ssn.dropped",
     );
     res.status(400).json({ error: "Invalid signed transaction" });
     return;
@@ -121,8 +157,15 @@ export async function appleSsnHandler(req: Request, res: Response) {
   const transactionId = transaction.transactionId;
   if (!originalTransactionId || !transactionId) {
     req.log.warn(
-      { notificationUUID: notification.notificationUUID },
-      "Apple S2S transaction missing originalTransactionId/transactionId",
+      {
+        reason: "missing_transaction_ids",
+        notificationType: notification.notificationType,
+        notificationSubtype: notification.subtype,
+        notificationUUID,
+        originalTransactionId,
+        transactionId,
+      },
+      "subscription.ssn.dropped",
     );
     res.status(400).json({ error: "Malformed transaction payload" });
     return;
@@ -135,12 +178,17 @@ export async function appleSsnHandler(req: Request, res: Response) {
   });
 
   if (!update) {
+    // TEST / CONSUMPTION_REQUEST / unknown types — no state change implied.
     req.log.info(
       {
+        reason: "no_actionable_update",
         notificationType: notification.notificationType,
-        notificationUUID: notification.notificationUUID,
+        notificationSubtype: notification.subtype,
+        notificationUUID,
+        originalTransactionId,
+        transactionId,
       },
-      "Apple S2S notification has no actionable state change — acking",
+      "subscription.ssn.dropped",
     );
     res.status(200).json({ ok: true, applied: false });
     return;
@@ -159,14 +207,23 @@ export async function appleSsnHandler(req: Request, res: Response) {
     });
 
     if (result.kind === "unknown_subscription") {
-      // SUBSCRIBED before verify? verify hasn't run yet — drop. The client
-      // will hit /verify shortly and bootstrap the row from its own JWS.
-      req.log.info(
+      // SUBSCRIBED before verify? verify hasn't run yet — drop and ack; the
+      // client will hit /verify shortly and bootstrap the row from its own
+      // JWS. A drop receipt (BillingReceipt, subscriptionId NULL) was
+      // persisted by applyNotification so the delivery stays auditable —
+      // this is the primary DB signal for "SSNs arriving for subs we don't
+      // know" (orphaned/never-verified subscriptions).
+      req.log.warn(
         {
-          originalTransactionId,
+          reason: "unknown_subscription",
           notificationType: notification.notificationType,
+          notificationSubtype: notification.subtype,
+          notificationUUID,
+          originalTransactionId,
+          transactionId,
+          receiptRecorded: result.receiptRecorded,
         },
-        "Apple S2S notification for unknown subscription — acking (verify will create)",
+        "subscription.ssn.dropped",
       );
       res.status(200).json({ ok: true, applied: false });
       return;
@@ -186,6 +243,7 @@ export async function appleSsnHandler(req: Request, res: Response) {
         notificationUUID,
         originalTransactionId,
         transactionId,
+        environment: notification.data?.environment,
         accountId: result.subscription.accountId,
         subscriptionStatus: result.subscription.status,
         replayed: result.kind === "replayed",

--- a/src/api/v2/subscriptions/handlers/google-play-rtdn.ts
+++ b/src/api/v2/subscriptions/handlers/google-play-rtdn.ts
@@ -218,11 +218,13 @@ export async function googlePlayRtdnHandler(req: Request, res: Response) {
     if (result.kind === "unknown_subscription") {
       // SUBSCRIPTION_PURCHASED before verify, or a notification whose
       // purchaseToken our row hasn't been linked to yet. Ack; /verify will
-      // create or refresh the row.
+      // create or refresh the row. A drop receipt (BillingReceipt with
+      // subscriptionId NULL) was persisted by applyNotification for audit.
       req.log.info(
         {
           messageId: message.messageId,
           notificationType: sub.notificationType,
+          receiptRecorded: result.receiptRecorded,
         },
         "play.rtdn.unknown_subscription — acking",
       );

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -829,11 +829,10 @@ const notificationProviderSubscriptionId = (
  * externalNotificationId — both derive from the same provider id) means this
  * delivery was already recorded → receiptRecorded: false.
  *
- * Note: because the drop receipt claims the notification's idempotencyKey, a
- * provider retry of the SAME notification arriving after /verify has created
- * the Subscription row resolves as "replayed" (receipt exists) rather than
- * re-applying state. That matches the ack semantics: the original delivery
- * was 200-acked, and /verify bootstraps current state from its own JWS.
+ * A provider retry of the SAME notification arriving after /verify has
+ * created the Subscription row is NOT lost: the apply path claims the drop
+ * receipt (guarded update from subscriptionId NULL) and applies the state
+ * change — see the adoption step in applyNotification.
  */
 const recordDroppedNotification = async (
   input: ApplyNotificationInput,
@@ -888,129 +887,169 @@ export const applyNotification = async (
 
   const receiptShape = notificationReceiptShape(input);
 
-  try {
-    return await prisma.$transaction(async (tx) => {
-      // Lock the row FIRST — before the receipt insert, whose Subscription FK
-      // takes a KEY SHARE lock. Requesting FOR UPDATE ahead of that avoids a
-      // KEY-SHARE→FOR-UPDATE upgrade deadlock between two concurrent
-      // notifications for the same subscription, and gives the staleness guard +
-      // renewal forfeit a serialized read of the TRUE current period rather than
-      // the pre-tx `subscription` snapshot a concurrent renewal may have
-      // superseded.
-      const locked = await lockSubscriptionPeriod(tx, subscription.id);
+  // Attempt 0 + at most one retry: the retry fires only when a P2002 exposes
+  // a concurrently-committed DROP receipt for this notification (see the
+  // catch below) — the second attempt's adoption claim then wins.
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await prisma.$transaction(async (tx) => {
+        // Lock the row FIRST — before the receipt insert, whose Subscription FK
+        // takes a KEY SHARE lock. Requesting FOR UPDATE ahead of that avoids a
+        // KEY-SHARE→FOR-UPDATE upgrade deadlock between two concurrent
+        // notifications for the same subscription, and gives the staleness guard +
+        // renewal forfeit a serialized read of the TRUE current period rather than
+        // the pre-tx `subscription` snapshot a concurrent renewal may have
+        // superseded.
+        const locked = await lockSubscriptionPeriod(tx, subscription.id);
 
-      await tx.billingReceipt.create({
-        data: {
-          subscriptionId: subscription.id,
-          provider: input.provider,
-          idempotencyKey: receiptShape.idempotencyKey,
-          externalNotificationId: receiptShape.externalNotificationId,
-          transactionId: receiptShape.transactionId,
-          notificationType: input.notificationType,
-          notificationSubtype: input.notificationSubtype ?? null,
-          signedPayload: input.signedPayload,
-        },
-      });
+        // ADOPTION of drop receipts: if this same notification previously
+        // arrived while the Subscription row didn't exist yet, it was persisted
+        // as a drop receipt (subscriptionId NULL) and 200-acked. A provider
+        // retry landing AFTER /verify created the row must APPLY, not resolve
+        // as "replayed" — otherwise the state change is swallowed forever. The
+        // guarded updateMany claims the drop receipt atomically (row lock +
+        // re-checked WHERE make exactly one concurrent claimer win; losers fall
+        // through to create → P2002 → outer catch → adoption retry or replayed).
+        const claimed = await tx.billingReceipt.updateMany({
+          where: {
+            idempotencyKey: receiptShape.idempotencyKey,
+            subscriptionId: null,
+          },
+          data: { subscriptionId: subscription.id },
+        });
+        if (claimed.count === 0) {
+          await tx.billingReceipt.create({
+            data: {
+              subscriptionId: subscription.id,
+              provider: input.provider,
+              idempotencyKey: receiptShape.idempotencyKey,
+              externalNotificationId: receiptShape.externalNotificationId,
+              transactionId: receiptShape.transactionId,
+              notificationType: input.notificationType,
+              notificationSubtype: input.notificationSubtype ?? null,
+              signedPayload: input.signedPayload,
+            },
+          });
+        }
 
-      // STALENESS GUARD (mirrors verify's `isStaleVerify`, repository.ts ~388):
-      // a valid but OUT-OF-ORDER notification — e.g. an EXPIRED/REVOKE for a
-      // period a later renewal already superseded — must not roll the
-      // subscription's entitlement window/status backwards NOR forfeit the
-      // now-active period. Skipping only the forfeit is insufficient: the stale
-      // update would still write a terminal status over the renewed active row.
-      // So we skip the ENTIRE state-apply (update + grant + forfeit) when the
-      // notification's own period end predates the stored one. The receipt is
-      // already recorded above, preserving idempotency/audit. The terminal
-      // mapping cases now carry `currentPeriodEnd` (from the JWS transaction's
-      // expiresDate / the refreshed Play purchase) precisely so this guard has a
-      // period to compare; updates that omit it (no period drift possible) fall
-      // through and apply as before.
-      if (
-        locked !== null &&
-        input.update.currentPeriodEnd !== undefined &&
-        input.update.currentPeriodEnd.getTime() <
-          locked.currentPeriodEnd.getTime()
-      ) {
-        // Stale/out-of-order: skip the state-apply, but return the row's CURRENT
-        // committed state — a concurrent renewal may have advanced it since the
-        // pre-lock `notificationLookup` snapshot.
-        const current = await tx.subscription.findUnique({
-          where: { id: subscription.id },
-        });
-        return {
-          kind: "applied" as const,
-          subscription: current ?? subscription,
-        };
-      }
-
-      const updated = await tx.subscription.update({
-        where: { id: subscription.id },
-        data: input.update,
-      });
-
-      // Single-ledger money-in / money-out, transactional with the state update.
-      if (
-        updated.status === SubscriptionStatus.expired ||
-        updated.status === SubscriptionStatus.revoked
-      ) {
-        // Expiry / refund / revoke → bounded clawback of the unused
-        // subscription portion. Cancel-while-active never reaches here: it
-        // only flips willRenew (status stays active), so credits stay to the
-        // period end. Idempotent per (subscription, periodStart). Stale
-        // out-of-order terminal events were already short-circuited by the
-        // staleness guard above, so this only fires for the current period
-        // (natural expiry or a legitimate mid-period refund/revoke). Forfeit the
-        // LOCKED current period — the one the sub is actually in.
-        await forfeitSubscriptionPeriod(tx, {
-          subscription: updated,
-          periodStart: locked?.currentPeriodStart ?? updated.currentPeriodStart,
-        });
-      } else if (
-        isEntitledSubscriptionStatus(updated.status) &&
-        locked !== null &&
-        updated.currentPeriodStart.getTime() >
-          locked.currentPeriodStart.getTime()
-      ) {
-        // A renewal advanced the period start past the LOCKED current one →
-        // forfeit the period the row actually advanced FROM (read under the row
-        // lock, so a concurrent renewal that already advanced is seen), bounding
-        // its consumes to spends made before the new period began, then grant the
-        // new period. A grace/billing-retry that keeps the same period does not
-        // advance `locked`, so it neither forfeits nor re-grants. The per-period
-        // forfeit key + the row lock make a racing verify for the same advance
-        // resolve to exactly one forfeit and one grant.
-        await forfeitSubscriptionPeriod(tx, {
-          subscription: updated,
-          periodStart: locked.currentPeriodStart,
-          consumesUntil: updated.currentPeriodStart,
-        });
-        const grantResult = await grantSubscriptionPeriod(tx, {
-          subscription: updated,
-          periodStart: updated.currentPeriodStart,
-        });
-        if (grantResult.kind === "granted") {
+        // STALENESS GUARD (mirrors verify's `isStaleVerify`, repository.ts ~388):
+        // a valid but OUT-OF-ORDER notification — e.g. an EXPIRED/REVOKE for a
+        // period a later renewal already superseded — must not roll the
+        // subscription's entitlement window/status backwards NOR forfeit the
+        // now-active period. Skipping only the forfeit is insufficient: the stale
+        // update would still write a terminal status over the renewed active row.
+        // So we skip the ENTIRE state-apply (update + grant + forfeit) when the
+        // notification's own period end predates the stored one. The receipt is
+        // already recorded above, preserving idempotency/audit. The terminal
+        // mapping cases now carry `currentPeriodEnd` (from the JWS transaction's
+        // expiresDate / the refreshed Play purchase) precisely so this guard has a
+        // period to compare; updates that omit it (no period drift possible) fall
+        // through and apply as before.
+        if (
+          locked !== null &&
+          input.update.currentPeriodEnd !== undefined &&
+          input.update.currentPeriodEnd.getTime() <
+            locked.currentPeriodEnd.getTime()
+        ) {
+          // Stale/out-of-order: skip the state-apply, but return the row's CURRENT
+          // committed state — a concurrent renewal may have advanced it since the
+          // pre-lock `notificationLookup` snapshot.
+          const current = await tx.subscription.findUnique({
+            where: { id: subscription.id },
+          });
           return {
             kind: "applied" as const,
-            subscription: grantResult.subscription,
+            subscription: current ?? subscription,
           };
         }
-      }
 
-      return { kind: "applied" as const, subscription: updated };
-    });
-  } catch (err) {
-    if (
-      err instanceof Prisma.PrismaClientKnownRequestError &&
-      err.code === "P2002"
-    ) {
-      const current = await prisma.subscription.findUnique({
-        where: { id: subscription.id },
+        const updated = await tx.subscription.update({
+          where: { id: subscription.id },
+          data: input.update,
+        });
+
+        // Single-ledger money-in / money-out, transactional with the state update.
+        if (
+          updated.status === SubscriptionStatus.expired ||
+          updated.status === SubscriptionStatus.revoked
+        ) {
+          // Expiry / refund / revoke → bounded clawback of the unused
+          // subscription portion. Cancel-while-active never reaches here: it
+          // only flips willRenew (status stays active), so credits stay to the
+          // period end. Idempotent per (subscription, periodStart). Stale
+          // out-of-order terminal events were already short-circuited by the
+          // staleness guard above, so this only fires for the current period
+          // (natural expiry or a legitimate mid-period refund/revoke). Forfeit the
+          // LOCKED current period — the one the sub is actually in.
+          await forfeitSubscriptionPeriod(tx, {
+            subscription: updated,
+            periodStart:
+              locked?.currentPeriodStart ?? updated.currentPeriodStart,
+          });
+        } else if (
+          isEntitledSubscriptionStatus(updated.status) &&
+          locked !== null &&
+          updated.currentPeriodStart.getTime() >
+            locked.currentPeriodStart.getTime()
+        ) {
+          // A renewal advanced the period start past the LOCKED current one →
+          // forfeit the period the row actually advanced FROM (read under the row
+          // lock, so a concurrent renewal that already advanced is seen), bounding
+          // its consumes to spends made before the new period began, then grant the
+          // new period. A grace/billing-retry that keeps the same period does not
+          // advance `locked`, so it neither forfeits nor re-grants. The per-period
+          // forfeit key + the row lock make a racing verify for the same advance
+          // resolve to exactly one forfeit and one grant.
+          await forfeitSubscriptionPeriod(tx, {
+            subscription: updated,
+            periodStart: locked.currentPeriodStart,
+            consumesUntil: updated.currentPeriodStart,
+          });
+          const grantResult = await grantSubscriptionPeriod(tx, {
+            subscription: updated,
+            periodStart: updated.currentPeriodStart,
+          });
+          if (grantResult.kind === "granted") {
+            return {
+              kind: "applied" as const,
+              subscription: grantResult.subscription,
+            };
+          }
+        }
+
+        return { kind: "applied" as const, subscription: updated };
       });
-      if (current) {
-        return { kind: "replayed", subscription: current };
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002"
+      ) {
+        // The conflict may come from a DROP receipt committed by a concurrent
+        // unknown-path delivery of this same notification AFTER our adoption
+        // claim ran (the uncommitted insert was invisible to updateMany, then
+        // our create lost the unique race). Re-read: if the receipt is still
+        // unmatched, retry once — the claim now sees the committed row and
+        // wins, so the state change is applied instead of being swallowed as
+        // a replay. Any other P2002 (receipt already matched) is a true
+        // provider replay.
+        if (attempt === 0) {
+          const conflicting = await prisma.billingReceipt.findUnique({
+            where: { idempotencyKey: receiptShape.idempotencyKey },
+            select: { subscriptionId: true },
+          });
+          if (conflicting !== null && conflicting.subscriptionId === null) {
+            continue;
+          }
+        }
+        const current = await prisma.subscription.findUnique({
+          where: { id: subscription.id },
+        });
+        if (current) {
+          return { kind: "replayed", subscription: current };
+        }
       }
+      throw err;
     }
-    throw err;
   }
 };
 

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -431,32 +431,40 @@ export const upsertFromVerify = async (
         // elapsed, and effectiveSubscriptionStatus resolves them to `expired`.
         // Backfilling a full period grant for such a LAPSED period would mint
         // credits that credits-get simultaneously frames as free-tier state.
+        // `subscription` is null only on drop receipts (`apple-ssn:*` /
+        // `play-rtdn:*` keys, subscriptionId NULL) — a verify idempotencyKey
+        // (`apple-verify:*` / `play-verify:*`) can never collide with those,
+        // so this narrows away an impossible state. If it ever DID happen,
+        // falling through to the create path is safe: the receipt insert
+        // below would P2002 and resolve via the outer conflict handler.
         const replayed = existingReceipt.subscription;
-        const isStaleReplay =
-          input.currentPeriodEnd < replayed.currentPeriodEnd;
-        if (!isStaleReplay && isEntitledSubscription(replayed)) {
-          const currentPeriodGrant = await tx.creditLedger.findUnique({
-            where: {
-              accountId_idempotencyKey: {
-                accountId: replayed.accountId,
-                idempotencyKey: subGrantKey(
-                  replayed.id,
-                  replayed.currentPeriodStart,
-                ),
+        if (replayed) {
+          const isStaleReplay =
+            input.currentPeriodEnd < replayed.currentPeriodEnd;
+          if (!isStaleReplay && isEntitledSubscription(replayed)) {
+            const currentPeriodGrant = await tx.creditLedger.findUnique({
+              where: {
+                accountId_idempotencyKey: {
+                  accountId: replayed.accountId,
+                  idempotencyKey: subGrantKey(
+                    replayed.id,
+                    replayed.currentPeriodStart,
+                  ),
+                },
               },
-            },
-          });
-          if (!currentPeriodGrant) {
-            await grantSubscriptionPeriod(tx, {
-              subscription: replayed,
-              periodStart: replayed.currentPeriodStart,
             });
+            if (!currentPeriodGrant) {
+              await grantSubscriptionPeriod(tx, {
+                subscription: replayed,
+                periodStart: replayed.currentPeriodStart,
+              });
+            }
           }
+          return {
+            subscription: replayed,
+            receiptCreated: false,
+          };
         }
-        return {
-          subscription: replayed,
-          receiptCreated: false,
-        };
       }
 
       // Lock the row for the rest of the tx and read its TRUE current period, so
@@ -771,7 +779,11 @@ export type ApplyNotificationInput =
 export type ApplyNotificationResult =
   | { kind: "replayed"; subscription: Subscription }
   | { kind: "applied"; subscription: Subscription }
-  | { kind: "unknown_subscription" };
+  // No Subscription row matched the provider identifier. A drop receipt
+  // (BillingReceipt with subscriptionId NULL) is persisted so the delivery is
+  // auditable from the DB; `receiptRecorded` is false when this notification
+  // was already recorded (provider retry of an already-acked delivery).
+  | { kind: "unknown_subscription"; receiptRecorded: boolean };
 
 const notificationLookup = (
   input: ApplyNotificationInput,
@@ -797,11 +809,68 @@ const notificationReceiptShape = (input: ApplyNotificationInput) => {
   };
 };
 
+// Provider-side subscription identity carried by a notification — what the
+// row WOULD have been looked up by (mirrors notificationLookup). Recorded on
+// drop receipts so unmatched deliveries can be grouped/joined later.
+const notificationProviderSubscriptionId = (
+  input: ApplyNotificationInput,
+): string =>
+  input.provider === BillingProvider.apple
+    ? input.originalTransactionId
+    : input.purchaseToken;
+
+/**
+ * Persist an unmatched provider notification as a drop receipt: a
+ * BillingReceipt with subscriptionId NULL, keyed by the same
+ * idempotencyKey/externalNotificationId a matched receipt would use. Makes
+ * "notifications arriving for subscriptions we don't know" queryable
+ * (`WHERE "subscriptionId" IS NULL`) instead of log-only. Idempotent on the
+ * notification identity: a P2002 on either unique (idempotencyKey or
+ * externalNotificationId — both derive from the same provider id) means this
+ * delivery was already recorded → receiptRecorded: false.
+ *
+ * Note: because the drop receipt claims the notification's idempotencyKey, a
+ * provider retry of the SAME notification arriving after /verify has created
+ * the Subscription row resolves as "replayed" (receipt exists) rather than
+ * re-applying state. That matches the ack semantics: the original delivery
+ * was 200-acked, and /verify bootstraps current state from its own JWS.
+ */
+const recordDroppedNotification = async (
+  input: ApplyNotificationInput,
+): Promise<{ receiptRecorded: boolean }> => {
+  const receiptShape = notificationReceiptShape(input);
+  try {
+    await prisma.billingReceipt.create({
+      data: {
+        subscriptionId: null,
+        provider: input.provider,
+        idempotencyKey: receiptShape.idempotencyKey,
+        externalNotificationId: receiptShape.externalNotificationId,
+        transactionId: receiptShape.transactionId,
+        notificationType: input.notificationType,
+        notificationSubtype: input.notificationSubtype ?? null,
+        providerSubscriptionId: notificationProviderSubscriptionId(input),
+        signedPayload: input.signedPayload,
+      },
+    });
+    return { receiptRecorded: true };
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return { receiptRecorded: false };
+    }
+    throw err;
+  }
+};
+
 /**
  * Apply a provider notification atomically:
  *   1. Look up the subscription by provider-specific identifier. If unknown,
- *      return "unknown_subscription" — the caller decides how to recover
- *      (typically ack and let /verify create the row).
+ *      persist a drop receipt (subscriptionId NULL) and return
+ *      "unknown_subscription" — the caller decides how to recover (typically
+ *      ack and let /verify create the row).
  *   2. Insert the BillingReceipt row keyed on the provider's external
  *      notification id. A P2002 unique violation means the provider retried
  *      the same notification — we return "replayed" with the current sub
@@ -813,7 +882,8 @@ export const applyNotification = async (
 ): Promise<ApplyNotificationResult> => {
   const subscription = await notificationLookup(input);
   if (!subscription) {
-    return { kind: "unknown_subscription" };
+    const { receiptRecorded } = await recordDroppedNotification(input);
+    return { kind: "unknown_subscription", receiptRecorded };
   }
 
   const receiptShape = notificationReceiptShape(input);

--- a/src/subscriptions/repository.ts
+++ b/src/subscriptions/repository.ts
@@ -1020,9 +1020,18 @@ export const applyNotification = async (
         return { kind: "applied" as const, subscription: updated };
       });
     } catch (err) {
+      // Only a BillingReceipt idempotencyKey conflict may resolve to
+      // adoption-retry/replay. Any other P2002 — in particular CreditLedger's
+      // (accountId, idempotencyKey) from grantSubscriptionPeriod /
+      // forfeitSubscriptionPeriod racing inside this tx — MUST rethrow
+      // (mirrors the verify path's guard): the tx rolled back receipt AND
+      // state update, so acking it as "replayed" would silently lose the
+      // notification (the provider stops retrying on 200). Rethrowing 500s
+      // the webhook and the provider redelivers.
       if (
         err instanceof Prisma.PrismaClientKnownRequestError &&
-        err.code === "P2002"
+        err.code === "P2002" &&
+        isBillingReceiptIdempotencyConflict(err)
       ) {
         // The conflict may come from a DROP receipt committed by a concurrent
         // unknown-path delivery of this same notification AFTER our adoption
@@ -1030,7 +1039,7 @@ export const applyNotification = async (
         // our create lost the unique race). Re-read: if the receipt is still
         // unmatched, retry once — the claim now sees the committed row and
         // wins, so the state change is applied instead of being swallowed as
-        // a replay. Any other P2002 (receipt already matched) is a true
+        // a replay. A conflict on an already-matched receipt is a true
         // provider replay.
         if (attempt === 0) {
           const conflicting = await prisma.billingReceipt.findUnique({

--- a/tests/subscriptions/apple-ssn.test.ts
+++ b/tests/subscriptions/apple-ssn.test.ts
@@ -38,6 +38,41 @@ const makeApp = () => {
   return app;
 };
 
+type LogRecord = {
+  level: "info" | "warn" | "error";
+  fields: Record<string, unknown>;
+  msg: string;
+};
+
+/**
+ * Same app, but req.log records every call so tests can assert the stable
+ * lifecycle events (subscription.ssn.received / applied / dropped) and their
+ * fields — they are a log-explorer/monitor contract.
+ */
+const makeAppWithLogCapture = (records: LogRecord[]) => {
+  const app = express();
+  app.use(pinoMiddleware);
+  app.use((req, _res, next) => {
+    const capture =
+      (level: LogRecord["level"]) => (fields: unknown, msg?: string) => {
+        records.push({
+          level,
+          fields: (fields ?? {}) as Record<string, unknown>,
+          msg: msg ?? "",
+        });
+      };
+    req.log = {
+      info: capture("info"),
+      warn: capture("warn"),
+      error: capture("error"),
+    } as unknown as typeof req.log;
+    next();
+  });
+  app.use(json());
+  app.use("/v2/webhooks/apple", appleWebhookRouter);
+  return app;
+};
+
 const installLocalTestingVerifier = () => {
   const verifier = new SignedDataVerifier(
     [],
@@ -58,7 +93,18 @@ const newAccount = async () => {
   return account.id;
 };
 
+// Drop receipts (unknown-subscription notifications) have subscriptionId
+// NULL, so the account-scoped receipt wipe below can't reach them. Tests that
+// exercise the drop path register their notificationUUIDs here.
+const dropNotificationUUIDs: string[] = [];
+
 const wipe = async () => {
+  if (dropNotificationUUIDs.length > 0) {
+    await prisma.billingReceipt.deleteMany({
+      where: { externalNotificationId: { in: dropNotificationUUIDs } },
+    });
+    dropNotificationUUIDs.length = 0;
+  }
   if (createdAccountIds.length === 0) return;
   await prisma.billingReceipt.deleteMany({
     where: { subscription: { accountId: { in: createdAccountIds } } },
@@ -479,10 +525,13 @@ describe("POST /v2/webhooks/apple/ssn", () => {
     );
   });
 
-  test("unknown subscription: acks 200, no row created", async () => {
+  test("unknown subscription: acks 200, no Subscription row, drop receipt persisted", async () => {
     installLocalTestingVerifier();
+    const uuid = "aaaaaaaa-0000-0000-0000-000000000080";
+    dropNotificationUUIDs.push(uuid);
     const signedPayload = await signNotification({
       notificationType: "DID_RENEW",
+      notificationUUID: uuid,
       signedTransactionInfo: await signTransaction({
         originalTransactionId: "9999999999999999",
         transactionId: "3000000000000080",
@@ -499,6 +548,176 @@ describe("POST /v2/webhooks/apple/ssn", () => {
       where: { originalTransactionId: "9999999999999999" },
     });
     expect(rows).toHaveLength(0);
+
+    // The dropped delivery is auditable from the DB: an unmatched
+    // BillingReceipt (subscriptionId NULL) carrying the OTX.
+    const receipt = await prisma.billingReceipt.findUnique({
+      where: { idempotencyKey: `apple-ssn:${uuid}` },
+    });
+    expect(receipt).not.toBeNull();
+    expect(receipt?.subscriptionId).toBeNull();
+    expect(receipt?.provider).toBe(BillingProvider.apple);
+    expect(receipt?.providerSubscriptionId).toBe("9999999999999999");
+    expect(receipt?.transactionId).toBe("3000000000000080");
+    expect(receipt?.notificationType).toBe("DID_RENEW");
+    expect(receipt?.externalNotificationId).toBe(uuid);
+  });
+
+  test("unknown subscription replay (same notificationUUID): acks 200, exactly one drop receipt", async () => {
+    installLocalTestingVerifier();
+    const uuid = "aaaaaaaa-0000-0000-0000-000000000081";
+    dropNotificationUUIDs.push(uuid);
+    const signedPayload = await signNotification({
+      notificationType: "DID_RENEW",
+      notificationUUID: uuid,
+      signedTransactionInfo: await signTransaction({
+        originalTransactionId: "9999999999999998",
+        transactionId: "3000000000000081",
+      }),
+    });
+
+    const first = await request(makeApp())
+      .post("/v2/webhooks/apple/ssn")
+      .send({ signedPayload });
+    expect(first.status).toBe(200);
+
+    const replay = await request(makeApp())
+      .post("/v2/webhooks/apple/ssn")
+      .send({ signedPayload });
+    expect(replay.status).toBe(200);
+    expect((replay.body as AckBody).applied).toBe(false);
+
+    const receipts = await prisma.billingReceipt.findMany({
+      where: { externalNotificationId: uuid },
+    });
+    expect(receipts).toHaveLength(1);
+  });
+
+  test("log lifecycle: DID_RENEW emits ssn.received then ssn.applied with identifiers", async () => {
+    installLocalTestingVerifier();
+    const otid = "1000000000000110";
+    await seedSubscription(otid);
+
+    const purchaseDate = new Date();
+    const expiresDate = new Date(
+      purchaseDate.getTime() + 30 * 24 * 60 * 60 * 1000,
+    );
+    const uuid = "aaaaaaaa-0000-0000-0000-000000000110";
+    const signedPayload = await signNotification({
+      notificationType: "DID_RENEW",
+      notificationUUID: uuid,
+      signedTransactionInfo: await signTransaction({
+        originalTransactionId: otid,
+        transactionId: "3000000000000110",
+        purchaseDate: purchaseDate.getTime(),
+        expiresDate: expiresDate.getTime(),
+      }),
+    });
+
+    const records: LogRecord[] = [];
+    const res = await request(makeAppWithLogCapture(records))
+      .post("/v2/webhooks/apple/ssn")
+      .send({ signedPayload });
+    expect(res.status).toBe(200);
+
+    const received = records.find((r) => r.msg === "subscription.ssn.received");
+    expect(received).toBeDefined();
+    expect(received?.fields.notificationType).toBe("DID_RENEW");
+    expect(received?.fields.notificationUUID).toBe(uuid);
+
+    const applied = records.find((r) => r.msg === "subscription.ssn.applied");
+    expect(applied).toBeDefined();
+    expect(applied?.fields.originalTransactionId).toBe(otid);
+    expect(applied?.fields.transactionId).toBe("3000000000000110");
+    expect(applied?.fields.notificationUUID).toBe(uuid);
+    expect(applied?.fields.replayed).toBe(false);
+    expect(records.some((r) => r.msg === "subscription.ssn.dropped")).toBe(
+      false,
+    );
+  });
+
+  test("log lifecycle: unknown subscription emits ssn.dropped with reason + full identifiers", async () => {
+    installLocalTestingVerifier();
+    const uuid = "aaaaaaaa-0000-0000-0000-000000000120";
+    dropNotificationUUIDs.push(uuid);
+    const signedPayload = await signNotification({
+      notificationType: "DID_RENEW",
+      subtype: "BILLING_RECOVERY",
+      notificationUUID: uuid,
+      signedTransactionInfo: await signTransaction({
+        originalTransactionId: "9999999999999997",
+        transactionId: "3000000000000120",
+      }),
+    });
+
+    const records: LogRecord[] = [];
+    const res = await request(makeAppWithLogCapture(records))
+      .post("/v2/webhooks/apple/ssn")
+      .send({ signedPayload });
+    expect(res.status).toBe(200);
+
+    expect(records.some((r) => r.msg === "subscription.ssn.received")).toBe(
+      true,
+    );
+    const dropped = records.find((r) => r.msg === "subscription.ssn.dropped");
+    expect(dropped).toBeDefined();
+    expect(dropped?.level).toBe("warn");
+    expect(dropped?.fields.reason).toBe("unknown_subscription");
+    expect(dropped?.fields.notificationType).toBe("DID_RENEW");
+    expect(dropped?.fields.notificationSubtype).toBe("BILLING_RECOVERY");
+    expect(dropped?.fields.notificationUUID).toBe(uuid);
+    expect(dropped?.fields.originalTransactionId).toBe("9999999999999997");
+    expect(dropped?.fields.receiptRecorded).toBe(true);
+    expect(records.some((r) => r.msg === "subscription.ssn.applied")).toBe(
+      false,
+    );
+  });
+
+  test("log lifecycle: actionless TEST notification emits ssn.dropped reason=no_actionable_update, no receipt", async () => {
+    installLocalTestingVerifier();
+    const otid = "1000000000000130";
+    await seedSubscription(otid);
+    const uuid = "aaaaaaaa-0000-0000-0000-000000000130";
+    const signedPayload = await signNotification({
+      notificationType: "TEST",
+      notificationUUID: uuid,
+      signedTransactionInfo: await signTransaction({
+        originalTransactionId: otid,
+        transactionId: "3000000000000130",
+      }),
+    });
+
+    const records: LogRecord[] = [];
+    const res = await request(makeAppWithLogCapture(records))
+      .post("/v2/webhooks/apple/ssn")
+      .send({ signedPayload });
+    expect(res.status).toBe(200);
+
+    const dropped = records.find((r) => r.msg === "subscription.ssn.dropped");
+    expect(dropped?.fields.reason).toBe("no_actionable_update");
+    expect(dropped?.fields.originalTransactionId).toBe(otid);
+    // Actionless types are log-only: no drop receipt (the sub is known — only
+    // unknown_subscription drops are persisted).
+    const receipts = await prisma.billingReceipt.findMany({
+      where: { externalNotificationId: uuid },
+    });
+    expect(receipts).toHaveLength(0);
+  });
+
+  test("log lifecycle: unverifiable payload emits ssn.dropped reason=invalid_notification_signature, no received", async () => {
+    installLocalTestingVerifier();
+    const records: LogRecord[] = [];
+    const res = await request(makeAppWithLogCapture(records))
+      .post("/v2/webhooks/apple/ssn")
+      .send({ signedPayload: "not.a.jws" });
+    expect(res.status).toBe(400);
+
+    const dropped = records.find((r) => r.msg === "subscription.ssn.dropped");
+    expect(dropped?.fields.reason).toBe("invalid_notification_signature");
+    // received fires only for signature-verified deliveries.
+    expect(records.some((r) => r.msg === "subscription.ssn.received")).toBe(
+      false,
+    );
   });
 
   test("replay (same notificationUUID) does not re-apply state — second flip is ignored", async () => {

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { Prisma } from "@prisma/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { getBalance } from "@/payments";
-import { subGrantKey } from "@/subscriptions/grants";
+import { grantSubscriptionPeriod, subGrantKey } from "@/subscriptions/grants";
 import {
   applyNotification,
   BillingProvider,
@@ -17,6 +18,11 @@ import {
 } from "@/subscriptions/repository";
 import { tierGrant } from "@/subscriptions/tier-config";
 import { prisma } from "@/utils/prisma";
+
+// Spy-wrap the grants module (call-through by default) so a single test can
+// inject a CreditLedger unique-violation INSIDE applyNotification's real
+// transaction (the organic race is reachable only under concurrency).
+vi.mock("@/subscriptions/grants", { spy: true });
 
 const perPeriod = () =>
   tierGrant(SUBSCRIPTION_TIER_PLUS, SubscriptionPeriod.monthly).perPeriod;
@@ -792,6 +798,64 @@ describe("applyNotification", () => {
     // 4. A further retry is now a plain replay — state applied exactly once.
     const replay = await applyNotification(input);
     expect(replay.kind).toBe("replayed");
+  });
+
+  test("CreditLedger P2002 inside the tx is rethrown — not acked as a replay, no receipt written", async () => {
+    const accountId = await newAccount();
+    await upsertFromVerify(
+      verifyInput({
+        accountId,
+        originalTransactionId: "otid-ledger-conflict",
+        transactionId: "tx-ledger-conflict-1",
+      }),
+    );
+
+    // Inject a CreditLedger (accountId, idempotencyKey) unique violation from
+    // grantSubscriptionPeriod inside the real transaction (grants.ts
+    // pre-checks make the organic conflict reachable only under a
+    // concurrent same-period race). The catch MUST rethrow: the tx rolled
+    // back receipt AND state update, so acking it as "replayed" would
+    // silently lose the notification (the provider stops retrying on 200).
+    const ledgerConflict = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`accountId`,`idempotencyKey`)",
+      {
+        code: "P2002",
+        clientVersion: Prisma.prismaVersion.client,
+        meta: {
+          modelName: "CreditLedger",
+          target: ["accountId", "idempotencyKey"],
+        },
+      },
+    );
+    vi.mocked(grantSubscriptionPeriod).mockRejectedValueOnce(ledgerConflict);
+
+    // A real renewal (period advance) so the grant path actually runs.
+    await expect(
+      applyNotification({
+        provider: BillingProvider.apple,
+        originalTransactionId: "otid-ledger-conflict",
+        transactionId: "tx-ledger-conflict-2",
+        notificationUUID: "notif-ledger-conflict",
+        notificationType: "DID_RENEW",
+        signedPayload: "stub-ledger-conflict",
+        update: {
+          status: SubscriptionStatus.active,
+          currentPeriodStart: new Date("2026-06-01T00:00:00.000Z"),
+          currentPeriodEnd: new Date("2026-07-01T00:00:00.000Z"),
+        },
+      }),
+    ).rejects.toThrow(ledgerConflict);
+
+    // The aborted tx persisted nothing: no receipt row for this notification,
+    // and the subscription still sits in its pre-renewal period.
+    const receipt = await prisma.billingReceipt.findUnique({
+      where: { idempotencyKey: "apple-ssn:notif-ledger-conflict" },
+    });
+    expect(receipt).toBeNull();
+    const sub = await findAppleByOriginalTransactionId("otid-ledger-conflict");
+    expect(sub?.currentPeriodStart.toISOString()).toBe(
+      "2026-05-01T00:00:00.000Z",
+    );
   });
 
   test("unknown Play purchaseToken: drop receipt keyed on messageId, carries the token", async () => {

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -691,8 +691,20 @@ describe("findCurrentByAccountId", () => {
 });
 
 describe("applyNotification", () => {
-  test("returns unknown_subscription when originalTransactionId has no row", async () => {
-    const result = await applyNotification({
+  // Drop receipts have subscriptionId NULL, so the account-scoped wipe cannot
+  // reach them — clean up by the notification ids these tests use.
+  const dropNotificationIds: string[] = [];
+  afterEach(async () => {
+    if (dropNotificationIds.length === 0) return;
+    await prisma.billingReceipt.deleteMany({
+      where: { externalNotificationId: { in: dropNotificationIds } },
+    });
+    dropNotificationIds.length = 0;
+  });
+
+  test("unknown originalTransactionId: persists a drop receipt, idempotent on notificationUUID", async () => {
+    dropNotificationIds.push("notif-missing");
+    const input = {
       provider: BillingProvider.apple,
       originalTransactionId: "otid-missing",
       transactionId: "tx-missing",
@@ -700,8 +712,64 @@ describe("applyNotification", () => {
       notificationType: "DID_RENEW",
       signedPayload: "stub",
       update: { status: SubscriptionStatus.active },
+    } as const;
+
+    const result = await applyNotification(input);
+    expect(result).toEqual({
+      kind: "unknown_subscription",
+      receiptRecorded: true,
     });
-    expect(result.kind).toBe("unknown_subscription");
+
+    // The delivery is now auditable from the DB: an unmatched BillingReceipt
+    // carrying the provider-side subscription identity.
+    const receipt = await prisma.billingReceipt.findUnique({
+      where: { idempotencyKey: "apple-ssn:notif-missing" },
+    });
+    expect(receipt).not.toBeNull();
+    expect(receipt?.subscriptionId).toBeNull();
+    expect(receipt?.provider).toBe(BillingProvider.apple);
+    expect(receipt?.providerSubscriptionId).toBe("otid-missing");
+    expect(receipt?.externalNotificationId).toBe("notif-missing");
+    expect(receipt?.transactionId).toBe("tx-missing");
+    expect(receipt?.notificationType).toBe("DID_RENEW");
+    expect(receipt?.signedPayload).toBe("stub");
+
+    // Provider retry of the same notificationUUID: still unknown, no second
+    // row, receiptRecorded false.
+    const replay = await applyNotification(input);
+    expect(replay).toEqual({
+      kind: "unknown_subscription",
+      receiptRecorded: false,
+    });
+    const rows = await prisma.billingReceipt.findMany({
+      where: { externalNotificationId: "notif-missing" },
+    });
+    expect(rows).toHaveLength(1);
+  });
+
+  test("unknown Play purchaseToken: drop receipt keyed on messageId, carries the token", async () => {
+    dropNotificationIds.push("msg-missing");
+    const result = await applyNotification({
+      provider: BillingProvider.googlePlay,
+      purchaseToken: "token-missing",
+      playOrderId: "order-missing",
+      messageId: "msg-missing",
+      notificationType: "PLAY_2",
+      signedPayload: "stub-play",
+      update: { status: SubscriptionStatus.active },
+    });
+    expect(result).toEqual({
+      kind: "unknown_subscription",
+      receiptRecorded: true,
+    });
+
+    const receipt = await prisma.billingReceipt.findUnique({
+      where: { idempotencyKey: "play-rtdn:msg-missing" },
+    });
+    expect(receipt?.subscriptionId).toBeNull();
+    expect(receipt?.provider).toBe(BillingProvider.googlePlay);
+    expect(receipt?.providerSubscriptionId).toBe("token-missing");
+    expect(receipt?.transactionId).toBe("order-missing");
   });
 
   test("applies status update and records audit receipt", async () => {

--- a/tests/subscriptions/repository.test.ts
+++ b/tests/subscriptions/repository.test.ts
@@ -747,6 +747,53 @@ describe("applyNotification", () => {
     expect(rows).toHaveLength(1);
   });
 
+  test("drop receipt adoption: retry after verify creates the row applies the update and links the receipt", async () => {
+    dropNotificationIds.push("notif-adopt");
+    const input = {
+      provider: BillingProvider.apple,
+      originalTransactionId: "otid-adopt",
+      transactionId: "tx-adopt",
+      notificationUUID: "notif-adopt",
+      notificationType: "DID_FAIL_TO_RENEW",
+      notificationSubtype: "GRACE_PERIOD",
+      signedPayload: "stub-adopt",
+      update: {
+        status: SubscriptionStatus.grace,
+        gracePeriodEnd: new Date("2026-06-20T00:00:00.000Z"),
+      },
+    } as const;
+
+    // 1. Notification arrives before verify → dropped + drop receipt.
+    const dropped = await applyNotification(input);
+    expect(dropped.kind).toBe("unknown_subscription");
+
+    // 2. /verify bootstraps the Subscription row.
+    const accountId = await newAccount();
+    const { subscription } = await upsertFromVerify(
+      verifyInput({
+        accountId,
+        originalTransactionId: "otid-adopt",
+        transactionId: "tx-adopt-verify",
+      }),
+    );
+
+    // 3. Provider retry of the SAME notificationUUID must now APPLY (not be
+    //    swallowed as a replay of the drop) and claim the drop receipt.
+    const retried = await applyNotification(input);
+    expect(retried.kind).toBe("applied");
+    if (retried.kind === "applied") {
+      expect(retried.subscription.status).toBe(SubscriptionStatus.grace);
+    }
+    const receipt = await prisma.billingReceipt.findUnique({
+      where: { idempotencyKey: "apple-ssn:notif-adopt" },
+    });
+    expect(receipt?.subscriptionId).toBe(subscription.id);
+
+    // 4. A further retry is now a plain replay — state applied exactly once.
+    const replay = await applyNotification(input);
+    expect(replay.kind).toBe("replayed");
+  });
+
   test("unknown Play purchaseToken: drop receipt keyed on messageId, carries the token", async () => {
     dropNotificationIds.push("msg-missing");
     const result = await applyNotification({


### PR DESCRIPTION
## Why

This PR makes the SSN feed observable and a silent feed alertable, and makes dropped deliveries auditable from the DB.

## What

**1. Stable structured log events** in the Apple SSN handler (log-explorer/monitor contract):
- `subscription.ssn.received` — one per signature-verified delivery (fires post-JWS-verification so unauthenticated garbage doesn't count as feed traffic)
- `subscription.ssn.applied` — existing event, now also carries `environment` (sandbox canary vs production)
- `subscription.ssn.dropped` — every non-applied outcome, always with `reason` + `notificationType`/`notificationSubtype`/`notificationUUID`/`originalTransactionId` where they exist at the drop point

**2. Persisted unknown-subscription drops.** The unknown-OTX path previously acked 200 and wrote nothing — dropped deliveries were visible only in logs. They are now persisted as `BillingReceipt` rows with `subscriptionId NULL` and the provider identity in a new `providerSubscriptionId` column, idempotent on the existing `apple-ssn:{notificationUUID}` / `play-rtdn:{messageId}` unique key. "SSNs arriving for subs we don't know" is now queryable: `SELECT * FROM "BillingReceipt" WHERE "subscriptionId" IS NULL`. Applies to both Apple SSN and Play RTDN via the shared `applyNotification`.

Migration `20260729130500` (hand-written minimal SQL): `subscriptionId` DROP NOT NULL + `providerSubscriptionId` TEXT + index. FK stays `ON DELETE RESTRICT` (pinned in the schema — optional relations otherwise default to SetNull).

**Adoption semantics:** a provider retry of a dropped notification landing after `/verify` created the row APPLIES the state change and links the receipt (guarded claim of the NULL-subscription receipt inside the apply transaction, with a single bounded retry for the concurrent-commit window). No new money paths — grants/forfeits go through the existing idempotent helpers.

**3. Alert definitions** — `docs/observability/subscription-notifications.md`: event reference, paste-ready Datadog log filters, DB audit queries, and two monitors (Datadog UI steps + terraform snippets following `infrastructure/plans/convos/monitors.tf` conventions):
- **Silent feed:** zero `subscription.ssn.applied` in 26h ⇒ alert (valid from day one — the daily sandbox renewal canary guarantees ≥1 applied/day on a healthy feed)
- **Drop spike:** `subscription.ssn.dropped` count >5/h ⇒ alert (`@reason:unknown_subscription` = orphan signal)

## Adversarial review (codex, 2 rounds)

- **Fixed:** lost-update window when a provider retry of a dropped notification arrives after `/verify` created the row (drop-receipt adoption + bounded P2002 retry — final shape is the reviewer's prescribed fix; locking order and staleness-guard interaction confirmed sound).
- **Rejected:** `CREATE INDEX CONCURRENTLY` — BillingReceipt is near-empty in prod (zero SSNs until today) and Prisma applies migrations transactionally; revisit if the table grows.
- **Noted as pre-existing follow-up (not this PR):** the unauthenticated webhook parses bodies under the global 50 MB json limit; a route-scoped body cap would shrink the DoS surface.
- **Deferred:** barrier-controlled concurrency tests for the drop/verify race (sequential drop→verify→retry adoption path is covered).

## Tests

- Handler: drop receipt persisted + notificationUUID idempotency (single row on replay), lifecycle log events (received/applied/dropped fields incl. drop reasons), existing SSN suite intact
- Repository: unknown-drop persistence for both providers, adoption (drop → verify → retry applies exactly once, receipt linked, further retry = replay)
- Full suite: 1633 passed / 2 skipped; typecheck, eslint, prettier clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787920540&installation_model_id=20076&pr_number=394&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F394&signature=a5146bf4078389b731b1d0d775e89841d464ad0285fe9e337f5925b7c559736a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured observability for subscription notifications, including received, applied, and dropped events with categorized reasons.
  * Unmatched Apple and Google subscription notifications are now recorded for auditing and can be linked when the subscription is later identified.
  * Improved handling of duplicate and out-of-order notifications to prevent incorrect subscription updates.
  * Added monitoring guidance for silent feeds, drop spikes, and account mismatches.

* **Bug Fixes**
  * Improved replay handling and credit restoration for eligible verification retries.
  * Added clearer handling and reporting for invalid or incomplete notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Why
> 
> This PR makes the SSN feed observable and a silent feed alertable, and makes dropped deliveries auditable from the DB.
> 
> ## What
> 
> **1. Stable structured log events** in the Apple SSN handler (log-explorer/monitor contract):
> - `subscription.ssn.received` — one per signature-verified delivery (fires post-JWS-verification so unauthenticated garbage doesn't count as feed traffic)
> - `subscription.ssn.applied` — existing event, now also carries `environment` (sandbox canary vs production)
> - `subscription.ssn.dropped` — every non-applied outcome, always with `reason` + `notificationType`/`notificationSubtype`/`notificationUUID`/`originalTransactionId` where they exist at the drop point
> 
> **2. Persisted unknown-subscription drops.** The unknown-OTX path previously acked 200 and wrote nothing — dropped deliveries were visible only in logs. They are now persisted as `BillingReceipt` rows with `subscriptionId NULL` and the provider identity in a new `providerSubscriptionId` column, idempotent on the existing `apple-ssn:{notificationUUID}` / `play-rtdn:{messageId}` unique key. "SSNs arriving for subs we don't know" is now queryable: `SELECT * FROM "BillingReceipt" WHERE "subscriptionId" IS NULL`. Applies to both Apple SSN and Play RTDN via the shared `applyNotification`.
> 
> Migration `20260729130500` (hand-written minimal SQL): `subscriptionId` DROP NOT NULL + `providerSubscriptionId` TEXT + index. FK stays `ON DELETE RESTRICT` (pinned in the schema — optional relations otherwise default to SetNull).
> 
> **Adoption semantics:** a provider retry of a dropped notification landing after `/verify` created the row APPLIES the state change and links the receipt (guarded claim of the NULL-subscription receipt inside the apply transaction, with a single bounded retry for the concurrent-commit window). No new money paths — grants/forfeits go through the existing idempotent helpers.
> 
> **3. Alert definitions** — `docs/observability/subscription-notifications.md`: event reference, paste-ready Datadog log filters, DB audit queries, and two monitors (Datadog UI steps + terraform snippets following `infrastructure/plans/convos/monitors.tf` conventions):
> - **Silent feed:** zero `subscription.ssn.applied` in 26h ⇒ alert (valid from day one — the daily sandbox renewal canary guarantees ≥1 applied/day on a healthy feed)
> - **Drop spike:** `subscription.ssn.dropped` count >5/h ⇒ alert (`@reason:unknown_subscription` = orphan signal)
> 
> ## Adversarial review (codex, 2 rounds)
> 
> - **Fixed:** lost-update window when a provider retry of a dropped notification arrives after `/verify` created the row (drop-receipt adoption + bounded P2002 retry — final shape is the reviewer's prescribed fix; locking order and staleness-guard interaction confirmed sound).
> - **Rejected:** `CREATE INDEX CONCURRENTLY` — BillingReceipt is near-empty in prod (zero SSNs until today) and Prisma applies migrations transactionally; revisit if the table grows.
> - **Noted as pre-existing follow-up (not this PR):** the unauthenticated webhook parses bodies under the global 50 MB json limit; a route-scoped body cap would shrink the DoS surface.
> - **Deferred:** barrier-controlled concurrency tests for the drop/verify race (sequential drop→verify→retry adoption path is covered).
> 
> ## Tests
> 
> - Handler: drop receipt persisted + notificationUUID idempotency (single row on replay), lifecycle log events (received/applied/dropped fields incl. drop reasons), existing SSN suite intact
> - Repository: unknown-drop persistence for both providers, adoption (drop → verify → retry applies exactly once, receipt linked, further retry = replay)
> - Full suite: 1633 passed / 2 skipped; typecheck, eslint, prettier clean
> 
> <!-- codesmith:footer -->
> ---
> <a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787920540&installation_model_id=20076&pr_number=394&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F394&signature=a5146bf4078389b731b1d0d775e89841d464ad0285fe9e337f5925b7c559736a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
> <sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>
> 
> <!-- codesmith:autofix:disabled -->
> <!-- /codesmith:footer -->
>
> <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
>
> ## Summary by CodeRabbit
>
> * **New Features**
>   * Added structured observability for subscription notifications, including received, applied, and dropped events with categorized reasons.
>   * Unmatched Apple and Google subscription notifications are now recorded for auditing and can be linked when the subscription is later identified.
>   * Improved handling of duplicate and out-of-order notifications to prevent incorrect subscription updates.
>   * Added monitoring guidance for silent feeds, drop spikes, and account mismatches.
>
> * **Bug Fixes**
>   * Improved replay handling and credit restoration for eligible verification retries.
>   * Added clearer handling and reporting for invalid or incomplete notifications.
>
> <!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- Macroscope's changelog starts here -->
> #### Changes since #394 opened
>
> - Refined `applyNotification` handler to only retry adoption or return replayed status when P2002 unique constraint violations occur on `BillingReceipt.idempotencyKey` [090def7]
> - Added test coverage for `applyNotification` handler behavior when `grantSubscriptionPeriod` throws a P2002 error for `CreditLedger` unique constraint [090def7]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->