### PR TITLE
feat(agents): owner-computed agentPowerDepleted on agent payloads (CON-807)

### DIFF
--- a/prisma/migrations/20260729121110_add_agent_instance/migration.sql
+++ b/prisma/migrations/20260729121110_add_agent_instance/migration.sql
@@ -1,0 +1,56 @@
+-- DropForeignKey
+ALTER TABLE "CreditLedger" DROP CONSTRAINT "CreditLedger_accountId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserCredits" DROP CONSTRAINT "UserCredits_accountId_fkey";
+
+-- AlterTable
+ALTER TABLE "AgentTemplate" ALTER COLUMN "id" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "AgentTemplateGeneration" ALTER COLUMN "id" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "InviteCode" ALTER COLUMN "id" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "InviteCodeRedemption" ALTER COLUMN "id" DROP DEFAULT;
+
+-- CreateTable
+CREATE TABLE "AgentInstance" (
+    "instanceId" TEXT NOT NULL,
+    "ownerAccountId" UUID NOT NULL,
+    "conversationId" TEXT,
+    "inboxId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentInstance_pkey" PRIMARY KEY ("instanceId")
+);
+
+-- CreateIndex
+CREATE INDEX "AgentInstance_conversationId_idx" ON "AgentInstance"("conversationId");
+
+-- CreateIndex
+CREATE INDEX "AgentInstance_ownerAccountId_idx" ON "AgentInstance"("ownerAccountId");
+
+-- AddForeignKey
+ALTER TABLE "UserCredits" ADD CONSTRAINT "UserCredits_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CreditLedger" ADD CONSTRAINT "CreditLedger_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentInstance" ADD CONSTRAINT "AgentInstance_ownerAccountId_fkey" FOREIGN KEY ("ownerAccountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "subscription_apple_aat_unique" RENAME TO "Subscription_provider_appAccountToken_key";
+
+-- RenameIndex
+ALTER INDEX "subscription_apple_otx_unique" RENAME TO "Subscription_provider_originalTransactionId_key";
+
+-- RenameIndex
+ALTER INDEX "subscription_play_oid_unique" RENAME TO "Subscription_provider_obfuscatedAccountId_key";
+
+-- RenameIndex
+ALTER INDEX "subscription_play_token_unique" RENAME TO "Subscription_provider_purchaseToken_key";

--- a/prisma/migrations/20260729121110_add_agent_instance/migration.sql
+++ b/prisma/migrations/20260729121110_add_agent_instance/migration.sql
@@ -1,20 +1,8 @@
--- DropForeignKey
-ALTER TABLE "CreditLedger" DROP CONSTRAINT "CreditLedger_accountId_fkey";
-
--- DropForeignKey
-ALTER TABLE "UserCredits" DROP CONSTRAINT "UserCredits_accountId_fkey";
-
--- AlterTable
-ALTER TABLE "AgentTemplate" ALTER COLUMN "id" DROP DEFAULT;
-
--- AlterTable
-ALTER TABLE "AgentTemplateGeneration" ALTER COLUMN "id" DROP DEFAULT;
-
--- AlterTable
-ALTER TABLE "InviteCode" ALTER COLUMN "id" DROP DEFAULT;
-
--- AlterTable
-ALTER TABLE "InviteCodeRedemption" ALTER COLUMN "id" DROP DEFAULT;
+-- AgentInstance only. `prisma migrate dev` also wanted to emit pre-existing
+-- schema/migration drift (CreditLedger/UserCredits FK re-validation, UUID
+-- default drops, Subscription index renames) — deliberately excluded here:
+-- locking the ledger tables is not this feature's business, and that drift
+-- predates this branch.
 
 -- CreateTable
 CREATE TABLE "AgentInstance" (
@@ -35,22 +23,4 @@ CREATE INDEX "AgentInstance_conversationId_idx" ON "AgentInstance"("conversation
 CREATE INDEX "AgentInstance_ownerAccountId_idx" ON "AgentInstance"("ownerAccountId");
 
 -- AddForeignKey
-ALTER TABLE "UserCredits" ADD CONSTRAINT "UserCredits_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "CreditLedger" ADD CONSTRAINT "CreditLedger_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "AgentInstance" ADD CONSTRAINT "AgentInstance_ownerAccountId_fkey" FOREIGN KEY ("ownerAccountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- RenameIndex
-ALTER INDEX "subscription_apple_aat_unique" RENAME TO "Subscription_provider_appAccountToken_key";
-
--- RenameIndex
-ALTER INDEX "subscription_apple_otx_unique" RENAME TO "Subscription_provider_originalTransactionId_key";
-
--- RenameIndex
-ALTER INDEX "subscription_play_oid_unique" RENAME TO "Subscription_provider_obfuscatedAccountId_key";
-
--- RenameIndex
-ALTER INDEX "subscription_play_token_unique" RENAME TO "Subscription_provider_purchaseToken_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,7 @@ model Account {
   creditLedger             CreditLedger[]
   subscriptions            Subscription[]
   connectionGrants         ConnectionGrant[]
+  agentInstances           AgentInstance[]
 }
 
 /// Consent record for backend-mediated Composio tool execution (fork Y).
@@ -534,4 +535,37 @@ model AgentVariant {
   updatedAt          DateTime  @updatedAt
 
   @@index([status, createdAt])
+}
+
+/// The backend's record of an agent it dispatched to the assistant runtime:
+/// who pays for the agent's turns (ownerAccountId — stamped from the joining
+/// user's authenticated JWT at dispatch, the same value sent upstream as the
+/// control plane's ownerAccountId) and where the agent landed (conversationId,
+/// inboxId — learned from the runtime's status rows as they materialize).
+///
+/// This mapping is what lets client-facing payloads carry the owner-computed
+/// `agentPowerDepleted` field (CON-807): an agent's "power" is its OWNER's
+/// wallet, so a viewer-independent power state needs the agent → owner link
+/// the backend itself originated at join time.
+///
+/// Rows are advisory, not membership truth: membership lives in the XMTP
+/// group, and the backend never learns agent destruction, so a row can
+/// outlive its agent. Readers key on inboxId and clients intersect with the
+/// actual XMTP member list, which makes stale rows inert.
+model AgentInstance {
+  /// Assistant runtime instance id (minted by the control plane).
+  instanceId     String   @id
+  ownerAccountId String   @db.Uuid
+  /// XMTP conversation the agent was dispatched to — declared at direct-add,
+  /// learned from the runtime status for invite joins. Null until known.
+  conversationId String?
+  /// The agent's XMTP inbox id, once Herald registration lands. Null until known.
+  inboxId        String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  owner Account @relation(fields: [ownerAccountId], references: [id], onDelete: Cascade)
+
+  @@index([conversationId])
+  @@index([ownerAccountId])
 }

--- a/src/api/v2/agents/handlers/join-status.ts
+++ b/src/api/v2/agents/handlers/join-status.ts
@@ -1,5 +1,9 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
+import {
+  getAgentPowerDepleted,
+  recordAgentInstanceStatus,
+} from "@/api/v2/agents/lib/agent-instances";
 import { resolveVariantWorkerOrigin } from "@/api/v2/agents/lib/variant-routing";
 import { XMTP_ENV } from "@/config";
 import {
@@ -144,6 +148,21 @@ export async function joinStatusHandler(req: Request, res: Response) {
       joinFailureReason = null,
     } = result.data;
 
+    // Opportunistically fill the AgentInstance row (inboxId/conversationId
+    // land asynchronously after dispatch) and compute the owner-funded power
+    // state for the payload. Additive + advisory: any failure here degrades
+    // to the legacy payload shape rather than failing the status read.
+    let agentPowerDepleted: boolean | null = null;
+    try {
+      await recordAgentInstanceStatus({ instanceId, inboxId, conversationId });
+      agentPowerDepleted = await getAgentPowerDepleted(instanceId);
+    } catch (error) {
+      req.log.error(
+        { error, instanceId },
+        "Agent power enrichment failed for join status",
+      );
+    }
+
     res.status(200).json({
       success: true,
       instanceId: result.data.instanceId,
@@ -152,6 +171,10 @@ export async function joinStatusHandler(req: Request, res: Response) {
       inboxId,
       conversationId,
       joinFailureReason,
+      // Owner-computed (the agent PAYER's wallet vs the runtime spend floor),
+      // never the caller's balance. Omitted (absent) when the instance is
+      // unknown to the backend — old rows predating AgentInstance bookkeeping.
+      ...(agentPowerDepleted !== null ? { agentPowerDepleted } : {}),
     });
   } catch (error) {
     if (error instanceof DOMException && error.name === "TimeoutError") {

--- a/src/api/v2/agents/handlers/join-status.ts
+++ b/src/api/v2/agents/handlers/join-status.ts
@@ -1,9 +1,6 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
-import {
-  getAgentPowerDepleted,
-  recordAgentInstanceStatus,
-} from "@/api/v2/agents/lib/agent-instances";
+import { recordStatusAndGetAgentPower } from "@/api/v2/agents/lib/agent-instances";
 import { resolveVariantWorkerOrigin } from "@/api/v2/agents/lib/variant-routing";
 import { XMTP_ENV } from "@/config";
 import {
@@ -152,14 +149,27 @@ export async function joinStatusHandler(req: Request, res: Response) {
     // land asynchronously after dispatch) and compute the owner-funded power
     // state for the payload. Additive + advisory: any failure here degrades
     // to the legacy payload shape rather than failing the status read.
+    // Guard: only trust identity facts from a status row that is actually
+    // about the polled instance — a confused upstream must not poison one
+    // instance's row with another's inbox/conversation.
     let agentPowerDepleted: boolean | null = null;
-    try {
-      await recordAgentInstanceStatus({ instanceId, inboxId, conversationId });
-      agentPowerDepleted = await getAgentPowerDepleted(instanceId);
-    } catch (error) {
-      req.log.error(
-        { error, instanceId },
-        "Agent power enrichment failed for join status",
+    if (result.data.instanceId === instanceId) {
+      try {
+        agentPowerDepleted = await recordStatusAndGetAgentPower({
+          instanceId,
+          inboxId,
+          conversationId,
+        });
+      } catch (error) {
+        req.log.error(
+          { error, instanceId },
+          "Agent power enrichment failed for join status",
+        );
+      }
+    } else {
+      req.log.warn(
+        { instanceId, upstreamInstanceId: result.data.instanceId },
+        "Assistant status row is for a different instance — skipping bookkeeping",
       );
     }
 

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -284,6 +284,13 @@ async function pollAssistantStatus<Outcome>(args: {
             { issues: parsed.error.issues, instanceId },
             "Assistant status poll returned malformed body",
           );
+        } else if (parsed.data.instanceId !== instanceId) {
+          // A status row about a different instance must not drive this
+          // join's outcome (or the identity facts recorded from it).
+          log.warn(
+            { instanceId, upstreamInstanceId: parsed.data.instanceId },
+            "Assistant status poll returned a different instance — ignoring",
+          );
         } else {
           const outcome = check(parsed.data);
           if (outcome !== null) return outcome;

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -1,5 +1,9 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
+import {
+  recordAgentInstanceDispatched,
+  recordAgentInstanceStatus,
+} from "@/api/v2/agents/lib/agent-instances";
 import { buildJoinPayload } from "@/api/v2/agents/lib/build-join-payload";
 import {
   allowedVariantWorkerOrigin,
@@ -202,7 +206,7 @@ const dispatchBodySchema = z
   );
 
 type PollOutcome =
-  | { kind: "joined" }
+  | { kind: "joined"; inboxId: string | null; conversationId: string | null }
   | { kind: "failed"; reason: string | null }
   | { kind: "pending" };
 
@@ -310,7 +314,14 @@ function pollUntilJoined(
     ...args,
     check: (status) => {
       if (status.joinStatus === "joined" || status.joinStatus === "ready") {
-        return { kind: "joined" };
+        // Carry the identity facts the status row already holds so the
+        // caller can record them (AgentInstance bookkeeping) without an
+        // extra status fetch.
+        return {
+          kind: "joined",
+          inboxId: status.inboxId ?? null,
+          conversationId: status.conversationId ?? null,
+        };
       }
       if (status.joinStatus === "failed") {
         return { kind: "failed", reason: status.joinFailureReason ?? null };
@@ -820,6 +831,25 @@ export async function joinHandler(req: Request, res: Response) {
     return;
   }
 
+  // Record who pays for this agent. The backend is the sole authority on
+  // ownerAccountId (stamped from the caller's JWT, dispatched upstream just
+  // above) — persisting it here is what lets conversation payloads carry the
+  // owner-computed agentPowerDepleted field (CON-807). Bookkeeping must never
+  // fail the join: the agent is already provisioning upstream, so log and
+  // continue.
+  try {
+    await recordAgentInstanceDispatched({
+      instanceId,
+      ownerAccountId: joiningUserAccountId,
+      conversationId: conversationId ?? null,
+    });
+  } catch (error) {
+    req.log.error(
+      { error, instanceId },
+      "Failed to record agent instance dispatch",
+    );
+  }
+
   // Direct-add: wait only for Herald registration so the caller gets the
   // inboxId to add to the group; the join completes when the runtime
   // observes the group welcome their addMembers produces.
@@ -860,6 +890,20 @@ export async function joinHandler(req: Request, res: Response) {
         "Agent registration still pending after server-side wait budget",
       );
     }
+    if (outcome.kind === "registered") {
+      try {
+        await recordAgentInstanceStatus({
+          instanceId,
+          inboxId: outcome.inboxId,
+          conversationId: null,
+        });
+      } catch (error) {
+        req.log.error(
+          { error, instanceId },
+          "Failed to record agent instance registration",
+        );
+      }
+    }
     res.status(200).json({
       success: true,
       joined: false,
@@ -899,6 +943,21 @@ export async function joinHandler(req: Request, res: Response) {
   }
 
   if (outcome.kind === "joined") {
+    // Invite joins learn the conversation (and inbox) only from the runtime's
+    // status row — fill them in now so the participation payload can list
+    // this agent. Bookkeeping must not fail an already-successful join.
+    try {
+      await recordAgentInstanceStatus({
+        instanceId,
+        inboxId: outcome.inboxId,
+        conversationId: outcome.conversationId,
+      });
+    } catch (error) {
+      req.log.error(
+        { error, instanceId },
+        "Failed to record agent instance join",
+      );
+    }
     res.status(200).json({ success: true, joined: true, instanceId });
     return;
   }

--- a/src/api/v2/agents/lib/agent-instances.ts
+++ b/src/api/v2/agents/lib/agent-instances.ts
@@ -1,0 +1,137 @@
+import { getBalance, getBalances, isAllowedFromBalance } from "@/payments";
+import { prisma } from "@/utils/prisma";
+
+/**
+ * AgentInstance bookkeeping + the owner-computed agent power read (CON-807).
+ *
+ * The backend is the authority on who PAYS for an agent: `ownerAccountId` is
+ * stamped from the joining user's JWT at dispatch (`join.ts`) and forwarded to
+ * the assistant control plane, whose runtime then spends against that account
+ * (`GET/POST /v2/accounts/:accountId/credits*`, gated by
+ * `isSpendAllowed` semantics). Recording the same fact locally is what lets
+ * client-facing payloads carry a viewer-independent `agentPowerDepleted`
+ * field: "this agent's payer cannot fund a turn right now" — the OWNER's
+ * wallet, never the viewer's.
+ *
+ * `agentPowerDepleted` MUST stay the exact negation of the runtime spend
+ * gate: `isSpendAllowed` = balance >= reservedMaxTurnCredits
+ * (src/payments/spendable.ts). Here that is `!isAllowedFromBalance(balance)`
+ * over balances read from the ledger wallet (`getBalance`/`getBalances`, the
+ * single source of truth).
+ */
+
+/** Wire shape of one agent entry on the conversation participation payload. */
+export type ConversationAgentPower = {
+  /** The agent's XMTP inbox id — the key clients match members against. */
+  inboxId: string;
+  /**
+   * true ⇔ the agent's payer cannot fund a turn right now. Owner-computed and
+   * viewer-independent: every member of the conversation sees the same value.
+   */
+  agentPowerDepleted: boolean;
+};
+
+/**
+ * Record a dispatched agent. Called from the join handler right after the
+ * control plane hands back an instanceId. Upsert: an idempotent join retry
+ * re-dispatches the same instanceId (the client idempotencyKey becomes the
+ * Workflow instance id upstream).
+ *
+ * First writer wins on ownership: the update arm deliberately does NOT touch
+ * ownerAccountId, so a later dispatch reusing the same idempotencyKey (and
+ * therefore adopting the same upstream instance) can never reassign who pays.
+ * It also never overwrites an already-learned conversationId with null — a
+ * retry that omits it must not erase what a status poll filled in.
+ */
+export async function recordAgentInstanceDispatched(args: {
+  instanceId: string;
+  ownerAccountId: string;
+  conversationId: string | null;
+}): Promise<void> {
+  const { instanceId, ownerAccountId, conversationId } = args;
+  await prisma.agentInstance.upsert({
+    where: { instanceId },
+    create: { instanceId, ownerAccountId, conversationId },
+    update: conversationId !== null ? { conversationId } : {},
+  });
+}
+
+/**
+ * Fill in what a runtime status row taught us (inboxId and, for invite joins,
+ * conversationId). Both are write-once facts — an agent's inbox and target
+ * conversation never change — so only null columns are filled and redundant
+ * polls turn into no-op UPDATEs matching zero rows. Update-only: a status for
+ * an instance the backend never recorded (pre-table dispatches) matches
+ * nothing, because a row without an owner would be unusable anyway.
+ */
+export async function recordAgentInstanceStatus(args: {
+  instanceId: string;
+  inboxId: string | null;
+  conversationId: string | null;
+}): Promise<void> {
+  const { instanceId, inboxId, conversationId } = args;
+  if (inboxId === null && conversationId === null) return;
+  if (inboxId !== null) {
+    await prisma.agentInstance.updateMany({
+      where: { instanceId, inboxId: null },
+      data: { inboxId },
+    });
+  }
+  if (conversationId !== null) {
+    await prisma.agentInstance.updateMany({
+      where: { instanceId, conversationId: null },
+      data: { conversationId },
+    });
+  }
+}
+
+/**
+ * The conversation's agents with their owner-computed power state, for the
+ * participation payload. Viewer-independent by construction: the caller's
+ * identity is never an input.
+ *
+ * Batched: one AgentInstance read + one balance read for the DISTINCT owners
+ * (getBalances), whatever the number of agents — no per-agent query.
+ *
+ * Agents whose inboxId is still unknown (registration in flight) are
+ * excluded: clients bind by inboxId, so an entry without one is unusable.
+ */
+export async function listConversationAgentPower(
+  conversationId: string,
+): Promise<ConversationAgentPower[]> {
+  const rows = await prisma.agentInstance.findMany({
+    where: { conversationId, inboxId: { not: null } },
+    select: { inboxId: true, ownerAccountId: true },
+    // Deterministic order (join order, inboxId tiebreak within a same-ms
+    // batch) so identical state always serializes identically.
+    orderBy: [{ createdAt: "asc" }, { inboxId: "asc" }],
+  });
+  if (rows.length === 0) return [];
+
+  const owners = [...new Set(rows.map((row) => row.ownerAccountId))];
+  const balances = await getBalances(owners);
+
+  return rows.map((row) => ({
+    // Non-null by the where clause; Prisma's select type can't narrow it.
+    inboxId: row.inboxId as string,
+    agentPowerDepleted: !isAllowedFromBalance(
+      balances.get(row.ownerAccountId) ?? 0n,
+    ),
+  }));
+}
+
+/**
+ * Owner-computed power state for a single instance (the join-status payload).
+ * Returns null when the instance is unknown to the backend — callers omit the
+ * field rather than guessing.
+ */
+export async function getAgentPowerDepleted(
+  instanceId: string,
+): Promise<boolean | null> {
+  const row = await prisma.agentInstance.findUnique({
+    where: { instanceId },
+    select: { ownerAccountId: true },
+  });
+  if (!row) return null;
+  return !isAllowedFromBalance(await getBalance(row.ownerAccountId));
+}

--- a/src/api/v2/agents/lib/agent-instances.ts
+++ b/src/api/v2/agents/lib/agent-instances.ts
@@ -46,9 +46,12 @@ export type ConversationAgentPower = {
  *   display bit could be mislabeled — the control plane recorded its own
  *   ownerAccountId at first dispatch and the runtime spends against THAT,
  *   never against this row.
- * - conversationId only fills a null, so a replayed dispatch declaring a
- *   different conversation cannot relocate the agent's entry into another
- *   conversation's participation payload.
+ * - conversationId only fills a null, and from a dispatch only when the
+ *   caller IS the recorded payer — so a replayed dispatch can neither
+ *   relocate the agent's entry into another conversation's participation
+ *   payload nor pre-claim an invite-join's conversation from a foreign
+ *   account. The runtime's own status rows (matched by instanceId) remain
+ *   the canonical fill path for invite joins.
  */
 export async function recordAgentInstanceDispatched(args: {
   instanceId: string;
@@ -66,10 +69,11 @@ export async function recordAgentInstanceDispatched(args: {
       error.code === "P2002";
     if (!isExistingRow) throw error;
     // Replay of a known instance: fill a still-null conversationId, touch
-    // nothing else.
+    // nothing else — and only when the replaying caller is the recorded
+    // payer, so a foreign replay cannot claim the conversation slot.
     if (conversationId !== null) {
       await prisma.agentInstance.updateMany({
-        where: { instanceId, conversationId: null },
+        where: { instanceId, ownerAccountId, conversationId: null },
         data: { conversationId },
       });
     }

--- a/src/api/v2/agents/lib/agent-instances.ts
+++ b/src/api/v2/agents/lib/agent-instances.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { getBalance, getBalances, isAllowedFromBalance } from "@/payments";
 import { prisma } from "@/utils/prisma";
 
@@ -33,15 +34,21 @@ export type ConversationAgentPower = {
 
 /**
  * Record a dispatched agent. Called from the join handler right after the
- * control plane hands back an instanceId. Upsert: an idempotent join retry
+ * control plane hands back an instanceId. An idempotent join retry
  * re-dispatches the same instanceId (the client idempotencyKey becomes the
- * Workflow instance id upstream).
+ * Workflow instance id upstream), so the row may already exist.
  *
- * First writer wins on ownership: the update arm deliberately does NOT touch
- * ownerAccountId, so a later dispatch reusing the same idempotencyKey (and
- * therefore adopting the same upstream instance) can never reassign who pays.
- * It also never overwrites an already-learned conversationId with null — a
- * retry that omits it must not erase what a status poll filled in.
+ * EVERY identity fact is write-once — first writer wins:
+ * - ownerAccountId is never updated after creation, so a later dispatch that
+ *   adopts the same upstream instance (idempotencyKey replay) can never
+ *   reassign who pays. Keys are client-minted UUIDs, so a cross-account
+ *   replay requires stealing an in-flight key; even then, only this advisory
+ *   display bit could be mislabeled — the control plane recorded its own
+ *   ownerAccountId at first dispatch and the runtime spends against THAT,
+ *   never against this row.
+ * - conversationId only fills a null, so a replayed dispatch declaring a
+ *   different conversation cannot relocate the agent's entry into another
+ *   conversation's participation payload.
  */
 export async function recordAgentInstanceDispatched(args: {
   instanceId: string;
@@ -49,11 +56,24 @@ export async function recordAgentInstanceDispatched(args: {
   conversationId: string | null;
 }): Promise<void> {
   const { instanceId, ownerAccountId, conversationId } = args;
-  await prisma.agentInstance.upsert({
-    where: { instanceId },
-    create: { instanceId, ownerAccountId, conversationId },
-    update: conversationId !== null ? { conversationId } : {},
-  });
+  try {
+    await prisma.agentInstance.create({
+      data: { instanceId, ownerAccountId, conversationId },
+    });
+  } catch (error) {
+    const isExistingRow =
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002";
+    if (!isExistingRow) throw error;
+    // Replay of a known instance: fill a still-null conversationId, touch
+    // nothing else.
+    if (conversationId !== null) {
+      await prisma.agentInstance.updateMany({
+        where: { instanceId, conversationId: null },
+        data: { conversationId },
+      });
+    }
+  }
 }
 
 /**
@@ -121,17 +141,35 @@ export async function listConversationAgentPower(
 }
 
 /**
- * Owner-computed power state for a single instance (the join-status payload).
- * Returns null when the instance is unknown to the backend — callers omit the
- * field rather than guessing.
+ * Join-status enrichment in one read: load the row once, fill any null
+ * identity facts (a write happens only when a null actually transitions —
+ * polling a settled row costs one SELECT and zero UPDATEs, so the polling
+ * endpoint cannot amplify write load), and return the owner-computed power
+ * state. Returns null when the instance is unknown to the backend — callers
+ * omit the field rather than guessing.
  */
-export async function getAgentPowerDepleted(
-  instanceId: string,
-): Promise<boolean | null> {
+export async function recordStatusAndGetAgentPower(args: {
+  instanceId: string;
+  inboxId: string | null;
+  conversationId: string | null;
+}): Promise<boolean | null> {
+  const { instanceId, inboxId, conversationId } = args;
   const row = await prisma.agentInstance.findUnique({
     where: { instanceId },
-    select: { ownerAccountId: true },
+    select: { ownerAccountId: true, inboxId: true, conversationId: true },
   });
   if (!row) return null;
+  if (inboxId !== null && row.inboxId === null) {
+    await prisma.agentInstance.updateMany({
+      where: { instanceId, inboxId: null },
+      data: { inboxId },
+    });
+  }
+  if (conversationId !== null && row.conversationId === null) {
+    await prisma.agentInstance.updateMany({
+      where: { instanceId, conversationId: null },
+      data: { conversationId },
+    });
+  }
   return !isAllowedFromBalance(await getBalance(row.ownerAccountId));
 }

--- a/src/api/v2/conversations/handlers/participation.ts
+++ b/src/api/v2/conversations/handlers/participation.ts
@@ -4,6 +4,10 @@ import {
   getAssistantApiKey,
   getAssistantApiUrl,
 } from "@/api/v2/agents/handlers/assistant-config";
+import {
+  listConversationAgentPower,
+  type ConversationAgentPower,
+} from "@/api/v2/agents/lib/agent-instances";
 import { resolveVariantWorkerOrigin } from "@/api/v2/agents/lib/variant-routing";
 import { XMTP_ENV } from "@/config";
 
@@ -161,10 +165,27 @@ export async function getParticipationHandler(req: Request, res: Response) {
       return;
     }
 
+    // Owner-computed power state for this conversation's agents (CON-807).
+    // Viewer-independent: computed from each agent OWNER's wallet against the
+    // same floor the runtime spend gate applies — never from the caller's own
+    // balance, so every member sees the same value. Additive, response-side
+    // only; enrichment failure degrades to the legacy shape (field omitted)
+    // rather than failing the mode read old clients depend on.
+    let agents: ConversationAgentPower[] | undefined;
+    try {
+      agents = await listConversationAgentPower(conversationId);
+    } catch (error) {
+      req.log.error(
+        { error, conversationId },
+        "Agent power enrichment failed for participation read",
+      );
+    }
+
     res.status(200).json({
       success: true,
       conversationId,
       mode: parsedUpstream.data.mode,
+      ...(agents !== undefined ? { agents } : {}),
     });
   } catch (error) {
     if (error instanceof DOMException && error.name === "TimeoutError") {

--- a/src/payments/AGENTS.md
+++ b/src/payments/AGENTS.md
@@ -28,7 +28,9 @@ becomes a lie.
 | Function                                           | Purpose                                                                                                              |
 | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `getBalance(accountId)`                            | Spendable balance — the source of truth.                                                                             |
+| `getBalances(accountIds)`                          | Batch `getBalance` — one query for many accounts (missing rows read as 0n). Use it instead of per-account loops.     |
 | `isAllowed(accountId)`                             | Advisory UX gate (`balance >= reservedMaxTurnCredits`). NOT authorization — `consume` enforces the floor atomically. |
+| `isAllowedFromBalance(balance)`                    | Pure form of the advisory gate, for balances already in hand (e.g. from `getBalances`).                              |
 | `getHistory(accountId, limit?, cursor?)`           | Ledger rows, descending, cursor-paginated.                                                                           |
 | `getBucketedConsumption(accountId, since, bucket)` | Consume sums per UTC day/week/month.                                                                                 |
 

--- a/src/payments/index.ts
+++ b/src/payments/index.ts
@@ -11,6 +11,7 @@ import {
   findLedgerByIdempotencyKey,
   LedgerFloorBreachError,
   getBalance as ledgerGetBalance,
+  getBalances as ledgerGetBalances,
   getBucketedConsumption as ledgerGetBucketedConsumption,
   getHistory as ledgerGetHistory,
   validateReplayPayload,
@@ -229,11 +230,24 @@ export const getBalance = async (accountId: string): Promise<bigint> =>
   ledgerGetBalance(accountId);
 
 /**
+ * Batch counterpart of `getBalance` — same source of truth, one query for
+ * many accounts. Accounts with no `UserCredits` row read as 0n.
+ */
+export const getBalances = async (
+  accountIds: readonly string[],
+): Promise<Map<string, bigint>> => ledgerGetBalances(accountIds);
+
+/**
  * Advisory balance check. NOT an authorization gate — only consume()
  * enforces the floor atomically. Use for UX hints (disable button).
  */
 export const isAllowed = async (accountId: string): Promise<boolean> =>
   isAllowedFromBalance(await ledgerGetBalance(accountId));
+
+// The pure form of the advisory check, for callers that already hold a
+// balance (e.g. a batch read via getBalances). Same floor as isAllowed /
+// isSpendAllowed: balance >= reservedMaxTurnCredits.
+export { isAllowedFromBalance } from "./credits/policy";
 
 export const getHistory = async (
   accountId: string,

--- a/src/payments/ledger/index.ts
+++ b/src/payments/ledger/index.ts
@@ -3,6 +3,7 @@ export {
   applyDeltaWithTx,
   findLedgerByIdempotencyKey,
   getBalance,
+  getBalances,
   getBucketedConsumption,
   getHistory,
   LedgerFloorBreachError,

--- a/src/payments/ledger/repository.ts
+++ b/src/payments/ledger/repository.ts
@@ -40,6 +40,26 @@ export const getBalance = async (accountId: string): Promise<bigint> => {
   return row?.balance ?? 0n;
 };
 
+/**
+ * Batch counterpart of `getBalance` — the same source of truth
+ * (`UserCredits.balance`), for callers that need many accounts in one read
+ * (e.g. per-conversation agent power) without an N+1. Accounts with no
+ * `UserCredits` row read as 0n, exactly like `getBalance`.
+ */
+export const getBalances = async (
+  accountIds: readonly string[],
+): Promise<Map<string, bigint>> => {
+  const balances = new Map<string, bigint>();
+  if (accountIds.length === 0) return balances;
+  for (const accountId of accountIds) balances.set(accountId, 0n);
+  const rows = await prisma.userCredits.findMany({
+    where: { accountId: { in: [...accountIds] } },
+    select: { accountId: true, balance: true },
+  });
+  for (const row of rows) balances.set(row.accountId, row.balance);
+  return balances;
+};
+
 export const findLedgerByIdempotencyKey = async (args: {
   accountId: string;
   idempotencyKey: string;

--- a/tests/agent-power-depleted.test.ts
+++ b/tests/agent-power-depleted.test.ts
@@ -471,22 +471,34 @@ describe("agentPowerDepleted (owner-computed agent power)", () => {
         ownerAccountId: owner,
         conversationId: null,
       });
-      // Replay from another account: may fill the still-null conversation,
-      // must not touch ownership.
+      // Replay from ANOTHER account: must neither touch ownership nor claim
+      // the still-null conversation slot.
       await recordAgentInstanceDispatched({
         instanceId,
         ownerAccountId: other,
+        conversationId: "eeeeeeeeeeeeeeee",
+      });
+      let row = await prisma.agentInstance.findUnique({
+        where: { instanceId },
+      });
+      expect(row?.ownerAccountId).toBe(owner);
+      expect(row?.conversationId).toBeNull();
+
+      // Replay from the recorded payer: may fill the null conversation.
+      await recordAgentInstanceDispatched({
+        instanceId,
+        ownerAccountId: owner,
         conversationId: "abc123def4567890",
       });
       // A further replay declaring a DIFFERENT conversation must not move
       // the agent's entry into another conversation's payload.
       await recordAgentInstanceDispatched({
         instanceId,
-        ownerAccountId: other,
+        ownerAccountId: owner,
         conversationId: "9999999999999999",
       });
 
-      const row = await prisma.agentInstance.findUnique({
+      row = await prisma.agentInstance.findUnique({
         where: { instanceId },
       });
       expect(row?.ownerAccountId).toBe(owner);

--- a/tests/agent-power-depleted.test.ts
+++ b/tests/agent-power-depleted.test.ts
@@ -1,0 +1,549 @@
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import express, {
+  type Response as ExpressResponse,
+  type NextFunction,
+  type Request,
+} from "express";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { __setAssistantConfigOverridesForTests } from "@/api/v2/agents/handlers/assistant-config";
+import { joinHandler } from "@/api/v2/agents/handlers/join";
+import { joinStatusHandler } from "@/api/v2/agents/handlers/join-status";
+import { recordAgentInstanceDispatched } from "@/api/v2/agents/lib/agent-instances";
+import { getParticipationHandler } from "@/api/v2/conversations/handlers/participation";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { getBalance, getBalances } from "@/payments";
+import type * as PaymentsModule from "@/payments";
+import { prisma } from "@/utils/prisma";
+import { seedAccount, seedBalance } from "./credits/helpers";
+
+// Wrap the two balance reads with counting passthroughs so the batch test can
+// assert "one getBalances call, zero per-agent getBalance calls" — spying on
+// prisma delegates directly is not an option (they are Proxy-backed and break
+// under vi.spyOn). Everything else in @/payments passes through untouched.
+vi.mock("@/payments", async (importOriginal) => {
+  const actual = await importOriginal<typeof PaymentsModule>();
+  return {
+    ...actual,
+    getBalance: vi.fn(actual.getBalance),
+    getBalances: vi.fn(actual.getBalances),
+  };
+});
+
+// The owner-computed `agentPowerDepleted` field (CON-807).
+//
+// Semantics under test: agentPowerDepleted === true ⇔ the agent's PAYER (the
+// account that added the agent) cannot fund a turn right now — the exact
+// negation of the runtime spend gate (balance >= reservedMaxTurnCredits;
+// tests pin PAYMENTS_RESERVED_MAX_TURN_CREDITS=1 in tests/setup.ts). The
+// field is viewer-independent: the VIEWER's own wallet must never leak into
+// it. That leak is the CON-807 bug this field exists to retire.
+
+let mockFetchImpl: (url: string, init?: RequestInit) => Promise<Response>;
+const originalFetch = globalThis.fetch;
+
+const ASSISTANT_URL = "https://assistants.test.local";
+const ASSISTANT_KEY = "test-assistant-key";
+const TEST_ACCOUNT_HEADER = "x-test-account-id";
+const DEFAULT_TEST_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+
+// Mirrors production mounting: authMiddleware+requireAccount populate
+// res.locals.accountId; here a header stands in so tests can act as
+// different VIEWERS (the point of the viewer-independence assertions).
+function testAccountMiddleware(
+  req: Request,
+  res: ExpressResponse,
+  next: NextFunction,
+) {
+  res.locals.accountId =
+    req.header(TEST_ACCOUNT_HEADER) ?? DEFAULT_TEST_ACCOUNT_ID;
+  next();
+}
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use(testAccountMiddleware);
+app.post("/api/v2/agents/join", joinHandler);
+app.get("/api/v2/agents/join/:instanceId", joinStatusHandler);
+app.get(
+  "/api/v2/conversations/:conversationId/participation",
+  getParticipationHandler,
+);
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Upstream control plane answering the participation read with a mode. */
+function mockParticipationUpstream(mode: string = "speak") {
+  mockFetchImpl = (url) => {
+    expect(url).toContain("/participation");
+    return Promise.resolve(jsonResponse(200, { mode }));
+  };
+}
+
+type ParticipationBody = {
+  success: boolean;
+  conversationId: string;
+  mode: string;
+  agents?: Array<{ inboxId: string; agentPowerDepleted: boolean }>;
+};
+
+describe("agentPowerDepleted (owner-computed agent power)", () => {
+  let server: Server;
+  let baseURL: string;
+
+  const createdAccountIds: string[] = [];
+  const createdInstanceIds: string[] = [];
+
+  const newAccount = async (): Promise<string> => {
+    const id = await seedAccount();
+    createdAccountIds.push(id);
+    return id;
+  };
+
+  const seedAgent = async (args: {
+    ownerAccountId: string;
+    conversationId: string | null;
+    inboxId: string | null;
+  }): Promise<string> => {
+    const instanceId = `pwr-${randomUUID()}`;
+    createdInstanceIds.push(instanceId);
+    await prisma.agentInstance.create({
+      data: { instanceId, ...args },
+    });
+    return instanceId;
+  };
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const addr = server.address();
+        if (!addr || typeof addr === "string") {
+          throw new Error("Failed to resolve test server address");
+        }
+        baseURL = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    globalThis.fetch = originalFetch;
+    __setAssistantConfigOverridesForTests({});
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(() => {
+    __setAssistantConfigOverridesForTests({
+      assistantApiUrl: ASSISTANT_URL,
+      assistantApiKey: ASSISTANT_KEY,
+      joinWaitBudgetMs: 200,
+      joinPollIntervalMs: 20,
+    });
+    mockFetchImpl = () => Promise.reject(new Error("unmocked fetch"));
+    globalThis.fetch = ((url: string, init?: RequestInit) =>
+      mockFetchImpl(url, init)) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    // Clear call history only — the @/payments wrappers keep their real
+    // passthrough implementations across tests.
+    vi.clearAllMocks();
+    __setAssistantConfigOverridesForTests({});
+    await prisma.agentInstance.deleteMany({
+      where: { instanceId: { in: createdInstanceIds.splice(0) } },
+    });
+    const accountIds = createdAccountIds.splice(0);
+    await prisma.creditLedger.deleteMany({
+      where: { accountId: { in: accountIds } },
+    });
+    await prisma.userCredits.deleteMany({
+      where: { accountId: { in: accountIds } },
+    });
+    await prisma.account.deleteMany({ where: { id: { in: accountIds } } });
+  });
+
+  const getParticipation = (conversationId: string, viewerAccountId: string) =>
+    originalFetch(
+      `${baseURL}/api/v2/conversations/${conversationId}/participation`,
+      { headers: { [TEST_ACCOUNT_HEADER]: viewerAccountId } },
+    );
+
+  const getJoinStatus = (instanceId: string, viewerAccountId: string) =>
+    originalFetch(
+      `${baseURL}/api/v2/agents/join/${encodeURIComponent(instanceId)}`,
+      { headers: { [TEST_ACCOUNT_HEADER]: viewerAccountId } },
+    );
+
+  describe("GET /conversations/:conversationId/participation", () => {
+    test("depleted OWNER → agentPowerDepleted: true for EVERY viewer (funded or broke)", async () => {
+      const owner = await newAccount(); // balance 0 < reserved 1 → depleted
+      const fundedViewer = await newAccount();
+      await seedBalance(fundedViewer, 1_000n);
+      const brokeViewer = await newAccount(); // balance 0
+
+      const conversationId = `c${randomUUID().replaceAll("-", "")}`;
+      await seedAgent({
+        ownerAccountId: owner,
+        conversationId,
+        inboxId: "inbox-depleted-owner",
+      });
+
+      mockParticipationUpstream();
+
+      for (const viewer of [fundedViewer, brokeViewer]) {
+        const res = await getParticipation(conversationId, viewer);
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as ParticipationBody;
+        expect(body.mode).toBe("speak");
+        expect(body.agents).toEqual([
+          { inboxId: "inbox-depleted-owner", agentPowerDepleted: true },
+        ]);
+      }
+    });
+
+    test("CON-807 regression: a ZERO-balance viewer sees a funded owner's agent as powered (agentPowerDepleted: false)", async () => {
+      // The original bug: iOS bound "lost power" to the VIEWER's wallet, so a
+      // broke viewer saw every agent as dead — including other people's
+      // funded agents. The backend field must be computed from the OWNER's
+      // wallet only, so this exact scenario must read false.
+      const owner = await newAccount();
+      await seedBalance(owner, 5n); // >= reserved (1) → owner can fund a turn
+      const brokeViewer = await newAccount(); // the CON-807 viewer: balance 0
+
+      const conversationId = `c${randomUUID().replaceAll("-", "")}`;
+      await seedAgent({
+        ownerAccountId: owner,
+        conversationId,
+        inboxId: "inbox-funded-owner",
+      });
+
+      mockParticipationUpstream();
+
+      const res = await getParticipation(conversationId, brokeViewer);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as ParticipationBody;
+      expect(body.agents).toEqual([
+        { inboxId: "inbox-funded-owner", agentPowerDepleted: false },
+      ]);
+    });
+
+    test("viewer-independence: byte-identical agents array for owner, funded viewer, and broke viewer", async () => {
+      const ownerFunded = await newAccount();
+      await seedBalance(ownerFunded, 100n);
+      const ownerBroke = await newAccount();
+      const fundedViewer = await newAccount();
+      await seedBalance(fundedViewer, 100n);
+      const brokeViewer = await newAccount();
+
+      const conversationId = `c${randomUUID().replaceAll("-", "")}`;
+      await seedAgent({
+        ownerAccountId: ownerFunded,
+        conversationId,
+        inboxId: "inbox-a",
+      });
+      await seedAgent({
+        ownerAccountId: ownerBroke,
+        conversationId,
+        inboxId: "inbox-b",
+      });
+
+      mockParticipationUpstream();
+
+      const bodies: ParticipationBody[] = [];
+      for (const viewer of [
+        ownerFunded,
+        ownerBroke,
+        fundedViewer,
+        brokeViewer,
+      ]) {
+        const res = await getParticipation(conversationId, viewer);
+        expect(res.status).toBe(200);
+        bodies.push((await res.json()) as ParticipationBody);
+      }
+      const [first, ...rest] = bodies;
+      for (const body of rest) {
+        expect(body.agents).toEqual(first.agents);
+      }
+      expect(first.agents).toEqual([
+        { inboxId: "inbox-a", agentPowerDepleted: false },
+        { inboxId: "inbox-b", agentPowerDepleted: true },
+      ]);
+    });
+
+    test("list is batched: one AgentInstance read + one balance read for N agents / M owners; unregistered agents excluded", async () => {
+      const owner1 = await newAccount();
+      await seedBalance(owner1, 50n);
+      const owner2 = await newAccount(); // depleted
+      const viewer = await newAccount();
+
+      const conversationId = `c${randomUUID().replaceAll("-", "")}`;
+      await seedAgent({
+        ownerAccountId: owner1,
+        conversationId,
+        inboxId: "inbox-1",
+      });
+      await seedAgent({
+        ownerAccountId: owner1,
+        conversationId,
+        inboxId: "inbox-2",
+      });
+      await seedAgent({
+        ownerAccountId: owner2,
+        conversationId,
+        inboxId: "inbox-3",
+      });
+      // Registration still in flight — no inboxId, must be excluded.
+      await seedAgent({
+        ownerAccountId: owner2,
+        conversationId,
+        inboxId: null,
+      });
+
+      mockParticipationUpstream();
+
+      vi.mocked(getBalances).mockClear();
+      vi.mocked(getBalance).mockClear();
+
+      const res = await getParticipation(conversationId, viewer);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as ParticipationBody;
+
+      expect(body.agents).toEqual([
+        { inboxId: "inbox-1", agentPowerDepleted: false },
+        { inboxId: "inbox-2", agentPowerDepleted: false },
+        { inboxId: "inbox-3", agentPowerDepleted: true },
+      ]);
+
+      // Batch contract: 3 rendered agents (4 rows) across 2 owners cost
+      // exactly ONE batched balance read over the DISTINCT owners — and
+      // zero per-agent getBalance calls.
+      expect(getBalances).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(getBalances).mock.calls[0][0]).toEqual(
+        expect.arrayContaining([owner1, owner2]),
+      );
+      expect(vi.mocked(getBalances).mock.calls[0][0]).toHaveLength(2);
+      expect(getBalance).not.toHaveBeenCalled();
+    });
+
+    test("no recorded agents → agents: [] (still viewer-independent, still 200)", async () => {
+      const viewer = await newAccount();
+      const conversationId = `c${randomUUID().replaceAll("-", "")}`;
+      mockParticipationUpstream("paused");
+
+      const res = await getParticipation(conversationId, viewer);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as ParticipationBody;
+      expect(body.mode).toBe("paused");
+      expect(body.agents).toEqual([]);
+    });
+
+    test("enrichment failure degrades to the legacy shape: 200 with mode, agents omitted", async () => {
+      const owner = await newAccount();
+      const viewer = await newAccount();
+      const conversationId = `c${randomUUID().replaceAll("-", "")}`;
+      // An agent must exist so the enrichment reaches the balance read that
+      // is made to fail.
+      await seedAgent({
+        ownerAccountId: owner,
+        conversationId,
+        inboxId: "inbox-degrade",
+      });
+      mockParticipationUpstream();
+
+      vi.mocked(getBalances).mockRejectedValueOnce(new Error("db down"));
+
+      const res = await getParticipation(conversationId, viewer);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as ParticipationBody;
+      expect(body.success).toBe(true);
+      expect(body.mode).toBe("speak");
+      expect(body).not.toHaveProperty("agents");
+    });
+  });
+
+  describe("join bookkeeping (the agent → owner mapping)", () => {
+    test("direct-add join records owner + conversation at dispatch and inboxId at registration", async () => {
+      const owner = await newAccount();
+      const conversationId = "abc123def4567890";
+      const instanceId = `pwr-${randomUUID()}`;
+      createdInstanceIds.push(instanceId);
+
+      mockFetchImpl = (url, init) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(jsonResponse(200, { instanceId }));
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId,
+            joinStatus: "pending_acceptance",
+            inboxId: "inbox-direct-add",
+            conversationId,
+          }),
+        );
+      };
+
+      const res = await originalFetch(`${baseURL}/api/v2/agents/join`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [TEST_ACCOUNT_HEADER]: owner,
+        },
+        body: JSON.stringify({ conversationId }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { inboxId: string | null };
+      expect(body.inboxId).toBe("inbox-direct-add");
+
+      const row = await prisma.agentInstance.findUnique({
+        where: { instanceId },
+      });
+      expect(row).not.toBeNull();
+      expect(row?.ownerAccountId).toBe(owner);
+      expect(row?.conversationId).toBe(conversationId);
+      expect(row?.inboxId).toBe("inbox-direct-add");
+    });
+
+    test("invite (slug) join learns conversationId + inboxId from the joined status row", async () => {
+      const owner = await newAccount();
+      const instanceId = `pwr-${randomUUID()}`;
+      createdInstanceIds.push(instanceId);
+
+      mockFetchImpl = (url, init) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(jsonResponse(200, { instanceId }));
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId,
+            joinStatus: "joined",
+            inboxId: "inbox-invite",
+            conversationId: "fedcba9876543210",
+          }),
+        );
+      };
+
+      const res = await originalFetch(`${baseURL}/api/v2/agents/join`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [TEST_ACCOUNT_HEADER]: owner,
+        },
+        body: JSON.stringify({ slug: "some-invite-slug" }),
+      });
+      expect(res.status).toBe(200);
+
+      const row = await prisma.agentInstance.findUnique({
+        where: { instanceId },
+      });
+      expect(row?.ownerAccountId).toBe(owner);
+      expect(row?.conversationId).toBe("fedcba9876543210");
+      expect(row?.inboxId).toBe("inbox-invite");
+    });
+
+    test("ownership is first-writer-wins: a re-dispatch for the same instance cannot reassign who pays", async () => {
+      const owner = await newAccount();
+      const other = await newAccount();
+      const instanceId = `pwr-${randomUUID()}`;
+      createdInstanceIds.push(instanceId);
+
+      await recordAgentInstanceDispatched({
+        instanceId,
+        ownerAccountId: owner,
+        conversationId: null,
+      });
+      await recordAgentInstanceDispatched({
+        instanceId,
+        ownerAccountId: other,
+        conversationId: "abc123def4567890",
+      });
+
+      const row = await prisma.agentInstance.findUnique({
+        where: { instanceId },
+      });
+      expect(row?.ownerAccountId).toBe(owner);
+      expect(row?.conversationId).toBe("abc123def4567890");
+    });
+  });
+
+  describe("GET /agents/join/:instanceId", () => {
+    test("carries owner-computed agentPowerDepleted and heals inboxId/conversationId, for any viewer", async () => {
+      const owner = await newAccount();
+      await seedBalance(owner, 10n);
+      const brokeViewer = await newAccount(); // not the owner, zero balance
+
+      const instanceId = await seedAgent({
+        ownerAccountId: owner,
+        conversationId: null,
+        inboxId: null,
+      });
+
+      mockFetchImpl = () =>
+        Promise.resolve(
+          jsonResponse(200, {
+            instanceId,
+            joinStatus: "ready",
+            inboxId: "inbox-heal",
+            conversationId: "abc123def4567890",
+          }),
+        );
+
+      const res = await getJoinStatus(instanceId, brokeViewer);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        joined: boolean;
+        agentPowerDepleted?: boolean;
+      };
+      expect(body.joined).toBe(true);
+      // Owner is funded → false, even though the CALLER is broke.
+      expect(body.agentPowerDepleted).toBe(false);
+
+      const row = await prisma.agentInstance.findUnique({
+        where: { instanceId },
+      });
+      expect(row?.inboxId).toBe("inbox-heal");
+      expect(row?.conversationId).toBe("abc123def4567890");
+    });
+
+    test("unknown instance (pre-bookkeeping dispatch) → field omitted, legacy shape intact", async () => {
+      const viewer = await newAccount();
+      const instanceId = `pwr-${randomUUID()}`; // deliberately never recorded
+
+      mockFetchImpl = () =>
+        Promise.resolve(
+          jsonResponse(200, {
+            instanceId,
+            joinStatus: "joined",
+            inboxId: "inbox-unknown",
+            conversationId: null,
+          }),
+        );
+
+      const res = await getJoinStatus(instanceId, viewer);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.success).toBe(true);
+      expect(body.joined).toBe(true);
+      expect(body).not.toHaveProperty("agentPowerDepleted");
+    });
+  });
+});

--- a/tests/agent-power-depleted.test.ts
+++ b/tests/agent-power-depleted.test.ts
@@ -460,7 +460,7 @@ describe("agentPowerDepleted (owner-computed agent power)", () => {
       expect(row?.inboxId).toBe("inbox-invite");
     });
 
-    test("ownership is first-writer-wins: a re-dispatch for the same instance cannot reassign who pays", async () => {
+    test("identity facts are write-once: a re-dispatch can fill a null conversationId but can never reassign the payer or relocate the agent", async () => {
       const owner = await newAccount();
       const other = await newAccount();
       const instanceId = `pwr-${randomUUID()}`;
@@ -471,10 +471,19 @@ describe("agentPowerDepleted (owner-computed agent power)", () => {
         ownerAccountId: owner,
         conversationId: null,
       });
+      // Replay from another account: may fill the still-null conversation,
+      // must not touch ownership.
       await recordAgentInstanceDispatched({
         instanceId,
         ownerAccountId: other,
         conversationId: "abc123def4567890",
+      });
+      // A further replay declaring a DIFFERENT conversation must not move
+      // the agent's entry into another conversation's payload.
+      await recordAgentInstanceDispatched({
+        instanceId,
+        ownerAccountId: other,
+        conversationId: "9999999999999999",
       });
 
       const row = await prisma.agentInstance.findUnique({
@@ -522,6 +531,41 @@ describe("agentPowerDepleted (owner-computed agent power)", () => {
       });
       expect(row?.inboxId).toBe("inbox-heal");
       expect(row?.conversationId).toBe("abc123def4567890");
+    });
+
+    test("upstream status about a DIFFERENT instance cannot poison the polled row", async () => {
+      const owner = await newAccount();
+      const viewer = await newAccount();
+
+      const instanceId = await seedAgent({
+        ownerAccountId: owner,
+        conversationId: null,
+        inboxId: null,
+      });
+
+      // Upstream answers with another instance's identity facts.
+      mockFetchImpl = () =>
+        Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "some-other-instance",
+            joinStatus: "joined",
+            inboxId: "inbox-foreign",
+            conversationId: "abc123def4567890",
+          }),
+        );
+
+      const res = await getJoinStatus(instanceId, viewer);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      // Legacy shape still served; enrichment skipped entirely.
+      expect(body.success).toBe(true);
+      expect(body).not.toHaveProperty("agentPowerDepleted");
+
+      const row = await prisma.agentInstance.findUnique({
+        where: { instanceId },
+      });
+      expect(row?.inboxId).toBeNull();
+      expect(row?.conversationId).toBeNull();
     });
 
     test("unknown instance (pre-bookkeeping dispatch) → field omitted, legacy shape intact", async () => {


### PR DESCRIPTION
## What

Adds the owner-computed, viewer-independent `agentPowerDepleted` field to the payloads where clients read agent info for conversations — the backend half of CON-807.

`agentPowerDepleted === true` ⇔ the agent's PAYER cannot fund a turn right now: computed from the agent OWNER's ledger wallet (`getBalance` — the single source of truth) against the exact same floor the runtime spend gate uses (`isSpendAllowed`: `balance >= PAYMENTS_RESERVED_MAX_TURN_CREDITS`, `src/payments/spendable.ts`). The viewer's own balance is never an input.

### Payload changes (response-side, additive only)

- `GET /v2/conversations/:conversationId/participation` → now also returns `agents: [{ inboxId, agentPowerDepleted }]` for the conversation's known agents. Identical for every authenticated caller. On enrichment failure the field is omitted and the legacy `{ success, conversationId, mode }` shape is served unchanged.
- `GET /v2/agents/join/:instanceId` → now also returns `agentPowerDepleted` for the polled instance (omitted when the instance predates the bookkeeping).
- No request schema was touched anywhere; shipped clients ignore unknown response fields, so old builds are unaffected.

### How the backend knows the owner

New `AgentInstance` table (`instanceId` PK → `ownerAccountId`, `conversationId`, `inboxId`). The backend is the sole authority on who pays for an agent — `ownerAccountId` is stamped from the joining caller's JWT at dispatch (`join.ts`), the same value sent to the assistant control plane. `conversationId`/`inboxId` are filled from the runtime's status rows (direct-add poller, invite-join poller, client join-status polling). All identity facts are write-once: a dispatch replay can never reassign the payer, and only the recorded payer can fill a still-null conversation from a dispatch; runtime status rows (matched by instanceId — mismatched upstream rows are ignored) are the canonical fill path. Bookkeeping failures never fail a join.

Rows are advisory, not membership truth (membership lives in the XMTP group; the backend never learns agent destruction). Clients bind entries by `inboxId` against the actual member list, so stale rows are inert. Agents that joined before this ships have no row and therefore no entry — absent data means "unknown", not "depleted".

### Performance

Participation enrichment is fully batched: one indexed `AgentInstance` read + one `getBalances` call over the DISTINCT owners per request, whatever the number of agents (pinned by a test: 3 agents / 2 owners → exactly 1 batched balance query, 0 per-agent reads). `@/payments` grows `getBalances` (batch `getBalance`, same source of truth, missing rows read as 0n) and re-exports `isAllowedFromBalance`; the payments AGENTS.md tables are updated. Join-status enrichment is one SELECT, with UPDATEs only when a null field actually transitions, so polling cannot amplify write load.

## For the iOS team — intended client semantics

Bind every per-agent "lost power" surface (in-stream `.agentOutOfCredits` cell, member-card row, `AgentLostPowerStatus`) to this field ONLY, matched by `inboxId` — and stop consulting `CreditsServices.shared.currentBalance.isDepleted` for any agent state (keep the viewer-wallet binding solely for viewer-scoped surfaces: home pill, tab indicator, settings). A healthy owner means NO icon for anyone, including a viewer at 0 credits — that viewer seeing someone else's funded agent as dead is exactly the CON-807 bug this retires. When `agentPowerDepleted` is true, the state is visible to ALL members identically; only the "add credits" CTA should remain owner-only. Treat a missing field/entry as unknown (show nothing), not as depleted.

## Testing

New `tests/agent-power-depleted.test.ts` (12 tests): depleted owner → `true` for every viewer; **CON-807 regression case** — a ZERO-balance viewer sees a funded owner's agent as `false`; byte-identical `agents` array across four viewer identities; batch contract (one `getBalances` for distinct owners, zero `getBalance` calls, unregistered agents excluded); graceful degradation to legacy shapes; join bookkeeping (direct-add + invite); write-once ownership/conversation incl. foreign-replay rejection; foreign upstream status rows cannot poison a row.

Full suite: 1638/1639 passing + typecheck + eslint + prettier green. (`tests/telemetry-metrics.test.ts` "413 even with honest length" flakes intermittently — untouched by this diff and reproducibly flaky standalone on the base.) Migration re-verified via `prisma migrate deploy` on a fresh database; `prisma migrate dev` had also emitted pre-existing drift (ledger FK re-validation, index renames) which was deliberately stripped from this migration.

Adversarial review (codex, 2 turns): 3 MAJORs found and fixed — migration drift removal, write-once conversation/ownership hardening incl. the foreign-replay fill, poll write amplification + upstream instanceId guard. Remaining accepted risk (judged SOUND by the reviewer): a concurrent cross-account replay of a stolen in-flight UUIDv4 idempotencyKey could mislabel the advisory display bit; the control plane records its own canonical owner and the runtime spends against that, never against this table.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787920999&installation_model_id=20076&pr_number=395&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F395&signature=8f30d9f0da731da6486c78ff0086c8c99f690fafb1efd9e1d3eceee0bd256382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add owner-computed `agentPowerDepleted` to agent join and participation payloads
> - Introduces a new `AgentInstance` table ([migration](https://github.com/xmtplabs/convos-backend/pull/395/files#diff-307e16ccb5e03619f04111e0e46ca460853540efca879930908e6d470bdf64ee)) to track instanceId, ownerAccountId, inboxId, and conversationId as write-once identity facts persisted during join flows.
> - `POST /api/v2/agents/join` now persists the agent instance owner at dispatch time; inboxId/conversationId are filled in when first observed during polling.
> - `GET /api/v2/agents/join/:instanceId` conditionally includes an `agentPowerDepleted` boolean derived from the owner account's credit balance.
> - `GET /api/v2/conversations/:conversationId/participation` now includes an `agents` array of `{ inboxId, agentPowerDepleted }` computed via a batched balance read across all agent owners; the field is omitted if enrichment fails.
> - Adds `getBalances` (batch) and `isAllowedFromBalance` (pure predicate) exports to [src/payments/index.ts](https://github.com/xmtplabs/convos-backend/pull/395/files#diff-330cf903314d2567b854d6d23e33b627ad5f2586062d657d9d8aeb1b0dd916fb) to support these lookups without redundant reads.
> - Behavioral Change: `agentPowerDepleted` is owner-based and viewer-independent; all enrichment failures are logged and degrade gracefully without affecting existing response shapes.
>
> #### 🖇️ Linked Issues
> Implements [CON-807](ticket:linear/CON-807).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd22a2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->