### PR TITLE
feat(subscriptions): allowlist Apple subscription reconcile job (pilot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "migrate:dev": "prisma migrate dev",
     "prisma:generate": "rimraf prisma/generated/zod && prisma generate",
     "start": "node --enable-source-maps --env-file-if-exists=.env --import @opentelemetry/instrumentation/hook.mjs --import ./dist/instrumentation.js dist/index.js",
+    "subs:reconcile": "tsx --env-file-if-exists=.env scripts/reconcile-apple-subscriptions.ts",
     "test": "vitest run",
     "test:local": "pnpm prisma migrate reset --force && vitest run",
     "test:notifications-client": "TEST_NOTIFICATION_DELIVERY_URL=http://host.docker.internal:8081 XMTP_NOTIFICATION_SECRET=test-notification-secret dev/restart-notification && vitest run tests/notifications.client.test.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -126,6 +126,57 @@ TestFlight purchases live in Apple's **sandbox** environment. A sandbox
 same id with `--sandbox`. If it also 404s with `--sandbox`, check that the
 bundle ID, environment, and API key in `.env` match the app.
 
+---
+
+# Apple Subscription Reconcile — allowlist pilot (`subs:reconcile`)
+
+Reconciles local `Subscription` rows against Apple ground truth
+(`GET /inApps/v1/subscriptions/{originalTransactionId}`) for an EXPLICIT
+allowlist of `originalTransactionId`s. This is the write-capable sibling of
+`apple:sub-status`: it maps Apple's per-item `status` enum to our
+`SubscriptionStatus` (same mapping contract as verify/SSN), updates the row
+through the normal repository path, and moves money ONLY through the
+idempotent per-period helpers (`grantSubscriptionPeriod` /
+`forfeitSubscriptionPeriod` — see `src/payments/AGENTS.md`).
+
+```bash
+# DRY-RUN (default): prints the intended changes, writes NOTHING.
+pnpm subs:reconcile <originalTransactionId...>
+
+# Execute (row update + idempotent grant/forfeit + AdminAudit row):
+pnpm subs:reconcile <originalTransactionId...> --apply
+
+# Options:
+#   --env production|sandbox   pin the App Store Server API host (default:
+#                              configured env first, opposite host on a
+#                              4040010/4040005 not-found — TestFlight OTXs
+#                              live in sandbox)
+#   --actor <email>            actor recorded on AdminAudit rows (apply mode)
+```
+
+Key properties:
+
+- **Dry-run first, always.** The dry-run reports, per id: the current row,
+  what Apple answered (and from which host), the intended row update, and the
+  planned ledger movement — including a prediction of whether a terminal
+  forfeit will no-op because the period was never granted.
+- **Idempotent.** Grants/forfeits key on `(subscription, period)`; a re-run
+  no-ops. The row write is concurrency-guarded on `updatedAt` — a verify/SSN
+  landing mid-run wins and the job skips.
+- **Fail-safe.** Any Apple error or ambiguous response leaves the row
+  untouched (`provider_unresolved`).
+- **Pilot scope.** Allowlist input only — no fleet scan, no cron. The scan
+  machinery lives on the unmerged branch `louis/credits-reconcile-cron`
+  (commit `2b0b041`) and gets resurrected when this graduates to a recurring
+  safety net.
+
+Unlike `apple:sub-status`, this job imports the server source and therefore
+needs the FULL server env (`DATABASE_URL`, the `APPLE_API_*` block,
+`PAYMENTS_GRANT_PLUS_MONTHLY`, plus everything `src/config.ts` requires at
+load). Run it where that env already exists (the API container, or a shell
+with the server `.env`). It never prints env values. Exits non-zero when any
+allowlisted id could not be fully processed.
+
 ## Finding originalTransactionIds
 
 Read-only SQL against the backend database (placeholders — substitute real

--- a/scripts/reconcile-apple-subscriptions.ts
+++ b/scripts/reconcile-apple-subscriptions.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env tsx
+
+/**
+ * Apple subscription reconcile — allowlist pilot CLI.
+ *
+ * Re-fetches Apple ground truth (Get All Subscription Statuses) for an
+ * EXPLICIT allowlist of originalTransactionIds and reconciles the local
+ * Subscription rows through the normal repository/ledger paths
+ * (src/subscriptions/reconcile/service.ts). DRY-RUN by default: prints the
+ * intended changes and writes nothing. `--apply` executes.
+ *
+ * Usage:
+ *   pnpm subs:reconcile <originalTransactionId...> [--apply] [--env production|sandbox] [--actor <email>]
+ *
+ * Options:
+ *   --apply            Execute the writes (default: dry-run, writes nothing).
+ *   --env <e>          Pin the App Store Server API environment (production|
+ *                      sandbox). Default: query the configured environment
+ *                      first and fall back to the opposite host on a 4040010/
+ *                      4040005 not-found (TestFlight OTXs live in sandbox).
+ *   --actor <email>    Actor recorded on the AdminAudit rows written in apply
+ *                      mode (default: subscription-reconcile-cli).
+ *   -h, --help         Show this help.
+ *
+ * Unlike scripts/check-apple-subscription-status.ts (read-only, self-
+ * contained), this job imports the server source: it needs the FULL server
+ * env (DATABASE_URL, the APPLE_API_* block, PAYMENTS_GRANT_PLUS_MONTHLY, and
+ * the vars @/config requires at load). Run it where that env exists — the
+ * API container / a shell with the server .env — never with hand-assembled
+ * partial env. Never prints env values.
+ */
+import { Environment } from "@apple/app-store-server-library";
+import {
+  runAppleAllowlistReconcile,
+  type OtxReconcileResult,
+} from "@/subscriptions/reconcile/service";
+import { prisma } from "@/utils/prisma";
+
+const USAGE = `Usage:
+  pnpm subs:reconcile <originalTransactionId...> [--apply] [--env production|sandbox] [--actor <email>]
+
+Reconciles the local Subscription rows for an explicit allowlist of Apple
+originalTransactionIds against Apple's Get All Subscription Statuses.
+DRY-RUN by default (prints intended changes, writes nothing); --apply executes.
+
+Options:
+  --apply          Execute (row update + idempotent per-period grant/forfeit
+                   through the ledger helpers + AdminAudit row).
+  --env <e>        Pin the App Store Server API environment: production |
+                   sandbox. Default: configured environment first, opposite
+                   host on a 4040010/4040005 not-found.
+  --actor <email>  Actor for AdminAudit rows (apply mode).
+  -h, --help       Show this help.
+
+Requires the full server env (DATABASE_URL, APPLE_API_*, ...). Exits non-zero
+when any allowlisted id could not be fully processed (no_row,
+provider_unresolved, skipped_row_changed, error).`;
+
+const FAILURE_OUTCOMES: ReadonlySet<OtxReconcileResult["outcome"]> = new Set([
+  "no_row",
+  "provider_unresolved",
+  "skipped_row_changed",
+  "error",
+]);
+
+const describeMoney = (result: OtxReconcileResult): string[] => {
+  const lines: string[] = [];
+  const { forfeit, grant } = result.money;
+  if (forfeit) {
+    const verdict = forfeit.result
+      ? `-> ${forfeit.result}`
+      : forfeit.priorGrantExists
+        ? "(a sub_grant row exists for that period; the helper will claw back only the unused portion)"
+        : "(NO sub_grant row for that period -> forfeit will no-op; zero ledger movement)";
+    lines.push(`forfeit period ${forfeit.periodStart} ${verdict}`);
+  }
+  if (grant) {
+    const verdict = grant.result
+      ? `-> ${grant.result}`
+      : grant.alreadyGranted
+        ? "(already granted -> idempotent replay, no ledger movement)"
+        : `(would write a ${grant.credits}-credit sub_grant row)`;
+    lines.push(`grant period ${grant.periodStart} ${verdict}`);
+  }
+  if (lines.length === 0) lines.push("none (status-only change)");
+  return lines;
+};
+
+const printResult = (result: OtxReconcileResult) => {
+  console.log(`\n== ${result.originalTransactionId} ==`);
+  console.log(`  outcome: ${result.outcome}`);
+  if (result.unresolvedReason)
+    console.log(`  reason: ${result.unresolvedReason}`);
+  if (result.error) console.log(`  error: ${result.error}`);
+  if (result.subscriptionId)
+    console.log(
+      `  subscription: ${result.subscriptionId} (account ${result.accountId})`,
+    );
+  if (result.before)
+    console.log(
+      `  row before: status=${result.before.status} period=[${result.before.currentPeriodStart} .. ${result.before.currentPeriodEnd}] grace=${result.before.gracePeriodEnd ?? "-"} env=${result.before.environment ?? "-"}`,
+    );
+  if (result.provider)
+    console.log(
+      `  apple says: status=${result.provider.appleStatus ?? "?"} expires=${result.provider.expiresDate ?? "?"} (answered by ${result.provider.environment})`,
+    );
+  if (result.intendedUpdate)
+    console.log(`  row update: ${JSON.stringify(result.intendedUpdate)}`);
+  if (result.after)
+    console.log(
+      `  row after:  status=${result.after.status} period=[${result.after.currentPeriodStart} .. ${result.after.currentPeriodEnd}] grace=${result.after.gracePeriodEnd ?? "-"}`,
+    );
+  if (result.outcome === "planned" || result.outcome === "applied") {
+    for (const line of describeMoney(result)) {
+      console.log(`  money: ${line}`);
+    }
+  }
+};
+
+const main = async () => {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    console.log(USAGE);
+    if (args.length === 0) process.exitCode = 1;
+    return;
+  }
+
+  const otxIds: string[] = [];
+  let apply = false;
+  let environment: Environment | undefined;
+  let actorEmail: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--apply") {
+      apply = true;
+    } else if (arg === "--env") {
+      const value = args[++i];
+      if (value === "production") environment = Environment.PRODUCTION;
+      else if (value === "sandbox") environment = Environment.SANDBOX;
+      else {
+        console.error(`--env must be "production" or "sandbox"\n`);
+        console.error(USAGE);
+        process.exit(1);
+      }
+    } else if (arg === "--actor") {
+      actorEmail = args[++i];
+      if (!actorEmail || actorEmail.startsWith("-")) {
+        console.error(`--actor requires an email argument\n`);
+        console.error(USAGE);
+        process.exit(1);
+      }
+    } else if (arg.startsWith("-")) {
+      console.error(`Unknown option: ${arg}\n`);
+      console.error(USAGE);
+      process.exit(1);
+    } else {
+      otxIds.push(arg);
+    }
+  }
+
+  if (otxIds.length === 0) {
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  console.log(
+    `${apply ? "APPLY" : "DRY-RUN (no writes; pass --apply to execute)"} — ${otxIds.length} originalTransactionId(s)` +
+      (environment ? ` — environment pinned to ${environment}` : ""),
+  );
+
+  const summary = await runAppleAllowlistReconcile({
+    originalTransactionIds: otxIds,
+    apply,
+    environment,
+    actorEmail,
+  });
+
+  for (const result of summary.results) {
+    printResult(result);
+  }
+
+  const failures = summary.results.filter((r) =>
+    FAILURE_OUTCOMES.has(r.outcome),
+  );
+  console.log(
+    `\n${summary.mode}: ${summary.results.length} processed — ` +
+      summary.results.map((r) => r.outcome).join(", "),
+  );
+  if (failures.length > 0) {
+    process.exitCode = 1;
+  }
+};
+
+main()
+  .catch((error: unknown) => {
+    console.error(
+      error instanceof Error ? (error.stack ?? error.message) : String(error),
+    );
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/src/api/v2/credits-admin/audit-repository.ts
+++ b/src/api/v2/credits-admin/audit-repository.ts
@@ -1,7 +1,11 @@
 import type { AdminAudit, Prisma } from "@prisma/client";
 import { prisma } from "@/utils/prisma";
 
-export type AdminAuditAction = "grant" | "adjust";
+// "reconcile" rows are written by the subscription reconcile job
+// (src/subscriptions/reconcile/service.ts) in apply mode, not by an admin
+// endpoint; deltaCredits records the net credits it moved (often 0 for pure
+// status flips).
+export type AdminAuditAction = "grant" | "adjust" | "reconcile";
 
 export const writeAdminAudit = async (args: {
   accountId: string;

--- a/src/api/v2/credits-admin/audit-repository.ts
+++ b/src/api/v2/credits-admin/audit-repository.ts
@@ -7,15 +7,20 @@ import { prisma } from "@/utils/prisma";
 // status flips).
 export type AdminAuditAction = "grant" | "adjust" | "reconcile";
 
-export const writeAdminAudit = async (args: {
-  accountId: string;
-  actorEmail: string;
-  action: AdminAuditAction;
-  deltaCredits: bigint;
-  reason: string;
-  idempotencyKey: string;
-}): Promise<void> => {
-  await prisma.adminAudit.upsert({
+export const writeAdminAudit = async (
+  args: {
+    accountId: string;
+    actorEmail: string;
+    action: AdminAuditAction;
+    deltaCredits: bigint;
+    reason: string;
+    idempotencyKey: string;
+  },
+  // Optional tx client so callers can commit the audit row atomically with
+  // the writes it describes (the reconcile job does).
+  tx: Pick<Prisma.TransactionClient, "adminAudit"> = prisma,
+): Promise<void> => {
+  await tx.adminAudit.upsert({
     where: {
       accountId_idempotencyKey: {
         accountId: args.accountId,

--- a/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
+++ b/src/api/v2/credits-admin/handlers/admin-page/console-view.ts
@@ -33,6 +33,7 @@ export const consoleView = (): string => `
         <span class="facet active" data-action="all">All</span>
         <span class="facet" data-action="grant">Grants</span>
         <span class="facet" data-action="adjust">Adjusts</span>
+        <span class="facet" data-action="reconcile">Reconciles</span>
       </div>
       <div id="ctl-balance" class="mode-ctl hidden">
         <input id="bal-min" type="number" placeholder="Min credits">

--- a/src/api/v2/credits-admin/schemas/requests.ts
+++ b/src/api/v2/credits-admin/schemas/requests.ts
@@ -16,7 +16,7 @@ export const auditQuerySchema = z.object({
 
 export const auditRecentQuerySchema = z.object({
   cursor: z.string().trim().min(1).max(512).optional(),
-  action: z.enum(["all", "grant", "adjust"]).default("all"),
+  action: z.enum(["all", "grant", "adjust", "reconcile"]).default("all"),
 });
 
 export const ledgerQuerySchema = z.object({

--- a/src/subscriptions/apple-server-api.ts
+++ b/src/subscriptions/apple-server-api.ts
@@ -1,4 +1,6 @@
 import {
+  APIError,
+  APIException,
   AppStoreServerAPIClient,
   Environment,
   type StatusResponse,
@@ -6,6 +8,7 @@ import {
 } from "@apple/app-store-server-library";
 import { IS_PRODUCTION } from "@/config";
 import { AppError } from "@/utils/errors";
+import logger from "@/utils/logger";
 
 const resolveEnvironment = () => {
   const raw = process.env.APPLE_ENV?.trim();
@@ -43,6 +46,10 @@ export const buildAppleApiConfig = (): AppleApiConfig => ({
 });
 
 let cachedClient: AppStoreServerAPIClient | null = null;
+const cachedClientsByEnvironment = new Map<
+  Environment,
+  AppStoreServerAPIClient
+>();
 
 export const getAppleApiClient = () => {
   if (cachedClient) return cachedClient;
@@ -57,12 +64,41 @@ export const getAppleApiClient = () => {
   return cachedClient;
 };
 
+/**
+ * A client pinned to an EXPLICIT App Store Server API environment, regardless
+ * of `APPLE_ENV`. Sandbox (TestFlight) transactions only resolve on the
+ * sandbox host, so callers that must read both worlds (the reconcile job)
+ * need a client per environment.
+ */
+export const getAppleApiClientForEnvironment = (environment: Environment) => {
+  const existing = cachedClientsByEnvironment.get(environment);
+  if (existing) return existing;
+  const cfg = buildAppleApiConfig();
+  const client = new AppStoreServerAPIClient(
+    cfg.signingKey,
+    cfg.keyId,
+    cfg.issuerId,
+    cfg.bundleId,
+    environment,
+  );
+  cachedClientsByEnvironment.set(environment, client);
+  return client;
+};
+
 export const resetAppleApiClientForTests = () => {
   cachedClient = null;
+  cachedClientsByEnvironment.clear();
 };
 
 export const setAppleApiClientForTests = (client: AppStoreServerAPIClient) => {
   cachedClient = client;
+};
+
+export const setAppleApiClientForEnvironmentForTests = (
+  environment: Environment,
+  client: AppStoreServerAPIClient,
+) => {
+  cachedClientsByEnvironment.set(environment, client);
 };
 
 /**
@@ -74,6 +110,71 @@ export const getSubscriptionStatuses = async (
   anyTransactionId: string,
 ): Promise<StatusResponse> =>
   getAppleApiClient().getAllSubscriptionStatuses(anyTransactionId);
+
+export type SubscriptionStatusesResult = {
+  response: StatusResponse;
+  /** The environment (host) that actually answered. */
+  environment: Environment;
+};
+
+// A transaction id that lives in the OTHER environment resolves as 404
+// not-found on this host (TRANSACTION_ID_NOT_FOUND = 4040010; some responses
+// use ORIGINAL_TRANSACTION_ID_NOT_FOUND = 4040005). Unlike the JWS verifier —
+// which sees INVALID_ENVIRONMENT after the signature checks — the Server API
+// gives no dedicated wrong-environment signal, so not-found is the fallback
+// trigger. Mirrors the JWS verifier's production→sandbox fallback map.
+const API_FALLBACK_ENVIRONMENT: Partial<Record<Environment, Environment>> = {
+  [Environment.PRODUCTION]: Environment.SANDBOX,
+  [Environment.SANDBOX]: Environment.PRODUCTION,
+};
+
+const isTransactionNotFound = (err: unknown): boolean =>
+  err instanceof APIException &&
+  (err.apiError === APIError.TRANSACTION_ID_NOT_FOUND ||
+    err.apiError === APIError.ORIGINAL_TRANSACTION_ID_NOT_FOUND);
+
+/**
+ * `getAllSubscriptionStatuses` with an environment fallback, for callers that
+ * hold transaction ids from both worlds (production purchases AND
+ * TestFlight/sandbox ones): query the configured environment first and, only
+ * on a not-found (4040010 / 4040005), retry the opposite host. Passing
+ * `opts.environment` pins the query to that environment (no fallback).
+ *
+ * Returned JWS payloads still need to be verified via the JWS verifier before
+ * being trusted (the verifier has its own, symmetric environment fallback).
+ */
+export const getSubscriptionStatusesWithEnvironmentFallback = async (
+  anyTransactionId: string,
+  opts?: { environment?: Environment },
+): Promise<SubscriptionStatusesResult> => {
+  if (opts?.environment) {
+    const response = await getAppleApiClientForEnvironment(
+      opts.environment,
+    ).getAllSubscriptionStatuses(anyTransactionId);
+    return { response, environment: opts.environment };
+  }
+
+  const primary = resolveEnvironment();
+  try {
+    const response =
+      await getAppleApiClientForEnvironment(primary).getAllSubscriptionStatuses(
+        anyTransactionId,
+      );
+    return { response, environment: primary };
+  } catch (err) {
+    const alternate = API_FALLBACK_ENVIRONMENT[primary];
+    if (!alternate || !isTransactionNotFound(err)) throw err;
+    logger.info(
+      { primary, alternate },
+      "apple.server_api.environment_fallback — transaction not found in the primary environment; retrying against the alternate host",
+    );
+    const response =
+      await getAppleApiClientForEnvironment(
+        alternate,
+      ).getAllSubscriptionStatuses(anyTransactionId);
+    return { response, environment: alternate };
+  }
+};
 
 /**
  * Fetch a single signed transaction by id. Returned `signedTransactionInfo`

--- a/src/subscriptions/jws-verifier.ts
+++ b/src/subscriptions/jws-verifier.ts
@@ -6,6 +6,7 @@ import {
   SignedDataVerifier,
   VerificationException,
   VerificationStatus,
+  type JWSRenewalInfoDecodedPayload,
   type JWSTransactionDecodedPayload,
   type ResponseBodyV2DecodedPayload,
 } from "@apple/app-store-server-library";
@@ -228,4 +229,15 @@ export const verifyAndDecodeTransaction = (
 ): Promise<JWSTransactionDecodedPayload> =>
   verifyWithEnvironmentFallback((verifier) =>
     verifier.verifyAndDecodeTransaction(signedTransactionInfo),
+  );
+
+// Decode `signedRenewalInfo` (carries `gracePeriodExpiresDate`, the real Apple
+// grace-period access deadline). Used by the subscription reconcile job — the
+// `status` enum alone distinguishes billing-retry (status=3) from grace
+// (status=4), but only the renewal info carries the grace deadline.
+export const verifyAndDecodeRenewalInfo = (
+  signedRenewalInfo: string,
+): Promise<JWSRenewalInfoDecodedPayload> =>
+  verifyWithEnvironmentFallback((verifier) =>
+    verifier.verifyAndDecodeRenewalInfo(signedRenewalInfo),
   );

--- a/src/subscriptions/reconcile/service.ts
+++ b/src/subscriptions/reconcile/service.ts
@@ -171,8 +171,15 @@ const appleStatusItemToUpdate = (
       };
       // The lapsed paid-period end is the transaction expiresDate; record it
       // as the window so the monotonic guard reasons about the right value.
+      // Carry the purchase date too: the item is Apple's LATEST transaction,
+      // so a renewal we missed before the grace advances the period identity
+      // (subject to the same stabilizer coherence rules as ACTIVE).
       const expiresMs = dateMs(transaction.expiresDate);
       if (expiresMs !== null) update.currentPeriodEnd = new Date(expiresMs);
+      const purchaseMs = dateMs(transaction.purchaseDate);
+      if (purchaseMs !== null) {
+        update.currentPeriodStart = new Date(purchaseMs);
+      }
       return update;
     }
 
@@ -187,28 +194,29 @@ const appleStatusItemToUpdate = (
       };
 
     case AppleSubscriptionStatus.EXPIRED: {
-      const update: NotificationStateUpdate = {
+      // The provider's final period end is MANDATORY for a terminal verdict:
+      // the staleness guard (mirrors applyNotification's) compares it against
+      // the stored window, and a terminal write that would also forfeit must
+      // never run without that comparison. Missing/invalid → fail safe.
+      const expiresMs = dateMs(transaction.expiresDate);
+      if (expiresMs === null) return null;
+      return {
         status: SubscriptionStatus.expired,
         willRenew: false,
         gracePeriodEnd: null,
+        currentPeriodEnd: new Date(expiresMs),
       };
-      // Carry the provider's final period end so the terminal staleness guard
-      // (mirrors applyNotification's) has a window to compare — an EXPIRED
-      // verdict whose window predates our stored one is refused wholesale.
-      const expiresMs = dateMs(transaction.expiresDate);
-      if (expiresMs !== null) update.currentPeriodEnd = new Date(expiresMs);
-      return update;
     }
 
     case AppleSubscriptionStatus.REVOKED: {
-      const update: NotificationStateUpdate = {
+      const expiresMs = dateMs(transaction.expiresDate);
+      if (expiresMs === null) return null;
+      return {
         status: SubscriptionStatus.revoked,
         willRenew: false,
         gracePeriodEnd: null,
+        currentPeriodEnd: new Date(expiresMs),
       };
-      const expiresMs = dateMs(transaction.expiresDate);
-      if (expiresMs !== null) update.currentPeriodEnd = new Date(expiresMs);
-      return update;
     }
 
     default:
@@ -300,11 +308,9 @@ const resolveAppleTruth = async (
   // granting with the row's stored tier/period would mint the wrong
   // allotment. The pilot does not remap SKUs — it fails safe and leaves the
   // row for the operator (the fleet job will carry the productId→tier/period
-  // remap when it lands).
-  if (
-    transaction.productId !== undefined &&
-    transaction.productId !== sub.productId
-  ) {
+  // remap when it lands). A MISSING provider productId also fails safe:
+  // grant sizing cannot be authenticated without it.
+  if (transaction.productId !== sub.productId) {
     logger.warn(
       {
         subscriptionId: sub.id,
@@ -470,7 +476,19 @@ const stabilizePeriodIdentity = (
   if (update.currentPeriodStart === undefined) return update;
   if (isRescue(sub, update)) return update;
   const newEnd = dateMs(update.currentPeriodEnd);
-  if (newEnd !== null && newEnd > sub.currentPeriodEnd.getTime()) return update;
+  const newStart = update.currentPeriodStart.getTime();
+  // Accept a new period identity only when the window moves COHERENTLY
+  // forward: both end and start strictly advance (a real renewal). An
+  // advancing end with a non-advancing start would re-key money under an
+  // older/equal start while `planMoney` sees no period advance — a second
+  // grant key for an already-granted stretch. Keep the stored identity then.
+  if (
+    newEnd !== null &&
+    newEnd > sub.currentPeriodEnd.getTime() &&
+    newStart > sub.currentPeriodStart.getTime()
+  ) {
+    return update;
+  }
   const { currentPeriodStart: _drop, ...rest } = update;
   return rest;
 };
@@ -495,8 +513,12 @@ const isStaleTerminalUpdate = (
  * active/trial/grace but passes `billingRetry` through unconditionally (the
  * known no-TTL gap, status.ts) — under which a long-lapsed row Apple reports
  * as status 3 would mint a full grant for a period whose paid window is over.
- * The reconcile job targets exactly such stale rows, so it additionally
- * requires a billingRetry row's paid window to still be live.
+ * Worse, the row's own `currentPeriodEnd` cannot be trusted as the check
+ * (Apple status 3 carries no window we apply, so the gate would read a
+ * possibly-stale/fabricated local end). The reconcile job therefore
+ * categorically refuses to materialize grants for billingRetry targets: Apple
+ * status 3 means the paid window ENDED at `expiresDate`; if a genuine grant is
+ * missing, the user's next verify materializes it through the normal path.
  */
 const isEntitledForReconcileGrant = (
   fields: {
@@ -506,14 +528,8 @@ const isEntitledForReconcileGrant = (
   },
   now: Date,
 ): boolean => {
-  if (!isEntitledSubscription(fields, now)) return false;
-  if (
-    fields.status === SubscriptionStatus.billingRetry &&
-    fields.currentPeriodEnd.getTime() <= now.getTime()
-  ) {
-    return false;
-  }
-  return true;
+  if (fields.status === SubscriptionStatus.billingRetry) return false;
+  return isEntitledSubscription(fields, now);
 };
 
 export type ReconcileMoneyReport = {

--- a/src/subscriptions/reconcile/service.ts
+++ b/src/subscriptions/reconcile/service.ts
@@ -141,10 +141,15 @@ const appleStatusItemToUpdate = (
         status: isTrial ? SubscriptionStatus.trial : SubscriptionStatus.active,
         currentPeriodEnd: new Date(expiresMs),
         isInTrial: isTrial,
-        willRenew: true,
         // Recovered to active — any prior grace window is over.
         gracePeriodEnd: null,
       };
+      // Apple status=1 does NOT imply auto-renew is on (a cancelled sub stays
+      // active until the period ends). Derive willRenew from the verified
+      // renewal info when we have it; otherwise leave the stored flag alone.
+      if (renewalInfo?.autoRenewStatus !== undefined) {
+        update.willRenew = renewalInfo.autoRenewStatus === 1;
+      }
       const purchaseMs = dateMs(transaction.purchaseDate);
       if (purchaseMs !== null) {
         update.currentPeriodStart = new Date(purchaseMs);
@@ -181,19 +186,30 @@ const appleStatusItemToUpdate = (
         gracePeriodEnd: null,
       };
 
-    case AppleSubscriptionStatus.EXPIRED:
-      return {
+    case AppleSubscriptionStatus.EXPIRED: {
+      const update: NotificationStateUpdate = {
         status: SubscriptionStatus.expired,
         willRenew: false,
         gracePeriodEnd: null,
       };
+      // Carry the provider's final period end so the terminal staleness guard
+      // (mirrors applyNotification's) has a window to compare — an EXPIRED
+      // verdict whose window predates our stored one is refused wholesale.
+      const expiresMs = dateMs(transaction.expiresDate);
+      if (expiresMs !== null) update.currentPeriodEnd = new Date(expiresMs);
+      return update;
+    }
 
-    case AppleSubscriptionStatus.REVOKED:
-      return {
+    case AppleSubscriptionStatus.REVOKED: {
+      const update: NotificationStateUpdate = {
         status: SubscriptionStatus.revoked,
         willRenew: false,
         gracePeriodEnd: null,
       };
+      const expiresMs = dateMs(transaction.expiresDate);
+      if (expiresMs !== null) update.currentPeriodEnd = new Date(expiresMs);
+      return update;
+    }
 
     default:
       // Unknown / unset status → fail closed (leave the row for a later run).
@@ -278,6 +294,27 @@ const resolveAppleTruth = async (
       "subscription_reconcile.apple.jws_verify_failed",
     );
     return { kind: "unresolved", reason: "jws_verify_failed" };
+  }
+
+  // Product identity guard: an upgrade/downgrade changes the productId, and
+  // granting with the row's stored tier/period would mint the wrong
+  // allotment. The pilot does not remap SKUs — it fails safe and leaves the
+  // row for the operator (the fleet job will carry the productId→tier/period
+  // remap when it lands).
+  if (
+    transaction.productId !== undefined &&
+    transaction.productId !== sub.productId
+  ) {
+    logger.warn(
+      {
+        subscriptionId: sub.id,
+        storedProductId: sub.productId,
+        providerProductId: transaction.productId,
+        op: "subscription_reconcile",
+      },
+      "subscription_reconcile.apple.product_id_mismatch",
+    );
+    return { kind: "unresolved", reason: "product_id_mismatch" };
   }
 
   // Decode renewal info when present — it carries gracePeriodExpiresDate, the
@@ -417,6 +454,68 @@ const clampGracePeriodEnd = (
     : { ...update, gracePeriodEnd: prev };
 };
 
+/**
+ * Period-identity stabilizer: `currentPeriodStart` is the grant/forfeit
+ * idempotency-key anchor (`sub_grant_<id>_<startEpoch>`), so rewriting it
+ * WITHOUT a genuine period change would re-key the same real period — a
+ * drifting provider `purchaseDate` on an unchanged window could then mint a
+ * second grant for a period that was already granted under the stored start.
+ * Keep the stored start unless the window END strictly advances (a real
+ * renewal moves both) or a rescue takes provider truth verbatim.
+ */
+const stabilizePeriodIdentity = (
+  sub: Subscription,
+  update: NotificationStateUpdate,
+): NotificationStateUpdate => {
+  if (update.currentPeriodStart === undefined) return update;
+  if (isRescue(sub, update)) return update;
+  const newEnd = dateMs(update.currentPeriodEnd);
+  if (newEnd !== null && newEnd > sub.currentPeriodEnd.getTime()) return update;
+  const { currentPeriodStart: _drop, ...rest } = update;
+  return rest;
+};
+
+/**
+ * Terminal staleness guard (mirrors `applyNotification`'s): an EXPIRED/REVOKED
+ * verdict whose provider window predates the stored one describes an OLDER
+ * period than the row holds — refuse the entire update rather than terminalize
+ * (and forfeit) a newer local period on stale provider data.
+ */
+const isStaleTerminalUpdate = (
+  sub: Subscription,
+  update: NotificationStateUpdate,
+): boolean =>
+  update.status !== undefined &&
+  isTerminalStatus(update.status) &&
+  update.currentPeriodEnd !== undefined &&
+  update.currentPeriodEnd.getTime() < sub.currentPeriodEnd.getTime();
+
+/**
+ * Grant gate for the reconcile job. `isEntitledSubscription` is time-aware for
+ * active/trial/grace but passes `billingRetry` through unconditionally (the
+ * known no-TTL gap, status.ts) — under which a long-lapsed row Apple reports
+ * as status 3 would mint a full grant for a period whose paid window is over.
+ * The reconcile job targets exactly such stale rows, so it additionally
+ * requires a billingRetry row's paid window to still be live.
+ */
+const isEntitledForReconcileGrant = (
+  fields: {
+    status: SubscriptionStatus;
+    currentPeriodEnd: Date;
+    gracePeriodEnd: Date | null;
+  },
+  now: Date,
+): boolean => {
+  if (!isEntitledSubscription(fields, now)) return false;
+  if (
+    fields.status === SubscriptionStatus.billingRetry &&
+    fields.currentPeriodEnd.getTime() <= now.getTime()
+  ) {
+    return false;
+  }
+  return true;
+};
+
 export type ReconcileMoneyReport = {
   forfeit?: {
     periodStart: string;
@@ -542,14 +641,20 @@ const planMoney = async (
     safeUpdate.currentPeriodStart ?? sub.currentPeriodStart;
 
   if (isTerminalStatus(targetStatus)) {
-    money.forfeit = {
-      periodStart: sub.currentPeriodStart.toISOString(),
-      priorGrantExists: await hasPeriodGrant(
-        sub.accountId,
-        sub.id,
-        sub.currentPeriodStart,
-      ),
-    };
+    // Forfeit only on an actual TRANSITION into a terminal status. A row that
+    // is already terminal never gets a retroactive forfeit backfill from this
+    // job — clawing back long-kept credits is a policy call out of pilot
+    // scope.
+    if (!isTerminalStatus(sub.status)) {
+      money.forfeit = {
+        periodStart: sub.currentPeriodStart.toISOString(),
+        priorGrantExists: await hasPeriodGrant(
+          sub.accountId,
+          sub.id,
+          sub.currentPeriodStart,
+        ),
+      };
+    }
     return money;
   }
 
@@ -574,9 +679,10 @@ const planMoney = async (
           ? (safeUpdate.gracePeriodEnd ?? null)
           : sub.gracePeriodEnd,
     };
-    // Time-aware gate, mirroring verify's replay-materializer: never plan a
-    // grant for an effectively-expired window.
-    if (isEntitledSubscription(projected, now)) {
+    // Time-aware gate (verify's replay-materializer + the billingRetry
+    // paid-window requirement): never plan a grant for an effectively-expired
+    // window.
+    if (isEntitledForReconcileGrant(projected, now)) {
       money.grant = {
         periodStart: targetPeriodStart.toISOString(),
         alreadyGranted: await hasPeriodGrant(
@@ -604,17 +710,22 @@ type AppliedOutcome = {
  * on the `updatedAt` read at plan time (a fresher verify/webhook wins — skip);
  * money moves ONLY through the idempotent per-period helpers, in the same
  * transaction, mirroring `applyNotification`'s branches:
- *   - terminal status → forfeit the period the row was in (no-ops when that
- *     period was never granted);
+ *   - TRANSITION into a terminal status → forfeit the period the row was in
+ *     (no-ops when that period was never granted; already-terminal rows are
+ *     never retro-forfeited — pilot policy);
  *   - entitled + period advanced → forfeit the old period (consumes bounded to
  *     the new period start), then grant the new period;
  *   - entitled + time-aware live window → materialize a missing current-period
  *     grant (idempotent replay when it exists).
+ * The AdminAudit row commits in the SAME transaction, keyed on the guarded
+ * snapshot's `updatedAt` — unique per CAS-guarded apply, replay-stable on a
+ * retry of the same snapshot.
  */
 const applyReconcileUpdate = async (
   snapshot: Subscription,
   safeUpdate: NotificationStateUpdate,
   now: Date,
+  audit: { actorEmail: string; originalTransactionId: string },
 ): Promise<AppliedOutcome> =>
   prisma.$transaction(async (tx) => {
     const guarded = await tx.subscription.updateMany({
@@ -632,10 +743,12 @@ const applyReconcileUpdate = async (
     let forfeitResult: ForfeitSubscriptionPeriodResult | undefined;
 
     if (isTerminalStatus(updated.status)) {
-      forfeitResult = await forfeitSubscriptionPeriod(tx, {
-        subscription: updated,
-        periodStart: snapshot.currentPeriodStart,
-      });
+      if (!isTerminalStatus(snapshot.status)) {
+        forfeitResult = await forfeitSubscriptionPeriod(tx, {
+          subscription: updated,
+          periodStart: snapshot.currentPeriodStart,
+        });
+      }
     } else if (isEntitledSubscriptionStatus(updated.status)) {
       if (
         updated.currentPeriodStart.getTime() >
@@ -647,13 +760,29 @@ const applyReconcileUpdate = async (
           consumesUntil: updated.currentPeriodStart,
         });
       }
-      if (isEntitledSubscription(updated, now)) {
+      if (isEntitledForReconcileGrant(updated, now)) {
         grantResult = await grantSubscriptionPeriod(tx, {
           subscription: updated,
           periodStart: updated.currentPeriodStart,
         });
       }
     }
+
+    const granted =
+      grantResult?.kind === "granted" ? BigInt(grantResult.credits) : 0n;
+    const forfeited =
+      forfeitResult?.kind === "forfeited" ? BigInt(forfeitResult.credits) : 0n;
+    await writeAdminAudit(
+      {
+        accountId: updated.accountId,
+        actorEmail: audit.actorEmail,
+        action: "reconcile",
+        deltaCredits: granted - forfeited,
+        reason: `apple subscription reconcile ${audit.originalTransactionId}: ${snapshot.status} -> ${updated.status}`,
+        idempotencyKey: `sub_reconcile_${updated.id}_${snapshot.updatedAt.getTime()}`,
+      },
+      tx,
+    );
 
     return { outcome: "applied" as const, updated, grantResult, forfeitResult };
   });
@@ -715,18 +844,21 @@ export async function runAppleAllowlistReconcile(
         continue;
       }
 
+      // Terminal staleness guard runs on the RAW provider update, BEFORE the
+      // monotonic floor could strip the regressing window and let the bare
+      // terminal status through.
+      if (isStaleTerminalUpdate(sub, truth.update)) {
+        result.outcome = "provider_unresolved";
+        result.unresolvedReason = "stale_provider_terminal";
+        continue;
+      }
+
       const safeUpdate = clampGracePeriodEnd(
         sub,
-        monotonicUpdate(sub, truth.update),
+        monotonicUpdate(sub, stabilizePeriodIdentity(sub, truth.update)),
       );
       const rowChangeNeeded = shouldWrite(sub, safeUpdate);
       const money = await planMoney(sub, safeUpdate, now);
-      if (!rowChangeNeeded) {
-        // No state transition → no forfeit. Backfilling a MISSED forfeit for a
-        // row that is already terminal claws back credits the user has been
-        // sitting on — a policy decision deliberately out of pilot scope.
-        delete money.forfeit;
-      }
       // An entitled, time-aware-live row missing its current-period sub_grant
       // is money drift even when the row state itself is in sync — still
       // reconcile it (the grant helper is idempotent either way).
@@ -746,7 +878,10 @@ export async function runAppleAllowlistReconcile(
         continue;
       }
 
-      const applied = await applyReconcileUpdate(sub, safeUpdate, now);
+      const applied = await applyReconcileUpdate(sub, safeUpdate, now, {
+        actorEmail,
+        originalTransactionId,
+      });
       result.outcome = applied.outcome;
       if (applied.outcome !== "applied" || !applied.updated) continue;
 
@@ -764,36 +899,20 @@ export async function runAppleAllowlistReconcile(
         result.money.grant.result = applied.grantResult.kind;
       }
 
-      // Audit trail for the operator-run apply. Idempotent per resulting
-      // state, so a re-run that no-ops (shouldWrite=false) or re-applies the
-      // same transition never duplicates rows.
-      const granted =
-        applied.grantResult?.kind === "granted"
-          ? BigInt(applied.grantResult.credits)
-          : 0n;
-      const forfeited =
-        applied.forfeitResult?.kind === "forfeited"
-          ? BigInt(applied.forfeitResult.credits)
-          : 0n;
-      await writeAdminAudit({
-        accountId: updated.accountId,
-        actorEmail,
-        action: "reconcile",
-        deltaCredits: granted - forfeited,
-        reason: `apple subscription reconcile ${originalTransactionId}: ${sub.status} -> ${updated.status}`,
-        idempotencyKey: `sub_reconcile_${updated.id}_${Math.floor(
-          updated.currentPeriodEnd.getTime() / 1000,
-        )}_${updated.status}`,
-      });
-
       logger.info(
         {
           subscriptionId: updated.id,
           accountId: updated.accountId,
           statusBefore: sub.status,
           statusAfter: updated.status,
-          granted: granted.toString(),
-          forfeited: forfeited.toString(),
+          granted:
+            applied.grantResult?.kind === "granted"
+              ? applied.grantResult.credits
+              : 0,
+          forfeited:
+            applied.forfeitResult?.kind === "forfeited"
+              ? applied.forfeitResult.credits
+              : 0,
           op: "subscription_reconcile",
         },
         "subscription_reconcile.applied",

--- a/src/subscriptions/reconcile/service.ts
+++ b/src/subscriptions/reconcile/service.ts
@@ -1,0 +1,826 @@
+import {
+  Status as AppleSubscriptionStatus,
+  type Environment,
+  type JWSRenewalInfoDecodedPayload,
+  type JWSTransactionDecodedPayload,
+} from "@apple/app-store-server-library";
+import { SubscriptionStatus } from "@prisma/client";
+import { writeAdminAudit } from "@/api/v2/credits-admin/audit-repository";
+import { getSubscriptionStatusesWithEnvironmentFallback } from "@/subscriptions/apple-server-api";
+import {
+  forfeitSubscriptionPeriod,
+  grantSubscriptionPeriod,
+  subGrantKey,
+  type ForfeitSubscriptionPeriodResult,
+  type GrantSubscriptionPeriodResult,
+} from "@/subscriptions/grants";
+import {
+  verifyAndDecodeRenewalInfo,
+  verifyAndDecodeTransaction,
+} from "@/subscriptions/jws-verifier";
+import {
+  findAppleByOriginalTransactionId,
+  type NotificationStateUpdate,
+  type Subscription,
+} from "@/subscriptions/repository";
+import {
+  deriveSubscriptionStatusFromTransaction,
+  isEntitledSubscription,
+  isEntitledSubscriptionStatus,
+} from "@/subscriptions/status";
+import { tierGrant } from "@/subscriptions/tier-config";
+import { requireSubscriptionTier } from "@/subscriptions/tiers";
+import logger from "@/utils/logger";
+import { prisma } from "@/utils/prisma";
+
+/**
+ * Apple subscription reconcile — ALLOWLIST PILOT.
+ *
+ * Prod received zero App Store Server Notifications from launch until
+ * 2026-07-29 (no Production Server URL was registered in App Store Connect),
+ * so Subscription rows are frozen at their last client verify: statuses stay
+ * `active` past `currentPeriodEnd`, EXPIRED/REFUND events were never applied,
+ * and renewal re-grants only ever arrived via app-open re-verifies. This job
+ * re-fetches PROVIDER GROUND TRUTH per subscription and refreshes the local
+ * row — the repair path for that drift class.
+ *
+ * PILOT SCOPE — deliberately narrow:
+ *   - Allowlist input only: explicit `originalTransactionId`s, resolved to
+ *     Subscription rows one by one. There is NO fleet scan and NO cron mode in
+ *     this module yet; the at-risk/rescue scan machinery exists on the
+ *     unmerged branch `louis/credits-reconcile-cron` (commit 2b0b041), from
+ *     which this module's Apple mapping and write-guards are ported, and gets
+ *     resurrected when the job is promoted from pilot to safety net.
+ *   - Apple only (both pilot rows are Apple). The Google path also lives in
+ *     2b0b041.
+ *   - DRY-RUN by default: the job reports intended changes and writes nothing.
+ *     `apply: true` executes.
+ *
+ * Provider truth, not transaction expiry (ported from 2b0b041):
+ *   Liveness comes from the per-item `status` enum on
+ *   `getAllSubscriptionStatuses` (1 active / 2 expired / 3 billing-retry /
+ *   4 grace / 5 revoked) PLUS the decoded `signedRenewalInfo`
+ *   (`gracePeriodExpiresDate`). The transaction's `expiresDate` is the
+ *   entitlement WINDOW, never the liveness verdict — a billing-retry sub has a
+ *   past `expiresDate` but must NOT be expired by us. Every signed payload is
+ *   verified through the JWS verifier before being trusted.
+ *
+ * Money (src/payments/AGENTS.md law):
+ *   ALL balance movement goes through the idempotent per-period helpers —
+ *   `grantSubscriptionPeriod` / `forfeitSubscriptionPeriod` — inside the same
+ *   transaction as the row update. A terminal transition forfeits the period
+ *   the row was in, which NO-OPS (`skipped_nothing_to_forfeit`) when that
+ *   period's grant was never written — reconciling a never-granted expired row
+ *   moves zero credits. An entitled row with a missing current-period grant is
+ *   materialized via `grantSubscriptionPeriod` (idempotent on the per-period
+ *   key — replays no-op). Dry-run only READS the ledger.
+ *
+ * Write-guards (ported from 2b0b041):
+ *   - Monotonic: never roll `currentPeriodEnd` backwards, except a confirmed
+ *     rescue (non-entitled row the provider reports live again).
+ *   - Non-extending grace clamp on `gracePeriodEnd`.
+ *   - Concurrency-guarded apply: `updateMany` predicated on the `updatedAt`
+ *     read at plan time — a webhook/verify landing mid-run wins, we skip.
+ *   - Fail-safe: any provider error or ambiguous data leaves the row
+ *     UNCHANGED (`provider_unresolved`).
+ */
+
+const dateMs = (
+  value: Date | number | string | undefined | null,
+): number | null => {
+  if (value === undefined || value === null) return null;
+  const ms =
+    value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+};
+
+const iso = (value: Date | null | undefined): string | null =>
+  value ? value.toISOString() : null;
+
+/**
+ * The diff a provider poll resolves into. `null` is the fail-safe signal:
+ * "could not resolve ground truth — do NOT touch the row this run."
+ */
+type ResolvedTruth = NotificationStateUpdate | null;
+
+/**
+ * Build the entitlement update from an Apple status item — the per-item
+ * `status` enum plus the decoded transaction and (optional) renewal info.
+ * Ported verbatim from 2b0b041 (see the module doc for the mapping contract).
+ *
+ *   1 ACTIVE   → active (or trial), window = expiresDate; clear gracePeriodEnd.
+ *   4 GRACE    → grace, gracePeriodEnd = renewalInfo.gracePeriodExpiresDate
+ *                (the real access deadline). ABSENT deadline → fail safe (null).
+ *   3 RETRY    → billingRetry WITHOUT a window and gracePeriodEnd cleared;
+ *                status.ts governs the row by currentPeriodEnd.
+ *   2 EXPIRED  → expired; clear gracePeriodEnd.
+ *   5 REVOKED  → revoked; clear gracePeriodEnd.
+ *   unknown    → null (fail closed; leave the row for a later run).
+ */
+const appleStatusItemToUpdate = (
+  appleStatus: AppleSubscriptionStatus | number | undefined,
+  transaction: JWSTransactionDecodedPayload,
+  renewalInfo: JWSRenewalInfoDecodedPayload | null,
+  now: Date,
+): ResolvedTruth => {
+  switch (appleStatus) {
+    case AppleSubscriptionStatus.ACTIVE: {
+      // Without an expiry we cannot reason about the window — fail safe.
+      const expiresMs = dateMs(transaction.expiresDate);
+      if (expiresMs === null) return null;
+      // Defensive: Apple says active but the window already lapsed — treat as
+      // unresolved rather than fabricate an active window in the past.
+      if (expiresMs <= now.getTime()) return null;
+      // status=1 covers both a paid active period and an introductory free
+      // trial. Reuse the transaction-derived status (offerType-aware) to keep
+      // the trial flag; the future-expiry gate above means it cannot derive
+      // `expired` here.
+      const derived = deriveSubscriptionStatusFromTransaction(transaction, now);
+      const isTrial = derived === SubscriptionStatus.trial;
+      const update: NotificationStateUpdate = {
+        status: isTrial ? SubscriptionStatus.trial : SubscriptionStatus.active,
+        currentPeriodEnd: new Date(expiresMs),
+        isInTrial: isTrial,
+        willRenew: true,
+        // Recovered to active — any prior grace window is over.
+        gracePeriodEnd: null,
+      };
+      const purchaseMs = dateMs(transaction.purchaseDate);
+      if (purchaseMs !== null) {
+        update.currentPeriodStart = new Date(purchaseMs);
+      }
+      return update;
+    }
+
+    case AppleSubscriptionStatus.BILLING_GRACE_PERIOD: {
+      const graceMs = dateMs(renewalInfo?.gracePeriodExpiresDate);
+      // Fail-SAFE: status=4 with no real grace deadline → leave the row
+      // UNCHANGED, do NOT actively write `expired`. status.ts fail-closes an
+      // un-refreshed grace row past its deadline at read time.
+      if (graceMs === null) return null;
+      const update: NotificationStateUpdate = {
+        status: SubscriptionStatus.grace,
+        // The access deadline is gracePeriodExpiresDate — the SINGLE grace
+        // field status.ts gates grace entitlement on.
+        gracePeriodEnd: new Date(graceMs),
+      };
+      // The lapsed paid-period end is the transaction expiresDate; record it
+      // as the window so the monotonic guard reasons about the right value.
+      const expiresMs = dateMs(transaction.expiresDate);
+      if (expiresMs !== null) update.currentPeriodEnd = new Date(expiresMs);
+      return update;
+    }
+
+    case AppleSubscriptionStatus.BILLING_RETRY:
+      // NOT entitled per Apple contract (access ended at expiresDate), but we
+      // must NOT write `expired` from the past expiresDate either (that would
+      // revoke a sub Apple is still retrying). billingRetry with NO window and
+      // grace cleared: status.ts governs the row by currentPeriodEnd.
+      return {
+        status: SubscriptionStatus.billingRetry,
+        gracePeriodEnd: null,
+      };
+
+    case AppleSubscriptionStatus.EXPIRED:
+      return {
+        status: SubscriptionStatus.expired,
+        willRenew: false,
+        gracePeriodEnd: null,
+      };
+
+    case AppleSubscriptionStatus.REVOKED:
+      return {
+        status: SubscriptionStatus.revoked,
+        willRenew: false,
+        gracePeriodEnd: null,
+      };
+
+    default:
+      // Unknown / unset status → fail closed (leave the row for a later run).
+      return null;
+  }
+};
+
+type AppleTruth =
+  | { kind: "unresolved"; reason: string }
+  | {
+      kind: "resolved";
+      update: ResolvedTruth;
+      appleStatus: number | undefined;
+      environment: Environment;
+      providerExpiresDate: Date | null;
+    };
+
+/**
+ * Poll Apple for ground truth on a single subscription: fetch statuses with
+ * the environment fallback (production first; a sandbox/TestFlight OTX 404s
+ * there and retries against the sandbox host), match THIS subscription's
+ * `originalTransactionId` in `lastTransactions`, and verify both signed
+ * payloads before trusting them. Never throws.
+ */
+const resolveAppleTruth = async (
+  sub: Subscription,
+  now: Date,
+  environment?: Environment,
+): Promise<AppleTruth> => {
+  const originalTransactionId = sub.originalTransactionId;
+  if (!originalTransactionId) {
+    return { kind: "unresolved", reason: "missing_original_transaction_id" };
+  }
+
+  let statuses;
+  try {
+    statuses = await getSubscriptionStatusesWithEnvironmentFallback(
+      originalTransactionId,
+      environment ? { environment } : undefined,
+    );
+  } catch (err) {
+    logger.warn(
+      { err, subscriptionId: sub.id, op: "subscription_reconcile" },
+      "subscription_reconcile.apple.status_fetch_failed",
+    );
+    return { kind: "unresolved", reason: "status_fetch_failed" };
+  }
+
+  // Match the status item for THIS subscription's originalTransactionId.
+  // `lastTransactions` carries one entry per product in the subscription
+  // group; match explicitly rather than taking the first item.
+  const groups = statuses.response.data ?? [];
+  let matched:
+    | {
+        status?: AppleSubscriptionStatus | number;
+        signedTransactionInfo?: string;
+        signedRenewalInfo?: string;
+      }
+    | undefined;
+  for (const group of groups) {
+    for (const item of group.lastTransactions ?? []) {
+      if (item.originalTransactionId === originalTransactionId) {
+        matched = item;
+        break;
+      }
+    }
+    if (matched) break;
+  }
+  // No matching status item, or no signed transaction → ambiguous, fail safe.
+  if (!matched?.signedTransactionInfo) {
+    return { kind: "unresolved", reason: "no_matching_status_item" };
+  }
+
+  let transaction: JWSTransactionDecodedPayload;
+  try {
+    transaction = await verifyAndDecodeTransaction(
+      matched.signedTransactionInfo,
+    );
+  } catch (err) {
+    logger.warn(
+      { err, subscriptionId: sub.id, op: "subscription_reconcile" },
+      "subscription_reconcile.apple.jws_verify_failed",
+    );
+    return { kind: "unresolved", reason: "jws_verify_failed" };
+  }
+
+  // Decode renewal info when present — it carries gracePeriodExpiresDate, the
+  // only source of the real grace deadline (status=4). A verify failure here
+  // is fail-safe: we can't trust grace, so leave the row untouched.
+  let renewalInfo: JWSRenewalInfoDecodedPayload | null = null;
+  if (matched.signedRenewalInfo) {
+    try {
+      renewalInfo = await verifyAndDecodeRenewalInfo(matched.signedRenewalInfo);
+    } catch (err) {
+      logger.warn(
+        { err, subscriptionId: sub.id, op: "subscription_reconcile" },
+        "subscription_reconcile.apple.renewal_verify_failed",
+      );
+      return { kind: "unresolved", reason: "renewal_verify_failed" };
+    }
+  }
+
+  const expiresMs = dateMs(transaction.expiresDate);
+  return {
+    kind: "resolved",
+    update: appleStatusItemToUpdate(
+      matched.status,
+      transaction,
+      renewalInfo,
+      now,
+    ),
+    appleStatus: matched.status,
+    environment: statuses.environment,
+    providerExpiresDate: expiresMs === null ? null : new Date(expiresMs),
+  };
+};
+
+/**
+ * Decide whether the resolved provider truth should be written (ported from
+ * 2b0b041). Write when the provider status differs from ours, the grace
+ * deadline genuinely changed, or the provider window is strictly LATER than
+ * what we hold. Same window + same status + same deadline is a no-op.
+ */
+const shouldWrite = (
+  sub: Subscription,
+  update: NotificationStateUpdate,
+): boolean => {
+  const newEnd = dateMs(update.currentPeriodEnd);
+  const currentEnd = sub.currentPeriodEnd.getTime();
+
+  const newStatus = update.status;
+  const statusChanged = newStatus !== undefined && newStatus !== sub.status;
+  if (statusChanged) return true;
+
+  // The grace deadline moved (set / cleared / pulled in) → write it.
+  const newDeadline = dateMs(update.gracePeriodEnd);
+  const currentDeadline = sub.gracePeriodEnd
+    ? sub.gracePeriodEnd.getTime()
+    : null;
+  if (
+    "gracePeriodEnd" in update &&
+    newDeadline !== currentDeadline &&
+    // A clamp no-op (new >= existing, both set) is handled by the clamp; only
+    // treat a genuine change as write-worthy.
+    !(
+      newDeadline !== null &&
+      currentDeadline !== null &&
+      newDeadline >= currentDeadline
+    )
+  ) {
+    return true;
+  }
+
+  // Otherwise only advance the window forward. Equal/older window with the
+  // same status is a replay/no-op.
+  if (newEnd !== null && newEnd > currentEnd) return true;
+
+  return false;
+};
+
+const RESCUABLE_SUBSCRIPTION_STATUSES: SubscriptionStatus[] = [
+  SubscriptionStatus.expired,
+  SubscriptionStatus.revoked,
+];
+
+const ENTITLED_TO_STATUSES: SubscriptionStatus[] = [
+  SubscriptionStatus.active,
+  SubscriptionStatus.trial,
+  SubscriptionStatus.grace,
+  SubscriptionStatus.billingRetry,
+];
+
+const isRescue = (
+  sub: Subscription,
+  update: NotificationStateUpdate,
+): boolean =>
+  RESCUABLE_SUBSCRIPTION_STATUSES.includes(sub.status) &&
+  update.status !== undefined &&
+  ENTITLED_TO_STATUSES.includes(update.status);
+
+/**
+ * Project the update onto the monotonic floor (ported from 2b0b041): never let
+ * `currentPeriodEnd` go backwards even if the provider returned an older
+ * window — EXCEPT a confirmed rescue (a non-entitled DB row the provider
+ * reports entitled again), where provider truth wins verbatim.
+ */
+const monotonicUpdate = (
+  sub: Subscription,
+  update: NotificationStateUpdate,
+): NotificationStateUpdate => {
+  const newEnd = dateMs(update.currentPeriodEnd);
+  if (newEnd === null) return update;
+  if (isRescue(sub, update)) return update;
+  if (newEnd < sub.currentPeriodEnd.getTime()) {
+    const {
+      currentPeriodEnd: _drop,
+      currentPeriodStart: _dropStart,
+      ...rest
+    } = update;
+    return rest;
+  }
+  return update;
+};
+
+/**
+ * Non-extending clamp on the grace deadline (ported from 2b0b041, mirrors the
+ * webhook path): once stamped, a later poll may only pull it IN
+ * (`min(existing, new)`), never push it out. Clearing to null is always
+ * honored, and a rescue takes the provider deadline verbatim.
+ */
+const clampGracePeriodEnd = (
+  sub: Subscription,
+  update: NotificationStateUpdate,
+): NotificationStateUpdate => {
+  const next = update.gracePeriodEnd;
+  const prev = sub.gracePeriodEnd;
+  if (!next || !prev) return update;
+  if (isRescue(sub, update)) return update;
+  return next.getTime() <= prev.getTime()
+    ? update
+    : { ...update, gracePeriodEnd: prev };
+};
+
+export type ReconcileMoneyReport = {
+  forfeit?: {
+    periodStart: string;
+    /** Whether a sub_grant row exists for that period (dry-run: predicts the
+     *  no-op; apply: the helper's actual verdict is in `result`). */
+    priorGrantExists: boolean;
+    result?: ForfeitSubscriptionPeriodResult["kind"];
+  };
+  grant?: {
+    periodStart: string;
+    alreadyGranted: boolean;
+    credits: number;
+    result?: GrantSubscriptionPeriodResult["kind"];
+  };
+};
+
+export type OtxReconcileResult = {
+  originalTransactionId: string;
+  outcome:
+    | "no_row"
+    | "provider_unresolved"
+    | "noop"
+    | "planned"
+    | "applied"
+    | "skipped_row_changed"
+    | "error";
+  subscriptionId?: string;
+  accountId?: string;
+  before?: {
+    status: SubscriptionStatus;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+    gracePeriodEnd: string | null;
+    environment: string | null;
+  };
+  provider?: {
+    appleStatus: number | null;
+    environment: string;
+    expiresDate: string | null;
+  };
+  /** ISO-serialized intended row update (dry-run and apply). */
+  intendedUpdate?: Record<string, string | boolean | null>;
+  after?: {
+    status: SubscriptionStatus;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+    gracePeriodEnd: string | null;
+  };
+  money: ReconcileMoneyReport;
+  unresolvedReason?: string;
+  error?: string;
+};
+
+export type AllowlistReconcileSummary = {
+  runAt: Date;
+  mode: "dry-run" | "apply";
+  results: OtxReconcileResult[];
+};
+
+export type RunAppleAllowlistReconcileOptions = {
+  /** Explicit allowlist — the ONLY selection mechanism in the pilot. */
+  originalTransactionIds: string[];
+  /** Execute the writes. Default false = dry-run (writes nothing). */
+  apply?: boolean;
+  /** Pin the App Store Server API environment (skips the fallback). */
+  environment?: Environment;
+  /** Actor recorded on AdminAudit rows written in apply mode. */
+  actorEmail?: string;
+  now?: Date;
+};
+
+const serializeUpdate = (
+  update: NotificationStateUpdate,
+): Record<string, string | boolean | null> => {
+  const out: Record<string, string | boolean | null> = {};
+  if (update.status !== undefined) out.status = update.status;
+  if (update.currentPeriodStart !== undefined)
+    out.currentPeriodStart = update.currentPeriodStart.toISOString();
+  if (update.currentPeriodEnd !== undefined)
+    out.currentPeriodEnd = update.currentPeriodEnd.toISOString();
+  if (update.willRenew !== undefined) out.willRenew = update.willRenew;
+  if (update.isInTrial !== undefined) out.isInTrial = update.isInTrial;
+  if ("gracePeriodEnd" in update)
+    out.gracePeriodEnd = iso(update.gracePeriodEnd ?? null);
+  if ("cancelledAt" in update)
+    out.cancelledAt = iso(update.cancelledAt ?? null);
+  return out;
+};
+
+const hasPeriodGrant = async (
+  accountId: string,
+  subscriptionId: string,
+  periodStart: Date,
+): Promise<boolean> => {
+  // Read-only ledger lookup (reporting only — allowed by the payments law).
+  const row = await prisma.creditLedger.findUnique({
+    where: {
+      accountId_idempotencyKey: {
+        accountId,
+        idempotencyKey: subGrantKey(subscriptionId, periodStart),
+      },
+    },
+  });
+  return row !== null;
+};
+
+const isTerminalStatus = (status: SubscriptionStatus): boolean =>
+  status === SubscriptionStatus.expired ||
+  status === SubscriptionStatus.revoked;
+
+/**
+ * Plan the money side effects of `safeUpdate` for reporting. Mirrors the
+ * apply path's branches; reads the ledger, writes nothing.
+ */
+const planMoney = async (
+  sub: Subscription,
+  safeUpdate: NotificationStateUpdate,
+  now: Date,
+): Promise<ReconcileMoneyReport> => {
+  const money: ReconcileMoneyReport = {};
+  const targetStatus = safeUpdate.status ?? sub.status;
+  const targetPeriodStart =
+    safeUpdate.currentPeriodStart ?? sub.currentPeriodStart;
+
+  if (isTerminalStatus(targetStatus)) {
+    money.forfeit = {
+      periodStart: sub.currentPeriodStart.toISOString(),
+      priorGrantExists: await hasPeriodGrant(
+        sub.accountId,
+        sub.id,
+        sub.currentPeriodStart,
+      ),
+    };
+    return money;
+  }
+
+  if (isEntitledSubscriptionStatus(targetStatus)) {
+    const periodAdvanced =
+      targetPeriodStart.getTime() > sub.currentPeriodStart.getTime();
+    if (periodAdvanced) {
+      money.forfeit = {
+        periodStart: sub.currentPeriodStart.toISOString(),
+        priorGrantExists: await hasPeriodGrant(
+          sub.accountId,
+          sub.id,
+          sub.currentPeriodStart,
+        ),
+      };
+    }
+    const projected = {
+      status: targetStatus,
+      currentPeriodEnd: safeUpdate.currentPeriodEnd ?? sub.currentPeriodEnd,
+      gracePeriodEnd:
+        "gracePeriodEnd" in safeUpdate
+          ? (safeUpdate.gracePeriodEnd ?? null)
+          : sub.gracePeriodEnd,
+    };
+    // Time-aware gate, mirroring verify's replay-materializer: never plan a
+    // grant for an effectively-expired window.
+    if (isEntitledSubscription(projected, now)) {
+      money.grant = {
+        periodStart: targetPeriodStart.toISOString(),
+        alreadyGranted: await hasPeriodGrant(
+          sub.accountId,
+          sub.id,
+          targetPeriodStart,
+        ),
+        credits: tierGrant(requireSubscriptionTier(sub.tier), sub.period)
+          .perPeriod,
+      };
+    }
+  }
+  return money;
+};
+
+type AppliedOutcome = {
+  outcome: "applied" | "skipped_row_changed";
+  updated?: Subscription;
+  grantResult?: GrantSubscriptionPeriodResult;
+  forfeitResult?: ForfeitSubscriptionPeriodResult;
+};
+
+/**
+ * Apply the reconcile update atomically. The row write is concurrency-guarded
+ * on the `updatedAt` read at plan time (a fresher verify/webhook wins — skip);
+ * money moves ONLY through the idempotent per-period helpers, in the same
+ * transaction, mirroring `applyNotification`'s branches:
+ *   - terminal status → forfeit the period the row was in (no-ops when that
+ *     period was never granted);
+ *   - entitled + period advanced → forfeit the old period (consumes bounded to
+ *     the new period start), then grant the new period;
+ *   - entitled + time-aware live window → materialize a missing current-period
+ *     grant (idempotent replay when it exists).
+ */
+const applyReconcileUpdate = async (
+  snapshot: Subscription,
+  safeUpdate: NotificationStateUpdate,
+  now: Date,
+): Promise<AppliedOutcome> =>
+  prisma.$transaction(async (tx) => {
+    const guarded = await tx.subscription.updateMany({
+      where: { id: snapshot.id, updatedAt: snapshot.updatedAt },
+      data: safeUpdate,
+    });
+    if (guarded.count === 0) {
+      return { outcome: "skipped_row_changed" as const };
+    }
+    const updated = await tx.subscription.findUniqueOrThrow({
+      where: { id: snapshot.id },
+    });
+
+    let grantResult: GrantSubscriptionPeriodResult | undefined;
+    let forfeitResult: ForfeitSubscriptionPeriodResult | undefined;
+
+    if (isTerminalStatus(updated.status)) {
+      forfeitResult = await forfeitSubscriptionPeriod(tx, {
+        subscription: updated,
+        periodStart: snapshot.currentPeriodStart,
+      });
+    } else if (isEntitledSubscriptionStatus(updated.status)) {
+      if (
+        updated.currentPeriodStart.getTime() >
+        snapshot.currentPeriodStart.getTime()
+      ) {
+        forfeitResult = await forfeitSubscriptionPeriod(tx, {
+          subscription: updated,
+          periodStart: snapshot.currentPeriodStart,
+          consumesUntil: updated.currentPeriodStart,
+        });
+      }
+      if (isEntitledSubscription(updated, now)) {
+        grantResult = await grantSubscriptionPeriod(tx, {
+          subscription: updated,
+          periodStart: updated.currentPeriodStart,
+        });
+      }
+    }
+
+    return { outcome: "applied" as const, updated, grantResult, forfeitResult };
+  });
+
+const DEFAULT_ACTOR_EMAIL = "subscription-reconcile-cli";
+
+export async function runAppleAllowlistReconcile(
+  opts: RunAppleAllowlistReconcileOptions,
+): Promise<AllowlistReconcileSummary> {
+  const now = opts.now ?? new Date();
+  const apply = opts.apply ?? false;
+  const actorEmail = opts.actorEmail?.trim() || DEFAULT_ACTOR_EMAIL;
+  const otxIds = [...new Set(opts.originalTransactionIds)];
+
+  const summary: AllowlistReconcileSummary = {
+    runAt: now,
+    mode: apply ? "apply" : "dry-run",
+    results: [],
+  };
+
+  for (const originalTransactionId of otxIds) {
+    const result: OtxReconcileResult = {
+      originalTransactionId,
+      outcome: "error",
+      money: {},
+    };
+    summary.results.push(result);
+
+    try {
+      const sub = await findAppleByOriginalTransactionId(originalTransactionId);
+      if (!sub) {
+        result.outcome = "no_row";
+        continue;
+      }
+      result.subscriptionId = sub.id;
+      result.accountId = sub.accountId;
+      result.before = {
+        status: sub.status,
+        currentPeriodStart: sub.currentPeriodStart.toISOString(),
+        currentPeriodEnd: sub.currentPeriodEnd.toISOString(),
+        gracePeriodEnd: iso(sub.gracePeriodEnd),
+        environment: sub.environment ?? null,
+      };
+
+      const truth = await resolveAppleTruth(sub, now, opts.environment);
+      if (truth.kind === "unresolved") {
+        result.outcome = "provider_unresolved";
+        result.unresolvedReason = truth.reason;
+        continue;
+      }
+      result.provider = {
+        appleStatus: truth.appleStatus ?? null,
+        environment: truth.environment,
+        expiresDate: iso(truth.providerExpiresDate),
+      };
+      if (truth.update === null) {
+        result.outcome = "provider_unresolved";
+        result.unresolvedReason = "ambiguous_provider_state";
+        continue;
+      }
+
+      const safeUpdate = clampGracePeriodEnd(
+        sub,
+        monotonicUpdate(sub, truth.update),
+      );
+      const rowChangeNeeded = shouldWrite(sub, safeUpdate);
+      const money = await planMoney(sub, safeUpdate, now);
+      if (!rowChangeNeeded) {
+        // No state transition → no forfeit. Backfilling a MISSED forfeit for a
+        // row that is already terminal claws back credits the user has been
+        // sitting on — a policy decision deliberately out of pilot scope.
+        delete money.forfeit;
+      }
+      // An entitled, time-aware-live row missing its current-period sub_grant
+      // is money drift even when the row state itself is in sync — still
+      // reconcile it (the grant helper is idempotent either way).
+      const grantMaterializationNeeded =
+        money.grant !== undefined && !money.grant.alreadyGranted;
+      if (!rowChangeNeeded && !grantMaterializationNeeded) {
+        result.outcome = "noop";
+        continue;
+      }
+      if (rowChangeNeeded) {
+        result.intendedUpdate = serializeUpdate(safeUpdate);
+      }
+      result.money = money;
+
+      if (!apply) {
+        result.outcome = "planned";
+        continue;
+      }
+
+      const applied = await applyReconcileUpdate(sub, safeUpdate, now);
+      result.outcome = applied.outcome;
+      if (applied.outcome !== "applied" || !applied.updated) continue;
+
+      const updated = applied.updated;
+      result.after = {
+        status: updated.status,
+        currentPeriodStart: updated.currentPeriodStart.toISOString(),
+        currentPeriodEnd: updated.currentPeriodEnd.toISOString(),
+        gracePeriodEnd: iso(updated.gracePeriodEnd),
+      };
+      if (result.money.forfeit && applied.forfeitResult) {
+        result.money.forfeit.result = applied.forfeitResult.kind;
+      }
+      if (result.money.grant && applied.grantResult) {
+        result.money.grant.result = applied.grantResult.kind;
+      }
+
+      // Audit trail for the operator-run apply. Idempotent per resulting
+      // state, so a re-run that no-ops (shouldWrite=false) or re-applies the
+      // same transition never duplicates rows.
+      const granted =
+        applied.grantResult?.kind === "granted"
+          ? BigInt(applied.grantResult.credits)
+          : 0n;
+      const forfeited =
+        applied.forfeitResult?.kind === "forfeited"
+          ? BigInt(applied.forfeitResult.credits)
+          : 0n;
+      await writeAdminAudit({
+        accountId: updated.accountId,
+        actorEmail,
+        action: "reconcile",
+        deltaCredits: granted - forfeited,
+        reason: `apple subscription reconcile ${originalTransactionId}: ${sub.status} -> ${updated.status}`,
+        idempotencyKey: `sub_reconcile_${updated.id}_${Math.floor(
+          updated.currentPeriodEnd.getTime() / 1000,
+        )}_${updated.status}`,
+      });
+
+      logger.info(
+        {
+          subscriptionId: updated.id,
+          accountId: updated.accountId,
+          statusBefore: sub.status,
+          statusAfter: updated.status,
+          granted: granted.toString(),
+          forfeited: forfeited.toString(),
+          op: "subscription_reconcile",
+        },
+        "subscription_reconcile.applied",
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        { err, originalTransactionId, op: "subscription_reconcile" },
+        "subscription_reconcile.otx.failed",
+      );
+      result.outcome = "error";
+      result.error = message;
+    }
+  }
+
+  logger.info(
+    {
+      mode: summary.mode,
+      outcomes: summary.results.map((r) => ({
+        otx: r.originalTransactionId,
+        outcome: r.outcome,
+      })),
+      runAt: now.toISOString(),
+      op: "subscription_reconcile",
+    },
+    "subscription_reconcile.completed",
+  );
+
+  return summary;
+}

--- a/src/subscriptions/reconcile/service.ts
+++ b/src/subscriptions/reconcile/service.ts
@@ -106,15 +106,19 @@ type ResolvedTruth = NotificationStateUpdate | null;
 /**
  * Build the entitlement update from an Apple status item — the per-item
  * `status` enum plus the decoded transaction and (optional) renewal info.
- * Ported verbatim from 2b0b041 (see the module doc for the mapping contract).
+ * Ported from 2b0b041, with the status-3 leg adapted to THIS branch's
+ * status.ts semantics (see the case comment).
  *
  *   1 ACTIVE   → active (or trial), window = expiresDate; clear gracePeriodEnd.
  *   4 GRACE    → grace, gracePeriodEnd = renewalInfo.gracePeriodExpiresDate
- *                (the real access deadline). ABSENT deadline → fail safe (null).
- *   3 RETRY    → billingRetry WITHOUT a window and gracePeriodEnd cleared;
- *                status.ts governs the row by currentPeriodEnd.
- *   2 EXPIRED  → expired; clear gracePeriodEnd.
- *   5 REVOKED  → revoked; clear gracePeriodEnd.
+ *                (the real access deadline — entitlement is bounded by it).
+ *                ABSENT deadline → fail safe (null).
+ *   3 RETRY    → null (fail safe): the paid period LAPSED and Apple is
+ *                retrying billing — never re-entitle, never extend. Writing
+ *                billingRetry would re-entitle indefinitely on this branch
+ *                (status.ts no-TTL).
+ *   2 EXPIRED  → expired; clear gracePeriodEnd; provider window REQUIRED.
+ *   5 REVOKED  → revoked; clear gracePeriodEnd; provider window REQUIRED.
  *   unknown    → null (fail closed; leave the row for a later run).
  */
 const appleStatusItemToUpdate = (
@@ -184,14 +188,18 @@ const appleStatusItemToUpdate = (
     }
 
     case AppleSubscriptionStatus.BILLING_RETRY:
-      // NOT entitled per Apple contract (access ended at expiresDate), but we
-      // must NOT write `expired` from the past expiresDate either (that would
-      // revoke a sub Apple is still retrying). billingRetry with NO window and
-      // grace cleared: status.ts governs the row by currentPeriodEnd.
-      return {
-        status: SubscriptionStatus.billingRetry,
-        gracePeriodEnd: null,
-      };
+      // NOT entitled per Apple contract: status 3 means the paid period
+      // LAPSED and Apple is retrying billing — the user must NOT be
+      // re-entitled and the period must NOT be extended. On THIS branch,
+      // writing `billingRetry` would do exactly that: status.ts entitles
+      // billingRetry unconditionally (the no-TTL gap, status.ts:76-84), so an
+      // expired/revoked/effectively-expired row would read fully entitled
+      // forever. (2b0b041 could safely write billingRetry because ITS
+      // status.ts governed the status by currentPeriodEnd; this branch does
+      // not.) We must not write `expired` either — Apple may still recover
+      // the sub (rescue on a later run). Fail safe: leave the row untouched;
+      // its entitlement stays governed by the existing time-aware read.
+      return null;
 
     case AppleSubscriptionStatus.EXPIRED: {
       // The provider's final period end is MANDATORY for a terminal verdict:
@@ -511,14 +519,13 @@ const isStaleTerminalUpdate = (
 /**
  * Grant gate for the reconcile job. `isEntitledSubscription` is time-aware for
  * active/trial/grace but passes `billingRetry` through unconditionally (the
- * known no-TTL gap, status.ts) — under which a long-lapsed row Apple reports
- * as status 3 would mint a full grant for a period whose paid window is over.
- * Worse, the row's own `currentPeriodEnd` cannot be trusted as the check
- * (Apple status 3 carries no window we apply, so the gate would read a
- * possibly-stale/fabricated local end). The reconcile job therefore
- * categorically refuses to materialize grants for billingRetry targets: Apple
- * status 3 means the paid window ENDED at `expiresDate`; if a genuine grant is
- * missing, the user's next verify materializes it through the normal path.
+ * known no-TTL gap, status.ts). The Apple mapping above never WRITES
+ * billingRetry (status 3 fails safe), but a row can already HOLD that status
+ * from the SSN path — and its local `currentPeriodEnd` cannot be trusted as a
+ * check. The reconcile job therefore categorically refuses to materialize
+ * grants for billingRetry rows: Apple status 3 means the paid window ENDED at
+ * `expiresDate`; if a genuine grant is missing, the user's next verify
+ * materializes it through the normal path.
  */
 const isEntitledForReconcileGrant = (
   fields: {

--- a/tests/subscriptions/apple-server-api-env-fallback.test.ts
+++ b/tests/subscriptions/apple-server-api-env-fallback.test.ts
@@ -1,0 +1,202 @@
+import {
+  APIException,
+  Environment,
+  type AppStoreServerAPIClient,
+  type StatusResponse,
+} from "@apple/app-store-server-library";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  getSubscriptionStatusesWithEnvironmentFallback,
+  resetAppleApiClientForTests,
+  setAppleApiClientForEnvironmentForTests,
+} from "@/subscriptions/apple-server-api";
+
+// 4040010 TRANSACTION_ID_NOT_FOUND / 4040005 ORIGINAL_TRANSACTION_ID_NOT_FOUND:
+// what the production host answers for a sandbox (TestFlight) transaction id —
+// the fallback triggers. Anything else must propagate untouched.
+const NOT_FOUND_TRANSACTION = 4040010;
+const NOT_FOUND_ORIGINAL_TRANSACTION = 4040005;
+const RATE_LIMITED = 4290000;
+
+const statusResponse = (environment: string): StatusResponse => ({
+  environment,
+  bundleId: "app.convos",
+  data: [],
+});
+
+const makeClient = (impl: (id: string) => Promise<StatusResponse>) => {
+  const getAllSubscriptionStatuses = vi.fn(impl);
+  return {
+    client: {
+      getAllSubscriptionStatuses,
+    } as unknown as AppStoreServerAPIClient,
+    getAllSubscriptionStatuses,
+  };
+};
+
+let savedAppleEnv: string | undefined;
+
+beforeEach(() => {
+  savedAppleEnv = process.env.APPLE_ENV;
+  // Pin the primary environment to production, like prod runs.
+  process.env.APPLE_ENV = "production";
+  resetAppleApiClientForTests();
+});
+
+afterEach(() => {
+  if (savedAppleEnv === undefined) delete process.env.APPLE_ENV;
+  else process.env.APPLE_ENV = savedAppleEnv;
+  resetAppleApiClientForTests();
+});
+
+describe("getSubscriptionStatusesWithEnvironmentFallback", () => {
+  test("production answers → production result, sandbox never consulted", async () => {
+    const prod = makeClient(() =>
+      Promise.resolve(statusResponse("Production")),
+    );
+    const sandbox = makeClient(() =>
+      Promise.resolve(statusResponse("Sandbox")),
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.PRODUCTION,
+      prod.client,
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.SANDBOX,
+      sandbox.client,
+    );
+
+    const result =
+      await getSubscriptionStatusesWithEnvironmentFallback("otx-1");
+
+    expect(result.environment).toBe(Environment.PRODUCTION);
+    expect(result.response.environment).toBe("Production");
+    expect(prod.getAllSubscriptionStatuses).toHaveBeenCalledWith("otx-1");
+    expect(sandbox.getAllSubscriptionStatuses).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["4040010 TRANSACTION_ID_NOT_FOUND", NOT_FOUND_TRANSACTION],
+    [
+      "4040005 ORIGINAL_TRANSACTION_ID_NOT_FOUND",
+      NOT_FOUND_ORIGINAL_TRANSACTION,
+    ],
+  ])(
+    "production %s → falls back to the sandbox host",
+    async (_label, apiError) => {
+      const prod = makeClient(() =>
+        Promise.reject(new APIException(404, apiError)),
+      );
+      const sandbox = makeClient(() =>
+        Promise.resolve(statusResponse("Sandbox")),
+      );
+      setAppleApiClientForEnvironmentForTests(
+        Environment.PRODUCTION,
+        prod.client,
+      );
+      setAppleApiClientForEnvironmentForTests(
+        Environment.SANDBOX,
+        sandbox.client,
+      );
+
+      const result =
+        await getSubscriptionStatusesWithEnvironmentFallback("otx-tf");
+
+      expect(result.environment).toBe(Environment.SANDBOX);
+      expect(result.response.environment).toBe("Sandbox");
+      expect(prod.getAllSubscriptionStatuses).toHaveBeenCalledWith("otx-tf");
+      expect(sandbox.getAllSubscriptionStatuses).toHaveBeenCalledWith("otx-tf");
+    },
+  );
+
+  test("non-not-found API error propagates — NO fallback", async () => {
+    const prod = makeClient(() =>
+      Promise.reject(new APIException(429, RATE_LIMITED)),
+    );
+    const sandbox = makeClient(() =>
+      Promise.resolve(statusResponse("Sandbox")),
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.PRODUCTION,
+      prod.client,
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.SANDBOX,
+      sandbox.client,
+    );
+
+    await expect(
+      getSubscriptionStatusesWithEnvironmentFallback("otx-1"),
+    ).rejects.toBeInstanceOf(APIException);
+    expect(sandbox.getAllSubscriptionStatuses).not.toHaveBeenCalled();
+  });
+
+  test("non-APIException (network error) propagates — NO fallback", async () => {
+    const prod = makeClient(() => Promise.reject(new Error("ECONNRESET")));
+    const sandbox = makeClient(() =>
+      Promise.resolve(statusResponse("Sandbox")),
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.PRODUCTION,
+      prod.client,
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.SANDBOX,
+      sandbox.client,
+    );
+
+    await expect(
+      getSubscriptionStatusesWithEnvironmentFallback("otx-1"),
+    ).rejects.toThrow("ECONNRESET");
+    expect(sandbox.getAllSubscriptionStatuses).not.toHaveBeenCalled();
+  });
+
+  test("explicit environment pins the host — not-found does NOT fall back", async () => {
+    const prod = makeClient(() =>
+      Promise.resolve(statusResponse("Production")),
+    );
+    const sandbox = makeClient(() =>
+      Promise.reject(new APIException(404, NOT_FOUND_TRANSACTION)),
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.PRODUCTION,
+      prod.client,
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.SANDBOX,
+      sandbox.client,
+    );
+
+    await expect(
+      getSubscriptionStatusesWithEnvironmentFallback("otx-1", {
+        environment: Environment.SANDBOX,
+      }),
+    ).rejects.toBeInstanceOf(APIException);
+    expect(prod.getAllSubscriptionStatuses).not.toHaveBeenCalled();
+  });
+
+  test("sandbox-primary (APPLE_ENV=sandbox) falls back to production on not-found", async () => {
+    process.env.APPLE_ENV = "sandbox";
+    const prod = makeClient(() =>
+      Promise.resolve(statusResponse("Production")),
+    );
+    const sandbox = makeClient(() =>
+      Promise.reject(new APIException(404, NOT_FOUND_TRANSACTION)),
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.PRODUCTION,
+      prod.client,
+    );
+    setAppleApiClientForEnvironmentForTests(
+      Environment.SANDBOX,
+      sandbox.client,
+    );
+
+    const result =
+      await getSubscriptionStatusesWithEnvironmentFallback("otx-1");
+
+    expect(result.environment).toBe(Environment.PRODUCTION);
+    expect(sandbox.getAllSubscriptionStatuses).toHaveBeenCalled();
+    expect(prod.getAllSubscriptionStatuses).toHaveBeenCalled();
+  });
+});

--- a/tests/subscriptions/reconcile/allowlist.integration.test.ts
+++ b/tests/subscriptions/reconcile/allowlist.integration.test.ts
@@ -1,0 +1,407 @@
+import { randomUUID } from "node:crypto";
+import { BillingProvider, SubscriptionStatus } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { subForfeitKey, subGrantKey } from "@/subscriptions/grants";
+import { runAppleAllowlistReconcile } from "@/subscriptions/reconcile/service";
+import { tierGrant } from "@/subscriptions/tier-config";
+import { prisma } from "@/utils/prisma";
+
+// MOCK the provider boundary. Apple's status fetch + the JWS verifiers are
+// stubbed so no real App Store Server API call is made; the environment
+// fallback itself has its own dedicated test
+// (tests/subscriptions/apple-server-api-env-fallback.test.ts).
+const getSubscriptionStatusesWithEnvironmentFallback =
+  vi.fn<(id: string, opts?: unknown) => Promise<unknown>>();
+vi.mock("@/subscriptions/apple-server-api", () => ({
+  getSubscriptionStatusesWithEnvironmentFallback: (
+    id: string,
+    opts?: unknown,
+  ) => getSubscriptionStatusesWithEnvironmentFallback(id, opts),
+}));
+
+const verifyAndDecodeTransaction = vi.fn<(jws: string) => Promise<unknown>>();
+const verifyAndDecodeRenewalInfo = vi.fn<(jws: string) => Promise<unknown>>();
+vi.mock("@/subscriptions/jws-verifier", () => ({
+  verifyAndDecodeTransaction: (jws: string) => verifyAndDecodeTransaction(jws),
+  verifyAndDecodeRenewalInfo: (jws: string) => verifyAndDecodeRenewalInfo(jws),
+}));
+
+// Apple status enum (mirrors @apple/app-store-server-library Status).
+const APPLE_STATUS_ACTIVE = 1;
+const APPLE_STATUS_EXPIRED = 2;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date(Date.UTC(2026, 6, 29, 12, 0, 0));
+
+const monthlyCredits = () => tierGrant("plus", "monthly").perPeriod;
+
+const tracker: string[] = [];
+
+const newAccount = async (): Promise<string> => {
+  const acct = await prisma.account.create({ data: {} });
+  tracker.push(acct.id);
+  return acct.id;
+};
+
+const seedAppleSub = async (opts: {
+  accountId: string;
+  status?: SubscriptionStatus;
+  currentPeriodStart: Date;
+  currentPeriodEnd: Date;
+}) => {
+  return prisma.subscription.create({
+    data: {
+      accountId: opts.accountId,
+      provider: BillingProvider.apple,
+      productId: "app.convos.subs.monthly",
+      tier: "plus",
+      period: "monthly",
+      status: opts.status ?? SubscriptionStatus.active,
+      originalTransactionId: `otx-${randomUUID()}`,
+      appAccountToken: randomUUID(),
+      startedAt: opts.currentPeriodStart,
+      currentPeriodStart: opts.currentPeriodStart,
+      currentPeriodEnd: opts.currentPeriodEnd,
+      willRenew: true,
+      isInTrial: false,
+      environment: "sandbox",
+    },
+  });
+};
+
+const appleStatusResponse = (
+  originalTransactionId: string,
+  opts: { status: number; txJws?: string; renewalJws?: string },
+) => ({
+  environment: "Production",
+  response: {
+    data: [
+      {
+        lastTransactions: [
+          {
+            originalTransactionId,
+            status: opts.status,
+            signedTransactionInfo: opts.txJws ?? "jws-tx",
+            ...(opts.renewalJws ? { signedRenewalInfo: opts.renewalJws } : {}),
+          },
+        ],
+      },
+    ],
+  },
+});
+
+const decodedTransaction = (opts: {
+  originalTransactionId: string;
+  expiresDate: number;
+  purchaseDate?: number;
+}) => ({
+  originalTransactionId: opts.originalTransactionId,
+  transactionId: `tx-${randomUUID()}`,
+  productId: "app.convos.subs.monthly",
+  purchaseDate: opts.purchaseDate ?? opts.expiresDate - 30 * DAY_MS,
+  expiresDate: opts.expiresDate,
+});
+
+const ledgerRows = (accountId: string) =>
+  prisma.creditLedger.findMany({ where: { accountId } });
+
+const auditRows = (accountId: string) =>
+  prisma.adminAudit.findMany({ where: { accountId } });
+
+beforeEach(() => {
+  getSubscriptionStatusesWithEnvironmentFallback.mockReset();
+  verifyAndDecodeTransaction.mockReset();
+  verifyAndDecodeRenewalInfo.mockReset();
+});
+
+afterEach(async () => {
+  if (tracker.length === 0) return;
+  await prisma.billingReceipt.deleteMany({
+    where: { subscription: { accountId: { in: tracker } } },
+  });
+  await prisma.subscription.deleteMany({
+    where: { accountId: { in: tracker } },
+  });
+  await prisma.adminAudit.deleteMany({
+    where: { accountId: { in: tracker } },
+  });
+  await prisma.creditLedger.deleteMany({
+    where: { accountId: { in: tracker } },
+  });
+  await prisma.userCredits.deleteMany({
+    where: { accountId: { in: tracker } },
+  });
+  await prisma.account.deleteMany({ where: { id: { in: tracker } } });
+  tracker.length = 0;
+});
+
+describe("runAppleAllowlistReconcile", () => {
+  test("expired-never-granted (the pilot shape): status flips, ZERO ledger movement", async () => {
+    const accountId = await newAccount();
+    // Stale drift row: DB says active, but the period ended 40 days ago and
+    // no sub_grant was ever written (pre-S2S era).
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 70 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() - 40 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_EXPIRED }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: NOW.getTime() - 40 * DAY_MS,
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    expect(summary.mode).toBe("apply");
+    expect(summary.results).toHaveLength(1);
+    const result = summary.results[0];
+    expect(result.outcome).toBe("applied");
+    expect(result.after?.status).toBe(SubscriptionStatus.expired);
+
+    const after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.expired);
+    expect(after.willRenew).toBe(false);
+
+    // The forfeit of a never-granted period MUST no-op (grants.ts
+    // `skipped_nothing_to_forfeit`): zero ledger writes, no wallet created.
+    expect(result.money.forfeit?.priorGrantExists).toBe(false);
+    expect(result.money.forfeit?.result).toBe("skipped_nothing_to_forfeit");
+    expect(result.money.grant).toBeUndefined();
+    expect(await ledgerRows(accountId)).toHaveLength(0);
+    expect(
+      await prisma.userCredits.findUnique({ where: { accountId } }),
+    ).toBeNull();
+
+    // Audit trail: one reconcile row, zero credit delta.
+    const audits = await auditRows(accountId);
+    expect(audits).toHaveLength(1);
+    expect(audits[0].action).toBe("reconcile");
+    expect(audits[0].deltaCredits).toBe(0n);
+
+    // Re-run: already reconciled → noop, still zero ledger, no new audit row.
+    const again = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+    expect(again.results[0].outcome).toBe("noop");
+    expect(await ledgerRows(accountId)).toHaveLength(0);
+    expect(await auditRows(accountId)).toHaveLength(1);
+  });
+
+  test("entitled row with missing current-period grant: materialized via the idempotent helper", async () => {
+    const accountId = await newAccount();
+    const periodStart = new Date(NOW.getTime() - 5 * DAY_MS);
+    const periodEnd = new Date(NOW.getTime() + 25 * DAY_MS);
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: periodStart,
+      currentPeriodEnd: periodEnd,
+    });
+    const otx = sub.originalTransactionId ?? "";
+
+    // Provider agrees with the row state — the drift is purely the missing
+    // sub_grant for the live period.
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_ACTIVE }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: periodEnd.getTime(),
+        purchaseDate: periodStart.getTime(),
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("applied");
+    expect(result.money.grant?.result).toBe("granted");
+    expect(result.money.grant?.credits).toBe(monthlyCredits());
+    expect(result.money.forfeit).toBeUndefined();
+
+    const rows = await ledgerRows(accountId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].idempotencyKey).toBe(subGrantKey(sub.id, periodStart));
+    expect(rows[0].delta).toBe(BigInt(monthlyCredits()));
+    const wallet = await prisma.userCredits.findUniqueOrThrow({
+      where: { accountId },
+    });
+    expect(wallet.balance).toBe(BigInt(monthlyCredits()));
+
+    // Idempotent: a second apply run replays to a no-op — no double grant.
+    const again = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+    expect(again.results[0].outcome).toBe("noop");
+    expect(await ledgerRows(accountId)).toHaveLength(1);
+  });
+
+  test("missed renewal: window advances, old period forfeited + new period granted through the helpers", async () => {
+    const accountId = await newAccount();
+    const oldStart = new Date(NOW.getTime() - 35 * DAY_MS);
+    const oldEnd = new Date(NOW.getTime() - 5 * DAY_MS);
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: oldStart,
+      currentPeriodEnd: oldEnd,
+    });
+    const otx = sub.originalTransactionId ?? "";
+
+    // The old period WAS granted (normal verify flow) and never consumed.
+    await prisma.$transaction(async (tx) => {
+      const { grantSubscriptionPeriod } =
+        await import("@/subscriptions/grants");
+      await grantSubscriptionPeriod(tx, {
+        subscription: sub,
+        periodStart: oldStart,
+      });
+    });
+
+    // Provider truth: a renewal we never heard about (no SSN feed).
+    const newStart = oldEnd;
+    const newEnd = new Date(oldEnd.getTime() + 30 * DAY_MS);
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_ACTIVE }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: newEnd.getTime(),
+        purchaseDate: newStart.getTime(),
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("applied");
+    expect(result.after?.currentPeriodEnd).toBe(newEnd.toISOString());
+    expect(result.money.forfeit?.result).toBe("forfeited");
+    expect(result.money.grant?.result).toBe("granted");
+
+    const keys = (await ledgerRows(accountId)).map((r) => r.idempotencyKey);
+    expect(keys).toContain(subGrantKey(sub.id, oldStart));
+    expect(keys).toContain(subForfeitKey(sub.id, oldStart));
+    expect(keys).toContain(subGrantKey(sub.id, newStart));
+    // Old unused grant clawed back, new period granted → exactly one period's
+    // credits in the wallet.
+    const wallet = await prisma.userCredits.findUniqueOrThrow({
+      where: { accountId },
+    });
+    expect(wallet.balance).toBe(BigInt(monthlyCredits()));
+  });
+
+  test("dry-run (default) writes NOTHING and reports the plan", async () => {
+    const accountId = await newAccount();
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 70 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() - 40 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_EXPIRED }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: NOW.getTime() - 40 * DAY_MS,
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      now: NOW,
+    });
+
+    expect(summary.mode).toBe("dry-run");
+    const result = summary.results[0];
+    expect(result.outcome).toBe("planned");
+    expect(result.intendedUpdate?.status).toBe(SubscriptionStatus.expired);
+    // The plan predicts the forfeit no-op (never granted).
+    expect(result.money.forfeit?.priorGrantExists).toBe(false);
+    expect(result.money.forfeit?.result).toBeUndefined();
+
+    // Nothing written: row untouched (status AND updatedAt), no ledger, no
+    // wallet, no audit.
+    const after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.active);
+    expect(after.updatedAt.getTime()).toBe(sub.updatedAt.getTime());
+    expect(await ledgerRows(accountId)).toHaveLength(0);
+    expect(
+      await prisma.userCredits.findUnique({ where: { accountId } }),
+    ).toBeNull();
+    expect(await auditRows(accountId)).toHaveLength(0);
+  });
+
+  test("allowlisted id without a Subscription row → no_row, nothing written", async () => {
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: ["otx-does-not-exist"],
+      apply: true,
+      now: NOW,
+    });
+    expect(summary.results[0].outcome).toBe("no_row");
+  });
+
+  test("provider fetch failure → provider_unresolved, row untouched", async () => {
+    const accountId = await newAccount();
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 70 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() - 40 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+
+    getSubscriptionStatusesWithEnvironmentFallback.mockRejectedValue(
+      new Error("apple 500"),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("provider_unresolved");
+    expect(result.unresolvedReason).toBe("status_fetch_failed");
+    const after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.active);
+    expect(after.updatedAt.getTime()).toBe(sub.updatedAt.getTime());
+  });
+});

--- a/tests/subscriptions/reconcile/allowlist.integration.test.ts
+++ b/tests/subscriptions/reconcile/allowlist.integration.test.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { BillingProvider, SubscriptionStatus } from "@prisma/client";
+import {
+  BillingProvider,
+  SubscriptionStatus,
+  type Subscription,
+} from "@prisma/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { subForfeitKey, subGrantKey } from "@/subscriptions/grants";
 import { runAppleAllowlistReconcile } from "@/subscriptions/reconcile/service";
@@ -29,6 +33,7 @@ vi.mock("@/subscriptions/jws-verifier", () => ({
 // Apple status enum (mirrors @apple/app-store-server-library Status).
 const APPLE_STATUS_ACTIVE = 1;
 const APPLE_STATUS_EXPIRED = 2;
+const APPLE_STATUS_BILLING_RETRY = 3;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const NOW = new Date(Date.UTC(2026, 6, 29, 12, 0, 0));
@@ -94,13 +99,21 @@ const decodedTransaction = (opts: {
   originalTransactionId: string;
   expiresDate: number;
   purchaseDate?: number;
+  productId?: string;
 }) => ({
   originalTransactionId: opts.originalTransactionId,
   transactionId: `tx-${randomUUID()}`,
-  productId: "app.convos.subs.monthly",
+  productId: opts.productId ?? "app.convos.subs.monthly",
   purchaseDate: opts.purchaseDate ?? opts.expiresDate - 30 * DAY_MS,
   expiresDate: opts.expiresDate,
 });
+
+const seedGrantForPeriod = async (sub: Subscription, periodStart: Date) => {
+  await prisma.$transaction(async (tx) => {
+    const { grantSubscriptionPeriod } = await import("@/subscriptions/grants");
+    await grantSubscriptionPeriod(tx, { subscription: sub, periodStart });
+  });
+};
 
 const ledgerRows = (accountId: string) =>
   prisma.creditLedger.findMany({ where: { accountId } });
@@ -216,9 +229,13 @@ describe("runAppleAllowlistReconcile", () => {
     const otx = sub.originalTransactionId ?? "";
 
     // Provider agrees with the row state — the drift is purely the missing
-    // sub_grant for the live period.
+    // sub_grant for the live period. Auto-renew is OFF (cancelled-but-active):
+    // willRenew must come from the renewal info, not be assumed true.
     getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
-      appleStatusResponse(otx, { status: APPLE_STATUS_ACTIVE }),
+      appleStatusResponse(otx, {
+        status: APPLE_STATUS_ACTIVE,
+        renewalJws: "jws-renewal",
+      }),
     );
     verifyAndDecodeTransaction.mockResolvedValue(
       decodedTransaction({
@@ -227,6 +244,7 @@ describe("runAppleAllowlistReconcile", () => {
         purchaseDate: periodStart.getTime(),
       }),
     );
+    verifyAndDecodeRenewalInfo.mockResolvedValue({ autoRenewStatus: 0 });
 
     const summary = await runAppleAllowlistReconcile({
       originalTransactionIds: [otx],
@@ -238,6 +256,10 @@ describe("runAppleAllowlistReconcile", () => {
     expect(result.outcome).toBe("applied");
     expect(result.money.grant?.result).toBe("granted");
     expect(result.money.grant?.credits).toBe(monthlyCredits());
+    const afterRow = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    expect(afterRow.willRenew).toBe(false);
     expect(result.money.forfeit).toBeUndefined();
 
     const rows = await ledgerRows(accountId);
@@ -272,14 +294,7 @@ describe("runAppleAllowlistReconcile", () => {
     const otx = sub.originalTransactionId ?? "";
 
     // The old period WAS granted (normal verify flow) and never consumed.
-    await prisma.$transaction(async (tx) => {
-      const { grantSubscriptionPeriod } =
-        await import("@/subscriptions/grants");
-      await grantSubscriptionPeriod(tx, {
-        subscription: sub,
-        periodStart: oldStart,
-      });
-    });
+    await seedGrantForPeriod(sub, oldStart);
 
     // Provider truth: a renewal we never heard about (no SSN feed).
     const newStart = oldEnd;
@@ -403,5 +418,197 @@ describe("runAppleAllowlistReconcile", () => {
     });
     expect(after.status).toBe(SubscriptionStatus.active);
     expect(after.updatedAt.getTime()).toBe(sub.updatedAt.getTime());
+  });
+
+  test("billingRetry past the paid window: status flips, NO grant is minted (no-TTL gap closed for reconcile)", async () => {
+    const accountId = await newAccount();
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 70 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() - 40 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_BILLING_RETRY }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: NOW.getTime() - 40 * DAY_MS,
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("applied");
+    expect(result.after?.status).toBe(SubscriptionStatus.billingRetry);
+    // status.ts entitles billingRetry with no TTL — the reconcile grant gate
+    // must still refuse to mint for a paid window that is already over.
+    expect(result.money.grant).toBeUndefined();
+    expect(await ledgerRows(accountId)).toHaveLength(0);
+  });
+
+  test("drifting provider purchaseDate on an unchanged window does NOT re-key the period (no double mint)", async () => {
+    const accountId = await newAccount();
+    const periodStart = new Date(NOW.getTime() - 5 * DAY_MS);
+    const periodEnd = new Date(NOW.getTime() + 25 * DAY_MS);
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: periodStart,
+      currentPeriodEnd: periodEnd,
+    });
+    const otx = sub.originalTransactionId ?? "";
+    // Current period already granted under the STORED period start.
+    await seedGrantForPeriod(sub, periodStart);
+
+    // Apple reports the same window end but a slightly different purchase
+    // date — same real period, different would-be grant key.
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_ACTIVE }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: periodEnd.getTime(),
+        purchaseDate: periodStart.getTime() - DAY_MS,
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    expect(summary.results[0].outcome).toBe("noop");
+    expect(await ledgerRows(accountId)).toHaveLength(1);
+  });
+
+  test("stale terminal verdict (provider window older than stored) is refused wholesale", async () => {
+    const accountId = await newAccount();
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 5 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() + 25 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+    await seedGrantForPeriod(sub, sub.currentPeriodStart);
+
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_EXPIRED }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: NOW.getTime() - 100 * DAY_MS,
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("provider_unresolved");
+    expect(result.unresolvedReason).toBe("stale_provider_terminal");
+    const after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.active);
+    // The granted live period was NOT forfeited.
+    expect(await ledgerRows(accountId)).toHaveLength(1);
+  });
+
+  test("already-terminal row: window backfill applies but NEVER retro-forfeits kept credits", async () => {
+    const accountId = await newAccount();
+    const periodStart = new Date(NOW.getTime() - 65 * DAY_MS);
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.expired,
+      currentPeriodStart: periodStart,
+      currentPeriodEnd: new Date(NOW.getTime() - 35 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+    // The (now over) period had been granted and the credits were kept.
+    await seedGrantForPeriod(sub, periodStart);
+
+    // Apple's final transaction ends LATER than our stored window.
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_EXPIRED }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: NOW.getTime() - 5 * DAY_MS,
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("applied");
+    expect(result.after?.currentPeriodEnd).toBe(
+      new Date(NOW.getTime() - 5 * DAY_MS).toISOString(),
+    );
+    // No forfeit was planned or executed — pilot policy: no retroactive
+    // clawback for rows that were already terminal.
+    expect(result.money.forfeit).toBeUndefined();
+    expect(await ledgerRows(accountId)).toHaveLength(1);
+    const wallet = await prisma.userCredits.findUniqueOrThrow({
+      where: { accountId },
+    });
+    expect(wallet.balance).toBe(BigInt(monthlyCredits()));
+  });
+
+  test("provider productId mismatch fails safe (no SKU remap in the pilot)", async () => {
+    const accountId = await newAccount();
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 70 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() - 40 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_EXPIRED }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: NOW.getTime() - 40 * DAY_MS,
+        productId: "app.convos.subs.annual",
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("provider_unresolved");
+    expect(result.unresolvedReason).toBe("product_id_mismatch");
+    const after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.active);
+    expect(await ledgerRows(accountId)).toHaveLength(0);
   });
 });

--- a/tests/subscriptions/reconcile/allowlist.integration.test.ts
+++ b/tests/subscriptions/reconcile/allowlist.integration.test.ts
@@ -449,10 +449,94 @@ describe("runAppleAllowlistReconcile", () => {
     const result = summary.results[0];
     expect(result.outcome).toBe("applied");
     expect(result.after?.status).toBe(SubscriptionStatus.billingRetry);
-    // status.ts entitles billingRetry with no TTL — the reconcile grant gate
-    // must still refuse to mint for a paid window that is already over.
+    // status.ts entitles billingRetry with no TTL and status 3 carries no
+    // trustworthy window — the reconcile grant gate categorically refuses to
+    // mint for billingRetry targets.
     expect(result.money.grant).toBeUndefined();
     expect(await ledgerRows(accountId)).toHaveLength(0);
+  });
+
+  test("advancing end with a NON-advancing provider start keeps the stored period key (no re-key)", async () => {
+    const accountId = await newAccount();
+    const periodStart = new Date(NOW.getTime() - 20 * DAY_MS);
+    const periodEnd = new Date(NOW.getTime() + 10 * DAY_MS);
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: periodStart,
+      currentPeriodEnd: periodEnd,
+    });
+    const otx = sub.originalTransactionId ?? "";
+    await seedGrantForPeriod(sub, periodStart);
+
+    // Provider end extends, but the provider start is OLDER than stored —
+    // an incoherent period identity that must not re-key money.
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_ACTIVE }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otx,
+        expiresDate: periodEnd.getTime() + 5 * DAY_MS,
+        purchaseDate: periodStart.getTime() - 10 * DAY_MS,
+      }),
+    );
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("applied");
+    const after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    // Window extended, stored period identity kept, grant replayed under the
+    // stored key — exactly one ledger row, no forfeit.
+    expect(after.currentPeriodStart.getTime()).toBe(periodStart.getTime());
+    expect(after.currentPeriodEnd.getTime()).toBe(
+      periodEnd.getTime() + 5 * DAY_MS,
+    );
+    expect(await ledgerRows(accountId)).toHaveLength(1);
+  });
+
+  test("terminal verdict without a provider expiresDate fails safe (no blind terminalize+forfeit)", async () => {
+    const accountId = await newAccount();
+    const sub = await seedAppleSub({
+      accountId,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 5 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() + 25 * DAY_MS),
+    });
+    const otx = sub.originalTransactionId ?? "";
+    await seedGrantForPeriod(sub, sub.currentPeriodStart);
+
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otx, { status: APPLE_STATUS_EXPIRED }),
+    );
+    // Decoded transaction lacks expiresDate entirely.
+    verifyAndDecodeTransaction.mockResolvedValue({
+      originalTransactionId: otx,
+      transactionId: `tx-${randomUUID()}`,
+      productId: "app.convos.subs.monthly",
+    });
+
+    const summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otx],
+      apply: true,
+      now: NOW,
+    });
+
+    const result = summary.results[0];
+    expect(result.outcome).toBe("provider_unresolved");
+    expect(result.unresolvedReason).toBe("ambiguous_provider_state");
+    const after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: sub.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.active);
+    expect(await ledgerRows(accountId)).toHaveLength(1);
   });
 
   test("drifting provider purchaseDate on an unchanged window does NOT re-key the period (no double mint)", async () => {

--- a/tests/subscriptions/reconcile/allowlist.integration.test.ts
+++ b/tests/subscriptions/reconcile/allowlist.integration.test.ts
@@ -7,6 +7,7 @@ import {
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { subForfeitKey, subGrantKey } from "@/subscriptions/grants";
 import { runAppleAllowlistReconcile } from "@/subscriptions/reconcile/service";
+import { isEntitledSubscription } from "@/subscriptions/status";
 import { tierGrant } from "@/subscriptions/tier-config";
 import { prisma } from "@/utils/prisma";
 
@@ -34,6 +35,7 @@ vi.mock("@/subscriptions/jws-verifier", () => ({
 const APPLE_STATUS_ACTIVE = 1;
 const APPLE_STATUS_EXPIRED = 2;
 const APPLE_STATUS_BILLING_RETRY = 3;
+const APPLE_STATUS_BILLING_GRACE = 4;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const NOW = new Date(Date.UTC(2026, 6, 29, 12, 0, 0));
@@ -420,40 +422,133 @@ describe("runAppleAllowlistReconcile", () => {
     expect(after.updatedAt.getTime()).toBe(sub.updatedAt.getTime());
   });
 
-  test("billingRetry past the paid window: status flips, NO grant is minted (no-TTL gap closed for reconcile)", async () => {
-    const accountId = await newAccount();
-    const sub = await seedAppleSub({
-      accountId,
-      status: SubscriptionStatus.active,
+  test("billingRetry must not re-entitle nor extend period; grace entitles only until gracePeriodExpiresDate", async () => {
+    // --- Leg 1a: EXPIRED row + Apple status 3 → NOT re-entitled. Writing
+    // billingRetry would restore indefinite entitlement (status.ts no-TTL);
+    // the mapping must fail safe and leave the row untouched.
+    const accountA = await newAccount();
+    const expiredRow = await seedAppleSub({
+      accountId: accountA,
+      status: SubscriptionStatus.expired,
       currentPeriodStart: new Date(NOW.getTime() - 70 * DAY_MS),
       currentPeriodEnd: new Date(NOW.getTime() - 40 * DAY_MS),
     });
-    const otx = sub.originalTransactionId ?? "";
+    const otxA = expiredRow.originalTransactionId ?? "";
 
     getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
-      appleStatusResponse(otx, { status: APPLE_STATUS_BILLING_RETRY }),
+      appleStatusResponse(otxA, { status: APPLE_STATUS_BILLING_RETRY }),
     );
     verifyAndDecodeTransaction.mockResolvedValue(
       decodedTransaction({
-        originalTransactionId: otx,
+        originalTransactionId: otxA,
         expiresDate: NOW.getTime() - 40 * DAY_MS,
       }),
     );
 
-    const summary = await runAppleAllowlistReconcile({
-      originalTransactionIds: [otx],
+    let summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otxA],
       apply: true,
       now: NOW,
     });
+    expect(summary.results[0].outcome).toBe("provider_unresolved");
+    let after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: expiredRow.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.expired);
+    expect(after.currentPeriodEnd.getTime()).toBe(
+      expiredRow.currentPeriodEnd.getTime(),
+    );
+    expect(isEntitledSubscription(after, NOW)).toBe(false);
+    expect(await ledgerRows(accountA)).toHaveLength(0);
 
-    const result = summary.results[0];
-    expect(result.outcome).toBe("applied");
-    expect(result.after?.status).toBe(SubscriptionStatus.billingRetry);
-    // status.ts entitles billingRetry with no TTL and status 3 carries no
-    // trustworthy window — the reconcile grant gate categorically refuses to
-    // mint for billingRetry targets.
-    expect(result.money.grant).toBeUndefined();
-    expect(await ledgerRows(accountId)).toHaveLength(0);
+    // --- Leg 1b: stale-ACTIVE row (effectively expired) + status 3 → row
+    // untouched, period NOT extended, still not entitled.
+    const accountB = await newAccount();
+    const staleActive = await seedAppleSub({
+      accountId: accountB,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: new Date(NOW.getTime() - 70 * DAY_MS),
+      currentPeriodEnd: new Date(NOW.getTime() - 40 * DAY_MS),
+    });
+    const otxB = staleActive.originalTransactionId ?? "";
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otxB, { status: APPLE_STATUS_BILLING_RETRY }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otxB,
+        expiresDate: NOW.getTime() - 40 * DAY_MS,
+      }),
+    );
+
+    summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otxB],
+      apply: true,
+      now: NOW,
+    });
+    expect(summary.results[0].outcome).toBe("provider_unresolved");
+    after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: staleActive.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.active);
+    expect(after.updatedAt.getTime()).toBe(staleActive.updatedAt.getTime());
+    expect(isEntitledSubscription(after, NOW)).toBe(false);
+    expect(await ledgerRows(accountB)).toHaveLength(0);
+
+    // --- Leg 2: Apple status 4 (grace) DOES entitle, but ONLY until
+    // signedRenewalInfo.gracePeriodExpiresDate.
+    const accountC = await newAccount();
+    const periodStart = new Date(NOW.getTime() - 35 * DAY_MS);
+    const graceRow = await seedAppleSub({
+      accountId: accountC,
+      status: SubscriptionStatus.active,
+      currentPeriodStart: periodStart,
+      currentPeriodEnd: new Date(NOW.getTime() - 5 * DAY_MS),
+    });
+    const otxC = graceRow.originalTransactionId ?? "";
+    // Period was granted normally; grace must not re-mint.
+    await seedGrantForPeriod(graceRow, periodStart);
+
+    const graceDeadline = NOW.getTime() + 10 * DAY_MS;
+    getSubscriptionStatusesWithEnvironmentFallback.mockResolvedValue(
+      appleStatusResponse(otxC, {
+        status: APPLE_STATUS_BILLING_GRACE,
+        renewalJws: "jws-renewal-grace",
+      }),
+    );
+    verifyAndDecodeTransaction.mockResolvedValue(
+      decodedTransaction({
+        originalTransactionId: otxC,
+        expiresDate: NOW.getTime() - 5 * DAY_MS,
+        purchaseDate: periodStart.getTime(),
+      }),
+    );
+    verifyAndDecodeRenewalInfo.mockResolvedValue({
+      gracePeriodExpiresDate: graceDeadline,
+    });
+
+    summary = await runAppleAllowlistReconcile({
+      originalTransactionIds: [otxC],
+      apply: true,
+      now: NOW,
+    });
+    expect(summary.results[0].outcome).toBe("applied");
+    after = await prisma.subscription.findUniqueOrThrow({
+      where: { id: graceRow.id },
+    });
+    expect(after.status).toBe(SubscriptionStatus.grace);
+    // Entitlement is bounded EXACTLY by the provider grace deadline.
+    expect(after.gracePeriodEnd?.getTime()).toBe(graceDeadline);
+    expect(isEntitledSubscription(after, NOW)).toBe(true);
+    expect(isEntitledSubscription(after, new Date(graceDeadline - 1000))).toBe(
+      true,
+    );
+    expect(isEntitledSubscription(after, new Date(graceDeadline))).toBe(false);
+    expect(isEntitledSubscription(after, new Date(graceDeadline + 1000))).toBe(
+      false,
+    );
+    // No re-mint: still exactly the one grant row.
+    expect(await ledgerRows(accountC)).toHaveLength(1);
   });
 
   test("advancing end with a NON-advancing provider start keeps the stored period key (no re-key)", async () => {


### PR DESCRIPTION
## What

An **allowlist-pilot reconcile job** for Apple subscriptions: re-fetches provider ground truth (`Get All Subscription Statuses`) for an explicit list of `originalTransactionId`s and reconciles the local `Subscription` rows through the normal repository + ledger paths. **Dry-run by default; `--apply` executes.**

This job is the repair path for that drift class — scoped, for this PR, to a two-row pilot.

## Pilot scope (the two target rows)

| Subscription id | OTX | DB says | Apple says (verified 2026-07-29 via API) |
|---|---|---|---|
| `6965097b-************` | `1020000017410296` | active (stale) | **status 2 EXPIRED**, expirationIntent 1 |
| `aec5db9c-************` | `110003542688181` | active (stale) | **status 2 EXPIRED**, expirationIntent 1 |

Neither row's period was ever granted, so a correct apply is **status flips only — zero ledger movement**: the terminal forfeit resolves to `skipped_nothing_to_forfeit` (`grants.ts` pre-check), pinned by test.

Deliberately **out** of this PR: fleet scan / cron mode and the Google path (both live on the unmerged `louis/credits-reconcile-cron` branch, commit `2b0b041`, from which this module's Apple mapping and write-guards are ported ~80%); SKU remapping (product mismatch fails safe); retroactive forfeit backfill for already-terminal rows (clawback policy decision — flagged, not taken).

## How it works

- `src/subscriptions/reconcile/service.ts` — `runAppleAllowlistReconcile`:
  - Apple per-item `status` enum is the liveness verdict (never the transaction `expiresDate` alone); every signed payload goes through the JWS verifier (which has its own env fallback).
  - Write-guards: terminal staleness guard (mirrors `applyNotification`; terminal verdicts REQUIRE a provider window), coherent period-identity stabilizer (`currentPeriodStart` anchors the per-period money keys — never re-keyed unless end AND start strictly advance), monotonic window floor, non-extending grace clamp, rescue-awareness, `updatedAt`-CAS concurrency guard (a mid-run verify/SSN wins).
  - Money moves **only** through `grantSubscriptionPeriod` / `forfeitSubscriptionPeriod` in the same transaction (src/payments/AGENTS.md law). Forfeit only on an actual transition into terminal; entitled rows with a missing current-period grant are materialized idempotently; billingRetry targets categorically never mint (status 3 carries no trustworthy window).
  - Apply writes an `AdminAudit` row (`action: "reconcile"`) **inside the same transaction**, keyed on the guarded snapshot — surfaced in the credits-admin activity filter.
- `src/subscriptions/apple-server-api.ts` — per-environment clients + `getSubscriptionStatusesWithEnvironmentFallback`: primary environment first, opposite host on 4040010/4040005 not-found (TestFlight OTXs live in sandbox; the client previously could not reach the sandbox host from prod), or an explicit `--env` pin.
- `src/subscriptions/jws-verifier.ts` — adds `verifyAndDecodeRenewalInfo` (grace deadline + autoRenewStatus source).
- `scripts/reconcile-apple-subscriptions.ts` + `pnpm subs:reconcile` — operator CLI; docs in `scripts/README.md`.

## Prod runbook (dry-run first, per prod rules)

This runs as a **controlled, reviewed, versioned job** — merged code invoked by an operator, never ad-hoc. The prod container image ships only `dist/` (no `scripts/`, no tsx), so the invocation runs from a checkout of the **deployed commit** with the prod env (same precedent as `pnpm apple:sub-status`, #393): full server env required (`DATABASE_URL` → prod, the `APPLE_API_*` prod block, `PAYMENTS_GRANT_PLUS_MONTHLY`, and the vars `src/config.ts` requires at load).

1. **Dry-run** (writes nothing) and capture the output:
   ```bash
   pnpm subs:reconcile 1020000017410296 110003542688181
   ```
   Expected plan: both rows `planned` with `status → expired`, `willRenew → false`; money line reads "NO sub_grant row for that period → forfeit will no-op; zero ledger movement"; no grants planned. **Anything else → stop and investigate.**
2. **Apply**:
   ```bash
   pnpm subs:reconcile 1020000017410296 110003542688181 --apply --actor <operator-email>
   ```
   Expected: both `applied`, `forfeit → skipped_nothing_to_forfeit`, one `AdminAudit` row each with `deltaCredits = 0`.
3. **Verify**: rows read `expired` (credits-admin account view / `GET /v2/accounts/me/subscription`); `CreditLedger` unchanged for both accounts; re-running either command reports `noop` (idempotent).

The CLI exits non-zero if any allowlisted id could not be fully processed (`no_row`, `provider_unresolved`, `skipped_row_changed`, `error`).

## Ordering vs #374 (account deletion + lineage)

This PR is **independent of and safe to land before #374**: it never touches `accountId`, provider identity keys, or anything lineage-shaped — only status/window fields plus per-period ledger rows through the shared idempotent helpers, which is exactly the state #374's backfill reads. It does not conflict with the interim re-home migration path either (that migration must still ship before #374 per the session analysis). When #374's own reconciliation sweep (`SubscriptionDriftSchedule`) lands, the fleet-mode graduation of this pilot should fold into that machinery rather than grow a second scanner.

## Review

Two adversarial read-only Codex review rounds before opening this PR:
- Round 1: 4 MAJOR / 4 MINOR — all fixed (billingRetry no-TTL grant gate, period-identity re-keying, terminal staleness guard, product-mismatch fail-safe, audit atomicity + keying, willRenew derivation).
- Round 2 (on the fixes): 4 MAJOR / 1 MINOR — all fixed (grace carries period identity, terminal verdicts require a provider window, coherent-advance rule for period identity, billingRetry categorically never mints, missing productId fails safe).
- Deliberate deviation from one MINOR: the env fallback also triggers on 4040005 (the statuses endpoint's documented not-found error) alongside 4040010 — a spurious fallback costs one extra read and can never cause a wrong write.

## Tests

`tests/subscriptions/reconcile/allowlist.integration.test.ts` (13 cases incl. the pilot shape: expired-never-granted → status flip, zero ledger writes; missing-grant materialization + idempotent re-run; missed-renewal forfeit+grant; dry-run writes nothing; stale-terminal refusal; no re-key double-mint; billingRetry never mints; terminal-without-window fail-safe; product mismatch; already-terminal no-clawback) and `tests/subscriptions/apple-server-api-env-fallback.test.ts` (7 cases). Full related suites green locally (`tests/subscriptions`, `tests/credits-admin`, `tests/credits`, `tests/payments` — the one daily-refill failure is pre-existing shared-DB dirt, reproduced on a clean tree). `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787921226&installation_model_id=20076&pr_number=396&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F396&signature=5f06ad46dbb7f26a5ddb137a749df2a7b943078d884b75434069977406154928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Apple subscription allowlist reconcile job as a dry-run/apply CLI
> - Adds [`scripts/reconcile-apple-subscriptions.ts`](https://github.com/xmtplabs/convos-backend/pull/396/files#diff-ea63fb1b516bbc53b607aae471144b4812f7c3fc7590ee7b5dc12a3ae569ed36) and a `subs:reconcile` npm script to dry-run or apply reconciliations for a specified list of Apple `originalTransactionId`s.
> - The core [`src/subscriptions/reconcile/service.ts`](https://github.com/xmtplabs/convos-backend/pull/396/files#diff-24220fa426d1d7df4f1e72c91dbddabcb976c8d6492d2b7a2fbd4c3eefc08b55) resolves Apple ground truth with environment fallback, maps provider status to local state, and idempotently grants/forfeits per-period credits within a single transaction.
> - Adds `getSubscriptionStatusesWithEnvironmentFallback` to [`src/subscriptions/apple-server-api.ts`](https://github.com/xmtplabs/convos-backend/pull/396/files#diff-03ef9d4660ffa60c7e259b3a602ccc77e2e73419989946dd02b1d1d61283a458) to transparently retry the opposite Apple environment on not-found errors, handling TestFlight/sandbox transactions.
> - Extends the admin audit system with a `reconcile` action type, a new `auditRecentQuerySchema` enum value, and a UI filter facet in the admin console.
> - Risk: apply mode performs CAS writes on `updatedAt` and moves money via `grantSubscriptionPeriod`/`forfeitSubscriptionPeriod`; conservative fail-safes (no `billingRetry`, monotonic window guards, product ID mismatch check) are in place but this is a pilot with manual invocation only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9af5bb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Apple subscription reconciliation tool with dry-run and apply modes.
  * Supports production/sandbox status lookup with automatic environment fallback.
  * Added safeguards for ambiguous provider responses, concurrent updates, and idempotent entitlement changes.
  * Added “Reconciles” filtering to the admin activity view.
  * Reconciliation actions are now recorded in admin audit activity.

* **Documentation**
  * Added usage instructions, options, prerequisites, and operational guarantees for the reconciliation tool.

* **Tests**
  * Added coverage for environment fallback and subscription reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->