### PR TITLE
feat(db): deletion + subscription-lineage data model (slice 1/5 of #374)

### DIFF
--- a/prisma/migrations/20260729100000_add_account_deletion/migration.sql
+++ b/prisma/migrations/20260729100000_add_account_deletion/migration.sql
@@ -1,0 +1,80 @@
+-- Account deletion: barrier, deletion record, purge outbox, billing
+-- tombstones, and the lastAuthAt activity stamp. Purely additive.
+
+-- AlterTable
+ALTER TABLE "Account" ADD COLUMN     "lastAuthAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "DeletedIdentity" (
+    "identityHash" TEXT NOT NULL,
+    "deletedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DeletedIdentity_pkey" PRIMARY KEY ("identityHash")
+);
+
+-- CreateTable
+CREATE TABLE "DeletionRecord" (
+    "operationId" UUID NOT NULL,
+    "accountRef" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'purging',
+    "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DeletionRecord_pkey" PRIMARY KEY ("operationId")
+);
+
+-- CreateTable
+CREATE TABLE "DeletionTask" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "operationId" UUID NOT NULL,
+    "kind" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "DeletionTask_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SubscriptionTombstone" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "provider" "BillingProvider" NOT NULL,
+    "providerKey" TEXT NOT NULL,
+    "accountRef" TEXT NOT NULL,
+    "deletedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SubscriptionTombstone_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DeletionRecord_accountRef_idx" ON "DeletionRecord"("accountRef");
+
+-- CreateIndex
+CREATE INDEX "DeletionRecord_status_requestedAt_idx" ON "DeletionRecord"("status", "requestedAt");
+
+-- CreateIndex
+CREATE INDEX "DeletionRecord_expiresAt_idx" ON "DeletionRecord"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "DeletionTask_status_nextAttemptAt_idx" ON "DeletionTask"("status", "nextAttemptAt");
+
+-- CreateIndex
+CREATE INDEX "DeletionTask_operationId_idx" ON "DeletionTask"("operationId");
+
+-- CreateIndex
+CREATE INDEX "SubscriptionTombstone_accountRef_idx" ON "SubscriptionTombstone"("accountRef");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SubscriptionTombstone_provider_providerKey_key" ON "SubscriptionTombstone"("provider", "providerKey");
+
+-- Backfill: existing accounts start their activity clock at migration time.
+-- A null lastAuthAt must never read as "inactive/no veto"; after this
+-- backfill, null only ever means a brand-new account that has not minted yet.
+UPDATE "Account" SET "lastAuthAt" = CURRENT_TIMESTAMP WHERE "lastAuthAt" IS NULL;

--- a/prisma/migrations/20260729101000_add_subscription_lineage/migration.sql
+++ b/prisma/migrations/20260729101000_add_subscription_lineage/migration.sql
@@ -1,0 +1,326 @@
+-- Subscription lineage rows are the canonical lockable object, with token
+-- aliases, a global once-per-period funding registry, custody/escrow state,
+-- the transfer journal, and quarantine.
+-- Supersedes SubscriptionTombstone (tombstone becomes a lineage state); the
+-- old table is retained additively so a rollback never references a dropped
+-- relation.
+
+-- AlterTable
+ALTER TABLE "Subscription" ADD COLUMN     "lineageId" UUID;
+
+-- CreateTable
+CREATE TABLE "SubscriptionLineage" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "provider" "BillingProvider" NOT NULL,
+    "lineageKey" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'live',
+    "tombstonedAt" TIMESTAMP(3),
+    "deletedAccountRef" TEXT,
+    "lastTransferAt" TIMESTAMP(3),
+    "lastTransferJournalId" UUID,
+    "liveTransferFrozenAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubscriptionLineage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LineageTokenAlias" (
+    "token" TEXT NOT NULL,
+    "lineageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LineageTokenAlias_pkey" PRIMARY KEY ("token")
+);
+
+-- CreateTable
+CREATE TABLE "LineagePeriodGrant" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "lineageId" UUID NOT NULL,
+    "providerPeriodKey" TEXT NOT NULL,
+    "accountId" UUID NOT NULL,
+    "ledgerKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LineagePeriodGrant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LineagePeriodCustody" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "lineageId" UUID NOT NULL,
+    "providerPeriodKey" TEXT NOT NULL,
+    "ownerAccountId" UUID,
+    "remainderCap" BIGINT NOT NULL,
+    "custodyStartedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "periodStart" TIMESTAMP(3) NOT NULL,
+    "periodEnd" TIMESTAMP(3) NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'held',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LineagePeriodCustody_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SubscriptionTransfer" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "lineageId" UUID NOT NULL,
+    "kind" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'committed',
+    "fromAccountId" UUID,
+    "toAccountId" UUID,
+    "conservedCredits" BIGINT NOT NULL DEFAULT 0,
+    "providerProof" JSONB,
+    "undoOfTransferId" UUID,
+    "undoneByTransferId" UUID,
+    "undoDeadlineAt" TIMESTAMP(3),
+    "contestEndsAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubscriptionTransfer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LineageQuarantine" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "provider" "BillingProvider" NOT NULL,
+    "token" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "payload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "LineageQuarantine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SubscriptionLineage_provider_lineageKey_key" ON "SubscriptionLineage"("provider", "lineageKey");
+
+-- Money-state invariants, database-enforced (not just application code):
+-- custody caps never go negative, states stay in their closed vocabularies,
+-- and escrow custody is exactly the ownerless state.
+ALTER TABLE "LineagePeriodCustody"
+  ADD CONSTRAINT "LineagePeriodCustody_cap_nonnegative_check" CHECK ("remainderCap" >= 0),
+  ADD CONSTRAINT "LineagePeriodCustody_state_check" CHECK ("state" IN ('held', 'escrow', 'invalidated', 'exhausted')),
+  ADD CONSTRAINT "LineagePeriodCustody_owner_state_check" CHECK (
+    ("state" = 'escrow' AND "ownerAccountId" IS NULL)
+    OR ("state" = 'held' AND "ownerAccountId" IS NOT NULL)
+    OR "state" IN ('invalidated', 'exhausted')
+  );
+ALTER TABLE "SubscriptionTransfer"
+  ADD CONSTRAINT "SubscriptionTransfer_kind_check" CHECK ("kind" IN ('transfer', 'restore', 'undo', 'escrow')),
+  ADD CONSTRAINT "SubscriptionTransfer_status_check" CHECK ("status" IN ('pending', 'committed', 'cancelled')),
+  ADD CONSTRAINT "SubscriptionTransfer_conserved_nonnegative_check" CHECK ("conservedCredits" >= 0);
+ALTER TABLE "SubscriptionLineage"
+  ADD CONSTRAINT "SubscriptionLineage_state_check" CHECK ("state" IN ('live', 'tombstoned'));
+
+-- CreateIndex
+CREATE INDEX "LineageTokenAlias_lineageId_idx" ON "LineageTokenAlias"("lineageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LineagePeriodGrant_lineageId_providerPeriodKey_key" ON "LineagePeriodGrant"("lineageId", "providerPeriodKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LineagePeriodCustody_lineageId_providerPeriodKey_key" ON "LineagePeriodCustody"("lineageId", "providerPeriodKey");
+
+-- CreateIndex
+CREATE INDEX "LineagePeriodCustody_lineageId_state_idx" ON "LineagePeriodCustody"("lineageId", "state");
+
+-- CreateIndex
+CREATE INDEX "SubscriptionTransfer_lineageId_createdAt_idx" ON "SubscriptionTransfer"("lineageId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SubscriptionTransfer_status_contestEndsAt_idx" ON "SubscriptionTransfer"("status", "contestEndsAt");
+
+-- CreateIndex
+CREATE INDEX "LineageQuarantine_resolvedAt_createdAt_idx" ON "LineageQuarantine"("resolvedAt", "createdAt");
+
+-- Backfill: one lineage per existing Subscription row. Apple keys on the
+-- stable OTX. Google keys on the recursively discovered root of the
+-- linkedPurchaseToken chain: keying on the immediate predecessor alone would
+-- give a twice-rotated chain two lineage identities, and a fractured lineage
+-- bypasses the global once-per-period funding registry and custody caps.
+INSERT INTO "SubscriptionLineage" ("provider", "lineageKey", "state", "updatedAt")
+SELECT DISTINCT s."provider", s."originalTransactionId", 'live', CURRENT_TIMESTAMP
+FROM "Subscription" s
+WHERE s."provider" = 'apple' AND s."originalTransactionId" IS NOT NULL
+ON CONFLICT ("provider", "lineageKey") DO NOTHING;
+
+-- Walk every Google row's predecessor chain across the rows we hold (each
+-- row contributes one purchaseToken -> linkedPurchaseToken edge; the token
+-- column is unique, so the walk is deterministic). The terminal token is the
+-- oldest chain member we can prove; a predecessor named only by a successor
+-- still terminates the walk as the root, mirroring the runtime resolver. A
+-- walk that stops with a parent still pending hit a loop or the depth bound:
+-- that chain is ambiguous and must never guess a monetary identity.
+CREATE TEMPORARY TABLE "_google_chain_roots" ON COMMIT DROP AS
+WITH RECURSIVE chain_walk AS (
+  SELECT s."id" AS subscription_id,
+         s."purchaseToken" AS token,
+         s."linkedPurchaseToken" AS parent,
+         1 AS depth,
+         ARRAY[s."purchaseToken"] AS path
+  FROM "Subscription" s
+  WHERE s."provider" = 'googlePlay' AND s."purchaseToken" IS NOT NULL
+  UNION ALL
+  SELECT s."id" AS subscription_id,
+         s."linkedPurchaseToken" AS token,
+         (SELECT p."linkedPurchaseToken" FROM "Subscription" p
+          WHERE p."provider" = 'googlePlay'
+            AND p."purchaseToken" = s."linkedPurchaseToken") AS parent,
+         1 AS depth,
+         ARRAY[s."linkedPurchaseToken"] AS path
+  FROM "Subscription" s
+  WHERE s."provider" = 'googlePlay'
+    AND s."purchaseToken" IS NULL
+    AND s."linkedPurchaseToken" IS NOT NULL
+  UNION ALL
+  SELECT w.subscription_id,
+         w.parent AS token,
+         p."linkedPurchaseToken" AS parent,
+         w.depth + 1,
+         w.path || w.parent
+  FROM chain_walk w
+  LEFT JOIN "Subscription" p
+    ON p."provider" = 'googlePlay' AND p."purchaseToken" = w.parent
+  WHERE w.parent IS NOT NULL
+    AND NOT w.parent = ANY(w.path)
+    AND w.depth < 25
+)
+SELECT DISTINCT ON (subscription_id)
+       subscription_id,
+       token AS root_token,
+       path,
+       (parent IS NOT NULL) AS ambiguous
+FROM chain_walk
+ORDER BY subscription_id, depth DESC;
+
+-- Ambiguous chains (loop or depth overflow) mint nothing: park them for an
+-- operator and leave the rows unkeyed. They re-resolve through the runtime
+-- resolver, which fails closed on the same conditions.
+INSERT INTO "LineageQuarantine" ("provider", "token", "reason", "payload")
+SELECT 'googlePlay'::"BillingProvider",
+       COALESCE(s."purchaseToken", s."linkedPurchaseToken"),
+       'backfill_chain_unresolved',
+       jsonb_build_object('subscriptionId', r.subscription_id, 'chain', to_jsonb(r.path))
+FROM "_google_chain_roots" r
+JOIN "Subscription" s ON s."id" = r.subscription_id
+WHERE r.ambiguous;
+
+INSERT INTO "SubscriptionLineage" ("provider", "lineageKey", "state", "updatedAt")
+SELECT DISTINCT 'googlePlay'::"BillingProvider", r.root_token, 'live', CURRENT_TIMESTAMP
+FROM "_google_chain_roots" r
+WHERE NOT r.ambiguous
+ON CONFLICT ("provider", "lineageKey") DO NOTHING;
+
+UPDATE "Subscription" s
+SET "lineageId" = l."id"
+FROM "SubscriptionLineage" l
+WHERE s."provider" = 'apple'
+  AND l."provider" = 'apple'
+  AND l."lineageKey" = s."originalTransactionId";
+
+UPDATE "Subscription" s
+SET "lineageId" = l."id"
+FROM "_google_chain_roots" r
+JOIN "SubscriptionLineage" l
+  ON l."provider" = 'googlePlay' AND l."lineageKey" = r.root_token
+WHERE s."id" = r.subscription_id AND NOT r.ambiguous;
+
+-- Alias seed: every chain member (current token, every rotated predecessor,
+-- and the root itself) resolves to the chain's lineage.
+INSERT INTO "LineageTokenAlias" ("token", "lineageId")
+SELECT DISTINCT t.token, l."id"
+FROM "_google_chain_roots" r
+JOIN "SubscriptionLineage" l
+  ON l."provider" = 'googlePlay' AND l."lineageKey" = r.root_token
+CROSS JOIN LATERAL unnest(r.path) AS t(token)
+WHERE NOT r.ambiguous
+ON CONFLICT ("token") DO NOTHING;
+
+-- Migrate any SubscriptionTombstone rows into tombstoned lineages. The old
+-- table stays in place (additive-only migration: a rollback or older replica
+-- that still references it must keep working); lineage state is the single
+-- source of truth from here on.
+INSERT INTO "SubscriptionLineage" ("provider", "lineageKey", "state", "tombstonedAt", "deletedAccountRef", "updatedAt")
+SELECT t."provider", t."providerKey", 'tombstoned', t."deletedAt", t."accountRef", CURRENT_TIMESTAMP
+FROM "SubscriptionTombstone" t
+ON CONFLICT ("provider", "lineageKey")
+DO UPDATE SET "state" = 'tombstoned',
+              "tombstonedAt" = EXCLUDED."tombstonedAt",
+              "deletedAccountRef" = EXCLUDED."deletedAccountRef",
+              "updatedAt" = CURRENT_TIMESTAMP;
+
+-- One live Subscription row per lineage, database-enforced (claim and
+-- webhook lookups by lineageId must be deterministic). Root canonicalization
+-- can map several rows of one rotated chain onto one lineage. Detaching the
+-- extras is not safe: a detached row stays addressable by its token, so a
+-- later verify resolves the same lineage and collides with the unique index
+-- below -- a P2002 outside the recognized conflict set, surfacing as an
+-- HTTP 500 (and a silently dropped update on the notification path).
+--
+-- Same-chain rows owned by different accounts are never merged silently:
+-- fail the migration with row-level diagnostics so an operator adjudicates
+-- ownership before this deploy proceeds.
+DO $$
+DECLARE
+  conflict_row RECORD;
+BEGIN
+  SELECT s."lineageId"::text AS lineage_id,
+         count(*) AS row_count,
+         array_agg(DISTINCT s."accountId"::text) AS account_ids,
+         array_agg(s."id"::text ORDER BY s."id") AS subscription_ids
+    INTO conflict_row
+    FROM "Subscription" s
+   WHERE s."lineageId" IS NOT NULL
+   GROUP BY s."lineageId"
+  HAVING count(*) > 1 AND count(DISTINCT s."accountId") > 1
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'subscription lineage % has % rows owned by different accounts % (subscription rows %): same-chain ownership must be adjudicated before this migration can run',
+      conflict_row.lineage_id, conflict_row.row_count,
+      conflict_row.account_ids, conflict_row.subscription_ids;
+  END IF;
+END $$;
+
+-- Same-account duplicates consolidate onto one survivor: keep the row with
+-- the newest entitlement window, move the losers' receipts onto it, then
+-- delete the losers so no stale row remains addressable.
+WITH survivors AS (
+  SELECT DISTINCT ON (s."lineageId") s."id", s."lineageId"
+  FROM "Subscription" s
+  WHERE s."lineageId" IS NOT NULL
+  ORDER BY s."lineageId", s."currentPeriodEnd" DESC, s."updatedAt" DESC, s."id"
+),
+losers AS (
+  SELECT s."id" AS loser_id, v."id" AS survivor_id
+  FROM "Subscription" s
+  JOIN survivors v ON v."lineageId" = s."lineageId" AND v."id" <> s."id"
+)
+UPDATE "BillingReceipt" b
+SET "subscriptionId" = losers.survivor_id
+FROM losers
+WHERE b."subscriptionId" = losers.loser_id;
+
+DELETE FROM "Subscription" s
+USING (
+  SELECT DISTINCT ON ("lineageId") "id", "lineageId"
+  FROM "Subscription"
+  WHERE "lineageId" IS NOT NULL
+  ORDER BY "lineageId", "currentPeriodEnd" DESC, "updatedAt" DESC, "id"
+) survivor
+WHERE s."lineageId" = survivor."lineageId" AND s."id" <> survivor."id";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subscription_lineageId_key" ON "Subscription"("lineageId");
+
+-- Widen the ledger scope CHECK to admit the lineage custody-move scope
+-- (claim transfers, undo, deletion escrow, refund compensation). Same
+-- drop-and-re-add pattern as 20260623120000_credits_single_ledger.
+ALTER TABLE "CreditLedger" DROP CONSTRAINT "CreditLedger_scope_check";
+ALTER TABLE "CreditLedger"
+  ADD CONSTRAINT "CreditLedger_scope_check"
+  CHECK ("scope" IN ('transaction', 'grant', 'daily_refill', 'sub_forfeit', 'sub_transfer'));

--- a/prisma/migrations/20260729102000_add_rate_limit_counter/migration.sql
+++ b/prisma/migrations/20260729102000_add_rate_limit_counter/migration.sql
@@ -1,0 +1,18 @@
+-- Shared-store rate-limit counters. The claim endpoint's global
+-- claims-per-hour ceiling must hold across every replica; the default
+-- express-rate-limit MemoryStore is per-process, so the global limiter is
+-- backed by this table instead (Postgres is the one store every replica
+-- already shares).
+
+-- CreateTable
+CREATE TABLE "RateLimitCounter" (
+    "key" TEXT NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RateLimitCounter_pkey" PRIMARY KEY ("key","windowStart")
+);
+
+-- CreateIndex
+CREATE INDEX "RateLimitCounter_windowStart_idx" ON "RateLimitCounter"("windowStart");

--- a/prisma/migrations/20260729103000_add_reconciliation_progress/migration.sql
+++ b/prisma/migrations/20260729103000_add_reconciliation_progress/migration.sql
@@ -1,0 +1,34 @@
+-- Reconciliation sweep durability:
+--
+-- 1. LineageQuarantine gains per-row retry state (attempts + nextAttemptAt
+--    backoff, needsOperatorAt escalation) so a batch of persistent rows can
+--    never starve newer recoverable ones - the sweep selects by
+--    nextAttemptAt, not by a fixed oldest-N window.
+--
+-- 2. SubscriptionTransfer gains committedAt: the moment the journal reached
+--    `committed` (settlement time for contested transfers, creation time for
+--    instant moves and restores). The post-transfer drift pass cursors on
+--    this - a default 72h-contested transfer's createdAt is 72 hours old by
+--    the time it settles, so createdAt-based selection would skip it.
+
+-- AlterTable
+ALTER TABLE "LineageQuarantine"
+    ADD COLUMN "attempts" INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN "needsOperatorAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "SubscriptionTransfer" ADD COLUMN "committedAt" TIMESTAMP(3);
+
+-- Backfill: every already-committed journal row committed no later than its
+-- last update (settlement bumps updatedAt when it flips status).
+UPDATE "SubscriptionTransfer" SET "committedAt" = "updatedAt"
+WHERE "status" = 'committed' AND "committedAt" IS NULL;
+
+-- CreateIndex
+CREATE INDEX "LineageQuarantine_resolvedAt_needsOperatorAt_nextAttemptAt_idx"
+    ON "LineageQuarantine"("resolvedAt", "needsOperatorAt", "nextAttemptAt");
+
+-- CreateIndex
+CREATE INDEX "SubscriptionTransfer_status_committedAt_idx"
+    ON "SubscriptionTransfer"("status", "committedAt");

--- a/prisma/migrations/20260729104000_harden_reconciliation_drift_cursor/migration.sql
+++ b/prisma/migrations/20260729104000_harden_reconciliation_drift_cursor/migration.sql
@@ -1,0 +1,58 @@
+-- Make SubscriptionTransfer.committedAt database-owned and rolling-safe.
+--
+-- Old replicas do not know this column. After this migration they may still
+-- insert committed rows or flip pending rows to committed, but the default +
+-- trigger below guarantee those journals receive database time. Existing
+-- NULLs are backfilled before NOT NULL is installed, so no committed journal
+-- can remain invisible to the composite drift cursor during a mixed-version
+-- rollout.
+
+ALTER TABLE "SubscriptionTransfer"
+    ALTER COLUMN "committedAt" SET DEFAULT CURRENT_TIMESTAMP;
+
+CREATE OR REPLACE FUNCTION "stamp_subscription_transfer_committed_at"()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status = 'committed' THEN
+            -- DB wall time, never an application-replica clock.
+            -- clock_timestamp() also avoids inheriting a long
+            -- transaction's start timestamp.
+            NEW."committedAt" := clock_timestamp();
+        END IF;
+    ELSIF NEW.status = 'committed' THEN
+        -- Every committedAt write remains database-owned. This also lets the
+        -- post-install backfill normalize journals written before the trigger
+        -- acquired its table lock without accepting a caller's future stamp.
+        NEW."committedAt" := clock_timestamp();
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "SubscriptionTransfer_stamp_committed_at"
+BEFORE INSERT OR UPDATE OF status, "committedAt"
+ON "SubscriptionTransfer"
+FOR EACH ROW
+EXECUTE FUNCTION "stamp_subscription_transfer_committed_at"();
+
+-- Protection is live before either backfill. Normalize every committed row,
+-- including a non-null application timestamp written before trigger install;
+-- a fresh monitoring window is conservative and compensation is idempotent.
+UPDATE "SubscriptionTransfer"
+SET "committedAt" = clock_timestamp()
+WHERE status = 'committed';
+
+-- Pending rows only need a non-null placeholder for the rolling-safe
+-- constraint; the trigger replaces it when status first becomes committed.
+UPDATE "SubscriptionTransfer"
+SET "committedAt" = COALESCE("updatedAt", CURRENT_TIMESTAMP)
+WHERE "committedAt" IS NULL;
+
+ALTER TABLE "SubscriptionTransfer"
+    ALTER COLUMN "committedAt" SET NOT NULL;
+
+-- Supports the exact deterministic keyset order used by the sweep. Keep the
+-- prior two-column index for additive rollout; it can be retired separately.
+CREATE INDEX "SubscriptionTransfer_status_committedAt_id_idx"
+    ON "SubscriptionTransfer"("status", "committedAt", id);

--- a/prisma/migrations/20260729105000_add_subscription_drift_schedule/migration.sql
+++ b/prisma/migrations/20260729105000_add_subscription_drift_schedule/migration.sql
@@ -1,0 +1,130 @@
+-- Replace the global drift cursor with a durable schedule per lineage.
+--
+-- Rolling order matters: create the table, install the trigger that captures
+-- every new committed journal from old or new replicas, then backfill all
+-- journals already present. A writer that commits before trigger installation
+-- is included by the later backfill; a writer after installation schedules
+-- itself in the same transaction as its journal.
+
+CREATE TABLE "SubscriptionDriftSchedule" (
+    "lineageId" UUID NOT NULL,
+    "nextDriftCheckAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "monitorUntil" TIMESTAMP(3) NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    "needsOperatorAt" TIMESTAMP(3),
+    "resolvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SubscriptionDriftSchedule_pkey" PRIMARY KEY ("lineageId"),
+    CONSTRAINT "SubscriptionDriftSchedule_lineageId_fkey"
+        FOREIGN KEY ("lineageId") REFERENCES "SubscriptionLineage"(id)
+        ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "SubscriptionDriftSchedule_due_idx"
+    ON "SubscriptionDriftSchedule"("resolvedAt", "needsOperatorAt", "nextDriftCheckAt", "lineageId");
+CREATE INDEX "SubscriptionDriftSchedule_monitor_idx"
+    ON "SubscriptionDriftSchedule"("resolvedAt", "monitorUntil");
+
+CREATE OR REPLACE FUNCTION "schedule_subscription_transfer_drift"()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Ignore idempotent updates to an already committed journal. A new
+    -- schedule window begins only on insert, first commitment, kind change,
+    -- or committedAt maintenance.
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status IS DISTINCT FROM 'committed'
+           OR NEW.kind NOT IN ('transfer', 'restore', 'undo') THEN
+            RETURN NEW;
+        END IF;
+    ELSIF NEW.status IS DISTINCT FROM 'committed'
+          OR NEW.kind NOT IN ('transfer', 'restore', 'undo')
+          OR NOT (
+              OLD.status IS DISTINCT FROM NEW.status
+              OR OLD.kind IS DISTINCT FROM NEW.kind
+              OR OLD."committedAt" IS DISTINCT FROM NEW."committedAt"
+          ) THEN
+        RETURN NEW;
+    END IF;
+
+    INSERT INTO "SubscriptionDriftSchedule" (
+        "lineageId",
+        "nextDriftCheckAt",
+        "monitorUntil",
+        attempts,
+        "needsOperatorAt",
+        "resolvedAt",
+        "updatedAt"
+    ) VALUES (
+        NEW."lineageId",
+        NEW."committedAt",
+        NEW."committedAt" + INTERVAL '24 hours',
+        0,
+        NULL,
+        NULL,
+        clock_timestamp()
+    )
+    ON CONFLICT ("lineageId") DO UPDATE SET
+        -- A lineage can accumulate journals. Preserve the earliest due
+        -- check and union their monitoring windows; never let an older
+        -- journal shorten the latest commit's full 24-hour window.
+        "nextDriftCheckAt" = LEAST(
+            "SubscriptionDriftSchedule"."nextDriftCheckAt",
+            EXCLUDED."nextDriftCheckAt"
+        ),
+        "monitorUntil" = GREATEST(
+            "SubscriptionDriftSchedule"."monitorUntil",
+            EXCLUDED."monitorUntil"
+        ),
+        attempts = 0,
+        "needsOperatorAt" = NULL,
+        "resolvedAt" = NULL,
+        "updatedAt" = clock_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "SubscriptionTransfer_schedule_drift"
+AFTER INSERT OR UPDATE OF status, kind, "committedAt"
+ON "SubscriptionTransfer"
+FOR EACH ROW
+EXECUTE FUNCTION "schedule_subscription_transfer_drift"();
+
+-- Backfill after trigger installation closes the only mixed-version gap.
+-- One provider check covers the lineage, so MIN supplies its oldest due time
+-- while MAX unions every qualifying journal's 24-hour monitoring deadline.
+INSERT INTO "SubscriptionDriftSchedule" (
+    "lineageId",
+    "nextDriftCheckAt",
+    "monitorUntil",
+    attempts,
+    "needsOperatorAt",
+    "resolvedAt",
+    "updatedAt"
+)
+SELECT
+    "lineageId",
+    MIN("committedAt"),
+    MAX("committedAt") + INTERVAL '24 hours',
+    0,
+    NULL,
+    NULL,
+    clock_timestamp()
+FROM "SubscriptionTransfer"
+WHERE status = 'committed'
+  AND kind IN ('transfer', 'restore', 'undo')
+GROUP BY "lineageId"
+ON CONFLICT ("lineageId") DO UPDATE SET
+    "nextDriftCheckAt" = LEAST(
+        "SubscriptionDriftSchedule"."nextDriftCheckAt",
+        EXCLUDED."nextDriftCheckAt"
+    ),
+    "monitorUntil" = GREATEST(
+        "SubscriptionDriftSchedule"."monitorUntil",
+        EXCLUDED."monitorUntil"
+    ),
+    attempts = 0,
+    "needsOperatorAt" = NULL,
+    "resolvedAt" = NULL,
+    "updatedAt" = clock_timestamp();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,10 @@ model Account {
   id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  /// Stamped on every SIWE token mint (generate-token.ts). Supports
+  /// activity-recency checks (e.g. the subscription-claim dead-or-silent
+  /// gate). Null for accounts that have not minted since the column landed.
+  lastAuthAt DateTime?
 
   authMethods              AuthMethod[]
   agentTemplates           AgentTemplate[]
@@ -315,6 +319,99 @@ model AuthNonce {
   createdAt DateTime @default(now())
 }
 
+/// Durable deletion barrier. One row per deleted identity, keyed by an
+/// HMAC-SHA256 (DELETION_HASH_SECRET) of the auth-method type plus the
+/// lowercased external key that lived in AuthMethod.externalKey. Consulted at
+/// token mint before auto-provisioning: a barred identity gets the terminal
+/// identity-deleted response and can never mint tokens or silently re-create
+/// an account. The bar is permanent — a genuinely new account requires new
+/// identity keys. The keyed hash is retained pseudonymous data; scope and
+/// rationale are documented in docs/plans/delete-my-account.md.
+model DeletedIdentity {
+  identityHash String   @id
+  deletedAt    DateTime @default(now())
+}
+
+/// Durable record of one account deletion, keyed by the client-generated
+/// operationId. Lets an idempotent retry (an unexpired pre-deletion JWT
+/// re-sending the same operationId) re-return the stored success after the
+/// account row is gone. accountRef is the keyed hash of the deleted
+/// accountId (same HMAC as DeletedIdentity) — the raw id is never retained.
+model DeletionRecord {
+  operationId String    @id @db.Uuid
+  accountRef  String
+  /// Lifecycle: purging (outbox still draining) | completed (drain done).
+  /// Plain string column, validated in app code (see the AuthMethod.type
+  /// comment for why Postgres enums are avoided).
+  status      String    @default("purging")
+  requestedAt DateTime  @default(now())
+  completedAt DateTime?
+  /// When the retention job may delete this record (set once the drain
+  /// completes, plus a bounded audit window).
+  expiresAt   DateTime?
+  updatedAt   DateTime  @updatedAt
+
+  @@index([accountRef])
+  @@index([status, requestedAt])
+  @@index([expiresAt])
+}
+
+/// Transactional-outbox row for one external purge action (S3 object,
+/// notification-server installation, Composio user, PostHog person),
+/// snapshotted inside the deletion transaction and drained asynchronously
+/// with retries. The payload necessarily retains account-linked identifiers
+/// until the drain completes; rows are removed as they finish and the
+/// deletion record tracks the overall purge SLA.
+model DeletionTask {
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  operationId   String    @db.Uuid
+  /// Purge executor id: s3_object | notification_installation |
+  /// composio_user | posthog_person. Plain string, validated in app code.
+  kind          String
+  /// Executor-specific target (bucket/key, installation id, ...).
+  payload       Json
+  /// pending | done | failed (terminal — operator remediation path).
+  status        String    @default("pending")
+  attempts      Int       @default(0)
+  nextAttemptAt DateTime  @default(now())
+  lastError     String?   @db.Text
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  completedAt   DateTime?
+
+  @@index([status, nextAttemptAt])
+  @@index([operationId])
+}
+
+/// Superseded by SubscriptionLineage.state = "tombstoned" (the lineage row is
+/// the tombstone carrier). Retained additively so a rollback or an older
+/// replica that still references the relation keeps working; no current code
+/// path reads or writes it.
+model SubscriptionTombstone {
+  id          String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  provider    BillingProvider
+  providerKey String
+  accountRef  String
+  deletedAt   DateTime        @default(now())
+
+  @@unique([provider, providerKey])
+  @@index([accountRef])
+}
+
+/// Shared-store rate-limit counters (fixed windows). Backs limiters whose
+/// ceiling must hold across every replica — the claim endpoint's global
+/// claims-per-hour ceiling — where the default in-process MemoryStore would
+/// silently become a per-replica limit.
+model RateLimitCounter {
+  key         String
+  windowStart DateTime
+  count       Int      @default(0)
+  updatedAt   DateTime @updatedAt
+
+  @@id([key, windowStart])
+  @@index([windowStart])
+}
+
 enum LedgerReason {
   consume
   grant
@@ -434,6 +531,12 @@ model Subscription {
   gracePeriodEnd        DateTime?
   // Apple-only: which Apple environment the sub came from. Null for Google.
   environment           AppleEnv?
+  // Owning SubscriptionLineage (scalar link, no FK: the lineage outlives the
+  // row across delete/restore cycles). Null only for rows predating the
+  // lineage backfill that have not been touched since. Unique: at most one
+  // live Subscription row per lineage, so claim/webhook lookups by lineageId
+  // are deterministic.
+  lineageId             String?            @unique @db.Uuid
   createdAt             DateTime           @default(now())
   updatedAt             DateTime           @updatedAt
 
@@ -480,6 +583,170 @@ model BillingReceipt {
   @@index([transactionId])
   @@index([provider, transactionId])
   @@index([subscriptionId, receivedAt])
+}
+
+/// One row per purchase lineage — Apple originalTransactionId, Google
+/// linkedPurchaseToken chain resolved to its root (rotated tokens live in
+/// LineageTokenAlias). The canonical lockable object for verify, claim,
+/// webhooks, and deletion (lock-order rule 1, see src/subscriptions/AGENTS.md),
+/// the cooldown anchor, and the tombstone carrier: a deleted owner flips
+/// state to "tombstoned" (webhooks ack as counted no-ops, verify grants no
+/// entitlement) until a claim restores it to "live".
+model SubscriptionLineage {
+  id                    String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  provider              BillingProvider
+  /// Apple OTX or the Google token-chain root.
+  lineageKey            String
+  /// live | tombstoned. Plain string, validated in app code.
+  state                 String          @default("live")
+  tombstonedAt          DateTime?
+  /// Keyed hash of the deleted accountId (same minimization as DeletionRecord).
+  deletedAccountRef     String?
+  /// Cooldown anchor: set on every committed transfer/restore/undo.
+  lastTransferAt        DateTime?
+  lastTransferJournalId String?         @db.Uuid
+  /// Set when an undo executes; while set, automated live transfers are
+  /// rejected (transfer_frozen) and only operator re-home proceeds.
+  liveTransferFrozenAt  DateTime?
+  createdAt             DateTime        @default(now())
+  updatedAt             DateTime        @updatedAt
+
+  driftSchedule SubscriptionDriftSchedule?
+
+  @@unique([provider, lineageKey])
+}
+
+/// Google rotated purchase tokens -> owning lineage. Populated at verify,
+/// webhook, and claim time whenever linkedPurchaseToken reveals a new alias;
+/// unfetchable-but-named predecessors are recorded too, so a later appearance
+/// can never mint a second lineage. Apple needs no aliases (OTX is stable).
+model LineageTokenAlias {
+  token     String   @id
+  lineageId String   @db.Uuid
+  createdAt DateTime @default(now())
+
+  @@index([lineageId])
+}
+
+/// Global once-per-period funding registry. One row per provider funding
+/// event (Apple transactionId / Google latestOrderId); the unique constraint
+/// is the cross-account dedupe CreditLedger's (accountId, idempotencyKey)
+/// cannot provide. accountId is a plain scalar (no FK): pseudonymized
+/// retained financial data that survives account deletion by design.
+model LineagePeriodGrant {
+  id                String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  lineageId         String   @db.Uuid
+  providerPeriodKey String
+  accountId         String   @db.Uuid
+  ledgerKey         String
+  createdAt         DateTime @default(now())
+
+  @@unique([lineageId, providerPeriodKey])
+}
+
+/// Custody/escrow state for one funded period. The source of truth for how
+/// much subscription value the current holder still carries: every move
+/// (transfer, undo, deletion-escrow, refund compensation) debits by
+/// D = min(lockedOwnerBalance, max(0, cap - ownerConsumesSince(custodyStartedAt)))
+/// then sets cap := D, so no chain of moves ever exceeds the original
+/// allotment and commingled promo/admin credits never transfer.
+/// ownerAccountId is a plain scalar (no FK), null iff state = escrow.
+model LineagePeriodCustody {
+  id                String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  lineageId         String   @db.Uuid
+  providerPeriodKey String
+  ownerAccountId    String?  @db.Uuid
+  remainderCap      BigInt
+  custodyStartedAt  DateTime @default(now())
+  periodStart       DateTime
+  periodEnd         DateTime
+  /// held | escrow | invalidated | exhausted. Plain string, app-validated.
+  state             String   @default("held")
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  @@unique([lineageId, providerPeriodKey])
+  @@index([lineageId, state])
+}
+
+/// Journal of every custody move on a lineage. kind: transfer | restore |
+/// undo | escrow. status: pending (live-tier contest window) | committed |
+/// cancelled. Account ids are plain scalars (pseudonymized retained data).
+model SubscriptionTransfer {
+  id                 String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  lineageId          String    @db.Uuid
+  kind               String
+  status             String    @default("committed")
+  fromAccountId      String?   @db.Uuid
+  toAccountId        String?   @db.Uuid
+  conservedCredits   BigInt    @default(0)
+  providerProof      Json?
+  undoOfTransferId   String?   @db.Uuid
+  /// One-shot undo CAS target: set exactly once by the undo that consumed
+  /// this transfer.
+  undoneByTransferId String?   @db.Uuid
+  undoDeadlineAt     DateTime?
+  contestEndsAt      DateTime?
+  /// Database-owned time when the journal reached `committed` (settlement
+  /// time for contested transfers, creation time for instant moves and
+  /// restores). Pending rows carry the column default, but a DB trigger
+  /// replaces it on the pending -> committed transition. The drift-schedule
+  /// trigger derives its 24h deadline from this: a 72h-contested transfer's
+  /// createdAt is already 72h old when it settles and cannot drive monitoring.
+  committedAt        DateTime  @default(now())
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  @@index([lineageId, createdAt])
+  @@index([status, contestEndsAt])
+  @@index([status, committedAt])
+  @@index([status, committedAt, id])
+}
+
+/// Durable, per-lineage post-transfer drift schedule. A database trigger on
+/// SubscriptionTransfer creates or extends this row whenever a transfer,
+/// restore, or undo commits. Per-row retry progress prevents one unavailable
+/// provider lineage from blocking every other lineage in the sweep.
+model SubscriptionDriftSchedule {
+  lineageId        String    @id @db.Uuid
+  nextDriftCheckAt DateTime  @default(now())
+  monitorUntil     DateTime
+  attempts         Int       @default(0)
+  needsOperatorAt  DateTime?
+  resolvedAt       DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  lineage SubscriptionLineage @relation(fields: [lineageId], references: [id], onDelete: Cascade)
+
+  @@index([resolvedAt, needsOperatorAt, nextDriftCheckAt, lineageId], map: "SubscriptionDriftSchedule_due_idx")
+  @@index([resolvedAt, monitorUntil], map: "SubscriptionDriftSchedule_monitor_idx")
+}
+
+/// Durable record of a Google token chain the resolver refused to auto-merge
+/// (alias conflict between lineages, or two funded lineages on one chain).
+/// Picked up by the reconciliation sweep / operators; the triggering events
+/// are acked but preserved here.
+model LineageQuarantine {
+  id              String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  provider        BillingProvider
+  token           String
+  reason          String
+  payload         Json?
+  /// Per-row retry progress: the sweep re-drives a row at most once per
+  /// backoff window (nextAttemptAt) and gives up to an operator after
+  /// enough attempts, so persistent rows can never starve newer ones.
+  attempts        Int             @default(0)
+  nextAttemptAt   DateTime        @default(now())
+  /// Escalated out of the retry pool: an operator owns this row. Set when
+  /// retries are exhausted or fresh provider state cannot resolve the
+  /// condition (e.g. a keyless void while the subscription is entitled).
+  needsOperatorAt DateTime?
+  createdAt       DateTime        @default(now())
+  resolvedAt      DateTime?
+
+  @@index([resolvedAt, createdAt])
+  @@index([resolvedAt, needsOperatorAt, nextAttemptAt])
 }
 
 model TelemetryBatch {

--- a/tests/deletion/lineage-backfill-migration.test.ts
+++ b/tests/deletion/lineage-backfill-migration.test.ts
@@ -1,0 +1,336 @@
+import { readFileSync } from "node:fs";
+import { BillingProvider, type Prisma } from "@prisma/client";
+import { describe, expect, test } from "vitest";
+import {
+  SubscriptionPeriod,
+  SubscriptionStatus,
+} from "@/subscriptions/repository";
+import { prisma } from "@/utils/prisma";
+import {
+  installReclaimHooks,
+  newAccount,
+  NEXT_PERIOD_END,
+  PERIOD_END,
+  PERIOD_START,
+  PRODUCT_ID,
+} from "./reclaim-fixtures";
+
+/**
+ * Data-shape tests for the lineage backfill in
+ * 20260729101000_add_subscription_lineage. The migration already ran against
+ * the test database, so each test replays the backfill statements against
+ * freshly seeded legacy-shaped rows inside a transaction that is always
+ * rolled back (the unique lineage index is dropped and re-created by the
+ * replayed statements themselves).
+ */
+
+installReclaimHooks();
+
+const MIGRATION_URL = new URL(
+  "../../prisma/migrations/20260729101000_add_subscription_lineage/migration.sql",
+  import.meta.url,
+);
+
+/** Split a SQL block into statements, honoring $$ bodies and -- comments. */
+const splitSqlStatements = (block: string): string[] => {
+  const statements: string[] = [];
+  let current = "";
+  let inDollarQuote = false;
+  let inLineComment = false;
+  for (let i = 0; i < block.length; i += 1) {
+    const ch = block[i];
+    if (inLineComment) {
+      if (ch === "\n") inLineComment = false;
+      current += ch;
+      continue;
+    }
+    if (!inDollarQuote && block.startsWith("--", i)) {
+      inLineComment = true;
+      current += ch;
+      continue;
+    }
+    if (block.startsWith("$$", i)) {
+      inDollarQuote = !inDollarQuote;
+      current += "$$";
+      i += 1;
+      continue;
+    }
+    if (ch === ";" && !inDollarQuote) {
+      if (current.trim().length > 0) statements.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim().length > 0) statements.push(current.trim());
+  return statements;
+};
+
+const isCommentOnly = (statement: string): boolean =>
+  statement
+    .split("\n")
+    .every((line) => line.trim() === "" || line.trim().startsWith("--"));
+
+const loadBackfillStatements = (): string[] => {
+  const sql = readFileSync(MIGRATION_URL, "utf8");
+  const start = sql.indexOf("-- Backfill:");
+  const end = sql.indexOf("-- Widen the ledger scope");
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error("backfill section not found in migration.sql");
+  }
+  return splitSqlStatements(sql.slice(start, end)).filter(
+    (statement) => !isCommentOnly(statement),
+  );
+};
+
+const backfillStatements = loadBackfillStatements();
+
+/**
+ * Replay the backfill inside `tx`. The replayed statements scan whole
+ * tables, so rows left behind by other test files are removed first (the
+ * transaction always rolls back, so the scrub never leaks). The applied
+ * migration already created the one-row-per-lineage unique index, so it is
+ * dropped up front; the replayed statements re-create it after
+ * consolidating, exactly like the real run.
+ */
+const replayBackfill = async (
+  tx: Prisma.TransactionClient,
+  keepSubscriptionIds: string[],
+): Promise<void> => {
+  await tx.billingReceipt.deleteMany({
+    where: { subscriptionId: { notIn: keepSubscriptionIds } },
+  });
+  await tx.subscription.deleteMany({
+    where: { id: { notIn: keepSubscriptionIds } },
+  });
+  await tx.lineageTokenAlias.deleteMany({});
+  await tx.lineageQuarantine.deleteMany({});
+  await tx.subscriptionLineage.deleteMany({});
+  await tx.subscriptionTombstone.deleteMany({});
+  await tx.$executeRawUnsafe('DROP INDEX "Subscription_lineageId_key"');
+  for (const statement of backfillStatements) {
+    await tx.$executeRawUnsafe(statement);
+  }
+};
+
+/** Sentinel that always rolls the replay transaction back. */
+class Rollback extends Error {}
+
+const inRolledBackTx = async (
+  fn: (tx: Prisma.TransactionClient) => Promise<void>,
+): Promise<void> => {
+  await prisma
+    .$transaction(
+      async (tx) => {
+        await fn(tx);
+        throw new Rollback("rollback");
+      },
+      { timeout: 30_000 },
+    )
+    .catch((err: unknown) => {
+      if (!(err instanceof Rollback)) throw err;
+    });
+};
+
+const seedGoogleRow = async (args: {
+  accountId: string;
+  purchaseToken: string | null;
+  linkedPurchaseToken?: string | null;
+  currentPeriodEnd?: Date;
+}) =>
+  prisma.subscription.create({
+    data: {
+      accountId: args.accountId,
+      provider: BillingProvider.googlePlay,
+      productId: PRODUCT_ID,
+      tier: "plus",
+      period: SubscriptionPeriod.monthly,
+      status: SubscriptionStatus.active,
+      purchaseToken: args.purchaseToken,
+      linkedPurchaseToken: args.linkedPurchaseToken ?? null,
+      obfuscatedAccountId: `oid-${args.purchaseToken ?? args.linkedPurchaseToken}`,
+      startedAt: PERIOD_START,
+      currentPeriodStart: PERIOD_START,
+      currentPeriodEnd: args.currentPeriodEnd ?? PERIOD_END,
+    },
+  });
+
+const seedReceipt = async (subscriptionId: string, orderId: string) =>
+  prisma.billingReceipt.create({
+    data: {
+      subscriptionId,
+      provider: BillingProvider.googlePlay,
+      idempotencyKey: `play-verify:${orderId}`,
+      transactionId: orderId,
+      notificationType: "VERIFY",
+      signedPayload: "{}",
+    },
+  });
+
+describe("google lineage backfill root canonicalization", () => {
+  test("a twice-rotated chain keys one lineage on the true root and consolidates onto the newest row", async () => {
+    const owner = await newAccount();
+    // Chain a <- b <- c: the root token "mig-a" has no row of its own (its
+    // identity is known only from b's predecessor pointer), b was rotated to
+    // c. Predecessor-only keying would mint TWO lineages (keys "mig-a" and
+    // "mig-b") for one purchase line.
+    const rowB = await seedGoogleRow({
+      accountId: owner,
+      purchaseToken: "mig-b",
+      linkedPurchaseToken: "mig-a",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const rowC = await seedGoogleRow({
+      accountId: owner,
+      purchaseToken: "mig-c",
+      linkedPurchaseToken: "mig-b",
+      currentPeriodEnd: NEXT_PERIOD_END,
+    });
+    const receiptB = await seedReceipt(rowB.id, "GPA.mig..1");
+    const receiptC = await seedReceipt(rowC.id, "GPA.mig..2");
+
+    await inRolledBackTx(async (tx) => {
+      await replayBackfill(tx, [rowB.id, rowC.id]);
+
+      // Exactly one monetary identity, keyed on the chain root.
+      const lineages = await tx.subscriptionLineage.findMany({
+        where: { provider: BillingProvider.googlePlay },
+      });
+      expect(lineages).toHaveLength(1);
+      expect(lineages[0].lineageKey).toBe("mig-a");
+
+      // Every chain member resolves to it.
+      const aliases = await tx.lineageTokenAlias.findMany({
+        orderBy: { token: "asc" },
+      });
+      expect(aliases.map((a) => a.token)).toEqual(["mig-a", "mig-b", "mig-c"]);
+      expect(new Set(aliases.map((a) => a.lineageId))).toEqual(
+        new Set([lineages[0].id]),
+      );
+
+      // Consolidation: the newest-entitlement row survives and carries the
+      // lineage; the stale rotated row is gone, its receipt moved over.
+      const rows = await tx.subscription.findMany({
+        where: { provider: BillingProvider.googlePlay },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(rowC.id);
+      expect(rows[0].lineageId).toBe(lineages[0].id);
+      const receipts = await tx.billingReceipt.findMany({
+        where: { id: { in: [receiptB.id, receiptC.id] } },
+      });
+      expect(receipts).toHaveLength(2);
+      expect(new Set(receipts.map((r) => r.subscriptionId))).toEqual(
+        new Set([rowC.id]),
+      );
+
+      // Nothing was ambiguous.
+      expect(await tx.lineageQuarantine.count()).toBe(0);
+    });
+  });
+
+  test("a predecessor known only from the successor's pointer becomes the root", async () => {
+    const owner = await newAccount();
+    const rowC = await seedGoogleRow({
+      accountId: owner,
+      purchaseToken: "orphan-c",
+      linkedPurchaseToken: "orphan-b",
+    });
+
+    await inRolledBackTx(async (tx) => {
+      await replayBackfill(tx, [rowC.id]);
+      const lineage = await tx.subscriptionLineage.findFirstOrThrow({
+        where: { provider: BillingProvider.googlePlay },
+      });
+      expect(lineage.lineageKey).toBe("orphan-b");
+      const aliases = await tx.lineageTokenAlias.findMany({
+        orderBy: { token: "asc" },
+      });
+      expect(aliases.map((a) => a.token)).toEqual(["orphan-b", "orphan-c"]);
+      const row = await tx.subscription.findFirstOrThrow({
+        where: { purchaseToken: "orphan-c" },
+      });
+      expect(row.lineageId).toBe(lineage.id);
+    });
+  });
+
+  test("a cyclic chain is quarantined, never keyed", async () => {
+    const owner = await newAccount();
+    const rowA = await seedGoogleRow({
+      accountId: owner,
+      purchaseToken: "cyc-a",
+      linkedPurchaseToken: "cyc-b",
+    });
+    const rowB = await seedGoogleRow({
+      accountId: owner,
+      purchaseToken: "cyc-b",
+      linkedPurchaseToken: "cyc-a",
+    });
+
+    await inRolledBackTx(async (tx) => {
+      await replayBackfill(tx, [rowA.id, rowB.id]);
+
+      // No lineage, no alias, no lineageId was guessed for the cycle.
+      expect(
+        await tx.subscriptionLineage.count({
+          where: { provider: BillingProvider.googlePlay },
+        }),
+      ).toBe(0);
+      expect(await tx.lineageTokenAlias.count()).toBe(0);
+      const rows = await tx.subscription.findMany({
+        where: { id: { in: [rowA.id, rowB.id] } },
+      });
+      expect(rows.map((r) => r.lineageId)).toEqual([null, null]);
+
+      // Both rows are parked for an operator with their walked chain.
+      const parked = await tx.lineageQuarantine.findMany({
+        where: { reason: "backfill_chain_unresolved" },
+        orderBy: { token: "asc" },
+      });
+      expect(parked.map((q) => q.token)).toEqual(["cyc-a", "cyc-b"]);
+    });
+  });
+
+  test("same-chain rows owned by different accounts fail the migration loudly", async () => {
+    const ownerOne = await newAccount();
+    const ownerTwo = await newAccount();
+    const rowB = await seedGoogleRow({
+      accountId: ownerOne,
+      purchaseToken: "dup-b",
+      linkedPurchaseToken: "dup-a",
+    });
+    const rowC = await seedGoogleRow({
+      accountId: ownerTwo,
+      purchaseToken: "dup-c",
+      linkedPurchaseToken: "dup-b",
+      currentPeriodEnd: NEXT_PERIOD_END,
+    });
+
+    await expect(
+      prisma.$transaction(
+        async (tx) => {
+          await replayBackfill(tx, [rowB.id, rowC.id]);
+        },
+        { timeout: 30_000 },
+      ),
+    ).rejects.toThrow(/adjudicated/);
+
+    // The failed transaction rolled everything back: rows intact, unkeyed,
+    // and the unique index still in place.
+    const rows = await prisma.subscription.findMany({
+      where: { id: { in: [rowB.id, rowC.id] } },
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.lineageId)).toEqual([null, null]);
+    expect(
+      await prisma.subscriptionLineage.count({
+        where: { provider: BillingProvider.googlePlay },
+      }),
+    ).toBe(0);
+    const indexes = await prisma.$queryRaw<Array<{ indexname: string }>>`
+      SELECT indexname FROM pg_indexes
+      WHERE tablename = 'Subscription' AND indexname = 'Subscription_lineageId_key'
+    `;
+    expect(indexes).toHaveLength(1);
+  });
+});

--- a/tests/deletion/reclaim-fixtures.ts
+++ b/tests/deletion/reclaim-fixtures.ts
@@ -1,0 +1,68 @@
+/**
+ * Slice-1 subset of the shared reclaim fixture module.
+ * Later slices of the #374 split expand it to the full version.
+ */
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { validateJWTKeys } from "@/utils/jwt";
+import { prisma } from "@/utils/prisma";
+
+export const DAY_MS = 24 * 60 * 60 * 1000;
+export const HOUR_MS = 60 * 60 * 1000;
+export const PERIOD_START = new Date(Date.now() - 5 * DAY_MS);
+export const PERIOD_END = new Date(Date.now() + 25 * DAY_MS);
+export const NEXT_PERIOD_END = new Date(PERIOD_END.getTime() + 30 * DAY_MS);
+export const PRODUCT_ID = "app.convos.subs.monthly";
+
+export const newAccount = async (lastAuthAt?: Date | null) => {
+  const account = await prisma.account.create({
+    data: {
+      lastAuthAt:
+        lastAuthAt === undefined ? new Date(Date.now() - HOUR_MS) : lastAuthAt,
+    },
+  });
+  return account.id;
+};
+
+export const wipeReclaimState = async () => {
+  await prisma.rateLimitCounter.deleteMany();
+  await prisma.deletionTask.deleteMany();
+  await prisma.deletionRecord.deleteMany();
+  await prisma.deletedIdentity.deleteMany();
+  await prisma.lineageQuarantine.deleteMany();
+  await prisma.subscriptionDriftSchedule.deleteMany();
+  await prisma.subscriptionTransfer.deleteMany();
+  await prisma.lineagePeriodCustody.deleteMany();
+  await prisma.lineagePeriodGrant.deleteMany();
+  await prisma.lineageTokenAlias.deleteMany();
+  await prisma.subscriptionLineage.deleteMany();
+  await prisma.adminAudit.deleteMany();
+  await prisma.billingReceipt.deleteMany();
+  await prisma.subscription.deleteMany();
+  await prisma.creditLedger.deleteMany();
+  await prisma.userCredits.deleteMany();
+  await prisma.deviceRegistration.deleteMany();
+  await prisma.authMethod.deleteMany();
+  await prisma.account.deleteMany({
+    where: { id: { not: "48a05ef4-4a71-57a0-957f-a3d410992b31" } },
+  });
+};
+
+export const installReclaimHooks = () => {
+  let previousLocalTesting: string | undefined;
+
+  beforeAll(async () => {
+    await validateJWTKeys();
+    previousLocalTesting = process.env.LOCAL_TESTING;
+    process.env.LOCAL_TESTING = "1";
+  });
+
+  afterAll(() => {
+    if (previousLocalTesting === undefined) {
+      delete process.env.LOCAL_TESTING;
+    } else {
+      process.env.LOCAL_TESTING = previousLocalTesting;
+    }
+  });
+
+  afterEach(wipeReclaimState);
+};

--- a/tests/deletion/schema-guards.test.ts
+++ b/tests/deletion/schema-guards.test.ts
@@ -1,0 +1,108 @@
+import { Prisma } from "@prisma/client";
+import { describe, expect, test } from "vitest";
+import { prisma } from "@/utils/prisma";
+
+/**
+ * Schema guards for the deletion feature: the RESTRICT protections must keep
+ * biting at the database layer, and every account-correlatable table must be
+ * explicitly accounted for in the teardown inventory below — a new table
+ * that could carry account data fails this test until it is added to the
+ * teardown (or documented as retained).
+ */
+
+describe("deletion schema guards", () => {
+  test("deleting an Account with children still fails at the DB layer", async () => {
+    const account = await prisma.account.create({
+      data: {
+        authMethods: {
+          create: { type: "SIWE", externalKey: `0x${"9".repeat(40)}` },
+        },
+      },
+    });
+    try {
+      await expect(
+        prisma.account.delete({ where: { id: account.id } }),
+      ).rejects.toMatchObject({ code: "P2003" });
+    } finally {
+      await prisma.authMethod.deleteMany({ where: { accountId: account.id } });
+      await prisma.account.delete({ where: { id: account.id } });
+    }
+  });
+
+  test("every account-correlatable model is in the teardown inventory", () => {
+    // Deleted by the teardown transaction (or cascading from it).
+    const deleted = new Set([
+      "Account",
+      "AuthMethod",
+      "UserCredits",
+      "CreditLedger",
+      "Subscription",
+      "BillingReceipt",
+      "AgentTemplate",
+      "AgentTemplateGeneration",
+      "ConnectionGrant",
+      "DeviceRegistration",
+      "ClientIdentifier",
+    ]);
+    // Retained by design, pseudonymized or bounded-lifetime (see
+    // docs/plans/delete-my-account.md retention regime).
+    const retained = new Set([
+      "AdminAudit", // ops carve-out; deletion entry uses sentinel + keyed ref
+      "DeletedIdentity", // the barrier itself (keyed hash)
+      "DeletionRecord", // operationId + keyed ref; expires after drain window
+      "DeletionTask", // outbox; removed with its record
+      "SubscriptionLineage", // provider keys + keyed deletedAccountRef
+      "LineageTokenAlias",
+      "LineagePeriodGrant", // pseudonymized retained financial data
+      "LineagePeriodCustody",
+      "SubscriptionTransfer",
+      "SubscriptionDriftSchedule", // lineage-only; cascades with retained lineage
+      "LineageQuarantine",
+      // Superseded by lineage state; kept additively for rollback safety.
+      // No code path writes it, so it never accumulates new account data
+      // (keyed accountRef only, same regime as SubscriptionLineage).
+      "SubscriptionTombstone",
+    ]);
+    // Ownerless infrastructure — carries no account correlation.
+    const ownerless = new Set([
+      "RuntimeConfig",
+      "InviteCode",
+      "InviteCodeRedemption",
+      "AuthNonce",
+      "GrantKind",
+      "TelemetryBatch",
+      "AgentVariant",
+      "AgentPromptHint",
+      "RateLimitCounter",
+    ]);
+
+    const accountCorrelatableFieldNames = [
+      "accountId",
+      "ownerAccountId",
+      "fromAccountId",
+      "toAccountId",
+      "accountRef",
+      "deletedAccountRef",
+    ];
+
+    for (const model of Prisma.dmmf.datamodel.models) {
+      const known =
+        deleted.has(model.name) ||
+        retained.has(model.name) ||
+        ownerless.has(model.name);
+      expect(
+        known,
+        `Model ${model.name} is not in the deletion inventory — add it to the teardown or document its retention`,
+      ).toBe(true);
+
+      const correlatable = model.fields.some((f) =>
+        accountCorrelatableFieldNames.includes(f.name),
+      );
+      if (correlatable && ownerless.has(model.name)) {
+        throw new Error(
+          `Model ${model.name} is marked ownerless but carries an account-correlatable field`,
+        );
+      }
+    }
+  });
+});

--- a/tests/deletion/schema.test.ts
+++ b/tests/deletion/schema.test.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "node:crypto";
+import { BillingProvider, type Prisma } from "@prisma/client";
+import { afterEach, describe, expect, test } from "vitest";
+import { prisma } from "@/utils/prisma";
+
+async function reset() {
+  await prisma.lineageTokenAlias.deleteMany();
+  await prisma.subscriptionLineage.deleteMany();
+  await prisma.deletionTask.deleteMany();
+  await prisma.deletionRecord.deleteMany();
+  await prisma.deletedIdentity.deleteMany();
+}
+
+describe("account-deletion schema", () => {
+  afterEach(reset);
+
+  test("DeletedIdentity dedupes on identityHash", async () => {
+    await prisma.deletedIdentity.create({ data: { identityHash: "hash-1" } });
+    await expect(
+      prisma.deletedIdentity.create({ data: { identityHash: "hash-1" } }),
+    ).rejects.toMatchObject({ code: "P2002" });
+  });
+
+  test("SubscriptionLineage is unique per (provider, lineageKey)", async () => {
+    await prisma.subscriptionLineage.create({
+      data: { provider: BillingProvider.apple, lineageKey: "otx-1" },
+    });
+    await expect(
+      prisma.subscriptionLineage.create({
+        data: { provider: BillingProvider.apple, lineageKey: "otx-1" },
+      }),
+    ).rejects.toMatchObject({ code: "P2002" });
+    // The same key under the other provider is a distinct lineage.
+    await expect(
+      prisma.subscriptionLineage.create({
+        data: { provider: BillingProvider.googlePlay, lineageKey: "otx-1" },
+      }),
+    ).resolves.toMatchObject({ provider: BillingProvider.googlePlay });
+  });
+
+  test("DeletionRecord defaults to purging; DeletionTask defaults to pending", async () => {
+    const operationId = randomUUID();
+    const record = await prisma.deletionRecord.create({
+      data: { operationId, accountRef: "ref-a" },
+    });
+    expect(record.status).toBe("purging");
+    expect(record.completedAt).toBeNull();
+
+    const task = await prisma.deletionTask.create({
+      data: {
+        operationId,
+        kind: "notification_installation",
+        payload: { identifier: "client-1" } satisfies Prisma.InputJsonValue,
+      },
+    });
+    expect(task.status).toBe("pending");
+    expect(task.attempts).toBe(0);
+    expect(task.nextAttemptAt).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
## What this is

Slice **1 of 5** of #374 (`feature/delete-account-impl`), re-landed as a reviewable series along its test-file seams. #374 is +13.5k/-0.6k across 92 files after nine adversarial review rounds; this series splits it into independently green, independently revertable tiers. Content is extracted **verbatim from the #374 tip** (45cd889) — nothing was re-designed.

## This slice: the complete additive data-model tier (zero behavior)

- All **six Prisma migrations** from #374, byte-identical, renumbered `20260729100000`–`20260729105000` so they sort after the applied otr-dev migration tip (`20260715140320_*`); relative order preserved, including the rolling-deploy-safe reconciliation ordering (the `committedAt` migration before `SubscriptionDriftSchedule`).
  - `add_account_deletion`: `DeletedIdentity`, `DeletionRecord`, `DeletionTask`, `SubscriptionTombstone`, `Account.lastAuthAt`
  - `add_subscription_lineage`: `SubscriptionLineage`, `LineageTokenAlias`, `LineagePeriodGrant`, `LineagePeriodCustody`, `SubscriptionTransfer`, `LineageQuarantine`, `Subscription.lineageId`, money-conservation CHECK constraints, and the **backfill of lineages from existing Subscription rows**
  - `add_rate_limit_counter`, `add_reconciliation_progress`, `harden_reconciliation_drift_cursor`, `add_subscription_drift_schedule`
- The full `prisma/schema.prisma` from the #374 tip (byte-identical).
- Schema-level tests, byte-identical: `tests/deletion/schema.test.ts`, `tests/deletion/schema-guards.test.ts`, and `tests/deletion/lineage-backfill-migration.test.ts` (only the migration-folder references updated for the renumbering).
- `tests/deletion/reclaim-fixtures.ts`: minimal subset of #374's shared fixture module (only what the backfill test imports); later slices expand it to the full version.

**No `src/` file is touched.** All new tables/columns are additive and unused by shipped code paths until the later slices land. No client-facing request schema changes (nothing for `assertLegacyShapeValidates` yet — that lands with the verify/tombstone slice). No credit movement of any kind — DDL only, and the CHECK constraints strengthen the ledger law at the DB layer.

## Why land the schema first

The lineage backfill is the highest-risk piece of #374 (it adjudicates existing prod `Subscription` rows). Isolating it on a small diff means prod data adjudication happens here, reviewable on its own, and every later slice becomes a pure-code diff with zero migration churn.

**Prod-apply note:** the lineage migration hard-fails the deploy (by design, `DO $$` guard) if any single lineage's rows are owned by different accounts. Before prod promote, run the read-only finder to confirm no multi-owner lineage exists in prod data (Apple: duplicate `originalTransactionId` across accounts; Google: token-chain roots).

## The series

1. **(this PR)** data model: all migrations + schema + schema tests
2. Deletion barrier at mint + fail-closed auth + router fencing (`barrier-mint`, `auth-require-account`, `router-fencing` tests)
3. Teardown endpoint + purge outbox/executors, behind `ACCOUNT_DELETION_ENABLED=false` (`delete-account`, `outbox*`, `executors` tests)
4. Tombstone semantics in verify/SSN/RTDN + additive `claimable` on the 409 (contract-pinned with `assertLegacyShapeValidates`) (`tombstones` tests)
5. Claim endpoint + reconciliation sweep + adversarial suites (`claim`, `adversarial*`, full `reclaim-fixtures`)

## Validation

- `prisma validate` / `prisma generate` clean; full 76-migration chain replayed from scratch on an empty DB (`migrate deploy`), then `migrate status` up to date
- Targeted schema suites: 9/9. **Full suite: 1636 passed / 0 failed** (180 files, CI-style env)
- `tsc --noEmit`, `eslint`, `prettier --check` all clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787922594&installation_model_id=20076&pr_number=397&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F397&signature=1c99cc8be4e5779169f99aa7b689de9b46792c319d8167e617c9f8ba62f1fdae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add account deletion and subscription lineage data model (slice 1/5 of #374)
> - Adds six new migrations introducing account deletion tables (`DeletedIdentity`, `DeletionRecord`, `DeletionTask`), subscription lineage tables (`SubscriptionLineage`, `LineageTokenAlias`, `LineagePeriodGrant`, `LineagePeriodCustody`, `SubscriptionTransfer`, `SubscriptionDriftSchedule`, `LineageQuarantine`), and a `RateLimitCounter` table.
> - Backfills `Account.lastAuthAt` for existing rows and creates Apple/Google lineages from existing subscription data via a recursive CTE that resolves `linkedPurchaseToken` chains; ambiguous or cyclic chains are quarantined.
> - `SubscriptionTransfer.committedAt` is database-owned via a trigger, guaranteed non-null, and indexed for deterministic sweep selection.
> - A per-lineage `SubscriptionDriftSchedule` is auto-maintained by a trigger on `SubscriptionTransfer` commits.
> - Adds vitest integration tests in [tests/deletion/](https://github.com/xmtplabs/convos-backend/pull/397/files#diff-16437fe8c7b1e6c81855492880c0517017142d34c60cf5d690f934ce50f21b28) that replay the backfill SQL against a live DB in rolled-back transactions to validate root canonicalization, quarantine behavior, and schema constraints.
> - Risk: migrations include multi-step backfills with `RAISE EXCEPTION` guards that abort if different-account duplicate lineages are detected; these are irreversible once applied.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 11e09e5. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->