### PR TITLE
Abilities: launch Gmail in the catalog (read-only)

### DIFF
--- a/src/api/v2/abilities/manifests.config.ts
+++ b/src/api/v2/abilities/manifests.config.ts
@@ -67,7 +67,7 @@ export type AbilityManifest = {
 };
 
 // The first-round abilities are all registered up front so each launch is a
-// flag flip. Only googlecalendar is live: it is the one ability with a
+// flag flip. googlecalendar and gmail are live: they are the abilities with a
 // working auth path and a service entry in bundles.config.ts.
 export const ABILITY_MANIFESTS: AbilityManifest[] = [
   {
@@ -111,11 +111,13 @@ export const ABILITY_MANIFESTS: AbilityManifest[] = [
   },
   {
     id: "gmail",
-    version: 1,
+    // v2: launched read-only — unhidden alongside the mail.read service
+    // bundle; subtitle narrowed to the read-only scope (no send until a write
+    // bundle ships).
+    version: 2,
     displayName: { en: "Gmail" },
-    subtitle: { en: "Read and send email" },
+    subtitle: { en: "Read and search email" },
     auth: { type: "oauth" },
-    hidden: true,
   },
 ];
 

--- a/src/api/v2/composio/handlers/exec.ts
+++ b/src/api/v2/composio/handlers/exec.ts
@@ -121,10 +121,19 @@ export async function execHandler(req: Request, res: Response) {
       return;
     }
 
+    // Gmail actions address a target mailbox through a user_id argument
+    // ("me" or a delegated address the OAuth principal can reach). Consent
+    // covers the connected member's own mailbox only, so a caller-supplied
+    // user_id is never honored: it is overwritten with "me" before the
+    // Composio call. Enforced here because raw exec is the one path every
+    // agent-supplied argument must pass through.
+    const pinnedArgs: Record<string, unknown> =
+      toolkit.toLowerCase() === "gmail" ? { ...args, user_id: "me" } : args;
+
     const result = await service.execute({
       action,
       userId: check.ownerAccountId,
-      arguments: args,
+      arguments: pinnedArgs,
       connectedAccountId,
       version,
     });

--- a/src/api/v2/connections/bundles.config.ts
+++ b/src/api/v2/connections/bundles.config.ts
@@ -103,6 +103,31 @@ export const SERVICE_CONFIGS: ServiceConfig[] = [
       },
     ],
   },
+  {
+    id: "gmail",
+    composioSlug: "gmail",
+    // v1: read-only launch — one mail.read bundle, fetch-only slugs. No
+    // send/draft/label/delete slug ships until a write bundle is added
+    // deliberately. Slugs verified against the live Composio v3 tool catalog
+    // (2026-07-31, full 63-slug list via getRawComposioTools with an explicit
+    // limit): GMAIL_FETCH_EMAILS, GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID and
+    // GMAIL_FETCH_MESSAGE_BY_THREAD_ID are all served.
+    version: 1,
+    displayName: { en: "Gmail" },
+    bundles: [
+      {
+        id: "mail.read",
+        title: { en: "Emails" },
+        description: { en: "Read and search emails in your inbox" },
+        defaultEnabled: true,
+        composioActions: [
+          "GMAIL_FETCH_EMAILS",
+          "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+          "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
+        ],
+      },
+    ],
+  },
 ];
 
 const BY_SERVICE = new Map<string, ServiceConfig>(

--- a/src/api/v2/connections/composio.service.ts
+++ b/src/api/v2/connections/composio.service.ts
@@ -202,11 +202,19 @@ export class ComposioService {
 
     const slugs = new Set<string>();
     try {
+      // The pinned SDK silently applies important=true (a featured subset)
+      // to a toolkits-only query with no limit — that would make this gate
+      // reject real slugs outside the featured slice. Ask for the full
+      // catalog explicitly: important: false plus the API's maximum limit.
       const tools = await withComposioTimeout(
         "tools.getRawComposioTools",
         COMPOSIO_CALL_TIMEOUT_MS,
         () =>
-          this.composio.tools.getRawComposioTools({ toolkits: [normalized] }),
+          this.composio.tools.getRawComposioTools({
+            toolkits: [normalized],
+            limit: 1000,
+            important: false,
+          }),
       );
       for (const tool of tools) {
         if (tool.slug) slugs.add(tool.slug);

--- a/tests/abilities-entitlement.test.ts
+++ b/tests/abilities-entitlement.test.ts
@@ -140,7 +140,7 @@ describe("POST /v2/abilities/:abilityId/entitlement", () => {
 
   test("404 unknown_ability for unknown and for hidden (unlaunched) abilities", async () => {
     const accountId = await makeAccount();
-    for (const abilityId of ["notarealability", "gmail"]) {
+    for (const abilityId of ["notarealability", "shopify"]) {
       const res = await request(makeApp())
         .post(`/abilities/${abilityId}/entitlement`)
         .set("X-Convos-AuthToken", await token(accountId))

--- a/tests/abilities-entitlements-worker.test.ts
+++ b/tests/abilities-entitlements-worker.test.ts
@@ -331,6 +331,38 @@ describe("GET /v2/abilities/entitlements — enumeration (DB)", () => {
     });
   });
 
+  test("gmail: mail.read resolves to the three fetch slugs, slugs on the wire", async () => {
+    const ownerAccountId = await makeAccount();
+    await seedGrant({
+      ownerAccountId,
+      ownerInboxId: "owner-inbox",
+      toolkit: "gmail",
+      bundleIds: ["mail.read"],
+      serviceVersion: 1,
+    });
+
+    const res = await enumerate({ headers: workerHeaders() });
+    expect(res.status).toBe(200);
+    expect(await asJson<EnumerateResponse>(res)).toEqual({
+      abilities: [
+        {
+          abilityId: "gmail",
+          owners: [
+            {
+              ownerInboxId: "owner-inbox",
+              // The same resolution exec enforces for mail.read, sorted.
+              actions: [
+                "GMAIL_FETCH_EMAILS",
+                "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+                "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   test("legacy explicit actions union with the bundle-resolved set", async () => {
     const ownerAccountId = await makeAccount();
     await seedGrant({

--- a/tests/abilities.test.ts
+++ b/tests/abilities.test.ts
@@ -218,7 +218,7 @@ describe("GET /v2/abilities", () => {
     const gmail = body.abilities.find((a) => a.id === "gmail");
     expect(gmail).toBeDefined();
     expect(gmail!.displayName.en).toBe("Gmail");
-    expect(typeof gmail!.subtitle.en).toBe("string");
+    expect(gmail!.subtitle.en).toBe("Read and search email");
     expect(gmail!.auth.type).toBe("oauth");
     expect(gmail!.bundles.map((b) => b.id)).toEqual(["mail.read"]);
     expect(gmail!.bundles[0].defaultEnabled).toBe(true);

--- a/tests/abilities.test.ts
+++ b/tests/abilities.test.ts
@@ -205,15 +205,29 @@ describe("GET /v2/abilities", () => {
     const res = await getAbilities(token);
     const body = res.body as AbilitiesResponse;
     const ids = body.abilities.map((a) => a.id);
-    for (const hidden of [
-      "coinbase",
-      "shopify",
-      "spotify",
-      "youtube",
-      "gmail",
-    ]) {
+    for (const hidden of ["coinbase", "shopify", "spotify", "youtube"]) {
       expect(ids).not.toContain(hidden);
     }
+  });
+
+  test("gmail is served with its read-only mail.read bundle", async () => {
+    const token = await createJwtToken({ deviceId: "device-abilities" });
+    const res = await getAbilities(token);
+    const body = res.body as AbilitiesResponse;
+
+    const gmail = body.abilities.find((a) => a.id === "gmail");
+    expect(gmail).toBeDefined();
+    expect(gmail!.displayName.en).toBe("Gmail");
+    expect(typeof gmail!.subtitle.en).toBe("string");
+    expect(gmail!.auth.type).toBe("oauth");
+    expect(gmail!.bundles.map((b) => b.id)).toEqual(["mail.read"]);
+    expect(gmail!.bundles[0].defaultEnabled).toBe(true);
+
+    // Composite version: manifest version + linked service version.
+    const manifest = ABILITY_MANIFESTS.find((m) => m.id === "gmail");
+    const svc = getServiceConfig("gmail");
+    expect(svc).toBeDefined();
+    expect(gmail!.version).toBe(manifest!.version + svc!.version);
   });
 
   test("a visible OAuth ability without a usable service entry is excluded, not served empty", async () => {
@@ -238,10 +252,10 @@ describe("GET /v2/abilities", () => {
   });
 
   test("an entitlement for a hidden ability does not unhide it", async () => {
-    await seedEntitlement("active", { abilityId: "gmail" });
+    await seedEntitlement("active", { abilityId: "spotify" });
     const res = await getAbilities(await accountToken());
     const body = res.body as AbilitiesResponse;
-    expect(body.abilities.map((a) => a.id)).not.toContain("gmail");
+    expect(body.abilities.map((a) => a.id)).not.toContain("spotify");
   });
 
   test("no Composio action slug, credential id, or deprecated bundle leaks", async () => {
@@ -251,6 +265,7 @@ describe("GET /v2/abilities", () => {
     expect(res.status).toBe(200);
     const payload = JSON.stringify(res.body);
     expect(payload).not.toMatch(/GOOGLECALENDAR_/);
+    expect(payload).not.toMatch(/GMAIL_/);
     expect(payload).not.toMatch(/composioActions/);
     // The Composio connection id is a bearer capability and stays backend-side.
     expect(payload).not.toContain("conn-1");

--- a/tests/composio-exec.test.ts
+++ b/tests/composio-exec.test.ts
@@ -66,6 +66,16 @@ const STUB_GOOGLECALENDAR_CATALOG_SLUGS = [
   "GOOGLECALENDAR_FIND_FREE_SLOTS",
 ];
 
+// The gmail vocabulary: the three mail.read slugs plus a real-but-UNBUNDLED
+// mutator (send), so the suite can prove exec denies it as no_grant, never
+// invalid_action.
+const STUB_GMAIL_CATALOG_SLUGS = [
+  "GMAIL_FETCH_EMAILS",
+  "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+  "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
+  "GMAIL_SEND_EMAIL",
+];
+
 // Minimal Composio stub: exec touches tools.execute, tools.getRawComposioTools
 // (slug-validity catalog), toolkits.get (version pinning) and (when a grant
 // pins no connection) connectedAccounts.list.
@@ -75,6 +85,7 @@ function installComposioStub(
       slug: string,
       body: {
         userId: string;
+        arguments?: Record<string, unknown>;
         connectedAccountId?: string;
         version?: string;
       },
@@ -98,10 +109,14 @@ function installComposioStub(
           return Promise.reject(new Error("Composio catalog unavailable"));
         }
         const toolkit = (query.toolkits ?? [])[0]?.toLowerCase();
-        const slugs =
-          toolkit === "googlecalendar"
-            ? (opts.catalogSlugs ?? STUB_GOOGLECALENDAR_CATALOG_SLUGS)
-            : (opts.catalogSlugs ?? []);
+        let fallback: string[] = [];
+        if (toolkit === "googlecalendar") {
+          fallback = STUB_GOOGLECALENDAR_CATALOG_SLUGS;
+        }
+        if (toolkit === "gmail") {
+          fallback = STUB_GMAIL_CATALOG_SLUGS;
+        }
+        const slugs = opts.catalogSlugs ?? fallback;
         return Promise.resolve(slugs.map((slug) => ({ slug })));
       },
     },
@@ -821,6 +836,87 @@ describe("POST /v2/composio/exec — grant authorization (DB)", () => {
       expect(res.status).toBe(403);
       expect((await asJson<{ code: string }>(res)).code).toBe("no_grant");
     }
+  });
+
+  test("gmail mail.read: every fetch slug is allowed; send is no_grant (exec as oracle)", async () => {
+    const ownerAccountId = await makeAccount();
+    await seedGrant({
+      ownerAccountId,
+      ownerInboxId: "owner-inbox",
+      granteeInboxId: AGENT_INBOX,
+      conversationId: CONVERSATION,
+      toolkit: "gmail",
+      actions: [],
+      bundleIds: ["mail.read"],
+      serviceVersion: 1,
+    });
+    installComposioStub({
+      connections: [
+        { id: "conn_gmail", userId: ownerAccountId, slug: "gmail" },
+      ],
+    });
+
+    for (const action of [
+      "GMAIL_FETCH_EMAILS",
+      "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+      "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
+    ]) {
+      const res = await exec(
+        { toolkit: "gmail", action, args: {} },
+        { headers: workerHeaders() },
+      );
+      expect(res.status).toBe(200);
+    }
+
+    // A real Composio slug deliberately outside mail.read: a consent gap
+    // (no_grant), never invalid_action — the read-only launch guarantee.
+    const send = await exec(
+      { toolkit: "gmail", action: "GMAIL_SEND_EMAIL", args: {} },
+      { headers: workerHeaders() },
+    );
+    expect(send.status).toBe(403);
+    expect((await asJson<{ code: string }>(send)).code).toBe("no_grant");
+  });
+
+  test("gmail: a caller-supplied user_id reaches Composio as 'me'", async () => {
+    // Composio's Gmail actions take a user_id mailbox selector ("me" or a
+    // delegated address). Consent covers the member's own mailbox only, so
+    // exec must overwrite the caller's value — a delegated mailbox never
+    // rides in on the raw exec path.
+    const ownerAccountId = await makeAccount();
+    await seedGrant({
+      ownerAccountId,
+      ownerInboxId: "owner-inbox",
+      granteeInboxId: AGENT_INBOX,
+      conversationId: CONVERSATION,
+      toolkit: "gmail",
+      actions: [],
+      bundleIds: ["mail.read"],
+      serviceVersion: 1,
+    });
+    const executed: Array<Record<string, unknown> | undefined> = [];
+    installComposioStub({
+      connections: [
+        { id: "conn_gmail", userId: ownerAccountId, slug: "gmail" },
+      ],
+      execute: (_slug, body) => {
+        executed.push(body.arguments);
+        return Promise.resolve({ data: { ok: true } });
+      },
+    });
+
+    const res = await exec(
+      {
+        toolkit: "gmail",
+        action: "GMAIL_FETCH_EMAILS",
+        args: { user_id: "someone@else.com", max_results: 5 },
+      },
+      { headers: workerHeaders() },
+    );
+    expect(res.status).toBe(200);
+    expect(executed).toHaveLength(1);
+    // The override replaces the mailbox selector and keeps the other args.
+    expect(executed[0]).toEqual({ user_id: "me", max_results: 5 });
   });
 
   test("legacy transition: no actions AND no bundleIds still means whole-toolkit", async () => {

--- a/tests/connections-actions.test.ts
+++ b/tests/connections-actions.test.ts
@@ -38,12 +38,36 @@ const STUB_GOOGLECALENDAR_CATALOG_SLUGS = [
   "GOOGLECALENDAR_CALENDARS_DELETE",
 ];
 
+// The gmail vocabulary: the three mail.read slugs plus a real-but-unbundled
+// mutator (send) that stays part of the served catalog vocabulary.
+const STUB_GMAIL_CATALOG_SLUGS = [
+  "GMAIL_FETCH_EMAILS",
+  "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+  "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
+  "GMAIL_SEND_EMAIL",
+];
+
+type CatalogQuery = {
+  toolkits?: string[];
+  limit?: number;
+  important?: boolean;
+};
+
+// The exact query the service last sent to the SDK — pinned below because the
+// SDK turns a toolkits-only query with no limit into a featured-only
+// (important=true) fetch, which would silently shrink the vocabulary.
+let lastCatalogQuery: CatalogQuery | null = null;
+
 function installComposioStub(catalogSlugs = STUB_GOOGLECALENDAR_CATALOG_SLUGS) {
+  lastCatalogQuery = null;
   const stub = {
     tools: {
-      getRawComposioTools: (query: { toolkits?: string[] }) => {
+      getRawComposioTools: (query: CatalogQuery) => {
+        lastCatalogQuery = query;
         const toolkit = (query.toolkits ?? [])[0]?.toLowerCase();
-        const slugs = toolkit === "googlecalendar" ? catalogSlugs : [];
+        let slugs: string[] = [];
+        if (toolkit === "googlecalendar") slugs = catalogSlugs;
+        if (toolkit === "gmail") slugs = STUB_GMAIL_CATALOG_SLUGS;
         return Promise.resolve(slugs.map((slug) => ({ slug })));
       },
     },
@@ -144,6 +168,40 @@ describe("GET /v2/connections/services/:toolkit/actions (no DB)", () => {
     expect(body.actions).not.toContain("GOOGLECALENDAR_LIST_EVENTS");
     expect(body.actions).not.toContain("listEvents");
     expect(body.actions).not.toContain("calendar.events.list");
+  });
+
+  test("requests the FULL catalog: explicit limit and important:false", async () => {
+    // The pinned SDK auto-applies important=true (featured subset) to a
+    // toolkits-only query with no limit; the service must opt out so real
+    // slugs outside the featured slice are never rejected as invalid.
+    installComposioStub();
+    const res = await getActions("gmail");
+    expect(res.status).toBe(200);
+    expect(lastCatalogQuery).toEqual({
+      toolkits: ["gmail"],
+      limit: 1000,
+      important: false,
+    });
+  });
+
+  test("gmail: every mail.read slug passes the catalog gate", async () => {
+    installComposioStub();
+    const res = await getActions("gmail");
+    expect(res.status).toBe(200);
+
+    const body = res.body as ActionsResponse;
+    expect(body.toolkit).toBe("gmail");
+    expect(body.composioSlug).toBe("gmail");
+    expect(body.actions).toEqual(
+      expect.arrayContaining([
+        "GMAIL_FETCH_EMAILS",
+        "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+        "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
+      ]),
+    );
+    // A real-but-unbundled mutator stays vocabulary (validity is sourced
+    // from Composio, not our consent bundles) — exec denies it as no_grant.
+    expect(body.actions).toContain("GMAIL_SEND_EMAIL");
   });
 
   test("case-insensitive toolkit match", async () => {

--- a/tests/connections-bundles.test.ts
+++ b/tests/connections-bundles.test.ts
@@ -67,6 +67,18 @@ describe("bundles catalog — resolveBundleActions (no DB)", () => {
     }
   });
 
+  test("mail.read resolves to exactly the three fetch slugs — read-only", () => {
+    // The read-only launch invariant, pinned as an exact allow-list (a verb
+    // heuristic would miss mutators like MARK or ARCHIVE and would not catch
+    // a dropped fetch slug).
+    const actions = [...resolveBundleActions("gmail", ["mail.read"])].sort();
+    expect(actions).toEqual([
+      "GMAIL_FETCH_EMAILS",
+      "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+      "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
+    ]);
+  });
+
   test("DEPRECATED bundles still resolve — legacy grants must keep working", () => {
     // calendar.events.read was retired from the public catalog in v4 but
     // real grants persist it; deprecation must never break exec resolution.
@@ -123,6 +135,7 @@ describe("bundles catalog — public view strips slugs (no DB)", () => {
     const json = JSON.stringify(getPublicServiceConfigs());
     // No Composio action slug should survive into the public payload.
     expect(json).not.toMatch(/GOOGLECALENDAR_/);
+    expect(json).not.toMatch(/GMAIL_/);
     expect(json).not.toMatch(/composioActions/);
   });
 
@@ -153,6 +166,21 @@ describe("bundles catalog — public view strips slugs (no DB)", () => {
     expect(gcal!.bundles[0].description.en).toBe(
       "View and edit events on all calendars",
     );
+  });
+
+  test("gmail serves exactly ONE bundle: the read-only 'Emails'", () => {
+    // Read-only launch: one on-by-default toggle covering fetch actions only;
+    // a write bundle is a deliberate later addition.
+    const gmail = getPublicServiceConfigs().find((s) => s.id === "gmail");
+    expect(gmail).toBeDefined();
+    expect(gmail!.composioSlug).toBe("gmail");
+    expect(gmail!.bundles).toHaveLength(1);
+    expect(gmail!.bundles[0].id).toBe("mail.read");
+    expect(gmail!.bundles[0].title.en).toBe("Emails");
+    expect(gmail!.bundles[0].description.en).toBe(
+      "Read and search emails in your inbox",
+    );
+    expect(gmail!.bundles[0].defaultEnabled).toBe(true);
   });
 
   test("deprecated bundles are excluded from the public view, and the flag never leaks", () => {

--- a/tests/connections-services.test.ts
+++ b/tests/connections-services.test.ts
@@ -86,6 +86,7 @@ describe("GET /v2/connections/services (no DB)", () => {
 
     // No Composio action slug may leak into the served payload.
     expect(JSON.stringify(body)).not.toMatch(/GOOGLECALENDAR_/);
+    expect(JSON.stringify(body)).not.toMatch(/GMAIL_/);
     expect(JSON.stringify(body)).not.toMatch(/composioActions/);
   });
 

--- a/tests/conversation-abilities.test.ts
+++ b/tests/conversation-abilities.test.ts
@@ -47,9 +47,12 @@ async function makeAccount(): Promise<string> {
   return account.id;
 }
 
-async function makeActiveEntitlement(accountId: string) {
+async function makeActiveEntitlement(
+  accountId: string,
+  abilityId = "googlecalendar",
+) {
   return prisma.abilityEntitlement.create({
-    data: { accountId, abilityId: "googlecalendar", status: "active" },
+    data: { accountId, abilityId, status: "active" },
   });
 }
 
@@ -276,7 +279,7 @@ describe("PUT /v2/conversations/:conversationId/abilities/:abilityId", () => {
 
   test("404 unknown_ability for unknown and hidden abilities", async () => {
     const accountId = await makeAccount();
-    for (const abilityId of ["notarealability", "gmail"]) {
+    for (const abilityId of ["notarealability", "shopify"]) {
       const res = await putAbility(
         accountId,
         { agentInboxId: "agent-1", bundleIds: ["calendar.events"] },
@@ -285,6 +288,34 @@ describe("PUT /v2/conversations/:conversationId/abilities/:abilityId", () => {
       expect(res.status).toBe(404);
       expect(res.body).toEqual({ code: "unknown_ability" });
     }
+  });
+
+  test("launched gmail: PUT extends an active entitlement with mail.read", async () => {
+    const accountId = await makeAccount();
+    const entitlement = await makeActiveEntitlement(accountId, "gmail");
+    const res = await putAbility(
+      accountId,
+      {
+        agentInboxId: "agent-1",
+        bundleIds: ["mail.read"],
+        extendedByInboxId: "owner-inbox-1",
+      },
+      { abilityId: "gmail" },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      abilityId: "gmail",
+      conversationId: CONVERSATION,
+      agentInboxId: "agent-1",
+      bundleIds: ["mail.read"],
+      status: "active",
+    });
+
+    const rows = await prisma.conversationAbility.findMany({
+      where: { entitlementId: entitlement.id },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].bundleIds).toEqual(["mail.read"]);
   });
 
   test("boot window (ledgers unconfirmed): PUT answers a retryable 503, never a false needs_entitlement", async () => {


### PR DESCRIPTION
Unhides the gmail manifest (v1 -> 2) and adds its service entry with a read-only mail.read bundle (GMAIL_FETCH_EMAILS, GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID, GMAIL_FETCH_MESSAGE_BY_THREAD_ID - slugs verified against the live Composio v3 catalog; all fetch-only).

Review hardening included: exec forces user_id="me" for all gmail actions on the raw path (delegated-mailbox passthrough closed, pinned by test), the /actions catalog gate queries the full (not featured-only) Composio listing, exact 3-slug bundle pin, gmail entitlement-enumeration and exec-as-oracle tests (send action denies as no_grant, never invalid_action).

Deliberately small - the marginal cost of adding an ability to the catalog: the original catalog change was 6 files, +86/-14; the rest is review-driven hardening and tests. No client changes needed (catalog-driven UI).

Launch caveat: hold merge-to-production until CON-817 (the Composio-managed gmail auth config requests the full mail.google.com scope + People API scopes - broader than this read-only bundle; a custom gmail.readonly auth config is required before user-facing launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9mVTQGi5wbxFnzJF9iLmC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788108841&installation_model_id=20076&pr_number=401&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F401&signature=3e8750cda2c4945918b4e5e0a5de1a88c4a6b93a8a4d2fbd26f190dafa563ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Launch Gmail ability in read-only mode in the abilities catalog
> - Makes the Gmail ability visible in the catalog by removing the `hidden` flag and bumping its manifest version to 2, with subtitle narrowed to 'Read and search email'.
> - Adds a Gmail service config in [bundles.config.ts](https://github.com/xmtplabs/convos-backend/pull/401/files#diff-220b04f44b8e0c1006d679a16bb8c8a6b17e2f628cf10fdb42661f9a5b08495f) with a single `mail.read` bundle (enabled by default) exposing three fetch actions: `GMAIL_FETCH_EMAILS`, `GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID`, and `GMAIL_FETCH_MESSAGE_BY_THREAD_ID`.
> - Pins `user_id` to `'me'` in [exec.ts](https://github.com/xmtplabs/convos-backend/pull/401/files#diff-b238f74374f8a7211412f99d1112058a07ed21c1bac4696d66d948f7d6244880) for all Gmail tool executions, ignoring any caller-supplied value.
> - Fixes action vocabulary fetching in `ComposioService.listToolkitActions` to request the full catalog (`limit: 1000`, `important: false`) instead of the default featured subset, preventing false `invalid_action` rejections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f39503.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gmail is now available as a live, read-only email integration.
  - Added support for fetching emails, messages, and threads through the `mail.read` capability.
  - Gmail entitlements can be created and extended for conversations.

- **Security & Access**
  - Email sending remains unavailable.
  - Gmail access is restricted to the authenticated mailbox, regardless of supplied mailbox identifiers.
  - Internal Gmail action details are excluded from public service catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->