### PR TITLE
fix(participation): fall back to the default worker when a pinned variant is gone

### DIFF
--- a/src/api/v2/agent-variants/handlers/list.ts
+++ b/src/api/v2/agent-variants/handlers/list.ts
@@ -16,8 +16,22 @@ export async function listAgentVariantsHandler(req: Request, res: Response) {
   }
 
   try {
+    // The picker gets the same liveness rule the router uses, so it can only
+    // offer a variant that requests will actually be routed to — listing an
+    // expired one invites a device to pin something that silently resolves to
+    // the default worker, which reads as the variant doing nothing.
+    //
+    // The variant-sweep CI (agent API key) gets the unfiltered set: it is the
+    // reaper, and an expired row is precisely what it exists to clean up.
+    // Hiding those would strand them in the registry forever.
+    const isReaper = res.locals.isApiKeyListener === true;
     const variants = await prisma.agentVariant.findMany({
-      where: { status: { in: ["ready", "building"] } },
+      where: {
+        status: { in: ["ready", "building"] },
+        ...(isReaper
+          ? {}
+          : { OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }] }),
+      },
       orderBy: { createdAt: "desc" },
     });
     res.status(200).json({ data: variants.map(serializeAgentVariant) });

--- a/src/api/v2/conversations/handlers/participation.ts
+++ b/src/api/v2/conversations/handlers/participation.ts
@@ -156,6 +156,12 @@ export async function fetchParticipation(
   }
 
   if (VARIANT_UNUSABLE_STATUSES.has(response.status)) {
+    // Hand the socket back before opening the second one. Dropping a response
+    // without reading it leaves undici holding the connection until GC gets to
+    // it, and every call from a device pinned to a dead variant takes this
+    // path, so the leak would compound. A cancel on an already-errored body is
+    // not worth surfacing: the response is being discarded either way.
+    await response.body?.cancel().catch(() => {});
     req.log.warn(
       { variantOrigin: target.baseUrl, status: response.status },
       "Variant worker cannot serve participation; falling back to the default assistant worker",

--- a/src/api/v2/conversations/handlers/participation.ts
+++ b/src/api/v2/conversations/handlers/participation.ts
@@ -64,13 +64,14 @@ const ERRORS = {
  */
 async function resolveAssistantTarget(
   req: Request,
-): Promise<{ baseUrl: string; headers: Record<string, string> } | null> {
+): Promise<AssistantTarget | null> {
   const assistantApiUrl = getAssistantApiUrl();
   if (!assistantApiUrl) return null;
 
   // Dev-only variant routing, same as the join poller: an assistant
   // provisioned on a variant worker does not exist on the default one.
-  let baseUrl = assistantApiUrl.replace(/\/+$/, "");
+  const defaultBaseUrl = assistantApiUrl.replace(/\/+$/, "");
+  let baseUrl = defaultBaseUrl;
   const variantId = querySchema.safeParse(req.query).data?.variantId;
   if (variantId && XMTP_ENV !== "production") {
     const origin = await resolveVariantWorkerOrigin(variantId);
@@ -84,7 +85,84 @@ async function resolveAssistantTarget(
   if (assistantApiKey) {
     headers.Authorization = `Bearer ${assistantApiKey}`;
   }
-  return { baseUrl, headers };
+  return { baseUrl, defaultBaseUrl, headers };
+}
+
+export type AssistantTarget = {
+  baseUrl: string;
+  defaultBaseUrl: string;
+  headers: Record<string, string>;
+};
+
+/**
+ * A variant answer that means "this worker cannot serve this conversation",
+ * as opposed to a real upstream failure worth reporting.
+ *
+ * 404 is a variant deployed from a branch that predates the participation
+ * route. 401/403 is a variant whose worker holds a different key than the one
+ * we authenticate with — its secret set can legitimately diverge from the
+ * default worker's. Neither says anything about the conversation, and both are
+ * answerable by the default worker.
+ */
+const VARIANT_UNUSABLE_STATUSES = new Set([401, 403, 404]);
+
+/**
+ * Send a participation request, falling back to the default worker when the
+ * pinned variant cannot answer it.
+ *
+ * A device keeps sending the variant it has selected in the debug menu long
+ * after that variant's worker is gone — the registry row outlives the
+ * deployment, so `resolveVariantWorkerOrigin` still hands back an origin whose
+ * hostname no longer resolves. Without this, every participation call from that
+ * device fails: the write surfaces "Participation not updated" and the read
+ * fails silently, leaving the control on a level the conversation is not in.
+ *
+ * The variant is a routing preference, never a correctness requirement — the
+ * conversation's level lives on the default control plane either way — so an
+ * unreachable variant degrades to the default worker instead of failing the
+ * member's request. A failure from the default worker is reported as-is.
+ */
+export async function fetchParticipation(
+  req: Pick<Request, "log">,
+  target: AssistantTarget,
+  conversationId: string,
+  init: RequestInit,
+  // `Response` in this file is express's; this one is the fetch response.
+): Promise<globalThis.Response> {
+  const request = (baseUrl: string) =>
+    fetch(upstreamUrl(baseUrl, conversationId), {
+      ...init,
+      headers: target.headers,
+      signal: AbortSignal.timeout(PARTICIPATION_FETCH_TIMEOUT_MS),
+    });
+
+  const onVariant = target.baseUrl !== target.defaultBaseUrl;
+  if (!onVariant) return request(target.defaultBaseUrl);
+
+  let response: globalThis.Response;
+  try {
+    response = await request(target.baseUrl);
+  } catch (error) {
+    // A timeout is a live-but-slow worker and stays the caller's problem; any
+    // other transport error (DNS, refused, reset) means the variant is simply
+    // not there.
+    if (error instanceof DOMException && error.name === "TimeoutError")
+      throw error;
+    req.log.warn(
+      { variantOrigin: target.baseUrl },
+      "Variant worker unreachable; falling back to the default assistant worker",
+    );
+    return request(target.defaultBaseUrl);
+  }
+
+  if (VARIANT_UNUSABLE_STATUSES.has(response.status)) {
+    req.log.warn(
+      { variantOrigin: target.baseUrl, status: response.status },
+      "Variant worker cannot serve participation; falling back to the default assistant worker",
+    );
+    return request(target.defaultBaseUrl);
+  }
+  return response;
 }
 
 function upstreamUrl(baseUrl: string, conversationId: string): string {
@@ -133,10 +211,8 @@ export async function getParticipationHandler(req: Request, res: Response) {
   const { conversationId } = parsedParams.data;
 
   try {
-    const upstream = await fetch(upstreamUrl(target.baseUrl, conversationId), {
+    const upstream = await fetchParticipation(req, target, conversationId, {
       method: "GET",
-      headers: target.headers,
-      signal: AbortSignal.timeout(PARTICIPATION_FETCH_TIMEOUT_MS),
     });
 
     if (!upstream.ok) {
@@ -216,11 +292,9 @@ export async function participationHandler(req: Request, res: Response) {
   const { mode } = parsedBody.data;
 
   try {
-    const upstream = await fetch(upstreamUrl(target.baseUrl, conversationId), {
+    const upstream = await fetchParticipation(req, target, conversationId, {
       method: "PATCH",
-      headers: target.headers,
       body: JSON.stringify({ mode }),
-      signal: AbortSignal.timeout(PARTICIPATION_FETCH_TIMEOUT_MS),
     });
 
     if (!upstream.ok) {

--- a/tests/conversations-participation-fallback.test.ts
+++ b/tests/conversations-participation-fallback.test.ts
@@ -83,6 +83,26 @@ describe("participation variant fallback", () => {
     },
   );
 
+  test("the discarded variant response is cancelled, not leaked", async () => {
+    // Every call from a device pinned to a dead variant abandons one response.
+    // Left unread, undici holds that connection until GC; cancelling returns it
+    // now, so the fallback path cannot exhaust the pool.
+    const abandoned = new Response("body the fallback never reads", {
+      status: 404,
+    });
+    stubFetch((url) =>
+      url.startsWith(VARIANT_BASE)
+        ? abandoned
+        : new Response(null, { status: 200 }),
+    );
+
+    await fetchParticipation(req, target(VARIANT_BASE), CONVERSATION, {
+      method: "GET",
+    });
+
+    expect(abandoned.bodyUsed).toBe(true);
+  });
+
   test("a variant's 500 is reported, not retried: the worker is there and broken", async () => {
     const calls = stubFetch(() => new Response(null, { status: 500 }));
 

--- a/tests/conversations-participation-fallback.test.ts
+++ b/tests/conversations-participation-fallback.test.ts
@@ -1,0 +1,141 @@
+import type { Request } from "express";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  fetchParticipation,
+  type AssistantTarget,
+} from "@/api/v2/conversations/handlers/participation";
+
+// A device keeps sending the variant selected in its debug menu long after that
+// variant's worker is gone, because the registry row outlives the deployment.
+// These pin the rule that a variant is a routing preference and never a
+// correctness requirement: when it cannot answer, the default control plane
+// does, rather than the member getting "Participation not updated".
+
+const DEFAULT_BASE = "https://assistants.example/api";
+const VARIANT_BASE = "https://ephemeral-pr-1.convos.fun";
+const CONVERSATION = "conv-1";
+
+function target(baseUrl: string): AssistantTarget {
+  return { baseUrl, defaultBaseUrl: DEFAULT_BASE, headers: {} };
+}
+
+const req = {
+  log: { warn: () => {}, error: () => {}, info: () => {}, debug: () => {} },
+} as unknown as Pick<Request, "log">;
+
+function stubFetch(handler: (url: string) => Response | Promise<Response>) {
+  const calls: string[] = [];
+  vi.stubGlobal("fetch", (input: string | URL) => {
+    const url = String(input);
+    calls.push(url);
+    return Promise.resolve(handler(url));
+  });
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("participation variant fallback", () => {
+  test("an unreachable variant host falls back to the default worker", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", (input: string | URL) => {
+      const url = String(input);
+      calls.push(url);
+      // What a torn-down ephemeral actually does: the hostname stops resolving.
+      if (url.startsWith(VARIANT_BASE)) {
+        return Promise.reject(new TypeError("fetch failed"));
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+
+    const response = await fetchParticipation(
+      req,
+      target(VARIANT_BASE),
+      CONVERSATION,
+      { method: "PATCH" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.startsWith(DEFAULT_BASE)).toBe(true);
+  });
+
+  test.each([401, 403, 404])(
+    "a variant answering %i falls back: it cannot serve this conversation",
+    async (status) => {
+      const calls = stubFetch((url) =>
+        url.startsWith(VARIANT_BASE)
+          ? new Response(null, { status })
+          : new Response(null, { status: 200 }),
+      );
+
+      const response = await fetchParticipation(
+        req,
+        target(VARIANT_BASE),
+        CONVERSATION,
+        { method: "GET" },
+      );
+
+      expect(response.status).toBe(200);
+      expect(calls).toHaveLength(2);
+    },
+  );
+
+  test("a variant's 500 is reported, not retried: the worker is there and broken", async () => {
+    const calls = stubFetch(() => new Response(null, { status: 500 }));
+
+    const response = await fetchParticipation(
+      req,
+      target(VARIANT_BASE),
+      CONVERSATION,
+      { method: "PATCH" },
+    );
+
+    expect(response.status).toBe(500);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("a timeout stays a timeout: a slow variant is live, not missing", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", (input: string | URL) => {
+      calls.push(String(input));
+      return Promise.reject(
+        new DOMException("The operation timed out.", "TimeoutError"),
+      );
+    });
+
+    await expect(
+      fetchParticipation(req, target(VARIANT_BASE), CONVERSATION, {
+        method: "GET",
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("no variant pinned means exactly one call, to the default worker", async () => {
+    const calls = stubFetch(() => new Response(null, { status: 200 }));
+
+    await fetchParticipation(req, target(DEFAULT_BASE), CONVERSATION, {
+      method: "GET",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.startsWith(DEFAULT_BASE)).toBe(true);
+  });
+
+  test("the default worker's own failure is never retried", async () => {
+    const calls = stubFetch(() => new Response(null, { status: 404 }));
+
+    const response = await fetchParticipation(
+      req,
+      target(DEFAULT_BASE),
+      CONVERSATION,
+      { method: "GET" },
+    );
+
+    expect(response.status).toBe(404);
+    expect(calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
A device keeps sending the variant selected in its debug menu long after that variant's worker is gone: the registry row outlives the deployment, so `resolveVariantWorkerOrigin` still hands back an origin whose hostname no longer resolves. Every participation call from that device then failed — the write surfaced "Participation not updated. The agents are still on their previous setting.", and the read failed silently, leaving the control on a level the conversation was not in. The agent-power surfaces read the same endpoint and broke the same way.

Fixes xmtplabs/convos-backend#403.

A variant is a routing preference, not a correctness requirement — the conversation's level lives on the default control plane either way. So an unreachable variant, or one that answers 401/403/404, now degrades to the default worker instead of failing the member's request. A timeout still surfaces (a slow variant is live, not missing), and a failure from the default worker is reported as-is.

The picker also stops listing expired variants, so a device cannot newly pin one that is already retired. The variant-sweep still sees them: it is the reaper, and an expired row is exactly what it exists to clean up.

Pairs with xmtplabs/convos-assistants#3141, which bounds a variant registry row's life so it stops outliving its worker in the first place. This side is the safety net for the rows already stranded.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

![View with \[code\]smith](https://camo.githubusercontent.com/6e22944985996f6a1201f1d35788e9dc855f2e6b7b781e7ed1c22d7fb14217e8/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f766965772d776974682d636f6465736d6974682d6461726b2d76322e737667) ![Autofix with \[code\]smith](https://camo.githubusercontent.com/8e7d836069a9e09b18eb0f68d9afc9beb6c2b13211745830b36a5d88a500d653/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f6175746f6669782d776974682d636f6465736d6974682d6461726b2e737667) Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.

> \[!NOTE\]
>
> ### Fall back to the default worker when a pinned variant is unreachable or returns 401/403/404
>
> * Adds `fetchParticipation` in [participation.ts](<https://github.com/xmtplabs/convos-backend/pull/404/files#diff-173b563c14d18889e14fd6b7d27328cc666889a974188b519adaa0240a1d8fec>) to wrap participation fetches with variant-aware fallback logic; both `getParticipationHandler` and `participationHandler` now call it instead of fetching directly.
> * On transport errors (excluding timeouts), the fallback retries the request against the default worker. On 401/403/404 from a variant, the response body is cancelled to avoid socket leaks and the request falls back to the default worker. 5xx responses and timeouts propagate as-is.
> * `resolveAssistantTarget` now returns `defaultBaseUrl` alongside `baseUrl` and `headers` so downstream code can route fallback requests.
> * Expired variants are filtered from `GET /v2/agent-variants` for normal callers; callers identified as `isApiKeyListener` receive the full set including expired variants.
>
> [Macroscope](<https://app.macroscope.com>) summarized c51ed05.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation participation routing for selected assistant variants.
  * Automatically falls back to the default worker when a variant is unavailable or returns authorization or not-found errors.
  * Preserves timeout and server-error responses without unnecessary retries.
  * Excludes expired variants from standard requests while retaining them for cleanup processing.
* **Tests**
  * Added coverage for variant fallback, error handling, response cancellation, and default routing behavior.