### PR TITLE
ci: allow devin-ai-integration bot in Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Allow bot-authored PRs (e.g. Devin) to trigger Claude review
-          allowed_bots: devin-ai-integration[bot], convos-os[bot]
+          allowed_bots: devin-ai-integration[bot], convos-os
 
           # Optional: Specify model (defaults to Claude Sonnet)
           model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
+          # Allow bot-authored PRs (e.g. Devin) to trigger Claude review
+          allowed_bots: devin-ai-integration[bot]
+
           # Optional: Specify model (defaults to Claude Sonnet)
           model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Allow bot-authored PRs (e.g. Devin) to trigger Claude review
-          allowed_bots: devin-ai-integration[bot], saulmc
+          allowed_bots: devin-ai-integration[bot], convosos
 
           # Optional: Specify model (defaults to Claude Sonnet)
           model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Allow bot-authored PRs (e.g. Devin) to trigger Claude review
-          allowed_bots: devin-ai-integration[bot]
+          allowed_bots: devin-ai-integration[bot], saulmc
 
           # Optional: Specify model (defaults to Claude Sonnet)
           model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Allow bot-authored PRs (e.g. Devin) to trigger Claude review
-          allowed_bots: devin-ai-integration[bot], convosos
+          allowed_bots: devin-ai-integration[bot], convos-os[bot]
 
           # Optional: Specify model (defaults to Claude Sonnet)
           model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}


### PR DESCRIPTION
Fix the ConvosOS bot name to the correct GitHub login (convos-os[bot]).

Proposed by saul@xmtp.com via ConvosOS.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `devin-ai-integration[bot]` to trigger Claude code review workflow
> Adds `allowed_bots` to the Claude code review action in [claude-code-review.yml](.github/workflows/claude-code-review.yml), listing `devin-ai-integration[bot]` and `convos-os` so PRs authored by these bots are no longer skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b1d0cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->