### PR TITLE
feat(agents): compose a default agent name from ownerProfileName

### DIFF
--- a/docs/plans/abilities-entitlements.md
+++ b/docs/plans/abilities-entitlements.md
@@ -47,14 +47,14 @@ contract is real - a thin wrapper, not a phase.
 
 ## Nomenclature
 
-| Term | Meaning | Backed by |
-| --- | --- | --- |
-| **Ability** | One integration (Google Calendar, Spotify...) described by a manifest | Code config (versioned TS module), per bundles-doc decision |
-| **Manifest** | An ability's public contract: id, name, icons, auth type, bundles; later tools[]/actions[] | Code config, served over HTTP |
-| **Bundle** | The user-facing permission unit inside an ability ("Events") | Existing bundles model, unchanged |
-| **Composio grant** | The external credential at the provider (Composio connected account / OAuth token) | Composio, keyed by `accountId` |
-| **Entitlement** | Account <-> ability binding with a backend-owned lifecycle status | New `AbilityEntitlement` row |
-| **Conversation ability** | An entitlement extended to an agent within one conversation | New `ConversationAbility` row (reshaped `ConnectionGrant`) |
+| Term                     | Meaning                                                                                    | Backed by                                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| **Ability**              | One integration (Google Calendar, Spotify...) described by a manifest                      | Code config (versioned TS module), per bundles-doc decision |
+| **Manifest**             | An ability's public contract: id, name, icons, auth type, bundles; later tools[]/actions[] | Code config, served over HTTP                               |
+| **Bundle**               | The user-facing permission unit inside an ability ("Events")                               | Existing bundles model, unchanged                           |
+| **Composio grant**       | The external credential at the provider (Composio connected account / OAuth token)         | Composio, keyed by `accountId`                              |
+| **Entitlement**          | Account <-> ability binding with a backend-owned lifecycle status                          | New `AbilityEntitlement` row                                |
+| **Conversation ability** | An entitlement extended to an agent within one conversation                                | New `ConversationAbility` row (reshaped `ConnectionGrant`)  |
 
 Review discussion deliberately used generic language to keep naming honest: a
 "binding" is the account <-> service credential + privileges (our entitlement), and the
@@ -115,33 +115,34 @@ yet) get the catalog with `entitlement: null` - browsable, not entitleable.
 
 ```jsonc
 {
-  "catalogVersion": 3,            // bump on any served-catalog change (manifests and bundles)
+  "catalogVersion": 3, // bump on any served-catalog change (manifests and bundles)
   // "entitlementsUnavailable": true  -- present only when entitlement state could not
   //                                     be derived (upstream outage); abilities then
   //                                     carry no entitlement key at all - see below
   "abilities": [
     {
       "id": "googlecalendar",
-      "version": 2,               // per-ability version (staleness handling)
+      "version": 2, // per-ability version (staleness handling)
       "displayName": { "en": "Google Calendar" },
       "subtitle": { "en": "Read and edit events" },
-      "icon": { "iosUrl": "https://...", "androidUrl": "https://..." },  // optional until the asset story lands (open question 1)
-      "auth": { "type": "oauth" },     // "oauth" | "none"; callback specifics stay backend-side
+      "icon": { "iosUrl": "https://...", "androidUrl": "https://..." }, // optional until the asset story lands (open question 1)
+      "auth": { "type": "oauth" }, // "oauth" | "none"; callback specifics stay backend-side
       "bundles": [
         {
           "id": "calendar.events",
           "title": { "en": "Events" },
           "description": { "en": "View and edit events on all calendars" },
-          "defaultEnabled": true
-        }
+          "defaultEnabled": true,
+        },
       ],
-      "entitlement": {                 // object or null when authoritative; omitted under entitlementsUnavailable
-        "status": "active",            // pending_auth | active | needs_reauth | expired | revoked
+      "entitlement": {
+        // object or null when authoritative; omitted under entitlementsUnavailable
+        "status": "active", // pending_auth | active | needs_reauth | expired | revoked
         "expiresAt": "2026-09-01T00:00:00Z",
-        "extensionCount": 2            // distinct conversations this entitlement is extended to
-      }
-    }
-  ]
+        "extensionCount": 2, // distinct conversations this entitlement is extended to
+      },
+    },
+  ],
 }
 ```
 

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -119,6 +119,19 @@ export const bodySchema = z
       .transform((v) => v.toLowerCase())
       .optional(),
     name: z.string().min(1).max(256).optional(),
+    // Raw profile name of the joining user, sent by clients that auto-attach
+    // a default agent at conversation creation. The server composes the
+    // agent's possessive display name from it ("Saul's agent") so the copy
+    // can change without a client release. Blank-after-trim collapses to
+    // absent rather than rejecting.
+    ownerProfileName: z
+      .string()
+      .max(64)
+      .optional()
+      .transform((v) => {
+        const trimmed = v?.trim();
+        return trimmed ? trimmed : undefined;
+      }),
     profileImage: z.string().min(1).max(2048).optional(),
     options: optionsSchema.optional(),
     timezone: timezoneSchema.optional(),
@@ -165,6 +178,12 @@ function buildInviteUrl(slug: string): string {
   return `https://${domain}/v2?i=${encodeURIComponent(slug)}`;
 }
 
+// The default display name for an auto-attached bare agent. Always "'s",
+// including names that end in s ("Jules's agent").
+function composeOwnerAgentName(ownerProfileName: string): string {
+  return `${ownerProfileName}'s agent`;
+}
+
 const assistantDispatchSchema = z.object({
   instanceId: z.string().min(1),
 });
@@ -188,6 +207,10 @@ const dispatchBodySchema = z
       .max(128)
       .optional(),
     template: z.record(z.string(), z.unknown()).nullable(),
+    // Agent display name for bare joins (template null): the worker resolves
+    // it as `template.agentName ?? name`. Template joins carry the name
+    // inside the template instead.
+    name: z.string().min(1).max(256).optional(),
     ownerAccountId: accountIdSchema,
     options: optionsSchema.optional(),
     timezone: timezoneSchema.optional(),
@@ -466,6 +489,7 @@ export async function joinHandler(req: Request, res: Response) {
     templateId,
     idempotencyKey,
     name,
+    ownerProfileName,
     profileImage,
     options,
     timezone,
@@ -719,6 +743,19 @@ export async function joinHandler(req: Request, res: Response) {
       template: joinPayload?.template ?? null,
       ownerAccountId: joiningUserAccountId,
     };
+    // Bare joins have no template row to carry a display name, so it rides as
+    // a top-level field the worker resolves as `template.agentName ?? name`.
+    // An explicit caller `name` wins; otherwise `ownerProfileName` composes
+    // the possessive default for auto-attached agents ("Saul's agent") —
+    // composition lives here so the copy can change without a client release.
+    const bareAgentName =
+      name ??
+      (ownerProfileName !== undefined
+        ? composeOwnerAgentName(ownerProfileName)
+        : undefined);
+    if (templateWithOverrides === null && bareAgentName !== undefined) {
+      dispatchBody.name = bareAgentName;
+    }
     if (Object.keys(upstreamOptions).length > 0) {
       dispatchBody.options = upstreamOptions;
     }

--- a/src/api/v2/agents/handlers/join.ts
+++ b/src/api/v2/agents/handlers/join.ts
@@ -118,7 +118,18 @@ export const bodySchema = z
       .uuid()
       .transform((v) => v.toLowerCase())
       .optional(),
-    name: z.string().min(1).max(256).optional(),
+    // Trimmed, with blank-after-trim collapsing to absent (not rejected, which
+    // would tighten the contract for shipped clients): a whitespace-only name
+    // must never shadow the composed ownerProfileName default or land as a
+    // blank display name.
+    name: z
+      .string()
+      .max(256)
+      .optional()
+      .transform((v) => {
+        const trimmed = v?.trim();
+        return trimmed ? trimmed : undefined;
+      }),
     // Raw profile name of the joining user, sent by clients that auto-attach
     // a default agent at conversation creation. The server composes the
     // agent's possessive display name from it ("Saul's agent") so the copy

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -18,11 +18,14 @@ export const authRateLimitMiddleware = rateLimit({
 });
 
 // Rate limiting for the agent-provisioning endpoint (POST /api/v2/agents/join).
-// Each request kicks off a container-boot workflow upstream — expensive,
-// hence the tight 10/5min cap.
+// Each request kicks off a container-boot workflow upstream — expensive, so
+// the cap stays tight relative to other endpoints — but clients that
+// auto-attach a default agent at conversation creation provision in bursts
+// (cache fill plus retries), so the window leaves headroom above steady-state
+// one-at-a-time joins.
 export const agentJoinLimiter = rateLimit({
   windowMs: 5 * 60 * 1000, // 5 minutes
-  limit: 10,
+  limit: 30,
   legacyHeaders: false,
   standardHeaders: "draft-8",
   message: { error: "Too many agent join requests, please try again later" },

--- a/tests/agents-join-contract.test.ts
+++ b/tests/agents-join-contract.test.ts
@@ -114,4 +114,42 @@ describe("agents/join body schema — ownerProfileName", () => {
       expect(parsed.data.ownerProfileName).toBeUndefined();
     }
   });
+
+  test("an over-long ownerProfileName is rejected", () => {
+    const parsed = bodySchema.safeParse({
+      conversationId: "deadbeefcafe1234",
+      ownerProfileName: "x".repeat(65),
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("a non-string ownerProfileName is rejected", () => {
+    const parsed = bodySchema.safeParse({
+      conversationId: "deadbeefcafe1234",
+      ownerProfileName: 42,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("a whitespace-only name collapses to absent instead of shadowing composition", () => {
+    const parsed = bodySchema.safeParse({
+      conversationId: "deadbeefcafe1234",
+      name: "   ",
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.name).toBeUndefined();
+    }
+  });
+
+  test("name is trimmed", () => {
+    const parsed = bodySchema.safeParse({
+      conversationId: "deadbeefcafe1234",
+      name: "  My Agent ",
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.name).toBe("My Agent");
+    }
+  });
 });

--- a/tests/agents-join-contract.test.ts
+++ b/tests/agents-join-contract.test.ts
@@ -83,3 +83,35 @@ describe("agents/join body schema — idempotencyKey", () => {
     expect(parsed.success).toBe(false);
   });
 });
+
+describe("agents/join body schema — ownerProfileName", () => {
+  test("legacy join body without ownerProfileName still validates", () => {
+    assertLegacyShapeValidates(
+      bodySchema,
+      { conversationId: "deadbeefcafe1234", name: "My Agent" },
+      "legacy join body (no ownerProfileName)",
+    );
+  });
+
+  test("ownerProfileName is optional, accepted, and trimmed", () => {
+    const parsed = bodySchema.safeParse({
+      conversationId: "deadbeefcafe1234",
+      ownerProfileName: "  Saul ",
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.ownerProfileName).toBe("Saul");
+    }
+  });
+
+  test("blank ownerProfileName collapses to absent", () => {
+    const parsed = bodySchema.safeParse({
+      conversationId: "deadbeefcafe1234",
+      ownerProfileName: "   ",
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.ownerProfileName).toBeUndefined();
+    }
+  });
+});

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -1013,7 +1013,9 @@ describe("agents join (assistant API)", () => {
       expect(capturedBody!.ownerAccountId).toBe(DEFAULT_TEST_ACCOUNT_ID);
     });
 
-    test("a bare join composes the agent name from ownerProfileName", async () => {
+    // Configures the dispatch mock for a registration that lands, and returns
+    // a getter for the captured dispatch body.
+    const captureDispatchBody = (instanceId: string) => {
       let capturedBody: Record<string, unknown> | null = null;
       mockFetchImpl = (_url, init) => {
         if (init?.method === "POST") {
@@ -1021,49 +1023,34 @@ describe("agents join (assistant API)", () => {
             string,
             unknown
           >;
-          return Promise.resolve(
-            jsonResponse(200, { instanceId: "inst-owner-name" }),
-          );
+          return Promise.resolve(jsonResponse(200, { instanceId }));
         }
         return Promise.resolve(
           jsonResponse(200, {
-            instanceId: "inst-owner-name",
+            instanceId,
             joinStatus: "pending_acceptance",
-            inboxId: "inbox-owner-name",
+            inboxId: `inbox-${instanceId}`,
           }),
         );
       };
+      return () => capturedBody;
+    };
+
+    test("a bare join composes the agent name from ownerProfileName", async () => {
+      const dispatchBody = captureDispatchBody("inst-owner-name");
 
       const res = await post({
         conversationId: "abcdef1234567890",
         ownerProfileName: "Saul",
       });
       expect(res.status).toBe(200);
-      expect(capturedBody).not.toBeNull();
-      expect(capturedBody!.name).toBe("Saul's agent");
-      expect(capturedBody!.template).toBeNull();
+      expect(dispatchBody()).not.toBeNull();
+      expect(dispatchBody()!.name).toBe("Saul's agent");
+      expect(dispatchBody()!.template).toBeNull();
     });
 
     test("an explicit name wins over ownerProfileName on a bare join", async () => {
-      let capturedBody: Record<string, unknown> | null = null;
-      mockFetchImpl = (_url, init) => {
-        if (init?.method === "POST") {
-          capturedBody = JSON.parse(init.body as string) as Record<
-            string,
-            unknown
-          >;
-          return Promise.resolve(
-            jsonResponse(200, { instanceId: "inst-explicit-name" }),
-          );
-        }
-        return Promise.resolve(
-          jsonResponse(200, {
-            instanceId: "inst-explicit-name",
-            joinStatus: "pending_acceptance",
-            inboxId: "inbox-explicit-name",
-          }),
-        );
-      };
+      const dispatchBody = captureDispatchBody("inst-explicit-name");
 
       const res = await post({
         conversationId: "abcdef1234567890",
@@ -1071,60 +1058,36 @@ describe("agents join (assistant API)", () => {
         ownerProfileName: "Saul",
       });
       expect(res.status).toBe(200);
-      expect(capturedBody!.name).toBe("Custom Bot");
+      expect(dispatchBody()!.name).toBe("Custom Bot");
+    });
+
+    test("a whitespace-only name falls back to the composed ownerProfileName default", async () => {
+      const dispatchBody = captureDispatchBody("inst-ws-name");
+
+      const res = await post({
+        conversationId: "abcdef1234567890",
+        name: "   ",
+        ownerProfileName: "Saul",
+      });
+      expect(res.status).toBe(200);
+      expect(dispatchBody()!.name).toBe("Saul's agent");
     });
 
     test("blank ownerProfileName is treated as absent on a bare join", async () => {
-      let capturedBody: Record<string, unknown> | null = null;
-      mockFetchImpl = (_url, init) => {
-        if (init?.method === "POST") {
-          capturedBody = JSON.parse(init.body as string) as Record<
-            string,
-            unknown
-          >;
-          return Promise.resolve(
-            jsonResponse(200, { instanceId: "inst-blank-name" }),
-          );
-        }
-        return Promise.resolve(
-          jsonResponse(200, {
-            instanceId: "inst-blank-name",
-            joinStatus: "pending_acceptance",
-            inboxId: "inbox-blank-name",
-          }),
-        );
-      };
+      const dispatchBody = captureDispatchBody("inst-blank-name");
 
       const res = await post({
         conversationId: "abcdef1234567890",
         ownerProfileName: "   ",
       });
       expect(res.status).toBe(200);
-      expect(capturedBody).not.toBeNull();
-      expect(capturedBody!).not.toHaveProperty("name");
+      expect(dispatchBody()).not.toBeNull();
+      expect(dispatchBody()!).not.toHaveProperty("name");
     });
 
     test("a template join carries the name inside the template, never top-level", async () => {
       __setTemplateFinderForTests(() => Promise.resolve(baseTemplate()));
-      let capturedBody: Record<string, unknown> | null = null;
-      mockFetchImpl = (_url, init) => {
-        if (init?.method === "POST") {
-          capturedBody = JSON.parse(init.body as string) as Record<
-            string,
-            unknown
-          >;
-          return Promise.resolve(
-            jsonResponse(200, { instanceId: "inst-tpl-name" }),
-          );
-        }
-        return Promise.resolve(
-          jsonResponse(200, {
-            instanceId: "inst-tpl-name",
-            joinStatus: "pending_acceptance",
-            inboxId: "inbox-tpl-name",
-          }),
-        );
-      };
+      const dispatchBody = captureDispatchBody("inst-tpl-name");
 
       const res = await post({
         conversationId: "abcdef1234567890",
@@ -1132,11 +1095,11 @@ describe("agents join (assistant API)", () => {
         ownerProfileName: "Saul",
       });
       expect(res.status).toBe(200);
-      expect(capturedBody).not.toBeNull();
-      expect(capturedBody!).not.toHaveProperty("name");
-      expect((capturedBody!.template as { agentName?: string }).agentName).toBe(
-        "Brewski",
-      );
+      expect(dispatchBody()).not.toBeNull();
+      expect(dispatchBody()!).not.toHaveProperty("name");
+      expect(
+        (dispatchBody()!.template as { agentName?: string }).agentName,
+      ).toBe("Brewski");
     });
 
     test("idempotencyKey is forwarded to the dispatch body, lowercased", async () => {

--- a/tests/agents-join.test.ts
+++ b/tests/agents-join.test.ts
@@ -1013,6 +1013,132 @@ describe("agents join (assistant API)", () => {
       expect(capturedBody!.ownerAccountId).toBe(DEFAULT_TEST_ACCOUNT_ID);
     });
 
+    test("a bare join composes the agent name from ownerProfileName", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-owner-name" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-owner-name",
+            joinStatus: "pending_acceptance",
+            inboxId: "inbox-owner-name",
+          }),
+        );
+      };
+
+      const res = await post({
+        conversationId: "abcdef1234567890",
+        ownerProfileName: "Saul",
+      });
+      expect(res.status).toBe(200);
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody!.name).toBe("Saul's agent");
+      expect(capturedBody!.template).toBeNull();
+    });
+
+    test("an explicit name wins over ownerProfileName on a bare join", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-explicit-name" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-explicit-name",
+            joinStatus: "pending_acceptance",
+            inboxId: "inbox-explicit-name",
+          }),
+        );
+      };
+
+      const res = await post({
+        conversationId: "abcdef1234567890",
+        name: "Custom Bot",
+        ownerProfileName: "Saul",
+      });
+      expect(res.status).toBe(200);
+      expect(capturedBody!.name).toBe("Custom Bot");
+    });
+
+    test("blank ownerProfileName is treated as absent on a bare join", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-blank-name" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-blank-name",
+            joinStatus: "pending_acceptance",
+            inboxId: "inbox-blank-name",
+          }),
+        );
+      };
+
+      const res = await post({
+        conversationId: "abcdef1234567890",
+        ownerProfileName: "   ",
+      });
+      expect(res.status).toBe(200);
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody!).not.toHaveProperty("name");
+    });
+
+    test("a template join carries the name inside the template, never top-level", async () => {
+      __setTemplateFinderForTests(() => Promise.resolve(baseTemplate()));
+      let capturedBody: Record<string, unknown> | null = null;
+      mockFetchImpl = (_url, init) => {
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init.body as string) as Record<
+            string,
+            unknown
+          >;
+          return Promise.resolve(
+            jsonResponse(200, { instanceId: "inst-tpl-name" }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(200, {
+            instanceId: "inst-tpl-name",
+            joinStatus: "pending_acceptance",
+            inboxId: "inbox-tpl-name",
+          }),
+        );
+      };
+
+      const res = await post({
+        conversationId: "abcdef1234567890",
+        templateId: "22222222-2222-4222-8222-222222222222",
+        ownerProfileName: "Saul",
+      });
+      expect(res.status).toBe(200);
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody!).not.toHaveProperty("name");
+      expect((capturedBody!.template as { agentName?: string }).agentName).toBe(
+        "Brewski",
+      );
+    });
+
     test("idempotencyKey is forwarded to the dispatch body, lowercased", async () => {
       let capturedBody: Record<string, unknown> | null = null;
       mockFetchImpl = (url, init) => {


### PR DESCRIPTION
## Summary

Backend leg of CON-824 (auto-attach a silent default agent when a user starts a group).

- **`ownerProfileName` on `POST /api/v2/agents/join`** (optional, append-only): clients that auto-attach a default agent send the raw profile name; the backend composes the possessive display name ("Saul's agent") and forwards it. Composition lives server-side so the copy can change without a client release. Blank-after-trim collapses to absent.
- **`name` now rides the dispatch body on bare joins.** Previously a caller-supplied `name` was silently dropped whenever no template was set — it only ever traveled inside the template row. The worker already resolves `template.agentName ?? name`, so no worker change is needed. An explicit caller `name` wins over the composed default; template joins are unchanged (their name stays inside the template). `name` is also trimmed, with whitespace-only collapsing to absent so it can never shadow the composed default.
- **Join rate limit 10 → 30 per 5 min.** Auto-attach clients provision at conversation-cache fill, which is bursty (several conversations plus retries) rather than one-at-a-time.

Contract tests pin the legacy shapes (`assertLegacyShapeValidates`) per the append-only rule; dispatch-body tests cover composition, explicit-name precedence, blank collapse, and the template-join case.

DB-backed suites don't run in this environment (no local database — `PrismaClientInitializationError`); the join handler + contract suites (67 tests) and `pnpm check` pass locally, CI covers the rest.

Also carries a whitespace-only prettier pass on an unrelated plan doc that was failing `format:check` on every PR.

Linear: CON-824

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fkjwmmeae96Thbk2UmsRs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788379289&installation_model_id=20076&pr_number=408&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F408&signature=b3fbc9545e3a3c6dd86e31324dcae9fe1bac5c5374852dda613ea68c57ece082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compose a default agent name from `ownerProfileName` for bare joins
> - Adds an optional `ownerProfileName` field to the agent join request body; when no explicit `name` is provided for a bare join (no template), the handler composes a default display name in the form "[Owner]'s agent".
> - Explicit `name` takes precedence over the composed default; whitespace-only `name` values are collapsed to absent and fall back to the composed name.
> - Template joins never include a top-level `name` field.
> - Increases the `agentJoinLimiter` rate limit from 10 to 30 requests per 5-minute window to support bursty provisioning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76d59e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bare agent joins can derive a default name from the owner’s profile name.
  * Explicit agent names take precedence, while template-based joins preserve names within the template.

* **Bug Fixes**
  * Names and profile names are trimmed, with blank values treated as absent.
  * Increased the join request limit from 10 to 30 requests per five minutes.

* **Documentation**
  * Improved formatting in the abilities and entitlements documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
