### PR TITLE
docs: record what end-to-end local testing actually takes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,12 @@ SIWE_ALLOWED_CHAIN_IDS=1
 NONCE_HMAC_SECRET=<any stable secret>
 ```
 
-Leaving the `.env.example` defaults produces a failure that reads as a cookie
-problem rather than a config one: `/auth/nonce` returns 200, then `/auth/token`
-returns 401 "Invalid nonce".
+Leaving the `.env.example` defaults gets you past `/auth/nonce` (200) and then
+401 `"Invalid SIWE"` from `/auth/token` — the SIWE verification in
+`generate-token.ts` step 3c. Read the error, because the neighbouring failure
+looks almost identical and has nothing to do with config: 401 `"Invalid nonce"`
+comes from steps 3a/3b, meaning the nonce cookie never came back or was already
+consumed. Over a tunnel that is usually the cookie, not the SIWE domain.
 
 **A physical device needs HTTPS.** Expose this backend through ngrok and give
 the app that URL as `CONVOS_API_BASE_URL` — `localhost` means the phone itself,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,34 @@ via `grantSubscriptionPeriod` / `forfeitSubscriptionPeriod`). Never write
 Read the full law before writing money code: **`src/payments/AGENTS.md`**.
 Repo-wide agent guidance: `AGENTS.md`.
 
+## End-to-End Local Testing
+
+Pointing the iOS app at this backend works, and the two settings that decide
+whether auth succeeds are not the ones `.env.example` ships.
+
+**SIWE must match what the app signs.** Local and dev iOS builds sign for
+`dev.convos.org`, so the backend needs:
+
+```
+SIWE_DOMAIN=dev.convos.org
+SIWE_URI=https://dev.convos.org
+SIWE_ALLOWED_CHAIN_IDS=1
+NONCE_HMAC_SECRET=<any stable secret>
+```
+
+Leaving the `.env.example` defaults produces a failure that reads as a cookie
+problem rather than a config one: `/auth/nonce` returns 200, then `/auth/token`
+returns 401 "Invalid nonce".
+
+**A physical device needs HTTPS.** Expose this backend through ngrok and give
+the app that URL as `CONVOS_API_BASE_URL` — `localhost` means the phone itself,
+and a LAN IP has no certificate. The simulator can use either. `trust proxy`
+has to be on for the nonce cookie to survive the tunnel.
+
+The app talks only to this service; the assistants Worker sits behind it and is
+never contacted directly. See `CLAUDE.md` in convos-ios for the app-side
+configuration, and `AGENTS.md` in convos-assistants for the Worker side.
+
 ## PR checklist
 
 - [ ] Any change touching `src/api/v2/**` request schemas: backwards-compatible


### PR DESCRIPTION
Pointing the iOS app at a locally-running backend works, and the two settings that decide whether auth succeeds are not the ones `.env.example` ships.

Local and dev iOS builds sign SIWE for `dev.convos.org`, so the backend needs that domain plus `NONCE_HMAC_SECRET`. Leaving the example defaults produces a failure that reads as a cookie problem rather than a config one: `/auth/nonce` returns 200, then `/auth/token` returns 401 "Invalid nonce". Also notes that a physical device needs the backend exposed over HTTPS (ngrok), since `localhost` means the phone itself and a LAN IP has no certificate.

Companion sections land in convos-ios `CLAUDE.md` (schemes, App Check) and convos-assistants `AGENTS.md` (herald sidecar, tunnel expiry), each cross-referencing the others.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788705744&installation_model_id=20076&pr_number=409&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F409&signature=f28ade3903a633da5f4f7a6437e2e431004ae98fc6425d15313b9bf8cccffa7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document end-to-end local testing setup for iOS app to backend SIWE authentication
> Adds an 'End-to-End Local Testing' section to [CLAUDE.md](https://github.com/xmtplabs/convos-backend/pull/409/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) covering how to connect the iOS app to the local backend for SIWE flows.
>
> - Lists required environment variables: `SIWE_DOMAIN`, `SIWE_URI`, `SIWE_ALLOWED_CHAIN_IDS`, and `NONCE_HMAC_SECRET`
> - Explains how to distinguish `Invalid SIWE` vs `Invalid nonce` errors during debugging
> - Notes that physical devices require HTTPS via ngrok and that trust proxy must be enabled for nonce cookies over tunnels
> - Describes service topology: the iOS app talks only to this service, with the assistants Worker sitting behind it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc13d27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for end-to-end local testing.
  * Documented required environment settings, nonce troubleshooting, HTTPS requirements for physical devices, proxy configuration, simulator behavior, and service boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->