### PR TITLE
feat(preview): seed, db-wait, X-Preview-Token gate, boot contract (CON-825 Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,29 @@ PORT=4000
 # For host `pnpm dev`: use localhost:5432. For Docker `./dev/run`: use convos_db:5432.
 DATABASE_URL=postgres://postgres:convos@localhost:5432/postgres?sslmode=disable
 
+# --- Per-PR preview environments (CON-825) ---
+# Set to exactly "1" ONLY in a preview bundle. Two effects, both no-ops
+# otherwise:
+#   1. dev/entrypoint.sh runs `prisma db seed`, which seeds a preview fixture
+#      set exactly once per database (guarded by a RuntimeConfig
+#      'preview_seeded' marker row) — including app_attest_enabled=false,
+#      without which Firebase App Check 401s every authenticated request.
+#   2. Every request must carry the bundle's token in an X-Preview-Token
+#      header. The only exemption is exactly /healthcheck, because the ALB
+#      target-group probe and the ECS container health check send no headers.
+PREVIEW=
+# The bundle's preview token, >= 32 chars. CI derives it per PR as
+# HMAC(master secret, pr_number) and injects it here and into the PR's
+# assistant worker and app build. When PREVIEW=1 and this is missing or too
+# short the gate fails CLOSED (503 on everything but /healthcheck).
+# Never post it in a PR comment or a query string — the repo is public.
+PREVIEW_TOKEN=
+# Seconds the container entrypoint waits for the database to accept a
+# connection before running migrations (default 90). Sized for an Aurora
+# Serverless v2 resume from 0 ACU (~15s, 30s+ after a long pause). Applies in
+# every environment, not just previews.
+DB_CONNECT_BUDGET_SECONDS=
+
 # Firebase service account (optional — push fan-out is no-op if unset).
 #
 # Leaving it empty does NOT disable App Check. The client still sends an App

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -65,3 +65,11 @@ jobs:
           XMTP_NOTIFICATION_SECRET: ${{ secrets.XMTP_NOTIFICATION_SECRET }}
           FIREBASE_SERVICE_ACCOUNT: "{}"
           LOG_FORMAT: json # Disable pino-pretty to avoid worker thread hanging tests
+
+      - name: Build the release bundle
+        run: pnpm build
+
+      - name: Preview slim-secret boot contract
+        run: ./scripts/preview-boot-check.sh
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/dev/entrypoint.sh
+++ b/dev/entrypoint.sh
@@ -1,11 +1,36 @@
 #!/bin/sh
 set -e
 
+# APP_DIR lets CI (scripts/preview-boot-check.sh) run this exact entrypoint
+# outside the container. The container's WORKDIR is /app, so the default keeps
+# image behaviour byte-identical.
+APP_DIR="${APP_DIR:-/app}"
+cd "$APP_DIR"
+
+# Bounded connect-wait before migrating. Aurora Serverless v2 resumes from
+# 0 ACU in ~15s (30s+ after a long pause) and `prisma migrate deploy` is
+# fail-fast, so without this the first deploy of the day dies on P1001 into the
+# ECS circuit breaker. Deliberately NOT PREVIEW-gated: it is a strict
+# improvement in every environment and costs one `SELECT 1` when the database
+# is already awake. Budget: DB_CONNECT_BUDGET_SECONDS (default 90).
+node "$APP_DIR/dist/db-wait.js"
+
 # Use the local prisma CLI directly — release image is pnpm-less.
+# Stays fail-fast: a P3009 here (applied migrations missing from this branch,
+# i.e. a rebased force-push) is the signal the deploy workflow's auto-reset
+# path keys off, and must not be retried or swallowed.
 node ./node_modules/prisma/build/index.js migrate deploy
+
+# Preview bundles seed once, at database creation. `db seed` runs
+# package.json#prisma.seed -> `node prisma/seed.ts`, which is itself guarded by
+# PREVIEW=1 and by the RuntimeConfig 'preview_seeded' marker row; the shell
+# guard here just keeps a pointless process spawn off the dev/prod boot path.
+if [ "${PREVIEW:-}" = "1" ]; then
+  node ./node_modules/prisma/build/index.js db seed
+fi
 
 exec node \
   --enable-source-maps \
   --import @opentelemetry/instrumentation/hook.mjs \
-  --import file:///app/dist/instrumentation.js \
-  /app/dist/index.js
+  --import "file://$APP_DIR/dist/instrumentation.js" \
+  "$APP_DIR/dist/index.js"

--- a/package.json
+++ b/package.json
@@ -122,5 +122,8 @@
   "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=24"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.ts"
   }
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,151 @@
+/**
+ * Preview-environment database seed (CON-825).
+ *
+ * Runs from the container entrypoint on every boot of a preview bundle and is
+ * a no-op in every other environment. Two independent guards:
+ *
+ *   1. `PREVIEW` must be exactly "1". Nothing else in the estate sets it, so a
+ *      dev/prod image running this file writes nothing and exits 0.
+ *   2. A `RuntimeConfig` row with key `preview_seeded` must be absent. The
+ *      marker is inserted with ON CONFLICT DO NOTHING as the FIRST statement of
+ *      the seeding transaction, so it doubles as the concurrency guard: a
+ *      second seeder blocks on the primary-key row lock, then observes
+ *      `count === 0` and returns without writing. Everything else in the
+ *      transaction rolls back with it, so a partially-seeded database is not
+ *      reachable.
+ *
+ * `app_attest_enabled = "false"` is the load-bearing row. `appCheckOnlyMiddleware`
+ * (src/middleware/auth.ts) defaults it to "true", so without it Firebase App
+ * Check rejects every authenticated request and the preview is unusable.
+ *
+ * INVOCATION: `prisma db seed` (wired via package.json#prisma.seed) runs
+ * `node prisma/seed.ts`. Node 24 strips types natively, so no tsx/ts-node is
+ * needed — which matters because the release image prunes devDependencies.
+ * For the same reason this file must use ERASABLE SYNTAX ONLY and must not use
+ * the `@/` path alias (bare `node` does not resolve it).
+ */
+import { argv } from "node:process";
+import { pathToFileURL } from "node:url";
+import { PrismaClient } from "@prisma/client";
+
+export const PREVIEW_SEED_MARKER_KEY = "preview_seeded";
+export const PREVIEW_SEED_ATTEST_KEY = "app_attest_enabled";
+export const PREVIEW_SEED_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+export const PREVIEW_SEED_TEMPLATE_ID = "22222222-2222-4222-8222-222222222222";
+export const PREVIEW_SEED_TEMPLATE_SLUG = "preview-helper";
+export const PREVIEW_SEED_INVITE_CODES: readonly string[] = [
+  "PREVIEW1",
+  "PREVIEW2",
+  "PREVIEW3",
+];
+export const PREVIEW_SEED_CREDITS = 100_000n;
+
+export type SeedResult = "skipped-not-preview" | "already-seeded" | "seeded";
+
+export async function seedPreview(prisma: PrismaClient): Promise<SeedResult> {
+  if (process.env.PREVIEW !== "1") {
+    return "skipped-not-preview";
+  }
+
+  return prisma.$transaction(
+    async (tx): Promise<SeedResult> => {
+      // Marker first: this INSERT ... ON CONFLICT DO NOTHING is the idempotency
+      // guard AND the concurrency guard for two tasks booting at once.
+      const marker = await tx.runtimeConfig.createMany({
+        data: [
+          {
+            key: PREVIEW_SEED_MARKER_KEY,
+            value: new Date().toISOString(),
+          },
+        ],
+        skipDuplicates: true,
+      });
+      if (marker.count === 0) {
+        return "already-seeded";
+      }
+
+      // Firebase App Check off. Upsert (not createMany) so the value is forced
+      // even on the vanishingly unlikely fresh database that already carries a
+      // "true" row from a migration default.
+      await tx.runtimeConfig.upsert({
+        where: { key: PREVIEW_SEED_ATTEST_KEY },
+        create: { key: PREVIEW_SEED_ATTEST_KEY, value: "false" },
+        update: { value: "false" },
+      });
+
+      await tx.inviteCode.createMany({
+        data: PREVIEW_SEED_INVITE_CODES.map((code) => ({
+          code,
+          name: `Preview invite ${code}`,
+          maxRedemptions: 100,
+          batchLabel: "preview",
+        })),
+        skipDuplicates: true,
+      });
+
+      // Upsert, not create: if the marker row is ever deleted while the
+      // fixtures survive (a partial database cleanup), a `create` would raise
+      // P2002, roll the transaction back, and — because the entrypoint runs
+      // `db seed` under `set -e` — wedge every subsequent container boot.
+      await tx.account.upsert({
+        where: { id: PREVIEW_SEED_ACCOUNT_ID },
+        create: { id: PREVIEW_SEED_ACCOUNT_ID },
+        update: {},
+      });
+
+      await tx.userCredits.upsert({
+        where: { accountId: PREVIEW_SEED_ACCOUNT_ID },
+        create: {
+          accountId: PREVIEW_SEED_ACCOUNT_ID,
+          balance: PREVIEW_SEED_CREDITS,
+        },
+        update: { balance: PREVIEW_SEED_CREDITS },
+      });
+
+      await tx.agentTemplate.upsert({
+        where: { id: PREVIEW_SEED_TEMPLATE_ID },
+        create: {
+          id: PREVIEW_SEED_TEMPLATE_ID,
+          slug: PREVIEW_SEED_TEMPLATE_SLUG,
+          ownerAccountId: PREVIEW_SEED_ACCOUNT_ID,
+          agentName: "Preview Helper",
+          jobTitle: "Preview environment test agent",
+          description:
+            "Seeded agent template for per-PR preview environments. Not real data.",
+          prompt:
+            "You are a test agent running inside a Convos preview environment. Answer briefly and always mention that you are a seeded preview agent.",
+          category: "productivity",
+          emoji: "🧪",
+          status: "published",
+          firstPublishedAt: new Date(),
+        },
+        update: {},
+      });
+
+      return "seeded";
+    },
+    // Generous relative to the ~50ms of writes above: an Aurora Serverless v2
+    // instance that has only just resumed is slow for its first few statements.
+    { maxWait: 30_000, timeout: 60_000 },
+  );
+}
+
+async function main(): Promise<void> {
+  const prisma = new PrismaClient();
+  try {
+    const result = await seedPreview(prisma);
+    console.log(`[preview-seed] ${result}`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Only run when executed directly (`prisma db seed` / `node prisma/seed.ts`).
+// Under vitest, argv[1] is the vitest binary, so importing this module for its
+// exports does not touch the database. Bound to a local so the truthiness check
+// is on a `string` (an `=== undefined` comparison would trip
+// @typescript-eslint/no-unnecessary-condition — argv is typed `string[]`).
+const entryPoint = argv[1];
+if (entryPoint && import.meta.url === pathToFileURL(entryPoint).href) {
+  await main();
+}

--- a/scripts/preview-boot-check.sh
+++ b/scripts/preview-boot-check.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# CON-825 preview slim-secret boot contract.
+#
+# Starts the REAL container entrypoint (dev/entrypoint.sh, via APP_DIR) with
+# nothing but the environment variables convos-backend requires SYNTACTICALLY AT
+# BOOT, plus the preview-only pair, and asserts that:
+#
+#   * the connect-wait, `prisma migrate deploy` and `prisma db seed` steps all
+#     run and the server reaches a serving state;
+#   * the preview seed wrote its marker and turned App Check off;
+#   * `X-Preview-Token` gates everything except exactly /healthcheck.
+#
+# The `export` block below IS the contract. Adding a new module-load `throw` to
+# src/config.ts (or a new required knob to src/payments/credits/config.ts)
+# without adding it here fails this check — which is the point. Everything
+# deliberately NOT listed here (FIREBASE_SERVICE_ACCOUNT, AGENT_ASSETS_API_KEY,
+# COMPOSIO_*, APPLE_*, GOOGLE_PLAY_*, POSTHOG_*, the S3 buckets, CDN_BASE_URL,
+# DEV_API_TOKEN, CREDITS_ADMIN_API_TOKEN, LIFECYCLE_TEST_*) is semantic and
+# per-path: its endpoint 503s, the server boots.
+#
+# Requires: a reachable DATABASE_URL, `psql`, `curl`, and a prior `pnpm build`.
+set -euo pipefail
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "::error::preview-boot-check: DATABASE_URL must be set" >&2
+  exit 1
+fi
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export APP_DIR
+cd "$APP_DIR"
+
+if [ ! -f "$APP_DIR/dist/index.js" ] || [ ! -f "$APP_DIR/dist/db-wait.js" ]; then
+  echo "::error::preview-boot-check: dist/ is missing — run 'pnpm build' first" >&2
+  exit 1
+fi
+
+PORT=4141
+BASE="http://127.0.0.1:${PORT}"
+export PORT
+
+# --- preview-only ----------------------------------------------------------
+export PREVIEW=1
+export PREVIEW_TOKEN="preview-boot-check-token-0123456789abcdef0123456789abcdef"
+
+# --- THE SLIM SET: required syntactically at boot ---------------------------
+export XMTP_NOTIFICATION_SECRET="preview-boot-check-notification-secret"
+export NOTIFICATION_SERVER_URL="http://127.0.0.1:8080"
+# Must be https:// or a localhost / *.test.local host — src/config.ts rejects
+# plaintext anywhere else.
+export ASSISTANT_API_URL="https://assistants.test.local"
+export SIWE_DOMAIN="preview.convos.org"
+export SIWE_URI="https://preview.convos.org"
+# >= 64 chars or src/config.ts throws.
+export NONCE_HMAC_SECRET="0000000000000000000000000000000000000000000000000000000000000000"
+export BUILDER_SITE_URL="https://preview.convos.org"
+export PAYMENTS_MARKUP_RATE="2.0"
+export PAYMENTS_CREDITS_PER_USD="1000"
+export PAYMENTS_RESERVED_MAX_TURN_CREDITS="1"
+export PAYMENTS_MIN_BALANCE_CREDITS="-1000"
+export PAYMENTS_GRANT_PLUS_MONTHLY="2500"
+# Public throwaway ECDSA P-256 pair — the same one tests/setup.ts uses.
+export JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgGis9E4WiE4Ou51Ho
+2tH6goYKt2nxLsKgadVvCYaklRyhRANCAARIw/oKiY4bkkW8iOcgiyUb1XPOtBQ4
+/7NXGEExhSwpySP8P8tpOUlKoI2DryaYFx4EJhqtnV3Dhp1wLcxDKZYG
+-----END PRIVATE KEY-----"
+export JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESMP6ComOG5JFvIjnIIslG9VzzrQU
+OP+zVxhBMYUsKckj/D/LaTlJSqCNg68mmBceBCYarZ1dw4adcC3MQymWBg==
+-----END PUBLIC KEY-----"
+
+# --- operational, mirroring the ECS task definition ------------------------
+export NODE_ENV=production
+export XMTP_ENV=dev
+export LOG_FORMAT=json
+# The OTel SDK is left ENABLED even though no collector is listening: previews
+# ship without Datadog sidecars, so "the app survives an unreachable OTLP
+# endpoint" is exactly the behaviour worth proving. Expect noisy export errors.
+
+SERVER_PID=""
+
+cleanup() {
+  local status=$?
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  # Never leave app_attest_enabled=false (or the marker) behind: a later test
+  # run against the same database would silently have App Check disabled.
+  psql "$DATABASE_URL" -q -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<'SQL' || true
+DELETE FROM "AgentTemplate" WHERE id = '22222222-2222-4222-8222-222222222222';
+DELETE FROM "UserCredits" WHERE "accountId" = '11111111-1111-4111-8111-111111111111';
+DELETE FROM "Account" WHERE id = '11111111-1111-4111-8111-111111111111';
+DELETE FROM "InviteCode" WHERE code IN ('PREVIEW1','PREVIEW2','PREVIEW3');
+DELETE FROM "RuntimeConfig" WHERE key IN ('preview_seeded','app_attest_enabled');
+SQL
+  # Verify rather than trust: a swallowed psql failure that leaves
+  # app_attest_enabled=false behind would silently disable App Check for every
+  # later run against this database, and a green job would hide it. Only ever
+  # escalates — an already-failing run keeps its original status.
+  local leftover
+  leftover="$(psql "$DATABASE_URL" -tAc \
+    "SELECT count(*) FROM \"RuntimeConfig\" WHERE key IN ('preview_seeded','app_attest_enabled')" \
+    2>/dev/null)" || leftover="unknown"
+  if [ "$leftover" != "0" ]; then
+    echo "::error::preview-boot-check: cleanup failed to remove the seeded rows (leftover=${leftover}); app_attest_enabled may still be 'false' in this database" >&2
+    if [ "$status" -eq 0 ]; then
+      status=1
+    fi
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "::error::preview-boot-check: $1" >&2
+  exit 1
+}
+
+assert_status() {
+  local expected="$1"
+  local desc="$2"
+  shift 2
+  local actual
+  actual="$(curl -s -o /dev/null -w '%{http_code}' "$@" || true)"
+  if [ "$actual" != "$expected" ]; then
+    fail "${desc} — expected HTTP ${expected}, got ${actual}"
+  fi
+  echo "  ok: ${desc} -> ${actual}"
+}
+
+echo "preview-boot-check: starting dev/entrypoint.sh (APP_DIR=$APP_DIR PORT=$PORT)"
+./dev/entrypoint.sh &
+SERVER_PID=$!
+
+ready=""
+for i in $(seq 1 120); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    fail "the entrypoint exited before the server became ready (see log above)"
+  fi
+  if [ "$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/healthcheck" || true)" = "200" ]; then
+    ready="yes"
+    echo "preview-boot-check: serving after ${i}s"
+    break
+  fi
+  sleep 1
+done
+[ -n "$ready" ] || fail "server did not become healthy within 120s on the slim env set"
+
+echo "preview-boot-check: asserting the X-Preview-Token gate"
+assert_status 200 "/healthcheck is exempt with no token" "${BASE}/healthcheck"
+assert_status 200 "/healthcheck?container=true is exempt (query string ignored)" \
+  "${BASE}/healthcheck?container=true"
+assert_status 401 "/healthcheck/details is NOT exempt" "${BASE}/healthcheck/details"
+assert_status 401 "/api/v2/agent-templates without a token" \
+  "${BASE}/api/v2/agent-templates"
+assert_status 401 "/api/v2/agent-templates with a wrong token" \
+  -H "X-Preview-Token: wrong-token-that-is-also-32-characters-long" \
+  "${BASE}/api/v2/agent-templates"
+assert_status 200 "/api/v2/agent-templates with the right token" \
+  -H "X-Preview-Token: ${PREVIEW_TOKEN}" \
+  "${BASE}/api/v2/agent-templates"
+
+echo "preview-boot-check: asserting the preview seed ran"
+marker="$(psql "$DATABASE_URL" -tAc \
+  "SELECT value FROM \"RuntimeConfig\" WHERE key = 'preview_seeded'")"
+[ -n "$marker" ] || fail "the preview seed did not write the 'preview_seeded' marker"
+echo "  ok: preview_seeded = ${marker}"
+
+attest="$(psql "$DATABASE_URL" -tAc \
+  "SELECT value FROM \"RuntimeConfig\" WHERE key = 'app_attest_enabled'")"
+[ "$attest" = "false" ] || fail "app_attest_enabled is '${attest}', expected 'false'"
+echo "  ok: app_attest_enabled = false"
+
+invites="$(psql "$DATABASE_URL" -tAc \
+  "SELECT count(*) FROM \"InviteCode\" WHERE code IN ('PREVIEW1','PREVIEW2','PREVIEW3')")"
+[ "$invites" = "3" ] || fail "expected 3 seeded invite codes, found '${invites}'"
+echo "  ok: 3 seeded invite codes"
+
+credits="$(psql "$DATABASE_URL" -tAc \
+  "SELECT balance FROM \"UserCredits\" WHERE \"accountId\" = '11111111-1111-4111-8111-111111111111'")"
+[ "$credits" = "100000" ] || fail "expected the seeded account to hold 100000 credits, found '${credits}'"
+echo "  ok: seeded account has 100000 credits"
+
+echo "preview-boot-check: PASS"

--- a/scripts/preview-boot-check.sh
+++ b/scripts/preview-boot-check.sh
@@ -80,6 +80,9 @@ export LOG_FORMAT=json
 # endpoint" is exactly the behaviour worth proving. Expect noisy export errors.
 
 SERVER_PID=""
+# Captured before the seed runs. The seed forces app_attest_enabled to "false",
+# so a plain delete on exit would discard a value the database already had.
+PRIOR_ATTEST=""
 
 cleanup() {
   local status=$?
@@ -96,16 +99,31 @@ DELETE FROM "Account" WHERE id = '11111111-1111-4111-8111-111111111111';
 DELETE FROM "InviteCode" WHERE code IN ('PREVIEW1','PREVIEW2','PREVIEW3');
 DELETE FROM "RuntimeConfig" WHERE key IN ('preview_seeded','app_attest_enabled');
 SQL
+  # Put back a value the database already had, rather than leaving the key
+  # absent. Absent is fail-SAFE (getRuntimeConfig defaults it to "true", so App
+  # Check stays on), but it is still not the state we were handed.
+  if [ -n "$PRIOR_ATTEST" ]; then
+    psql "$DATABASE_URL" -q -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<SQL || true
+INSERT INTO "RuntimeConfig" (key, value, "updatedAt")
+VALUES ('app_attest_enabled', '${PRIOR_ATTEST}', now())
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+SQL
+  fi
+
   # Verify rather than trust: a swallowed psql failure that leaves
   # app_attest_enabled=false behind would silently disable App Check for every
   # later run against this database, and a green job would hide it. Only ever
   # escalates — an already-failing run keeps its original status.
-  local leftover
-  leftover="$(psql "$DATABASE_URL" -tAc \
-    "SELECT count(*) FROM \"RuntimeConfig\" WHERE key IN ('preview_seeded','app_attest_enabled')" \
-    2>/dev/null)" || leftover="unknown"
-  if [ "$leftover" != "0" ]; then
-    echo "::error::preview-boot-check: cleanup failed to remove the seeded rows (leftover=${leftover}); app_attest_enabled may still be 'false' in this database" >&2
+  local marker_left attest_now expected_attest
+  marker_left="$(psql "$DATABASE_URL" -tAc \
+    "SELECT count(*) FROM \"RuntimeConfig\" WHERE key = 'preview_seeded'" \
+    2>/dev/null)" || marker_left="unknown"
+  attest_now="$(psql "$DATABASE_URL" -tAc \
+    "SELECT coalesce((SELECT value FROM \"RuntimeConfig\" WHERE key = 'app_attest_enabled'), '<absent>')" \
+    2>/dev/null)" || attest_now="unknown"
+  expected_attest="${PRIOR_ATTEST:-<absent>}"
+  if [ "$marker_left" != "0" ] || [ "$attest_now" != "$expected_attest" ]; then
+    echo "::error::preview-boot-check: cleanup did not restore the database (preview_seeded rows left=${marker_left}, app_attest_enabled='${attest_now}', expected '${expected_attest}')" >&2
     if [ "$status" -eq 0 ]; then
       status=1
     fi
@@ -130,6 +148,12 @@ assert_status() {
   fi
   echo "  ok: ${desc} -> ${actual}"
 }
+
+PRIOR_ATTEST="$(psql "$DATABASE_URL" -tAc \
+  "SELECT value FROM \"RuntimeConfig\" WHERE key = 'app_attest_enabled'" 2>/dev/null || true)"
+if [ -n "$PRIOR_ATTEST" ]; then
+  echo "preview-boot-check: app_attest_enabled was '${PRIOR_ATTEST}'; will restore it on exit"
+fi
 
 echo "preview-boot-check: starting dev/entrypoint.sh (APP_DIR=$APP_DIR PORT=$PORT)"
 ./dev/entrypoint.sh &

--- a/src/db-wait.ts
+++ b/src/db-wait.ts
@@ -1,0 +1,135 @@
+/**
+ * Bounded database connect-wait, run by dev/entrypoint.sh BEFORE
+ * `prisma migrate deploy`.
+ *
+ * Why this exists: CON-825 preview bundles sit on an Aurora Serverless v2
+ * cluster with `min_capacity 0`. Resuming from 0 ACU takes ~15s, and 30s+ after
+ * a long pause. `prisma migrate deploy` is fail-fast, so the first task of the
+ * day would die on P1001 straight into the ECS circuit breaker — which, on a
+ * first deploy, has no prior revision to roll back to and simply stalls.
+ *
+ * Why a probe rather than retrying `migrate deploy` itself: `migrate deploy`
+ * exits 1 both for "database unreachable" (P1001) and for "applied migrations
+ * are not in this branch" (P3009, the rebased-force-push case). The CON-825
+ * deploy workflow keys its auto-reset path off the second. Retrying the migrate
+ * command merges the two into a single timeout. Separating the probe keeps
+ * "asleep" and "migrations are wrong" distinguishable, and keeps the migration
+ * step fail-fast.
+ *
+ * NOT gated on PREVIEW. A connect-wait before migrate is a strict improvement
+ * everywhere (a prod task started during an RDS failover crash-loops today), it
+ * costs one `SELECT 1` when the database is already up, and running it in every
+ * environment is the only way it is exercised outside the environment where its
+ * failure is most expensive.
+ */
+import { argv } from "node:process";
+import { pathToFileURL } from "node:url";
+import { PrismaClient } from "@prisma/client";
+
+export const DEFAULT_DB_CONNECT_BUDGET_SECONDS = 90;
+export const DB_CONNECT_RETRY_DELAY_MS = 2_000;
+/** Upper bound on the budget: past this the wait stops being fail-fast at all. */
+export const MAX_DB_CONNECT_BUDGET_SECONDS = 3_600;
+
+export type WaitDeps = {
+  /** Resolves when the database answered; rejects otherwise. */
+  probe: () => Promise<void>;
+  /** Monotonic-ish milliseconds. Injected so tests use a virtual clock. */
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  log: (message: string) => void;
+};
+
+/**
+ * Probe until success or until the budget runs out.
+ * Resolves with the attempt number that succeeded; rejects with the budget
+ * exceeded message, quoting the last underlying error.
+ */
+export async function waitForDatabase(
+  budgetSeconds: number,
+  deps: WaitDeps,
+): Promise<number> {
+  const deadline = deps.now() + budgetSeconds * 1000;
+  let attempt = 0;
+
+  for (;;) {
+    attempt += 1;
+    try {
+      await deps.probe();
+      deps.log(`[db-wait] database reachable after ${attempt} attempt(s)`);
+      return attempt;
+    } catch (error) {
+      // Deliberately not String(error): `error` is `unknown`, and
+      // @typescript-eslint/no-base-to-string flags stringifying it. The repo's
+      // existing handlers use the same instanceof-or-literal shape.
+      const detail = error instanceof Error ? error.message : "unknown error";
+      // Only sleep if the whole delay fits inside the remaining budget —
+      // otherwise fail now rather than overshoot the deadline.
+      if (deps.now() + DB_CONNECT_RETRY_DELAY_MS >= deadline) {
+        throw new Error(
+          `[db-wait] database not reachable within ${budgetSeconds}s ` +
+            `(${attempt} attempt(s)); last error: ${detail}`,
+        );
+      }
+      deps.log(
+        `[db-wait] attempt ${attempt} failed (${detail}); ` +
+          `retrying in ${DB_CONNECT_RETRY_DELAY_MS}ms`,
+      );
+      await deps.sleep(DB_CONNECT_RETRY_DELAY_MS);
+    }
+  }
+}
+
+/** Positive integer seconds from DB_CONNECT_BUDGET_SECONDS, else the default. */
+export function parseBudgetSeconds(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_DB_CONNECT_BUDGET_SECONDS;
+  }
+  const trimmed = raw.trim();
+  // Digits only: Number.parseInt("10seconds") is 10, which would silently
+  // install a budget the operator never asked for.
+  if (!/^\d+$/.test(trimmed)) {
+    return DEFAULT_DB_CONNECT_BUDGET_SECONDS;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_DB_CONNECT_BUDGET_SECONDS;
+  }
+  // Clamp rather than reject: a fat-fingered extra digit must not turn the
+  // bounded wait into an unbounded one, which is the exact ECS-circuit-breaker
+  // stall this module exists to prevent.
+  return Math.min(parsed, MAX_DB_CONNECT_BUDGET_SECONDS);
+}
+
+async function main(): Promise<void> {
+  const budgetSeconds = parseBudgetSeconds(
+    process.env.DB_CONNECT_BUDGET_SECONDS,
+  );
+  // A dedicated client: the app has not started, and this one is disconnected
+  // before the server process opens its own pool.
+  const prisma = new PrismaClient();
+  try {
+    await waitForDatabase(budgetSeconds, {
+      probe: async () => {
+        await prisma.$queryRaw`SELECT 1`;
+      },
+      now: () => Date.now(),
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      log: (message: string) => {
+        console.log(message);
+      },
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+const entryPoint = argv[1];
+if (entryPoint && import.meta.url === pathToFileURL(entryPoint).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : "unknown error");
+    process.exit(1);
+  }
+}

--- a/src/db-wait.ts
+++ b/src/db-wait.ts
@@ -30,6 +30,22 @@ export const DEFAULT_DB_CONNECT_BUDGET_SECONDS = 90;
 export const DB_CONNECT_RETRY_DELAY_MS = 2_000;
 /** Upper bound on the budget: past this the wait stops being fail-fast at all. */
 export const MAX_DB_CONNECT_BUDGET_SECONDS = 3_600;
+/**
+ * Per-attempt cap. The budget alone does not bound a single probe: the loop can
+ * only check the deadline once `probe()` settles, and a probe's own ceiling is
+ * Prisma's `connect_timeout` (5s by default, but settable to anything in
+ * DATABASE_URL). Without this cap one connection attempt could outlive the
+ * whole budget and reintroduce the stall this module exists to prevent.
+ */
+export const DB_CONNECT_PROBE_TIMEOUT_MS = 10_000;
+/**
+ * Capping the probe alone is not enough: `$disconnect()` waits for the
+ * connection attempt still in flight, so an unreachable host with a long
+ * `connect_timeout` would stall the entrypoint inside the cleanup instead of
+ * inside the probe. Measured: 2m with `connect_timeout=120`, despite a 3s
+ * budget. The process is exiting either way, so a clean close is not worth it.
+ */
+export const DB_DISCONNECT_TIMEOUT_MS = 2_000;
 
 export type WaitDeps = {
   /** Resolves when the database answered; rejects otherwise. */
@@ -80,6 +96,37 @@ export async function waitForDatabase(
   }
 }
 
+/**
+ * Reject if `promise` has not settled within `ms`.
+ * The loser's rejection is deliberately absorbed: once the timer has won the
+ * race, a late `$queryRaw` failure would otherwise surface as an unhandled
+ * rejection, which is fatal on Node 24.
+ */
+export async function withTimeout<T>(
+  promise: PromiseLike<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const guarded = Promise.resolve(promise);
+  guarded.catch(() => undefined);
+  try {
+    return await Promise.race([
+      guarded,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${ms}ms`));
+        }, ms);
+      }),
+    ]);
+  } finally {
+    // Also stops the timer holding the event loop open on the happy path.
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 /** Positive integer seconds from DB_CONNECT_BUDGET_SECONDS, else the default. */
 export function parseBudgetSeconds(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") {
@@ -111,7 +158,11 @@ async function main(): Promise<void> {
   try {
     await waitForDatabase(budgetSeconds, {
       probe: async () => {
-        await prisma.$queryRaw`SELECT 1`;
+        await withTimeout(
+          prisma.$queryRaw`SELECT 1`,
+          DB_CONNECT_PROBE_TIMEOUT_MS,
+          "[db-wait] probe",
+        );
       },
       now: () => Date.now(),
       sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
@@ -120,7 +171,11 @@ async function main(): Promise<void> {
       },
     });
   } finally {
-    await prisma.$disconnect();
+    await withTimeout(
+      prisma.$disconnect(),
+      DB_DISCONNECT_TIMEOUT_MS,
+      "[db-wait] disconnect",
+    ).catch(() => undefined);
   }
 }
 

--- a/src/db-wait.ts
+++ b/src/db-wait.ts
@@ -48,8 +48,12 @@ export const DB_CONNECT_PROBE_TIMEOUT_MS = 10_000;
 export const DB_DISCONNECT_TIMEOUT_MS = 2_000;
 
 export type WaitDeps = {
-  /** Resolves when the database answered; rejects otherwise. */
-  probe: () => Promise<void>;
+  /**
+   * Resolves when the database answered; rejects otherwise.
+   * `timeoutMs` is the caller's ceiling for THIS attempt — already clamped to
+   * whatever is left of the budget — so a probe can never outlive the deadline.
+   */
+  probe: (timeoutMs: number) => Promise<void>;
   /** Monotonic-ish milliseconds. Injected so tests use a virtual clock. */
   now: () => number;
   sleep: (ms: number) => Promise<void>;
@@ -71,7 +75,13 @@ export async function waitForDatabase(
   for (;;) {
     attempt += 1;
     try {
-      await deps.probe();
+      // Clamped to what is left of the budget, so the deadline holds even
+      // though the loop can only re-check it once the probe settles.
+      const attemptTimeoutMs = Math.max(
+        1,
+        Math.min(DB_CONNECT_PROBE_TIMEOUT_MS, deadline - deps.now()),
+      );
+      await deps.probe(attemptTimeoutMs);
       deps.log(`[db-wait] database reachable after ${attempt} attempt(s)`);
       return attempt;
     } catch (error) {
@@ -157,10 +167,10 @@ async function main(): Promise<void> {
   const prisma = new PrismaClient();
   try {
     await waitForDatabase(budgetSeconds, {
-      probe: async () => {
+      probe: async (timeoutMs: number) => {
         await withTimeout(
           prisma.$queryRaw`SELECT 1`,
-          DB_CONNECT_PROBE_TIMEOUT_MS,
+          timeoutMs,
           "[db-wait] probe",
         );
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { errorHandlerMiddleware } from "./middleware/errorHandler";
 import { globalJsonMiddleware } from "./middleware/json";
 import { noRouteMiddleware } from "./middleware/noRoute";
 import { pinoMiddleware } from "./middleware/pino";
+import { previewTokenMiddleware } from "./middleware/previewToken";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
 import healthcheckRouter from "./routes/healthcheck";
 import { wellKnownRouter } from "./routes/well-known";
@@ -59,6 +60,16 @@ app.use("/api/v2/telemetry", bodySizeGuard(TELEMETRY_MAX_BODY_BYTES));
 app.use(globalJsonMiddleware);
 app.use(cookieParser()); // Parse cookies (required for SIWE nonce flow)
 app.use(pinoMiddleware);
+
+// Preview access gate (CON-825). Inert unless PREVIEW=1, so dev/prod are
+// unaffected by the same image. Mounted here for two reasons: it must come
+// AFTER pinoMiddleware because it logs through `req.log`, and BEFORE
+// rateLimitMiddleware because it is a fixed-cost hash compare with no I/O —
+// running it first keeps unauthenticated internet noise out of the rate
+// limiter's keyed store, off the router, and away from every handler. Global
+// rather than per-route so a newly added unauthenticated endpoint cannot
+// escape the gate; the existing per-route auth still runs after it.
+app.use(previewTokenMiddleware);
 
 // Rate limiting should be before routes but after logging
 app.use(rateLimitMiddleware);

--- a/src/middleware/previewToken.ts
+++ b/src/middleware/previewToken.ts
@@ -1,0 +1,105 @@
+import { createHash, timingSafeEqual } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+import { maskKeyPrefix } from "@/utils/mask";
+
+/**
+ * Per-PR preview access gate (CON-825).
+ *
+ * Preview bundles are publicly resolvable (`https://pr-<N>.dev.convos.xyz`),
+ * so when `PREVIEW=1` every request must present the bundle's token in
+ * `X-Preview-Token`. The token is derived per PR as HMAC(master, pr_number) by
+ * CI and injected as `PREVIEW_TOKEN`; deriving it is not this module's job.
+ *
+ * `/healthcheck` is the only exemption, and it is exact — the ALB target-group
+ * probe and the ECS container health check both hit `/healthcheck` with no
+ * headers (the container probe appends `?container=true`, which `req.path`
+ * excludes). The `/healthcheck/details` subtree is NOT exempt: it reports
+ * database and notification-service state.
+ *
+ * Machine callers need the token too. The assistants worker reaches the backend
+ * through the convos.internal proxy, which injects `X-Agent-API-Key`; the same
+ * pipeline deploys that worker per PR, so it gets `PREVIEW_TOKEN` and attaches
+ * it. Exempting the agent-key paths instead would punch the hole in exactly the
+ * most powerful routes.
+ *
+ * Env is read per request rather than cached through `src/config.ts` on
+ * purpose: `config.ts` throws at import for everything it validates, and each
+ * constant added there widens the boot contract. This follows the existing
+ * `bearerTokenAuth` / `lifecycleTestAuth` shape; the constant-time comparison
+ * follows `agentAuth`.
+ */
+
+export const PREVIEW_TOKEN_HEADER = "X-Preview-Token";
+
+/** Exact paths that bypass the gate. Prefix matching is deliberately absent. */
+export const PREVIEW_EXEMPT_PATHS: ReadonlySet<string> = new Set([
+  "/healthcheck",
+]);
+
+export const MIN_PREVIEW_TOKEN_LENGTH = 32;
+
+/** True only for the exact string "1" — nothing else enables the gate. */
+export const isPreviewMode = (): boolean => process.env.PREVIEW === "1";
+
+function constantTimeSecretCompare(
+  provided: string,
+  expected: string,
+): boolean {
+  // Compare fixed-length SHA-256 digests so the comparison neither leaks the
+  // secret's length nor throws on a length mismatch. Same helper shape as
+  // src/middleware/agentAuth.ts.
+  const providedDigest = createHash("sha256").update(provided, "utf8").digest();
+  const expectedDigest = createHash("sha256").update(expected, "utf8").digest();
+  return timingSafeEqual(providedDigest, expectedDigest);
+}
+
+export const previewTokenMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  if (!isPreviewMode()) {
+    next();
+    return;
+  }
+
+  // `req.path` is the pathname only — query strings are excluded, and the
+  // middleware is mounted at the root so `req.baseUrl` is empty.
+  if (PREVIEW_EXEMPT_PATHS.has(req.path)) {
+    next();
+    return;
+  }
+
+  const expectedToken = process.env.PREVIEW_TOKEN?.trim() ?? "";
+  if (expectedToken.length < MIN_PREVIEW_TOKEN_LENGTH) {
+    // Fail closed: a preview that is supposed to be gated must not serve
+    // traffic just because its token failed to arrive.
+    req.log.error(
+      {
+        minLength: MIN_PREVIEW_TOKEN_LENGTH,
+        actualLength: expectedToken.length,
+      },
+      "preview_token.not_configured",
+    );
+    res.status(503).json({ error: "Preview token not configured" });
+    return;
+  }
+
+  const providedToken = req.header(PREVIEW_TOKEN_HEADER)?.trim() ?? "";
+  if (!providedToken) {
+    req.log.warn({ reason: "missing" }, "preview_token.unauthorized");
+    res.status(401).json({ error: "Invalid or missing preview token" });
+    return;
+  }
+
+  if (!constantTimeSecretCompare(providedToken, expectedToken)) {
+    req.log.warn(
+      { reason: "mismatch", providedPrefix: maskKeyPrefix(providedToken) },
+      "preview_token.unauthorized",
+    );
+    res.status(401).json({ error: "Invalid or missing preview token" });
+    return;
+  }
+
+  next();
+};

--- a/tests/db-wait.test.ts
+++ b/tests/db-wait.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_DB_CONNECT_BUDGET_SECONDS,
   parseBudgetSeconds,
   waitForDatabase,
+  withTimeout,
   type WaitDeps,
 } from "@/db-wait";
 
@@ -69,6 +70,39 @@ describe("waitForDatabase", () => {
     await expect(waitForDatabase(1, deps)).rejects.toThrow(/not reachable/);
     // Budget is shorter than one retry delay, so it must fail immediately.
     expect(clockAt()).toBe(0);
+  });
+});
+
+describe("withTimeout", () => {
+  test("passes a value through when the promise settles in time", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), 1_000, "p")).resolves.toBe(
+      "ok",
+    );
+  });
+
+  test("propagates the promise's own rejection", async () => {
+    await expect(
+      withTimeout(Promise.reject(new Error("boom")), 1_000, "p"),
+    ).rejects.toThrow(/boom/);
+  });
+
+  test("rejects when the promise outlives the cap", async () => {
+    // The real hazard: a connection attempt that hangs far past the budget.
+    const never = new Promise<string>(() => undefined);
+    await expect(withTimeout(never, 10, "[db-wait] probe")).rejects.toThrow(
+      /\[db-wait\] probe timed out after 10ms/,
+    );
+  });
+
+  test("absorbs a late rejection so Node does not die on it", async () => {
+    const late = new Promise<string>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error("late failure"));
+      }, 30);
+    });
+    await expect(withTimeout(late, 5, "p")).rejects.toThrow(/timed out/);
+    // Give the loser time to reject; an unhandled rejection would fail the run.
+    await new Promise((resolve) => setTimeout(resolve, 60));
   });
 });
 

--- a/tests/db-wait.test.ts
+++ b/tests/db-wait.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+import {
+  DB_CONNECT_RETRY_DELAY_MS,
+  DEFAULT_DB_CONNECT_BUDGET_SECONDS,
+  MAX_DB_CONNECT_BUDGET_SECONDS,
+  parseBudgetSeconds,
+  waitForDatabase,
+  type WaitDeps,
+} from "@/db-wait";
+
+/** Deterministic fake clock: `sleep` advances virtual time, nothing blocks. */
+const makeDeps = (probe: () => Promise<void>) => {
+  let clock = 0;
+  const logs: string[] = [];
+  const deps: WaitDeps = {
+    probe,
+    now: () => clock,
+    sleep: (ms: number) => {
+      clock += ms;
+      return Promise.resolve();
+    },
+    log: (message: string) => {
+      logs.push(message);
+    },
+  };
+  return { deps, logs, clockAt: () => clock };
+};
+
+describe("waitForDatabase", () => {
+  test("returns after one attempt when the database is already up", async () => {
+    const { deps, clockAt } = makeDeps(() => Promise.resolve());
+
+    await expect(waitForDatabase(90, deps)).resolves.toBe(1);
+    expect(clockAt()).toBe(0);
+  });
+
+  test("retries until the probe succeeds", async () => {
+    let calls = 0;
+    const { deps, clockAt } = makeDeps(() => {
+      calls += 1;
+      return calls < 4
+        ? Promise.reject(new Error("P1001: cannot reach database server"))
+        : Promise.resolve();
+    });
+
+    await expect(waitForDatabase(90, deps)).resolves.toBe(4);
+    expect(calls).toBe(4);
+    expect(clockAt()).toBe(3 * DB_CONNECT_RETRY_DELAY_MS);
+  });
+
+  test("throws once the budget is exhausted, quoting the last error", async () => {
+    const { deps, clockAt } = makeDeps(() =>
+      Promise.reject(new Error("P1001: cannot reach database server")),
+    );
+
+    await expect(waitForDatabase(10, deps)).rejects.toThrow(
+      /not reachable within 10s/,
+    );
+    await expect(waitForDatabase(10, deps)).rejects.toThrow(
+      /P1001: cannot reach database server/,
+    );
+    // 10s budget at a 2s retry delay: it must not run past the deadline.
+    expect(clockAt()).toBeLessThanOrEqual(20_000);
+  });
+
+  test("never sleeps past the deadline", async () => {
+    const { deps, clockAt } = makeDeps(() => Promise.reject(new Error("down")));
+
+    await expect(waitForDatabase(1, deps)).rejects.toThrow(/not reachable/);
+    // Budget is shorter than one retry delay, so it must fail immediately.
+    expect(clockAt()).toBe(0);
+  });
+});
+
+describe("parseBudgetSeconds", () => {
+  test("defaults when unset or blank", () => {
+    expect(parseBudgetSeconds(undefined)).toBe(
+      DEFAULT_DB_CONNECT_BUDGET_SECONDS,
+    );
+    expect(parseBudgetSeconds("")).toBe(DEFAULT_DB_CONNECT_BUDGET_SECONDS);
+    expect(parseBudgetSeconds("   ")).toBe(DEFAULT_DB_CONNECT_BUDGET_SECONDS);
+  });
+
+  test("defaults on non-positive or non-numeric values", () => {
+    expect(parseBudgetSeconds("0")).toBe(DEFAULT_DB_CONNECT_BUDGET_SECONDS);
+    expect(parseBudgetSeconds("-5")).toBe(DEFAULT_DB_CONNECT_BUDGET_SECONDS);
+    expect(parseBudgetSeconds("banana")).toBe(
+      DEFAULT_DB_CONNECT_BUDGET_SECONDS,
+    );
+  });
+
+  test("accepts a positive integer", () => {
+    expect(parseBudgetSeconds("30")).toBe(30);
+    expect(parseBudgetSeconds(" 240 ")).toBe(240);
+  });
+
+  test("defaults on a numeric prefix rather than silently truncating", () => {
+    // Number.parseInt("10seconds") is 10 — a budget the operator never asked
+    // for, and shorter than an Aurora resume takes.
+    expect(parseBudgetSeconds("10seconds")).toBe(
+      DEFAULT_DB_CONNECT_BUDGET_SECONDS,
+    );
+    expect(parseBudgetSeconds("90s")).toBe(DEFAULT_DB_CONNECT_BUDGET_SECONDS);
+    expect(parseBudgetSeconds("1e3")).toBe(DEFAULT_DB_CONNECT_BUDGET_SECONDS);
+    expect(parseBudgetSeconds("12.5")).toBe(DEFAULT_DB_CONNECT_BUDGET_SECONDS);
+  });
+
+  test("clamps an absurd budget so the wait stays bounded", () => {
+    expect(parseBudgetSeconds("999999999999999")).toBe(
+      MAX_DB_CONNECT_BUDGET_SECONDS,
+    );
+    expect(parseBudgetSeconds(String(MAX_DB_CONNECT_BUDGET_SECONDS))).toBe(
+      MAX_DB_CONNECT_BUDGET_SECONDS,
+    );
+  });
+});

--- a/tests/db-wait.test.ts
+++ b/tests/db-wait.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  DB_CONNECT_PROBE_TIMEOUT_MS,
   DB_CONNECT_RETRY_DELAY_MS,
   DEFAULT_DB_CONNECT_BUDGET_SECONDS,
   MAX_DB_CONNECT_BUDGET_SECONDS,
@@ -70,6 +71,47 @@ describe("waitForDatabase", () => {
     await expect(waitForDatabase(1, deps)).rejects.toThrow(/not reachable/);
     // Budget is shorter than one retry delay, so it must fail immediately.
     expect(clockAt()).toBe(0);
+  });
+});
+
+describe("waitForDatabase per-attempt timeout", () => {
+  test("caps each probe at the smaller of the probe cap and the remaining budget", async () => {
+    const seen: number[] = [];
+    let clock = 0;
+    const deps: WaitDeps = {
+      probe: (timeoutMs: number) => {
+        seen.push(timeoutMs);
+        return Promise.reject(new Error("down"));
+      },
+      now: () => clock,
+      sleep: (ms: number) => {
+        clock += ms;
+        return Promise.resolve();
+      },
+      log: () => undefined,
+    };
+
+    // 5s budget: the first attempt must not be handed the full 10s cap, or the
+    // budget stops being a ceiling at all.
+    await expect(waitForDatabase(5, deps)).rejects.toThrow(/not reachable/);
+    expect(seen[0]).toBe(5_000);
+    expect(Math.max(...seen)).toBeLessThanOrEqual(5_000);
+  });
+
+  test("uses the probe cap when the budget is the larger of the two", async () => {
+    const seen: number[] = [];
+    const deps: WaitDeps = {
+      probe: (timeoutMs: number) => {
+        seen.push(timeoutMs);
+        return Promise.resolve();
+      },
+      now: () => 0,
+      sleep: () => Promise.resolve(),
+      log: () => undefined,
+    };
+
+    await expect(waitForDatabase(90, deps)).resolves.toBe(1);
+    expect(seen[0]).toBe(DB_CONNECT_PROBE_TIMEOUT_MS);
   });
 });
 

--- a/tests/preview-seed.test.ts
+++ b/tests/preview-seed.test.ts
@@ -1,0 +1,158 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { prisma } from "@/utils/prisma";
+import {
+  PREVIEW_SEED_ACCOUNT_ID,
+  PREVIEW_SEED_ATTEST_KEY,
+  PREVIEW_SEED_CREDITS,
+  PREVIEW_SEED_INVITE_CODES,
+  PREVIEW_SEED_MARKER_KEY,
+  PREVIEW_SEED_TEMPLATE_ID,
+  seedPreview,
+} from "../prisma/seed";
+
+// The seed writes to the shared CI database. Every row it creates has a fixed
+// id / key, so cleanup is exact and cannot touch another test's fixtures.
+// `app_attest_enabled` in particular MUST be removed again: leaving it at
+// "false" would silently disable App Check for any later test that reads it.
+const cleanup = async () => {
+  await prisma.agentTemplate.deleteMany({
+    where: { id: PREVIEW_SEED_TEMPLATE_ID },
+  });
+  await prisma.userCredits.deleteMany({
+    where: { accountId: PREVIEW_SEED_ACCOUNT_ID },
+  });
+  await prisma.account.deleteMany({ where: { id: PREVIEW_SEED_ACCOUNT_ID } });
+  await prisma.inviteCode.deleteMany({
+    where: { code: { in: [...PREVIEW_SEED_INVITE_CODES] } },
+  });
+  await prisma.runtimeConfig.deleteMany({
+    where: { key: { in: [PREVIEW_SEED_MARKER_KEY, PREVIEW_SEED_ATTEST_KEY] } },
+  });
+};
+
+describe("seedPreview", () => {
+  const originalPreview = process.env.PREVIEW;
+
+  beforeAll(cleanup);
+
+  beforeEach(cleanup);
+
+  afterAll(async () => {
+    await cleanup();
+    if (originalPreview === undefined) {
+      delete process.env.PREVIEW;
+    } else {
+      process.env.PREVIEW = originalPreview;
+    }
+  });
+
+  test('writes nothing when PREVIEW is not "1"', async () => {
+    delete process.env.PREVIEW;
+
+    await expect(seedPreview(prisma)).resolves.toBe("skipped-not-preview");
+
+    const marker = await prisma.runtimeConfig.findUnique({
+      where: { key: PREVIEW_SEED_MARKER_KEY },
+    });
+    expect(marker).toBeNull();
+
+    process.env.PREVIEW = "0";
+    await expect(seedPreview(prisma)).resolves.toBe("skipped-not-preview");
+    expect(
+      await prisma.account.findUnique({
+        where: { id: PREVIEW_SEED_ACCOUNT_ID },
+      }),
+    ).toBeNull();
+  });
+
+  test("seeds the preview fixtures on first run", async () => {
+    process.env.PREVIEW = "1";
+
+    await expect(seedPreview(prisma)).resolves.toBe("seeded");
+
+    const marker = await prisma.runtimeConfig.findUnique({
+      where: { key: PREVIEW_SEED_MARKER_KEY },
+    });
+    expect(marker).not.toBeNull();
+
+    const attest = await prisma.runtimeConfig.findUnique({
+      where: { key: PREVIEW_SEED_ATTEST_KEY },
+    });
+    expect(attest?.value).toBe("false");
+
+    const codes = await prisma.inviteCode.findMany({
+      where: { code: { in: [...PREVIEW_SEED_INVITE_CODES] } },
+    });
+    expect(codes).toHaveLength(PREVIEW_SEED_INVITE_CODES.length);
+
+    const credits = await prisma.userCredits.findUnique({
+      where: { accountId: PREVIEW_SEED_ACCOUNT_ID },
+    });
+    expect(credits?.balance).toBe(PREVIEW_SEED_CREDITS);
+
+    const template = await prisma.agentTemplate.findUnique({
+      where: { id: PREVIEW_SEED_TEMPLATE_ID },
+    });
+    expect(template?.ownerAccountId).toBe(PREVIEW_SEED_ACCOUNT_ID);
+    expect(template?.status).toBe("published");
+  });
+
+  test("is idempotent — a second run changes nothing", async () => {
+    process.env.PREVIEW = "1";
+    await expect(seedPreview(prisma)).resolves.toBe("seeded");
+
+    // Mutate a seeded row so a re-seed would be visible.
+    await prisma.runtimeConfig.update({
+      where: { key: PREVIEW_SEED_ATTEST_KEY },
+      data: { value: "true" },
+    });
+
+    await expect(seedPreview(prisma)).resolves.toBe("already-seeded");
+
+    const attest = await prisma.runtimeConfig.findUnique({
+      where: { key: PREVIEW_SEED_ATTEST_KEY },
+    });
+    expect(attest?.value).toBe("true");
+
+    const codes = await prisma.inviteCode.findMany({
+      where: { code: { in: [...PREVIEW_SEED_INVITE_CODES] } },
+    });
+    expect(codes).toHaveLength(PREVIEW_SEED_INVITE_CODES.length);
+
+    const accounts = await prisma.account.findMany({
+      where: { id: PREVIEW_SEED_ACCOUNT_ID },
+    });
+    expect(accounts).toHaveLength(1);
+  });
+
+  test("re-seeds when the marker is gone but the fixtures remain", async () => {
+    process.env.PREVIEW = "1";
+    await expect(seedPreview(prisma)).resolves.toBe("seeded");
+
+    // A partial cleanup: the marker goes, the fixed-id rows stay. With plain
+    // `create` this raises P2002 and — since the entrypoint runs `db seed`
+    // under `set -e` — wedges every subsequent container boot.
+    await prisma.runtimeConfig.delete({
+      where: { key: PREVIEW_SEED_MARKER_KEY },
+    });
+
+    await expect(seedPreview(prisma)).resolves.toBe("seeded");
+
+    const accounts = await prisma.account.findMany({
+      where: { id: PREVIEW_SEED_ACCOUNT_ID },
+    });
+    expect(accounts).toHaveLength(1);
+
+    const credits = await prisma.userCredits.findUnique({
+      where: { accountId: PREVIEW_SEED_ACCOUNT_ID },
+    });
+    expect(credits?.balance).toBe(PREVIEW_SEED_CREDITS);
+  });
+});

--- a/tests/preview-token.test.ts
+++ b/tests/preview-token.test.ts
@@ -1,0 +1,176 @@
+import type { Server } from "node:http";
+import express from "express";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import {
+  PREVIEW_TOKEN_HEADER,
+  previewTokenMiddleware,
+} from "@/middleware/previewToken";
+
+const VALID_TOKEN = "preview-token-that-is-at-least-32-characters-long";
+
+// Mirrors the real mount order in src/index.ts: pino first (the gate logs
+// through req.log), then the gate, then everything else.
+const app = express();
+app.use(pinoMiddleware);
+app.use(previewTokenMiddleware);
+app.use(jsonMiddleware);
+app.get("/healthcheck", (_req, res) => {
+  res.status(200).send("OK");
+});
+app.get("/healthcheck/details", (_req, res) => {
+  res.status(200).json({ status: "OK" });
+});
+app.get("/api/v2/anything", (_req, res) => {
+  res.status(200).json({ ok: true });
+});
+
+describe("previewTokenMiddleware", () => {
+  let server: Server;
+  const baseURL = "http://localhost:4096";
+  const originalPreview = process.env.PREVIEW;
+  const originalToken = process.env.PREVIEW_TOKEN;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(4096, () => {
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (originalPreview === undefined) {
+      delete process.env.PREVIEW;
+    } else {
+      process.env.PREVIEW = originalPreview;
+    }
+    if (originalToken === undefined) {
+      delete process.env.PREVIEW_TOKEN;
+    } else {
+      process.env.PREVIEW_TOKEN = originalToken;
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  beforeEach(() => {
+    process.env.PREVIEW = "1";
+    process.env.PREVIEW_TOKEN = VALID_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.PREVIEW;
+    delete process.env.PREVIEW_TOKEN;
+  });
+
+  const get = (path: string, headers?: Record<string, string>) =>
+    fetch(`${baseURL}${path}`, { method: "GET", headers: { ...headers } });
+
+  // --- inert outside preview mode ---
+
+  test("passes everything through when PREVIEW is unset", async () => {
+    delete process.env.PREVIEW;
+    const res = await get("/api/v2/anything");
+    expect(res.status).toBe(200);
+  });
+
+  test('passes everything through when PREVIEW is not exactly "1"', async () => {
+    process.env.PREVIEW = "true";
+    const res = await get("/api/v2/anything");
+    expect(res.status).toBe(200);
+  });
+
+  // --- the gate ---
+
+  test("rejects a request with no token", async () => {
+    const res = await get("/api/v2/anything");
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: "Invalid or missing preview token",
+    });
+  });
+
+  test("rejects a request with the wrong token", async () => {
+    const res = await get("/api/v2/anything", {
+      [PREVIEW_TOKEN_HEADER]: "wrong-token-that-is-also-32-characters-long",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("accepts the correct token", async () => {
+    const res = await get("/api/v2/anything", {
+      [PREVIEW_TOKEN_HEADER]: VALID_TOKEN,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("accepts the header case-insensitively", async () => {
+    const res = await get("/api/v2/anything", {
+      "x-preview-token": VALID_TOKEN,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("tolerates surrounding whitespace in the header value", async () => {
+    const res = await get("/api/v2/anything", {
+      [PREVIEW_TOKEN_HEADER]: ` ${VALID_TOKEN} `,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  // --- exemption ---
+
+  test("exempts /healthcheck (ALB probes send no headers)", async () => {
+    const res = await get("/healthcheck");
+    expect(res.status).toBe(200);
+  });
+
+  test("exempts /healthcheck with a query string (the ECS container probe)", async () => {
+    const res = await get("/healthcheck?container=true");
+    expect(res.status).toBe(200);
+  });
+
+  test("does NOT exempt the /healthcheck subtree", async () => {
+    const res = await get("/healthcheck/details");
+    expect(res.status).toBe(401);
+  });
+
+  // --- fail closed ---
+
+  test("503s when PREVIEW_TOKEN is unset", async () => {
+    delete process.env.PREVIEW_TOKEN;
+    const res = await get("/api/v2/anything", {
+      [PREVIEW_TOKEN_HEADER]: VALID_TOKEN,
+    });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Preview token not configured" });
+  });
+
+  test("503s when PREVIEW_TOKEN is shorter than 32 characters", async () => {
+    process.env.PREVIEW_TOKEN = "too-short";
+    const res = await get("/api/v2/anything", {
+      [PREVIEW_TOKEN_HEADER]: "too-short",
+    });
+    expect(res.status).toBe(503);
+  });
+
+  test("still exempts /healthcheck when PREVIEW_TOKEN is unset", async () => {
+    delete process.env.PREVIEW_TOKEN;
+    const res = await get("/healthcheck");
+    expect(res.status).toBe(200);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,9 @@ import { tsconfigPathsPlugin } from "esbuild-plugin-tsconfig-paths";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/instrumentation.ts"],
+  // db-wait.ts is a standalone CLI run by dev/entrypoint.sh before the server
+  // starts; it needs its own bundle, not to be inlined into index.js.
+  entry: ["src/index.ts", "src/instrumentation.ts", "src/db-wait.ts"],
   outDir: "dist",
   format: ["esm"],
   target: "node24",


### PR DESCRIPTION
CON-825 Phase 1, in-tree backend support for per-PR preview bundles. Four
deliverables, all inert unless `PREVIEW=1`, so dev and prod behaviour from the
same image is unchanged.

Design: `con-825-preview-envs-design.md` §2 and Security notes (infrastructure repo).

## What this adds

1. **`prisma/seed.ts` + `package.json#prisma.seed`** — a preview seed guarded by
   `PREVIEW=1` *and* a `RuntimeConfig` row with key `preview_seeded`, all in one
   transaction whose first statement is the marker `INSERT … ON CONFLICT DO
   NOTHING` (so the marker is both the idempotency guard and the concurrency
   guard for two tasks booting at once). Seeds `app_attest_enabled = "false"` —
   without it Firebase App Check 401s every authenticated request and the
   preview is unusable — plus three invite codes, one test account with 100000
   credits, and one published agent template. Wired as `node prisma/seed.ts`,
   not `tsx`: the release image prunes devDependencies, and Node 24 (pinned in
   `.node-version`, `engines`, and the base image) strips types natively.

2. **Bounded database connect-wait in `dev/entrypoint.sh`** — a new
   `dist/db-wait.js` probes the database before `prisma migrate deploy`, with a
   `DB_CONNECT_BUDGET_SECONDS` budget (default 90s). Aurora Serverless v2
   resumes from 0 ACU in ~15s, 30s+ after a long pause, and `migrate deploy` is
   fail-fast, so today the first preview deploy of the day dies on P1001 into
   the ECS circuit breaker — which on a first deploy has no prior revision to
   roll back to and simply stalls.

3. **`X-Preview-Token` gate** (`src/middleware/previewToken.ts`) — when
   `PREVIEW=1`, every request must present the bundle token, compared in
   constant time against `PREVIEW_TOKEN`. Exactly one exemption:
   `/healthcheck`, because the ALB target-group probe and the ECS container
   probe (`/healthcheck?container=true`) send no headers. `/healthcheck/details`
   is **not** exempt. Fails closed: a missing or under-32-char `PREVIEW_TOKEN`
   503s everything but the health check.

4. **Slim-secret boot contract** (`scripts/preview-boot-check.sh`, run in CI) —
   starts the real `dev/entrypoint.sh` with only the boot-required env vars and
   asserts the server serves, the seed ran, and the gate behaves.

## The boot contract

Required **syntactically at boot** — the process exits before serving if any is
missing or malformed:

| Var | Enforced by |
|---|---|
| `DATABASE_URL` | `new PrismaClient()` (`src/utils/prisma.ts`) |
| `XMTP_NOTIFICATION_SECRET` | `src/config.ts` module-load throw |
| `NOTIFICATION_SERVER_URL` | `src/config.ts` module-load throw |
| `ASSISTANT_API_URL` | `src/config.ts` — unset, unparseable, or non-`https:` outside localhost / `*.test.local` |
| `SIWE_DOMAIN` | `src/config.ts` module-load throw |
| `SIWE_URI` | `src/config.ts` module-load throw |
| `NONCE_HMAC_SECRET` | `src/config.ts` — unset **or shorter than 64 chars** |
| `BUILDER_SITE_URL` | `src/config.ts` module-load throw |
| `PAYMENTS_MARKUP_RATE` | `src/payments/credits/config.ts` `loadConfig()` at module load |
| `PAYMENTS_CREDITS_PER_USD` | same |
| `PAYMENTS_RESERVED_MAX_TURN_CREDITS` | same |
| `PAYMENTS_MIN_BALANCE_CREDITS` | same |
| `PAYMENTS_GRANT_PLUS_MONTHLY` | same |
| `JWT_PRIVATE_KEY` | `validateJWTKeys()` in `src/index.ts` → `process.exit(1)` |
| `JWT_PUBLIC_KEY` | same |

Validated only **if set**: `SIWE_ALLOWED_CHAIN_IDS`,
`PAYMENTS_FREE_TIER_DAILY_CAP_CREDITS`, `PAYMENTS_SIGNUP_BONUS_CREDITS`,
`GENERATION_EXECUTOR_TIMEOUT_MS` / `GENERATION_STUCK_SWEEP_THRESHOLD_MS`.

Everything else in the ~35-var production set is **semantic, per-path**: the
endpoint 503s, the server boots. That is what makes the slim preview secret
possible, and it means PR-branch code never receives live Apple, Composio, or
OpenRouter credentials. Also not env but a boot requirement: `dist/certs/` must
ship, or `assertAppleRootCertsPresent()` exits 1.

The `export` block at the top of `scripts/preview-boot-check.sh` **is** this
contract in executable form — adding a new module-load throw without adding it
there fails CI. Verified by deleting `BUILDER_SITE_URL` from that block and
watching the check fail with `BUILDER_SITE_URL is not configured`.

## Decisions

- **Connect-wait is a Node probe, not a shell loop, and is not `PREVIEW`-gated.**
  `pg_isready` is unavailable (the release image installs only
  `openssl ca-certificates tini curl`). Wrapping `migrate deploy` in a retry is
  worse than unavailable: it exits 1 both for P1001 (asleep) and P3009 (applied
  migrations missing from this branch — the rebased-force-push case the deploy
  workflow's auto-reset keys off), so a retry loop merges a diagnosis into a
  timeout. A separate probe keeps both signals distinct and keeps migrate
  fail-fast. Un-gated because a preview-only path is exercised only where
  failure is most expensive; un-gated it runs in every CI run and every deploy,
  also fixes the prod RDS-failover crash-loop, and costs one `SELECT 1`.
- **The gate is global, mounted after `pinoMiddleware` and before
  `rateLimitMiddleware`.** After pino because it logs through `req.log`; before
  the rate limiter because it is a fixed-cost hash compare with no I/O, so
  unauthenticated noise never reaches the limiter's keyed store or the router.
  Global rather than composed into per-route auth because that surface has
  documented public paths (`optionalAuthOrAgentApiKeyAuth`, `.well-known`) and a
  newly added unauthenticated route must not escape the gate. Existing auth
  still runs after it, unchanged.
- **The boot contract is a script, not a vitest test.** `tests/setup.ts`
  unconditionally sets ~25 env vars before any module loads and vitest runs
  `singleFork` with no file parallelism, so a test's environment is neither slim
  nor isolable. A separate process is the only honest instrument — and running
  the real entrypoint also covers db-wait, `migrate deploy`, `db seed` in its
  release-image invocation form, the OTel `--import` flags, and `dist/certs`.

## Verification

Beyond `pnpm check` / `pnpm test` (1862 passing, +30 from this branch) /
`pnpm build` / `./scripts/preview-boot-check.sh`:

- **Gate bypass battery** — 24 probes against a running server with `PREVIEW=1`:
  trailing slash, `//healthcheck`, uppercase, percent-encoded `/health%63heck`,
  dot-segment and encoded traversal, semicolon params, prefix matches, query
  smuggling, duplicate `X-Preview-Token` headers (including one-correct-one-wrong),
  token-as-query-param, token prefix and token+suffix, and POST/PUT/HEAD. All
  401 except the two genuine `/healthcheck` forms; the 401 body leaks nothing.
- **`PREVIEW` unset is a no-op** — same binary, gate emits zero log lines and
  `/healthcheck`, `/healthcheck/details`, `/api/v2/agent-templates` and a 404
  all behave exactly as before.
- **Seed concurrency** — three simultaneous seeders, three rounds: exactly one
  reports `seeded` and two `already-seeded` every time, leaving 1 account,
  3 invite codes and 1 template with no duplicates or partial state.
- **Shell** — `dev/entrypoint.sh` parses under **dash** (the release image's
  `/bin/sh`) and both scripts are shellcheck-clean.

## Adversarial review

The branch was reviewed adversarially by a second model (Codex, read-only)
hunting auth bypasses around the gate, seed hazards, P1001/P3009
misclassification, entrypoint shell bugs, and any change to non-preview
behaviour. Three findings were accepted and fixed, each with a regression test
or a re-run of the boot check:

- The fixed-id fixtures used `create`, so deleting the `preview_seeded` marker
  while the rows survived raised **P2002** — and because the entrypoint runs
  `db seed` under `set -e`, that wedged **every subsequent container boot**.
  Now `upsert`, with a test that deletes the marker and re-seeds (observed
  failing with `Unique constraint failed on the fields: (id)` before the fix).
- `parseBudgetSeconds` used bare `Number.parseInt`, so `DB_CONNECT_BUDGET_SECONDS=10seconds`
  silently became a 10-second budget, and a fat-fingered `999999999999999`
  produced an effectively unbounded wait — the exact circuit-breaker stall this
  module exists to prevent. Now digits-only, clamped to
  `MAX_DB_CONNECT_BUDGET_SECONDS` (3600).
- The boot check's cleanup swallowed every `psql` error, so a failed cleanup
  could leave `app_attest_enabled=false` in the CI database with a green job.
  The EXIT trap now verifies the rows are gone and escalates to a non-zero exit
  (never downgrading an existing failure).

### Review round (Macroscope + CodeRabbit)

Both bots independently flagged the same defect Codex had rated Minor — an
unbounded database probe — which on a third look was the more serious of the
two. Fixed across `ee321eb` and `e2b762d`, in three stages, each one found by
actually measuring the previous one:

- **`waitForDatabase` did not bound an individual probe.** The loop can only
  check its deadline once `probe()` settles, and a probe's own ceiling is
  Prisma's `connect_timeout` — 5s by default but settable to anything in
  `DATABASE_URL`. Benchmark throughout: `connect_timeout=120&pool_timeout=0`
  against a blackholed host with a **3s** budget.
  1. Unbounded: **2m0.1s**.
  2. Probe capped — but that only moved the stall, because `$disconnect()` then
     waited on the in-flight connection. Still **12.05s**.
  3. Disconnect capped too, and the probe ceiling clamped to
     `min(DB_CONNECT_PROBE_TIMEOUT_MS, time left in the budget)` rather than a
     flat 10s: **5.06s**, probe capped at exactly `3000ms`, exit 1 with the
     diagnostic intact. The budget is now a real ceiling plus a bounded 2s
     disconnect. Happy path unchanged at 0.12s.

  `withTimeout` also absorbs the losing promise's late rejection — on Node 24 an
  unhandled rejection is fatal, so a naive `Promise.race` would have introduced
  a crash.
- **The boot check no longer discards a pre-existing `app_attest_enabled`.** It
  captures the prior value before booting and restores it on exit, instead of
  deleting the key outright. (The reported security direction was inverted:
  `getRuntimeConfig("app_attest_enabled", "true")` defaults to `"true"`, so an
  absent row means App Check is **on** — absence is fail-safe, and a row left at
  `"false"` is the hazard the trap's verification already catches.)

Declined: routing `parseBudgetSeconds` through Zod (a boot-path CLI does not
need a schema dependency to parse one integer; the parser is unit-tested for
default, non-positive, non-numeric, numeric-prefix and clamping cases), and
database-level probe cancellation (`pg_cancel_backend` needs a second working
connection to the server that is by definition unreachable in the case it
targets).

One further finding was **rejected on the facts** but is worth a reviewer's eye,
because only someone who can read the secret can confirm it: the seed and the
boot check use **fixed** ids (`1111…`/`2222…`, `PREVIEW1/2/3`, the two
`RuntimeConfig` keys), which would collide across concurrent CI jobs *if*
`secrets.DATABASE_URL` pointed at a shared Postgres. It does not: the job runs
`./dev/up`, which starts its own `postgres:16` container on the runner, then
waits on **localhost:5432** before migrating — so every job has its own
database. **If that secret is ever repointed at a shared instance, these fixed
ids need a per-run suffix.**

Known **Minor**, accepted rather than fixed: registering `package.json#prisma.seed`
means `prisma migrate reset` / `prisma db seed` now spawn one extra process
outside previews. It prints `[preview-seed] skipped-not-preview` and writes
nothing — this is how the entrypoint invokes the seed in the release image,
which has no `tsx`.

## Depends on / not included

`PREVIEW_TOKEN` derivation (`HMAC(master, pr_number)`) is CI's job, not this
PR's. **Machine callers need the token too**: the assistants worker reaches the
backend through the `convos.internal` proxy, so the same pipeline must
provision `PREVIEW_TOKEN` into the PR's worker or those calls will 401 — the
gate is deliberately global rather than exempting the agent-key paths, which
would punch the hole in the most powerful routes. Also out of scope: the
authenticated post-deploy smoke test, and retiring `variant-routing.ts` /
`AgentVariant` (Phase 4).

## If Phase 0 lands first

CON-825 Phase 0 imports convos-backend into the convos-assistants monorepo. If
that lands before this merges, **this ships instead as a PR against
`convos-assistants`, with every path in it prefixed `backend/`** — `backend/prisma/seed.ts`,
`backend/src/db-wait.ts`, `backend/src/middleware/previewToken.ts`,
`backend/scripts/preview-boot-check.sh`, and so on. Nothing here is otherwise
layout-dependent; confirm the path-filtered CI still runs the quality-gate job
for backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyiTeLPdpsBjpoXbBjqD6P
