### PR TITLE
test(abilities): pin v1 grant convergence rows and the check on both sides of cutover

### DIFF
--- a/tests/ability-grant-convergence.test.ts
+++ b/tests/ability-grant-convergence.test.ts
@@ -126,10 +126,11 @@ async function withReadiness<T>(
 }
 
 beforeAll(async () => {
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
     server = app.listen(4017, () => {
       resolve();
     });
+    server.once("error", reject);
   });
 });
 

--- a/tests/ability-grant-convergence.test.ts
+++ b/tests/ability-grant-convergence.test.ts
@@ -1,0 +1,349 @@
+import type { Server } from "node:http";
+import express from "express";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { checkEntitlement } from "@/api/v2/abilities/check-entitlement";
+import { __setEntitlementReadReadinessForTests } from "@/api/v2/abilities/read-readiness";
+import { connectionsRouter } from "@/api/v2/connections/connections.router";
+import { authMiddleware, requireAccount } from "@/middleware/auth";
+import { jsonMiddleware } from "@/middleware/json";
+import { pinoMiddleware } from "@/middleware/pino";
+import { createJwtToken } from "@/utils/jwt";
+import logger from "@/utils/logger";
+import { prisma } from "@/utils/prisma";
+
+vi.mock("firebase-admin/app");
+vi.mock("firebase-admin/app-check");
+vi.mock("firebase-admin/messaging");
+
+// The V1 grant convergence contract, pinned end to end.
+//
+// iOS persists a capability approval with POST /v2/connections/grants; exec
+// authorizes with checkEntitlement's conversation path. Between the two sits
+// the dual-store migration: the legacy ConnectionGrant row and the
+// AbilityEntitlement + ConversationAbility pair, written together in one
+// transaction (v1-grant-adapter.ts), read on either side of the read-model
+// cutover (read-readiness.ts).
+//
+// This suite asserts the contract the hard way — exact rows in all three
+// tables after the real HTTP write, then the authorization decision with the
+// readiness gate forced BOTH ways on that same posted grant. A single live
+// exec passing cannot catch a write that landed in only one store: whichever
+// store the replica happens to read may be the one that got the row. Only
+// row-level assertions on both stores do.
+//
+// Adjacent coverage, deliberately not repeated here: V1 endpoint semantics
+// (upsert, revoke, listing) in connection-grants.test.ts; exec's HTTP surface
+// and denial vocabulary in composio-exec.test.ts; adapter edge cases
+// (case-variant reconciliation, V2 PUT mirroring) in both.
+
+const app = express();
+app.use(pinoMiddleware);
+app.use(jsonMiddleware);
+app.use(
+  "/api/v2/connections",
+  authMiddleware,
+  requireAccount,
+  connectionsRouter,
+);
+
+let server: Server;
+const baseURL = "http://localhost:4017";
+
+const OWNER_INBOX = "owner-inbox-convergence";
+const AGENT_INBOX = "agent-inbox-convergence";
+const CONVERSATION = "conv-convergence";
+
+// The shape a shipped iOS build sends on approval. Mixed-case toolkit on
+// purpose: the legacy row must keep the client's casing while the
+// entitlement row stores the canonical id — both are asserted below.
+const GRANT_BODY = {
+  ownerInboxId: OWNER_INBOX,
+  granteeInboxId: AGENT_INBOX,
+  conversationId: CONVERSATION,
+  toolkit: "GoogleCalendar",
+  actions: ["GOOGLECALENDAR_EVENTS_LIST"],
+  bundleIds: ["calendar.events"],
+  serviceVersion: 2,
+};
+
+const accountIds: string[] = [];
+
+async function makeAccount(): Promise<string> {
+  const account = await prisma.account.create({ data: {} });
+  accountIds.push(account.id);
+  return account.id;
+}
+
+async function token(accountId: string): Promise<string> {
+  return createJwtToken({ deviceId: "device-convergence", accountId });
+}
+
+async function postGrant(accountId: string, body: unknown) {
+  return fetch(`${baseURL}/api/v2/connections/grants`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Convos-AuthToken": await token(accountId),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Exec's authorization question for the granted conversation, verbatim. */
+function checkConversation() {
+  return checkEntitlement({
+    caller: {
+      kind: "conversation",
+      conversationId: CONVERSATION,
+      agentInboxId: AGENT_INBOX,
+    },
+    abilityId: "googlecalendar",
+    action: "GOOGLECALENDAR_EVENTS_LIST",
+    catalog: null,
+    log: logger,
+  });
+}
+
+/** Run `fn` with the readiness gate pinned, always restoring afterwards. */
+async function withReadiness<T>(
+  ready: boolean,
+  fn: () => Promise<T>,
+): Promise<T> {
+  __setEntitlementReadReadinessForTests(ready);
+  try {
+    return await fn();
+  } finally {
+    __setEntitlementReadReadinessForTests(null);
+  }
+}
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = app.listen(4017, () => {
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  __setEntitlementReadReadinessForTests(null);
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  // Account delete cascades grants, entitlements, and extensions.
+  await prisma.account.deleteMany({ where: { id: { in: accountIds } } });
+  accountIds.length = 0;
+});
+
+describe("V1 grant convergence — rows", () => {
+  test("one POST writes the exact rows in all three tables (one transaction)", async () => {
+    const accountId = await makeAccount();
+    const res = await postGrant(accountId, GRANT_BODY);
+    expect(res.status).toBe(200);
+    const { id } = (await res.json()) as { id: string };
+
+    // The legacy store: exactly one row, every field as the V1 contract
+    // stores it — toolkit in the client's casing, no connectionId (never
+    // accepted from the body), live (revokedAt null).
+    const grants = await prisma.connectionGrant.findMany({
+      where: { ownerAccountId: accountId },
+    });
+    expect(grants).toHaveLength(1);
+    const grant = grants[0];
+    expect(grant).toMatchObject({
+      id,
+      ownerAccountId: accountId,
+      ownerInboxId: OWNER_INBOX,
+      granteeInboxId: AGENT_INBOX,
+      conversationId: CONVERSATION,
+      toolkit: "GoogleCalendar",
+      actions: ["GOOGLECALENDAR_EVENTS_LIST"],
+      bundleIds: ["calendar.events"],
+      serviceVersion: 2,
+      connectionId: null,
+      expiresAt: null,
+      revokedAt: null,
+    });
+
+    // The entitlement store: exactly one entitlement, canonical lowercase
+    // ability id, active, no tombstone.
+    const entitlements = await prisma.abilityEntitlement.findMany({
+      where: { accountId },
+    });
+    expect(entitlements).toHaveLength(1);
+    const entitlement = entitlements[0];
+    expect(entitlement).toMatchObject({
+      accountId,
+      abilityId: "googlecalendar",
+      status: "active",
+      revokedAt: null,
+    });
+
+    // The extension: exactly one row, sharing the legacy grant's id (V1
+    // DELETE-by-id must address it), scope carried 1:1, the extender
+    // recorded as the V1 owner inbox, createdAt aligned with the grant.
+    const extensions = await prisma.conversationAbility.findMany({
+      where: { entitlementId: entitlement.id },
+    });
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0]).toMatchObject({
+      id: grant.id,
+      entitlementId: entitlement.id,
+      conversationId: CONVERSATION,
+      agentInboxId: AGENT_INBOX,
+      actions: ["GOOGLECALENDAR_EVENTS_LIST"],
+      bundleIds: ["calendar.events"],
+      extendedByInboxId: OWNER_INBOX,
+      expiresAt: null,
+    });
+    expect(extensions[0].createdAt).toEqual(grant.createdAt);
+  });
+
+  test("re-approval refreshes scope in BOTH stores — same id, one row each", async () => {
+    const accountId = await makeAccount();
+    const first = (await (await postGrant(accountId, GRANT_BODY)).json()) as {
+      id: string;
+    };
+    // The owner re-approves with a narrowed scope (read-only bundle, no
+    // explicit actions). Both stores must converge on it — a store keeping
+    // the old scope would keep authorizing it on its side of the cutover.
+    const res = await postGrant(accountId, {
+      ...GRANT_BODY,
+      actions: [],
+      bundleIds: ["calendar.events.read"],
+    });
+    expect(res.status).toBe(200);
+    const second = (await res.json()) as { id: string };
+    expect(second.id).toBe(first.id);
+
+    const grants = await prisma.connectionGrant.findMany({
+      where: { ownerAccountId: accountId },
+    });
+    expect(grants).toHaveLength(1);
+    expect(grants[0].actions).toEqual([]);
+    expect(grants[0].bundleIds).toEqual(["calendar.events.read"]);
+
+    const extensions = await prisma.conversationAbility.findMany({
+      where: { entitlement: { is: { accountId } } },
+    });
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0].id).toBe(first.id);
+    expect(extensions[0].actions).toEqual([]);
+    expect(extensions[0].bundleIds).toEqual(["calendar.events.read"]);
+  });
+
+  test("a rejected POST leaves every store untouched (no partial state)", async () => {
+    const accountId = await makeAccount();
+    const res = await postGrant(accountId, {
+      ...GRANT_BODY,
+      bundleIds: ["calendar.bogus"],
+    });
+    expect(res.status).toBe(400);
+
+    expect(
+      await prisma.connectionGrant.count({
+        where: { ownerAccountId: accountId },
+      }),
+    ).toBe(0);
+    expect(
+      await prisma.abilityEntitlement.count({ where: { accountId } }),
+    ).toBe(0);
+    expect(
+      await prisma.conversationAbility.count({
+        where: { entitlement: { is: { accountId } } },
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("V1 grant convergence — the check on both sides of the cutover", () => {
+  test("the posted grant authorizes exec pre- and post-cutover; before it, neither side does", async () => {
+    const accountId = await makeAccount();
+
+    // Baseline: no grant yet — both stores must deny, or the allow below
+    // proves nothing.
+    for (const ready of [true, false]) {
+      const denied = await withReadiness(ready, checkConversation);
+      expect(denied).toEqual({ allowed: false, code: "no_grant" });
+    }
+
+    const res = await postGrant(accountId, GRANT_BODY);
+    expect(res.status).toBe(200);
+    const entitlement = await prisma.abilityEntitlement.findUniqueOrThrow({
+      where: {
+        accountId_abilityId: { accountId, abilityId: "googlecalendar" },
+      },
+    });
+
+    // Post-cutover (readiness confirmed): the decision comes from the
+    // entitlement tables — entitlementId names the row created by the POST.
+    const postCutover = await withReadiness(true, checkConversation);
+    expect(postCutover.allowed).toBe(true);
+    if (postCutover.allowed) {
+      expect(postCutover.ownerAccountId).toBe(accountId);
+      expect(postCutover.entitlementId).toBe(entitlement.id);
+      expect(postCutover.actions).toContain("GOOGLECALENDAR_EVENTS_LIST");
+    }
+
+    // Pre-cutover (boot window): the same grant authorizes from the legacy
+    // matcher — entitlementId null is that path's signature.
+    const preCutover = await withReadiness(false, checkConversation);
+    expect(preCutover.allowed).toBe(true);
+    if (preCutover.allowed) {
+      expect(preCutover.ownerAccountId).toBe(accountId);
+      expect(preCutover.entitlementId).toBeNull();
+      expect(preCutover.actions).toContain("GOOGLECALENDAR_EVENTS_LIST");
+    }
+  });
+
+  test("revoking the grant denies on BOTH sides; the entitlement survives, the extension does not", async () => {
+    const accountId = await makeAccount();
+    const { id } = (await (await postGrant(accountId, GRANT_BODY)).json()) as {
+      id: string;
+    };
+
+    const res = await fetch(`${baseURL}/api/v2/connections/grants/${id}`, {
+      method: "DELETE",
+      headers: { "X-Convos-AuthToken": await token(accountId) },
+    });
+    expect(res.status).toBe(204);
+
+    // Row state after the revoke transaction: legacy soft-revoked (audit
+    // trail), extension deleted, the account-level entitlement kept — it is
+    // the connection binding, not the conversation opt-in.
+    const grant = await prisma.connectionGrant.findUniqueOrThrow({
+      where: { id },
+    });
+    expect(grant.revokedAt).not.toBeNull();
+    expect(
+      await prisma.conversationAbility.findUnique({ where: { id } }),
+    ).toBeNull();
+    const entitlement = await prisma.abilityEntitlement.findUniqueOrThrow({
+      where: {
+        accountId_abilityId: { accountId, abilityId: "googlecalendar" },
+      },
+    });
+    expect(entitlement.status).toBe("active");
+
+    // And the decision: no side of the cutover keeps authorizing — the
+    // surviving entitlement alone must not, and the revoked legacy row must
+    // not.
+    for (const ready of [true, false]) {
+      const denied = await withReadiness(ready, checkConversation);
+      expect(denied).toEqual({ allowed: false, code: "no_grant" });
+    }
+  });
+});


### PR DESCRIPTION
## What

An integration suite (`tests/ability-grant-convergence.test.ts`) pinning the V1 grant convergence contract end to end: `POST /v2/connections/grants` (the iOS capability-approval write) must land the same fact in both stores in one transaction — the legacy `ConnectionGrant` row and the `AbilityEntitlement` + `ConversationAbility` pair (`src/api/v2/connections/v1-grant-adapter.ts`) — and exec's `checkEntitlement` must authorize that same grant on either side of the read-model cutover (`src/api/v2/abilities/read-readiness.ts`).

## Why row-level assertions

A single live exec passing cannot catch a write that landed in only one store: whichever store the replica happens to read may be the one that got the row. The suite therefore asserts exact rows in all three tables after the real HTTP write, then the authorization decision with the readiness gate forced both ways on that same posted grant.

## What it pins

- One POST writes the exact rows in all three tables: shared cross-store id, canonical lowercase ability id on the entitlement, client-cased toolkit on the legacy row, scope carried 1:1, extender recorded from the owner inbox.
- Re-approval refreshes scope in both stores — same id, still one row each.
- A rejected POST (unknown bundle) leaves every store untouched.
- The posted grant authorizes `checkEntitlement`'s conversation path with readiness forced both ways: post-cutover the decision names the entitlement row; pre-cutover it comes from the legacy matcher (`entitlementId` null). Before the grant exists, both sides deny `no_grant`.
- Revoking the grant denies on both sides: legacy row soft-revoked, extension deleted, and the surviving account-level entitlement alone does not authorize.

Adjacent coverage deliberately not repeated here: endpoint semantics in `tests/connection-grants.test.ts`, exec's HTTP surface in `tests/composio-exec.test.ts`, adapter edge cases in both.

## Verification

- New suite: 5/5 green.
- Full abilities/connections batch (`connection-grants`, `check-entitlement`, `composio-exec`, `conversation-abilities`, `abilities*`, `ability-entitlements-backfill` + this file): 199/199, three consecutive runs.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean.
- Full local `pnpm test`: the only failures (26, in auth-siwe/auth-e2e/subscriptions-credits files) reproduce identically on pristine `origin/otr-dev` in the same environment — pre-existing local-env issues, untouched by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-backend/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789117947&installation_model_id=20076&pr_number=412&repository=xmtplabs%2Fconvos-backend&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-backend%2Fpull%2F412&signature=b5dfd980ee85a1658b74e9ab3c7d691bdc2d5c0be7e9880052e809fd44dd3e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add V1 grant convergence end-to-end tests covering row writes and authorization checks on both sides of cutover
> - Adds a Vitest suite in [ability-grant-convergence.test.ts](https://github.com/xmtplabs/convos-backend/pull/412/files#diff-0c6d1f98f492898d89873955c7c30c3926e85d7910f2abd7821d450e7a4be8a3) that spins up a real Express server on port 4017 and exercises the `POST /api/v2/connections/grants` endpoint against live Prisma stores.
> - The `V1 grant convergence — rows` block verifies that a grant POST writes exactly one row each to `connectionGrant`, `abilityEntitlement`, and `conversationAbility`, that re-approval updates scope in both stores without creating duplicate rows, and that a rejected POST (invalid `bundleId`) leaves all stores empty.
> - The `V1 grant convergence — the check on both sides of the cutover` block toggles `__setEntitlementReadReadinessForTests` to assert `checkEntitlement` returns `no_grant` before any grant, returns `allowed=true` with correct metadata after a grant, and returns `no_grant` after revocation while confirming the entitlement row survives but the `conversationAbility` extension is deleted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 080e116.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for grant synchronization across connection, entitlement, and conversation permissions.
  * Added validation for scope updates, rejected changes, authorization transitions, and grant revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->