### PR TITLE
docs: mark repository as deprecated — moved to convos-assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!CAUTION]
 > This repo is no longer maintained.
 
-Convos backend development has moved to the [convos-assistants](https://github.com/xmtplabs/convos-assistants) monorepo, where this code now lives under `backend/`. Open issues and pull requests there.
+Convos backend development has moved.
 
 The documentation below is provided for historical reference only.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+![Status](https://img.shields.io/badge/Deprecated-brown)
+
+> [!CAUTION]
+> This repo is no longer maintained.
+
+Convos backend development has moved to the [convos-assistants](https://github.com/xmtplabs/convos-assistants) monorepo, where this code now lives under `backend/`. Open issues and pull requests there.
+
+The documentation below is provided for historical reference only.
+
 # Convos Backend
 
 This is the official repository for Convos backend service.


### PR DESCRIPTION
Adds the org-standard archived-repo notice to the top of the README (same format as xmtp/didethresolver): Deprecated badge, caution callout, a note that development has moved, and that the docs below are historical.

Merging this is the documentation half of archiving. The settings half — **Settings → Archive this repository**, which makes the repo read-only — is an admin action to take once in-flight work here is resolved (notably open PR #410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyiTeLPdpsBjpoXbBjqD6P

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark repository as deprecated in README
> Adds a deprecation badge and caution notice to [README.md](https://github.com/xmtplabs/convos-backend/pull/413/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) indicating the repository is no longer maintained and that Convos backend development has moved to `convos-assistants`. The remaining documentation is retained for historical reference.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b12be68. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->